### PR TITLE
v0.0.45

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
   - Added `allParameters`.
 - `ASTTypeInt` and `ASTTypeDouble`:
   - Added `bits`
+  - Added `ASTTypeInt.instance32` and `ASTTypeInt.instance64`.
+  - Added `ASTTypeDouble.instance32` and `ASTTypeDouble.instance64`.
 - `ASTValueNum`:
   - Added field `negative`.
 
@@ -13,15 +15,19 @@
   - Changed to 64 bits.
   - `Wasm`: split in `Wasm32` and `Wasm64` with improved opcodes.
   - Allow operations with different types (auto casting).
+  - Handle `unreachable` end of function cases.
   - Implemented:
     - `generateASTValue`, `generateASTValueDouble`, `generateASTValueInt`.
     - `generateASTExpressionVariableAssignment`, `generateASTStatementExpression`
     - `generateASTBranchIfBlock`, `generateASTBranchIfElseBlock`, `generateASTBranchIfElseIfsElseBlock`.
     - `generateASTStatementReturnWithExpression`, `generateASTStatementReturn`, `generateASTStatementReturnValue`.
+
 - `ApolloParserWasm`:
   - Identify if an `ASTTypeInt` or `ASTTypeDouble` type is a `32` or `64` bits. 
+
 - `ApolloRunnerWasm`:
   - Use the parsed Wasm functions (AST) to normalize the parameters before calling the Wasm function.  
+
 - `WasmModule`:
   - Added `resolveReturnedValue`.
     - Browser implementation: when the function returns a `f64`, the JS `bigint` needs to be converted to a Dart `BigInt`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,31 @@
 ## 0.0.45
 
+- `ASTBranchIfElseBlock` and `ASTBranchIfElseIfsElseBlock`:
+  - `blockElse`: optional.
+- `ASTParametersDeclaration`:
+  - Added `allParameters`.
+- `ASTTypeInt` and `ASTTypeDouble`:
+  - Added `bits`
+- `ASTValueNum`:
+  - Added field `negative`.
+
 - `ApolloGeneratorWasm`:
-  - Implemented `generateASTStatementReturnWithExpression`
+  - Changed to 64 bits.
+  - `Wasm`: split in `Wasm32` and `Wasm64` with improved opcodes.
+  - Allow operations with different types (auto casting).
+  - Implemented:
+    - `generateASTValue`, `generateASTValueDouble`, `generateASTValueInt`.
+    - `generateASTExpressionVariableAssignment`, `generateASTStatementExpression`
+    - `generateASTBranchIfBlock`, `generateASTBranchIfElseBlock`, `generateASTBranchIfElseIfsElseBlock`.
+    - `generateASTStatementReturnWithExpression`, `generateASTStatementReturn`, `generateASTStatementReturnValue`.
+- `ApolloParserWasm`:
+  - Identify if an `ASTTypeInt` or `ASTTypeDouble` type is a `32` or `64` bits. 
+- `ApolloRunnerWasm`:
+  - Use the parsed Wasm functions (AST) to normalize the parameters before calling the Wasm function.  
+- `WasmModule`:
+  - Added `resolveReturnedValue`.
+    - Browser implementation: when the function returns a `f64`, the JS `bigint` needs to be converted to a Dart `BigInt`.
+- New `WasmModuleExecutionError`.
 
 ## 0.0.44
 

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -35,7 +35,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.0.44';
+  static final String VERSION = '0.0.45';
 
   static int _idCount = 0;
 

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -328,11 +328,18 @@ abstract class ApolloCodeGenerator
     generateASTBlock(branch.blockIf,
         out: out, indent: '$indent  ', withBrackets: false);
     out.write(indent);
-    out.write('} else {\n');
-    generateASTBlock(branch.blockElse,
-        out: out, indent: '$indent  ', withBrackets: false);
-    out.write(indent);
-    out.write('}\n');
+
+    var blockElse = branch.blockElse;
+
+    if (blockElse != null) {
+      out.write('} else {\n');
+      generateASTBlock(blockElse,
+          out: out, indent: '$indent  ', withBrackets: false);
+      out.write(indent);
+      out.write('}\n');
+    } else {
+      out.write('}\n');
+    }
 
     return out;
   }
@@ -365,11 +372,18 @@ abstract class ApolloCodeGenerator
     }
 
     out.write(indent);
-    out.write('} else {\n');
-    generateASTBlock(branch.blockElse,
-        out: out, indent: '$indent  ', withBrackets: false);
-    out.write(indent);
-    out.write('}\n');
+
+    var blockElse = branch.blockElse;
+
+    if (blockElse != null) {
+      out.write('} else {\n');
+      generateASTBlock(blockElse,
+          out: out, indent: '$indent  ', withBrackets: false);
+      out.write(indent);
+      out.write('}\n');
+    } else {
+      out.write('}\n');
+    }
 
     return out;
   }

--- a/lib/src/ast/apollovm_ast_statement.dart
+++ b/lib/src/ast/apollovm_ast_statement.dart
@@ -232,7 +232,28 @@ class ASTStatementValue extends ASTStatement {
       value.resolveType(context);
 }
 
-enum ASTAssignmentOperator { set, multiply, divide, sum, subtract }
+enum ASTAssignmentOperator {
+  set,
+  multiply,
+  divide,
+  sum,
+  subtract;
+
+  ASTExpressionOperator? get asASTExpressionOperator {
+    switch (this) {
+      case sum:
+        return ASTExpressionOperator.add;
+      case subtract:
+        return ASTExpressionOperator.subtract;
+      case multiply:
+        return ASTExpressionOperator.multiply;
+      case divide:
+        return ASTExpressionOperator.divide;
+      default:
+        return null;
+    }
+  }
+}
 
 ASTAssignmentOperator getASTAssignmentOperator(String op) {
   op = op.trim();
@@ -533,7 +554,7 @@ class ASTBranchIfBlock extends ASTBranch {
 class ASTBranchIfElseBlock extends ASTBranch {
   ASTExpression condition;
   ASTBlock blockIf;
-  ASTBlock blockElse;
+  ASTBlock? blockElse;
 
   ASTBranchIfElseBlock(this.condition, this.blockIf, this.blockElse);
 
@@ -543,7 +564,7 @@ class ASTBranchIfElseBlock extends ASTBranch {
 
     condition.resolveNode(parentNode);
     blockIf.resolveNode(parentNode);
-    blockElse.resolveNode(parentNode);
+    blockElse?.resolveNode(parentNode);
   }
 
   @override
@@ -555,7 +576,7 @@ class ASTBranchIfElseBlock extends ASTBranch {
     if (evalValue) {
       await blockIf.run(parentContext, runStatus);
     } else {
-      await blockElse.run(parentContext, runStatus);
+      await blockElse?.run(parentContext, runStatus);
     }
 
     return ASTValueVoid.instance;
@@ -572,7 +593,7 @@ class ASTBranchIfElseIfsElseBlock extends ASTBranch {
   ASTExpression condition;
   ASTBlock blockIf;
   List<ASTBranchIfBlock> blocksElseIf;
-  ASTBlock blockElse;
+  ASTBlock? blockElse;
 
   ASTBranchIfElseIfsElseBlock(
       this.condition, this.blockIf, this.blocksElseIf, this.blockElse);
@@ -589,7 +610,7 @@ class ASTBranchIfElseIfsElseBlock extends ASTBranch {
       e.resolveNode(parentNode);
     }
 
-    blockElse.resolveNode(parentNode);
+    blockElse?.resolveNode(parentNode);
   }
 
   @override
@@ -611,7 +632,7 @@ class ASTBranchIfElseIfsElseBlock extends ASTBranch {
         }
       }
 
-      await blockElse.run(parentContext, runStatus);
+      await blockElse?.run(parentContext, runStatus);
       return ASTValueVoid.instance;
     }
   }

--- a/lib/src/ast/apollovm_ast_toplevel.dart
+++ b/lib/src/ast/apollovm_ast_toplevel.dart
@@ -984,6 +984,13 @@ class ASTParametersDeclaration {
     }
   }
 
+  /// Returns a list with all the [positionalParameters], [optionalParameters] and [namedParameters].
+  List<ASTFunctionParameterDeclaration> get allParameters => [
+        ...?positionalParameters,
+        ...?optionalParameters,
+        ...?namedParameters,
+      ];
+
   int get positionalParametersSize => positionalParameters?.length ?? 0;
 
   int get optionalParametersSize => optionalParameters?.length ?? 0;

--- a/lib/src/ast/apollovm_ast_type.dart
+++ b/lib/src/ast/apollovm_ast_type.dart
@@ -402,7 +402,7 @@ class ASTTypeNum<T extends num> extends ASTTypeNumber<T> {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      super == other && other is ASTTypeInt && runtimeType == other.runtimeType;
+      super == other && other is ASTTypeNum && runtimeType == other.runtimeType;
 
   @override
   int get hashCode => name.hashCode;
@@ -416,6 +416,8 @@ class ASTTypeNum<T extends num> extends ASTTypeNumber<T> {
 /// [ASTType] for integer ([int]).
 class ASTTypeInt extends ASTTypeNum<int> {
   static final ASTTypeInt instance = ASTTypeInt();
+  static final ASTTypeInt instance32 = ASTTypeInt(bits: 32);
+  static final ASTTypeInt instance64 = ASTTypeInt(bits: 64);
 
   /// Amount of bits of the `int` (optional).
   final int? bits;
@@ -451,9 +453,19 @@ class ASTTypeInt extends ASTTypeNum<int> {
   }
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      super == other && other is ASTTypeInt && runtimeType == other.runtimeType;
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    if (other is ASTTypeInt && runtimeType == other.runtimeType) {
+      if (bits != null && other.bits != null) {
+        return bits == other.bits;
+      }
+
+      return true;
+    }
+
+    return false;
+  }
 
   @override
   int get hashCode => name.hashCode;
@@ -467,6 +479,8 @@ class ASTTypeInt extends ASTTypeNum<int> {
 /// [ASTType] for [double].
 class ASTTypeDouble extends ASTTypeNum<double> {
   static final ASTTypeDouble instance = ASTTypeDouble();
+  static final ASTTypeDouble instance32 = ASTTypeDouble(bits: 32);
+  static final ASTTypeDouble instance64 = ASTTypeDouble(bits: 64);
 
   /// Amount of bits of the `float`/`double` (optional).
   final int? bits;
@@ -502,9 +516,19 @@ class ASTTypeDouble extends ASTTypeNum<double> {
   }
 
   @override
-  bool operator ==(Object other) =>
-      identical(this, other) ||
-      super == other && other is ASTTypeInt && runtimeType == other.runtimeType;
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    if (other is ASTTypeDouble && runtimeType == other.runtimeType) {
+      if (bits != null && other.bits != null) {
+        return bits == other.bits;
+      }
+
+      return true;
+    }
+
+    return false;
+  }
 
   @override
   int get hashCode => name.hashCode;

--- a/lib/src/ast/apollovm_ast_type.dart
+++ b/lib/src/ast/apollovm_ast_type.dart
@@ -417,7 +417,10 @@ class ASTTypeNum<T extends num> extends ASTTypeNumber<T> {
 class ASTTypeInt extends ASTTypeNum<int> {
   static final ASTTypeInt instance = ASTTypeInt();
 
-  ASTTypeInt() : super._('int');
+  /// Amount of bits of the `int` (optional).
+  final int? bits;
+
+  ASTTypeInt({this.bits}) : super._('int');
 
   @override
   bool acceptsType(ASTType type) {
@@ -457,7 +460,7 @@ class ASTTypeInt extends ASTTypeNum<int> {
 
   @override
   String toString() {
-    return 'int';
+    return 'int${bits != null ? '($bits)' : ''}';
   }
 }
 
@@ -465,7 +468,10 @@ class ASTTypeInt extends ASTTypeNum<int> {
 class ASTTypeDouble extends ASTTypeNum<double> {
   static final ASTTypeDouble instance = ASTTypeDouble();
 
-  ASTTypeDouble() : super._('double');
+  /// Amount of bits of the `float`/`double` (optional).
+  final int? bits;
+
+  ASTTypeDouble({this.bits}) : super._('double');
 
   @override
   bool acceptsType(ASTType type) {
@@ -505,7 +511,7 @@ class ASTTypeDouble extends ASTTypeNum<double> {
 
   @override
   String toString() {
-    return 'double';
+    return 'double${bits != null ? '($bits)' : ''}';
   }
 }
 

--- a/lib/src/ast/apollovm_ast_value.dart
+++ b/lib/src/ast/apollovm_ast_value.dart
@@ -422,6 +422,8 @@ abstract class ASTValueNum<T extends num> extends ASTValuePrimitive<T> {
     throw StateError("Can't parse number: $o");
   }
 
+  bool get isZero => value == 0;
+
   @override
   FutureOr<ASTValue> operator +(ASTValue other);
 

--- a/lib/src/ast/apollovm_ast_value.dart
+++ b/lib/src/ast/apollovm_ast_value.dart
@@ -396,12 +396,29 @@ class ASTValueBool extends ASTValuePrimitive<bool> {
 
 /// [ASTValue] for numbers ([num]).
 abstract class ASTValueNum<T extends num> extends ASTValuePrimitive<T> {
-  ASTValueNum(ASTType<T> type, T value) : super(type, value);
+  final bool negative;
 
-  static ASTValueNum from(dynamic o) {
-    if (o is int) return ASTValueInt(o);
-    if (o is double) return ASTValueDouble(o);
-    if (o is String) return from(parseNum(o.trim()));
+  ASTValueNum(ASTType<T> type, T value, {bool? negative})
+      : negative = negative ?? value.isNegative,
+        super(
+          type,
+          negative != null
+              ? (negative
+                  ? (value.isNegative ? value : (-value as T))
+                  : (value.isNegative ? (-value as T) : value))
+              : value,
+        ) {
+    assert(this.value.isNegative == this.negative);
+  }
+
+  static ASTValueNum from(dynamic o, {bool? negative}) {
+    if (o is int) {
+      return ASTValueInt(o, negative: negative);
+    } else if (o is double) {
+      return ASTValueDouble(o, negative: negative);
+    } else if (o is String) {
+      return from(parseNum(o.trim()), negative: negative);
+    }
     throw StateError("Can't parse number: $o");
   }
 
@@ -505,7 +522,7 @@ abstract class ASTValueNum<T extends num> extends ASTValuePrimitive<T> {
 
 /// [ASTValue] for integer ([int]).
 class ASTValueInt extends ASTValueNum<int> {
-  ASTValueInt(int n) : super(ASTTypeInt.instance, n);
+  ASTValueInt(int n, {super.negative}) : super(ASTTypeInt.instance, n);
 
   @override
   ASTValue operator +(ASTValue other) {
@@ -565,7 +582,7 @@ class ASTValueInt extends ASTValueNum<int> {
 
 /// [ASTValue] for [double].
 class ASTValueDouble extends ASTValueNum<double> {
-  ASTValueDouble(double n) : super(ASTTypeDouble.instance, n);
+  ASTValueDouble(double n, {super.negative}) : super(ASTTypeDouble.instance, n);
 
   @override
   ASTValue operator +(ASTValue other) {

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -267,13 +267,12 @@ class DartGrammarDefinition extends DartGrammarLexer {
               char(')').trimHidden() &
               codeBlock() &
               ref0(branchElseIfs).plus() &
-              string('else').trimHidden() &
-              codeBlock())
+              (string('else').trimHidden() & codeBlock()).optional())
           .map((v) {
         var condition = v[2];
         var blockIf = v[4];
         var blockElseIfs = v[5] as List;
-        var blockElse = v[7];
+        var blockElse = v[6]?[1];
 
         return ASTBranchIfElseIfsElseBlock(condition, blockIf,
             blockElseIfs.cast<ASTBranchIfBlock>().toList(), blockElse);
@@ -625,12 +624,15 @@ class DartGrammarDefinition extends DartGrammarLexer {
       .cast<ASTValue>();
 
   Parser<ASTValueBool> literalBool() =>
-      ((string('true') | string('false')).trim()).map((v) {
+      (string('true') | string('false').trim()).map((v) {
         return ASTValueBool(v == 'true');
       });
 
-  Parser<ASTValueNum> literalNum() => (numberLexicalToken().trim()).map((v) {
-        return ASTValueNum.from(v);
+  Parser<ASTValueNum> literalNum() =>
+      (char('-').optional() & numberLexicalToken()).trim().map((v) {
+        var negative = v[0] == '-';
+        var value = v[1];
+        return ASTValueNum.from(value, negative: negative);
       });
 
   Parser<ASTValue<String>> literalString() =>

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -584,12 +584,15 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
       .cast<ASTValue>();
 
   Parser<ASTValueBool> literalBool() =>
-      ((string('true') | string('false')).trim()).map((v) {
+      (string('true') | string('false')).trim().map((v) {
         return ASTValueBool(v == 'true');
       });
 
-  Parser<ASTValueNum> literalNum() => (numberLexicalToken()).map((v) {
-        return ASTValueNum.from(v);
+  Parser<ASTValueNum> literalNum() =>
+      (char('-').optional() & numberLexicalToken()).trim().map((v) {
+        var negative = v[0] == '-';
+        var value = v[1];
+        return ASTValueNum.from(value, negative: negative);
       });
 
   Parser<ASTValueString> literalString() => (stringLexicalToken()).map((v) {

--- a/lib/src/languages/wasm/wasm.dart
+++ b/lib/src/languages/wasm/wasm.dart
@@ -44,6 +44,8 @@ class Wasm {
 
   static const functionReturn = 0x0f;
 
+  static const unreachable = 0x00;
+
   static List<int> brIf(int i) => <int>[0x0d, ...Leb128.encodeUnsigned(i)];
 
   static List<int> call(int i) => <int>[0x10, ...Leb128.encodeUnsigned(i)];

--- a/lib/src/languages/wasm/wasm.dart
+++ b/lib/src/languages/wasm/wasm.dart
@@ -32,92 +32,199 @@ class Wasm {
   static const globalType = 0x03;
   static const functionType = 0x60;
 
-  static const i32Eqz = 0x45;
-  static const i32Eq = 0x46;
-  static const i32Ne = 0x47;
-  static const i32LtS = 0x48;
-  static const i32LtU = 0x49;
-  static const i32GtS = 0x4a;
-  static const i32LeS = 0x4c;
-  static const i32LeU = 0x4d;
-  static const i32GeS = 0x4e;
+  static List<int> block(WasmType blockType) => <int>[0x02, blockType.value];
 
-  static const f64Eq = 0x61;
-  static const f64Ne = 0x62;
-  static const f64Lt = 0x63;
-  static const f64Gt = 0x64;
-  static const f64Le = 0x65;
-  static const f64Ge = 0x66;
+  static List<int> loop(WasmType blockType) => <int>[0x03, blockType.value];
 
-  static const i32Add = 0x6a;
-  static const i32Sub = 0x6b;
-  static const i32Mul = 0x6c;
-  static const i32RemS = 0x6f;
-  static const i32And = 0x71;
-  static const i32Or = 0x72;
+  static List<int> ifInstruction(WasmType retType) =>
+      <int>[0x04, retType.value];
 
-  static const i64RemS = 0x81;
-  static const i64And = 0x83;
-  static const i64Or = 0x84;
-
-  static const f64Abs = 0x99;
-  static const f64Neg = 0x9a;
-  static const f64Ceil = 0x9b;
-  static const f64Floor = 0x9c;
-  static const f64Sqrt = 0x9f;
-  static const f64Add = 0xa0;
-  static const f64Sub = 0xa1;
-  static const f64Mul = 0xa2;
-  static const f64Div = 0xa3;
-  static const f64Min = 0xa4;
-  static const f64Max = 0xa5;
-
-  static const i32TruncF64S = 0xaa;
-  static const i32TruncF64U = 0xab;
-  static const i64TruncSF64 = 0xb0;
-  static const f64ConvertI64S = 0xb9;
-  static const f64ConvertI32S = 0xb7;
-
-  static block(WasmType blockType) => [0x02, blockType];
-
-  static loop(WasmType blockType) => [0x03, blockType];
-
-  static ifInstruction(WasmType retType) => [0x04, retType];
   static const elseInstruction = 0x05;
   static const end = 0x0b;
 
-  static List<int> brIf(int i) => [0x0d, ...Leb128.encodeUnsigned(i)];
+  static const functionReturn = 0x0f;
 
-  static call(int i) => [0x10, ...Leb128.encodeUnsigned(i)];
+  static List<int> brIf(int i) => <int>[0x0d, ...Leb128.encodeUnsigned(i)];
+
+  static List<int> call(int i) => <int>[0x10, ...Leb128.encodeUnsigned(i)];
 
   static const drop = 0x1a;
   static const select = 0x1b;
 
-  static List<int> localGet(int i) => [0x20, ...Leb128.encodeUnsigned(i)];
+  static List<int> localGet(int i) => <int>[0x20, ...Leb128.encodeUnsigned(i)];
 
-  static List<int> localSet(int i) => [0x21, ...Leb128.encodeUnsigned(i)];
+  static List<int> localSet(int i) => <int>[0x21, ...Leb128.encodeUnsigned(i)];
 
-  static List<int> localTee(int i) => [0x22, ...Leb128.encodeUnsigned(i)];
+  static List<int> localTee(int i) => <int>[0x22, ...Leb128.encodeUnsigned(i)];
 
-  static List<int> globalGet(int i) => [0x23, ...Leb128.encodeUnsigned(i)];
+  static List<int> globalGet(int i) => <int>[0x23, ...Leb128.encodeUnsigned(i)];
 
-  static List<int> globalSet(int i) => [0x24, ...Leb128.encodeUnsigned(i)];
+  static List<int> globalSet(int i) => <int>[0x24, ...Leb128.encodeUnsigned(i)];
 
-  static List<int> f64Load(FloatAlign align, int offset) => [
-        0x2b,
-        ...Leb128.encodeUnsigned(align.index),
-        ...Leb128.encodeUnsigned(offset)
-      ];
+  static List<int> encodeString(String s) {
+    var strBs = latin1.encode(s);
+    return Uint8List.fromList(
+        [...Leb128.encodeUnsigned(strBs.length), ...strBs]);
+  }
+}
 
-  static List<int> f64Store(FloatAlign align, int offset) => [
-        0x39,
-        ...Leb128.encodeUnsigned(align.index),
-        ...Leb128.encodeUnsigned(offset)
-      ];
+/// Wasm 32-bits opcodes.
+class Wasm32 {
+  static List<int> i32Const(int i) => <int>[0x41, ...Leb128.encodeSigned(i)];
 
-  static List<int> i32Const(int i) => [0x41, ...Leb128.encodeUnsigned(i)];
+  static List<int> f32Const(double i) => <int>[0x43, ...encodeF32(i)];
 
-  static List<int> f64Const(double i) => [0x44, ...encodeF64(i)];
+  static const int i32ExtendToI64Signed = 0xAC;
+  static const int i32ExtendToI64Unsigned = 0xAD;
+
+  static const int i32ConvertToF32Signed = 0xB2;
+  static const int i32ConvertToF32Unsigned = 0xB3;
+  static const int i32ConvertToF64Signed = 0xB7;
+  static const int i32ConvertToF64Unsigned = 0xB8;
+
+  static const int i32Add = 0x6A;
+  static const int i32Subtract = 0x6B;
+  static const int i32Multiply = 0x6C;
+  static const int i32DivideSigned = 0x6D;
+  static const int i32DivideUnsigned = 0x6E;
+
+  static const int i32RemainderSigned = 0x6F;
+  static const int i32RemainderUnsigned = 0x70;
+
+  static const int i32BitwiseAnd = 0x71;
+  static const int i32BitwiseOr = 0x72;
+  static const int i32BitwiseXor = 0x73;
+  static const int i32ShiftLeft = 0x74;
+  static const int i32ShiftRightSigned = 0x75;
+  static const int i32ShiftRightUnsigned = 0x76;
+  static const int i32RotateLeft = 0x77;
+  static const int i32RotateRight = 0x78;
+
+  static const int i32EqualsToZero = 0x45;
+  static const int i32Equals = 0x46;
+  static const int i32NotEquals = 0x47;
+
+  static const int i32LessThanSigned = 0x48;
+  static const int i32LessThanUnsigned = 0x49;
+  static const int i32GreaterThanSigned = 0x4A;
+  static const int i32GreaterThanUnsigned = 0x4B;
+
+  static const int i32LessThanOrEqualsSigned = 0x4C;
+  static const int i32LessThanOrEqualsUnsigned = 0x4D;
+  static const int i32GreaterThanOrEqualsSigned = 0x4E;
+  static const int i32GreaterThanOrEqualsUnsigned = 0x4F;
+
+  static const int f32LessThan = 0x5D;
+  static const int f32GreaterThan = 0x5E;
+  static const int f32LessThanOrEquals = 0x5F;
+  static const int f32GreaterThanOrEquals = 0x60;
+
+  static const int f32Min = 0x96;
+  static const int f32Max = 0x97;
+
+  static const int f32Equals = 0x5B;
+  static const int f32NotEquals = 0x5C;
+
+  static const int f32Absolute = 0x8B;
+  static const int f32Negation = 0x8C;
+  static const int f32Ceil = 0x8D;
+  static const int f32Floor = 0x8E;
+  static const int f32Sqrt = 0x91;
+
+  static const int f32Add = 0x92;
+  static const int f32Subtract = 0x93;
+  static const int f32Multiply = 0x94;
+  static const int f32Divide = 0x95;
+
+  static const int f32TruncateToF32Signed = 0x8F;
+  static const int f32TruncateToI32Signed = 0xA8;
+  static const int f32TruncateToI32Unsigned = 0xA9;
+  static const int f32TruncateToi64Signed = 0xAE;
+  static const int f32TruncateToi64Unsigned = 0xAF;
+
+  static Uint8List encodeF32(double d) {
+    final arr = Uint8List(4);
+    writeFloat32(arr, 0, d);
+    return arr;
+  }
+
+  static void writeFloat32(Uint8List buffer, int offset, double value) {
+    var byteData =
+        buffer.buffer.asByteData(buffer.offsetInBytes, buffer.lengthInBytes);
+    byteData.setFloat32(offset, value, Endian.little);
+  }
+}
+
+/// Wasm 64-bits opcodes.
+class Wasm64 {
+  static List<int> i64Const(int i) => <int>[0x42, ...Leb128.encodeSigned(i)];
+
+  static List<int> f64Const(double i) => <int>[0x44, ...encodeF64(i)];
+
+  static const int i64ConvertToF32Signed = 0xB4;
+  static const int i64ConvertToF32Unsigned = 0xB5;
+  static const int i64ConvertToF64Signed = 0xB9;
+  static const int i64ConvertToF64Unsigned = 0xBA;
+
+  static const int i64Add = 0x7C;
+  static const int i64Subtract = 0x7D;
+  static const int i64Multiply = 0x7E;
+  static const int i64DivideSigned = 0x7F;
+  static const int i64DivideUnsigned = 0x80;
+
+  static const int i64RemainderSigned = 0x81;
+  static const int i64RemainderUnsigned = 0x82;
+
+  static const int i64BitwiseAnd = 0x83;
+  static const int i64BitwiseOr = 0x84;
+  static const int i64BitwiseXor = 0x85;
+  static const int i64ShiftLeft = 0x86;
+  static const int i64ShiftRightSigned = 0x87;
+  static const int i64ShiftRightUnsigned = 0x88;
+  static const int i64RotateLeft = 0x89;
+  static const int i64RotateRight = 0x8A;
+
+  static const int i64EqualsToZero = 0x50;
+  static const int i64Equals = 0x51;
+  static const int i64NotEquals = 0x52;
+
+  static const int i64LessThanSigned = 0x53;
+  static const int i64LessThanUnsigned = 0x54;
+  static const int i64GreaterThanSigned = 0x55;
+  static const int i64GreaterThanUnsigned = 0x56;
+
+  static const int i64LessThanOrEqualsSigned = 0x57;
+  static const int i64LessThanOrEqualsUnsigned = 0x58;
+  static const int i64GreaterThanOrEqualsSigned = 0x59;
+  static const int i64GreaterThanOrEqualsUnsigned = 0x5A;
+
+  static const int f64LessThan = 0x63;
+  static const int f64GreaterThan = 0x64;
+  static const int f64LessThanOrEquals = 0x65;
+  static const int f64GreaterThanOrEquals = 0x66;
+
+  static const int f64Min = 0xa4;
+  static const int f64Max = 0xa5;
+
+  static const int f64Equals = 0x61;
+  static const int f64NotEquals = 0x62;
+
+  static const int f64Absolute = 0x99;
+  static const int f64Negation = 0x9a;
+  static const int f64Ceil = 0x9b;
+  static const int f64Floor = 0x9c;
+  static const int f64Sqrt = 0x9f;
+
+  static const int f64Add = 0xA0;
+  static const int f64Subtract = 0xA1;
+  static const int f64Multiply = 0xA2;
+  static const int f64Divide = 0xA3;
+
+  static const int f64TruncateToF64Signed = 0x9D;
+  static const int f64TruncateToI32Signed = 0xAA;
+  static const int f64TruncateToI32Unsigned = 0xAB;
+  static const int f64TruncateToi64Signed = 0xB0;
+  static const int f64TruncateToi64Unsigned = 0xB1;
 
   static Uint8List encodeF64(double d) {
     final arr = Uint8List(8);
@@ -131,9 +238,15 @@ class Wasm {
     byteData.setFloat64(offset, value, Endian.little);
   }
 
-  static List<int> encodeString(String s) {
-    var strBs = latin1.encode(s);
-    return Uint8List.fromList(
-        [...Leb128.encodeUnsigned(strBs.length), ...strBs]);
-  }
+  static List<int> f64Load(FloatAlign align, int offset) => <int>[
+        0x2b,
+        ...Leb128.encodeUnsigned(align.index),
+        ...Leb128.encodeUnsigned(offset)
+      ];
+
+  static List<int> f64Store(FloatAlign align, int offset) => <int>[
+        0x39,
+        ...Leb128.encodeUnsigned(align.index),
+        ...Leb128.encodeUnsigned(offset)
+      ];
 }

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -292,18 +292,19 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     generateASTBlock(branch.blockIf, out: out, context: context);
 
-    out.writeByte(Wasm.elseInstruction, description: "[OP] else");
-
     {
       final blocksElseIf = branch.blocksElseIf.toList();
       var blockElse = branch.blockElse;
 
       if (blocksElseIf.isEmpty) {
         if (blockElse != null) {
+          out.writeByte(Wasm.elseInstruction, description: "[OP] else");
           generateASTBlock(blockElse, out: out, context: context);
         }
       } else {
         var blocksElseIf0 = blocksElseIf.removeAt(0);
+
+        out.writeByte(Wasm.elseInstruction, description: "[OP] else");
 
         if (blocksElseIf.length == 1) {
           generateASTBranchIfElseBlock(

--- a/lib/src/languages/wasm/wasm_parser.dart
+++ b/lib/src/languages/wasm/wasm_parser.dart
@@ -147,14 +147,23 @@ extension _ListIntExtension on List<int> {
   List<ASTType> toASTTypes() => map((t) => t.toASTType()).toList();
 }
 
+final _astTypeInt32 = ASTTypeInt(bits: 32);
+final _astTypeInt64 = ASTTypeInt(bits: 64);
+final _astTypeDouble32 = ASTTypeDouble(bits: 32);
+final _astTypeDouble64 = ASTTypeDouble(bits: 64);
+
 extension _IntExtension on int {
   ASTType toASTType() {
     final t = this;
 
-    if (t == WasmType.i32Type.value || t == WasmType.i64Type.value) {
-      return ASTTypeInt.instance;
-    } else if (t == WasmType.f32Type.value || t == WasmType.f64Type.value) {
-      return ASTTypeDouble.instance;
+    if (t == WasmType.i32Type.value) {
+      return _astTypeInt32;
+    } else if (t == WasmType.i64Type.value) {
+      return _astTypeInt64;
+    } else if (t == WasmType.f32Type.value) {
+      return _astTypeDouble32;
+    } else if (t == WasmType.f64Type.value) {
+      return _astTypeDouble64;
     } else {
       throw StateError("Can't handle type: $t");
     }

--- a/lib/src/languages/wasm/wasm_parser.dart
+++ b/lib/src/languages/wasm/wasm_parser.dart
@@ -147,10 +147,10 @@ extension _ListIntExtension on List<int> {
   List<ASTType> toASTTypes() => map((t) => t.toASTType()).toList();
 }
 
-final _astTypeInt32 = ASTTypeInt(bits: 32);
-final _astTypeInt64 = ASTTypeInt(bits: 64);
-final _astTypeDouble32 = ASTTypeDouble(bits: 32);
-final _astTypeDouble64 = ASTTypeDouble(bits: 64);
+final _astTypeInt32 = ASTTypeInt.instance32;
+final _astTypeInt64 = ASTTypeInt.instance64;
+final _astTypeDouble32 = ASTTypeDouble.instance32;
+final _astTypeDouble64 = ASTTypeDouble.instance64;
 
 extension _IntExtension on int {
   ASTType toASTType() {

--- a/lib/src/languages/wasm/wasm_runtime.dart
+++ b/lib/src/languages/wasm/wasm_runtime.dart
@@ -62,20 +62,52 @@ abstract class WasmModule {
   /// Returns a module function mapped to [F].
   F? getFunction<F extends Function>(String functionName);
 
+  /// Resolves the returned [value] from a called module function.
+  Object? resolveReturnedValue(Object? value);
+
   /// Disposes this module instance.
   FutureOr<void> dispose() {}
 }
 
-/// Thrown when [WasmModule] fails to load.
-class WasmModuleLoadError extends Error {
+/// [WasmModule] error.
+class WasmModuleError extends Error {
   final String message;
 
+  WasmModuleError(this.message);
+
+  @override
+  String toString() {
+    return 'WasmModuleError: $message';
+  }
+}
+
+/// Thrown when [WasmModule] fails to load.
+class WasmModuleLoadError extends WasmModuleError {
   final Object? cause;
 
-  WasmModuleLoadError(this.message, {this.cause});
+  WasmModuleLoadError(super.message, {this.cause});
 
   @override
   String toString() {
     return 'WasmModuleLoadError: $message\nCause: $cause';
+  }
+}
+
+/// Thrown when [WasmModule] execution fails.
+class WasmModuleExecutionError extends WasmModuleError {
+  final String functionName;
+  final List? parameters;
+  final Function? function;
+
+  final Object? cause;
+
+  WasmModuleExecutionError(this.functionName,
+      {this.parameters, this.function, String? message, this.cause})
+      : super(
+            "Error executing Wasm function> $functionName( $parameters )${function != null ? ' -> $function' : ''}");
+
+  @override
+  String toString() {
+    return 'WasmModuleExecutionError: $message\nCause: $cause';
   }
 }

--- a/lib/src/languages/wasm/wasm_runtime_browser.dart
+++ b/lib/src/languages/wasm/wasm_runtime_browser.dart
@@ -49,6 +49,23 @@ class WasmModuleBrowser extends WasmModule {
   }
 
   @override
+  Object? resolveReturnedValue(Object? value) {
+    if (value == null) return null;
+
+    if (browser_wasm.JsBigInt.isJsBigInt(value)) {
+      var bigInt = browser_wasm.JsBigInt.toBigInt(value);
+
+      if (bigInt.isValidInt) {
+        return bigInt.toInt();
+      } else {
+        return bigInt;
+      }
+    }
+
+    return value;
+  }
+
+  @override
   String toString() {
     return 'WasmModuleBrowser{name: $name, instance: $instance}';
   }

--- a/lib/src/languages/wasm/wasm_runtime_generic.dart
+++ b/lib/src/languages/wasm/wasm_runtime_generic.dart
@@ -29,6 +29,9 @@ class WasmModuleGeneric extends WasmModule {
 
   @override
   F? getFunction<F extends Function>(String functionName) => null;
+
+  @override
+  Object? resolveReturnedValue(Object? value) => value;
 }
 
 WasmRuntime createWasmRuntime() {

--- a/test/apollovm_wasm_test.dart
+++ b/test/apollovm_wasm_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:apollovm/apollovm.dart';
 import 'package:data_serializer/data_serializer.dart';
 import 'package:test/test.dart';
@@ -139,7 +141,7 @@ void main() async {
           },
           expecteWasm: {
             'test':
-                '0061736D0100000001060160017E017E03020100070801046164643600000A13011100200042E40055044042010F0B42000F0B',
+                '0061736D0100000001060160017E017E03020100070801046164643600000A16011400200042E40055044042010F0B42000F0042000B',
           }),
     );
 
@@ -199,7 +201,7 @@ void main() async {
           },
           expecteWasm: {
             'test':
-                '0061736D0100000001060160017E017E03020100070801046164643800000A20011E00200042E40055044042010F052000420051044042000F05427F0F0B0B0B',
+                '0061736D0100000001060160017E017E03020100070801046164643800000A21011F00200042E40055044042010F05200050044042000F05427F0F0B0B0042000B',
           }),
     );
 
@@ -222,6 +224,8 @@ void main() async {
             else {
               return -1 ;
             }
+            
+            return -2 ;
           }
           
         ''',
@@ -234,7 +238,7 @@ void main() async {
           },
           expecteWasm: {
             'test':
-                '0061736D0100000001060160017E017E03020100070801046164643900000A21011F00200042E40055044042E4000F052000420051044042000F05427F0F0B0B0B',
+                '0061736D0100000001060160017E017E03020100070801046164643900000A31012F00200042E40055044042E4000F05200050044042000F052000420151044042010F05427F0F0B0B0B427E0F0042000B',
           }),
     );
 
@@ -264,7 +268,7 @@ void main() async {
           },
           expecteWasm: {
             'test':
-                '0061736D0100000001060160017E017E0302010007090105616464313000000A1F011D00200042E40055044042010F052000420051044042000F0B0B42750F0B',
+                '0061736D0100000001060160017E017E0302010007090105616464313000000A20011E00200042E40055044042010F05200050044042000F0B0B42750F0042000B',
           }),
     );
   });
@@ -340,6 +344,7 @@ Future<void> _testWasm(
   expecteWasm ??= {};
 
   BytesOutput? compiledWasm;
+  Uint8List? expectedWasmBytes;
 
   for (var namespace in wasmModules.entries) {
     for (var module in namespace.value.entries) {
@@ -363,7 +368,7 @@ Future<void> _testWasm(
 
       // _saveWasmFile(language, functionName, wasmBytes);
 
-      expect(wasmBytes, expectedBytes);
+      expectedWasmBytes = expectedBytes;
 
       compiledWasm ??= wasm;
     }
@@ -410,6 +415,12 @@ Future<void> _testWasm(
   } else {
     print('** `WasmRuntime` not supported: ${wasmRuntime.platformVersion}');
   }
+
+  expect(expectedWasmBytes, isNotNull, reason: "Null `expectedWasmBytes`");
+
+  print('<< EXPECTED WASM: HEX>>\n${hex.encode(expectedWasmBytes!)}');
+
+  expect(compiledWasm?.output(), expectedWasmBytes);
 }
 
 /*

--- a/test/apollovm_wasm_test.dart
+++ b/test/apollovm_wasm_test.dart
@@ -264,7 +264,7 @@ void main() async {
           },
           expecteWasm: {
             'test':
-                '0061736D0100000001060160017E017E0302010007090105616464313000000A20011E00200042E40055044042010F052000420051044042000F050B0B42750F0B',
+                '0061736D0100000001060160017E017E0302010007090105616464313000000A1F011D00200042E40055044042010F052000420051044042000F0B0B42750F0B',
           }),
     );
   });
@@ -413,7 +413,7 @@ Future<void> _testWasm(
 }
 
 /*
-void _saveWasmFile(String language, String functionName, Uint8List wasmBytes) {
+void _saveWasmFile(String language, String functionName, List<int> wasmBytes) {
   try {
     var fileName = 'apollovm-$language-$functionName-test.wasm';
 

--- a/test/apollovm_wasm_test.dart
+++ b/test/apollovm_wasm_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 void main() async {
   group('ApolloVM - Wasm Generator', () {
     test(
-      'basic 1',
+      'empty',
       () => _testWasm(
           language: 'dart',
           code: r'''
@@ -16,7 +16,9 @@ void main() async {
           
         ''',
           functionName: 'empty',
-          parameters: [],
+          executions: {
+            []: null,
+          },
           expecteWasm: {
             'test':
                 '0061736D010000000104016000000302010007090105656D70747900000A040102000B',
@@ -24,7 +26,7 @@ void main() async {
     );
 
     test(
-      'basic 2',
+      'add1',
       () => _testWasm(
           language: 'dart',
           code: r'''
@@ -36,16 +38,17 @@ void main() async {
           
         ''',
           functionName: 'add1',
-          parameters: [101],
-          expectedResult: 111,
+          executions: {
+            [101]: 111,
+          },
           expecteWasm: {
             'test':
-                '0061736D0100000001060160017F017F03020100070801046164643100000A0F010D01017F2000410A6A210120010B',
+                '0061736D0100000001060160017E017E03020100070801046164643100000A10010E01017E2000420A7C210120010F0B',
           }),
     );
 
     test(
-      'basic 3',
+      'add3',
       () => _testWasm(
           language: 'dart',
           code: r'''
@@ -57,16 +60,17 @@ void main() async {
           
         ''',
           functionName: 'add3',
-          parameters: [101, 50],
-          expectedResult: 161,
+          executions: {
+            [101, 50]: 161,
+          },
           expecteWasm: {
             'test':
-                '0061736D0100000001070160027F7F017F03020100070801046164643300000A12011001017F20002001410A6A6A210220020B',
+                '0061736D0100000001070160027E7E017E03020100070801046164643300000A13011101017E20002001420A7C7C210220020F0B',
           }),
     );
 
     test(
-      'basic 4',
+      'add4',
       () => _testWasm(
           language: 'dart',
           code: r'''
@@ -80,16 +84,17 @@ void main() async {
           
         ''',
           functionName: 'add4',
-          parameters: [101, 50, 30],
-          expectedResult: 146,
+          executions: {
+            [101, 50, 30]: 146,
+          },
           expecteWasm: {
             'test':
-                '0061736D0100000001080160037F7F7F017F03020100070801046164643400000A27012503017F017F017F20002001410A6A6A21032002B74102B7A3AA2104200320046B210520050B',
+                '0061736D0100000001080160037E7E7E017E03020100070801046164643400000A28012603017E017E017E20002001420A7C7C21032002B94202B9A3B02104200320047D210520050F0B',
           }),
     );
 
     test(
-      'basic 5',
+      'add5',
       () => _testWasm(
           language: 'dart',
           code: r'''
@@ -103,11 +108,163 @@ void main() async {
           
         ''',
           functionName: 'add5',
-          parameters: [101, 50, 30],
-          expectedResult: 21316,
+          executions: {
+            [101, 50, 30]: 21316,
+            [10, 50, 300]: 6400,
+          },
           expecteWasm: {
             'test':
-                '0061736D0100000001080160037F7F7F017F03020100070801046164643500000A2A012803017F017F017F20002001410A6A6A21032002B74102B7A3AA2104200320046B2105200520056C0B',
+                '0061736D0100000001080160037E7E7E017E03020100070801046164643500000A2A012803017E017E017E20002001420A7C7C21032002B94202B9A3B02104200320047D2105200520057E0B',
+          }),
+    );
+
+    test(
+      'add6',
+      () => _testWasm(
+          language: 'dart',
+          code: r'''
+      
+          int add6(int a) {
+            if (a > 100) {
+              return 1 ;
+            } 
+            return 0 ;
+          }
+          
+        ''',
+          functionName: 'add6',
+          executions: {
+            [101]: 1,
+            [10]: 0,
+          },
+          expecteWasm: {
+            'test':
+                '0061736D0100000001060160017E017E03020100070801046164643600000A13011100200042E40055044042010F0B42000F0B',
+          }),
+    );
+
+    test(
+      'add7',
+      () => _testWasm(
+          language: 'dart',
+          code: r'''
+      
+          int add7(int a) {
+            if (a > 100) {
+              a = a + 100;
+            }
+            else {
+              a = a + 10;
+            }
+            
+            return a ;
+          }
+          
+        ''',
+          functionName: 'add7',
+          executions: {
+            [111]: 211,
+            [11]: 21,
+          },
+          expecteWasm: {
+            'test':
+                '0061736D0100000001060160017E017E03020100070801046164643700000A20011E00200042E400550440200042E4007C2100052000420A7C21000B20000F0B',
+          }),
+    );
+
+    test(
+      'add8',
+      () => _testWasm(
+          language: 'dart',
+          code: r'''
+      
+          int add8(int a) {
+            if (a > 100) {
+              return 1 ;
+            } 
+            else if ( a == 0 ) {
+              return 0 ;
+            }
+            else {
+              return -1 ;
+            }
+          }
+          
+        ''',
+          functionName: 'add8',
+          executions: {
+            [101]: 1,
+            [0]: 0,
+            [10]: -1,
+          },
+          expecteWasm: {
+            'test':
+                '0061736D0100000001060160017E017E03020100070801046164643800000A20011E00200042E40055044042010F052000420051044042000F05427F0F0B0B0B',
+          }),
+    );
+
+    test(
+      'add9',
+      () => _testWasm(
+          language: 'dart',
+          code: r'''
+      
+          int add9(int a) {
+            if (a > 100) {
+              return 100 ;
+            } 
+            else if ( a == 0 ) {
+              return 0 ;
+            }
+            else if ( a == 1 ) {
+              return 1 ;
+            }
+            else {
+              return -1 ;
+            }
+          }
+          
+        ''',
+          functionName: 'add9',
+          executions: {
+            [101]: 100,
+            [0]: 0,
+            [1]: 1,
+            [10]: -1,
+          },
+          expecteWasm: {
+            'test':
+                '0061736D0100000001060160017E017E03020100070801046164643900000A21011F00200042E40055044042E4000F052000420051044042000F05427F0F0B0B0B',
+          }),
+    );
+
+    test(
+      'add10',
+      () => _testWasm(
+          language: 'dart',
+          code: r'''
+      
+          int add10(int a) {
+            if (a > 100) {
+              return 1 ;
+            } 
+            else if ( a == 0 ) {
+              return 0 ;
+            }
+            
+            return -11 ;
+          }
+          
+        ''',
+          functionName: 'add10',
+          executions: {
+            [101]: 1,
+            [0]: 0,
+            [10]: -11,
+          },
+          expecteWasm: {
+            'test':
+                '0061736D0100000001060160017E017E0302010007090105616464313000000A20011E00200042E40055044042010F052000420051044042000F050B0B42750F0B',
           }),
     );
   });
@@ -117,11 +274,16 @@ Future<void> _testWasm(
     {required String language,
     required String code,
     required String functionName,
-    required List parameters,
-    Object? expectedResult,
+    required Map<List, Object?> executions,
     Map<String, dynamic>? expecteWasm}) async {
   print('==================================================================');
-  print("$language>> $functionName$parameters");
+  print("$language>> $functionName");
+
+  for (var e in executions.entries) {
+    var parameters = e.key;
+    var expectedResult = e.value;
+    print('  -- $parameters -> $expectedResult');
+  }
 
   var vm = ApolloVM();
 
@@ -143,13 +305,22 @@ Future<void> _testWasm(
   // Map the `print` function in the VM:
   dartRunner.externalPrintFunction = (o) => print("» $o");
 
-  var astValue = await dartRunner.executeFunction('', functionName,
-      positionalParameters: parameters);
+  for (var e in executions.entries) {
+    var parameters = e.key;
+    var expectedResult = e.value;
 
-  var result = astValue.getValueNoContext();
-  print('Result: $result');
+    print('<<<<<<<<<<<<<<<<<<<<<<<<<<<<');
+    print('EXECUTE AST> $parameters -> $expectedResult');
 
-  expect(result, expectedResult);
+    var astValue = await dartRunner.executeFunction('', functionName,
+        positionalParameters: parameters);
+
+    var result = astValue.getValueNoContext();
+    print('Result: $result');
+
+    expect(result, expectedResult);
+    print('>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
+  }
 
   print('------------------------------------------------------------------');
 
@@ -190,11 +361,11 @@ Future<void> _testWasm(
       print('<<WASM: Bytes>>');
       print(wasmBytes);
 
+      // _saveWasmFile(language, functionName, wasmBytes);
+
       expect(wasmBytes, expectedBytes);
 
       compiledWasm ??= wasm;
-
-      //_saveWasmFile(language, functionName, wasmBytes);
     }
   }
 
@@ -220,13 +391,22 @@ Future<void> _testWasm(
     // Map the `print` function in the VM:
     wasmRunner.externalPrintFunction = (o) => print("wasm» $o");
 
-    var wasmAstValue = await wasmRunner.executeFunction('', functionName,
-        positionalParameters: parameters);
+    for (var e in executions.entries) {
+      var parameters = e.key;
+      var expectedResult = e.value;
 
-    var wasmResult = wasmAstValue.getValueNoContext();
-    print('Wasm Result: $wasmResult');
+      print('<<<<<<<<<<<<<<<<<<<<<<<<<<<<');
+      print('EXECUTE WASM> $parameters -> $expectedResult');
 
-    expect(wasmResult, expectedResult);
+      var wasmAstValue = await wasmRunner.executeFunction('', functionName,
+          positionalParameters: parameters);
+
+      var wasmResult = wasmAstValue.getValueNoContext();
+      print('Wasm Result: $wasmResult');
+
+      expect(wasmResult, expectedResult);
+      print('>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
+    }
   } else {
     print('** `WasmRuntime` not supported: ${wasmRuntime.platformVersion}');
   }
@@ -243,4 +423,4 @@ void _saveWasmFile(String language, String functionName, Uint8List wasmBytes) {
     print('>> SAVED: $file');
   } catch (_) {}
 }
-*/
+ */


### PR DESCRIPTION
- `ASTBranchIfElseBlock` and `ASTBranchIfElseIfsElseBlock`:
  - `blockElse`: optional.
- `ASTParametersDeclaration`:
  - Added `allParameters`.
- `ASTTypeInt` and `ASTTypeDouble`:
  - Added `bits`
- `ASTValueNum`:
  - Added field `negative`.

- `ApolloGeneratorWasm`:
  - Changed to 64 bits.
  - `Wasm`: split in `Wasm32` and `Wasm64` with improved opcodes.
  - Allow operations with different types (auto casting).
  - Implemented:
    - `generateASTValue`, `generateASTValueDouble`, `generateASTValueInt`.
    - `generateASTExpressionVariableAssignment`, `generateASTStatementExpression` - `generateASTBranchIfBlock`, `generateASTBranchIfElseBlock`, `generateASTBranchIfElseIfsElseBlock`. - `generateASTStatementReturnWithExpression`, `generateASTStatementReturn`, `generateASTStatementReturnValue`.
- `ApolloParserWasm`:
  - Identify if an `ASTTypeInt` or `ASTTypeDouble` type is a `32` or `64` bits.
- `ApolloRunnerWasm`:
  - Use the parsed Wasm functions (AST) to normalize the parameters before calling the Wasm function.
- `WasmModule`:
  - Added `resolveReturnedValue`. - Browser implementation: when the function returns a `f64`, the JS `bigint` needs to be converted to a Dart `BigInt`.
- New `WasmModuleExecutionError`.