### PR TITLE
v0.1.0 - feature: implement WasmRuntimeWeb (deprecate WasmRuntimeDartHTML)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+## 0.1.0
+
+- `WasmRuntime`:
+  - Added `WasmModuleFunction` typedef to represent a WebAssembly-exported function with metadata including the Dart function and a `varArgs` flag.
+  - Updated `WasmModule.getFunction` signature to return `WasmModuleFunction<F>?` instead of just `F?`.
+
+- `WasmRunnerWasm`:
+  - Updated function invocation logic in `ApolloRunnerWasm` to handle `WasmModuleFunction` with `varArgs` flag.
+  - Added special handling for functions with no arguments and functions expecting a single `List` argument.
+
+- `wasm_runtime_generic.dart`:
+  - Updated `WasmModuleGeneric.getFunction` to return `null` as `WasmModuleFunction<F>?`.
+
+- `wasm_runtime_io.dart`:
+  - Updated `WasmModuleIO.getFunction` to return a `WasmModuleFunction` with `varArgs: true`.
+
+- `wasm_runtime_dart_html.dart`:
+  - Deprecated `WasmRuntimeDartHTML` in favor of `WasmRuntimeWeb`.
+  - Updated `WasmModuleBrowser.getFunction` to return a `WasmModuleFunction` with `varArgs: true`.
+  - Updated `createWasmRuntime` to return `WasmRuntimeDartHTML` with deprecation warning.
+
+- `wasm_runtime_web.dart`:
+  - New `WasmRuntimeWeb` implementation using `dart:js_interop` and `web` package.
+  - Added JS interop bindings for WebAssembly APIs using extension types.
+  - Implemented `WasmModuleBrowser` wrapping `_WasmInstance` with proper JS interop.
+  - `getFunction` returns a Dart function wrapping JS function calls with argument conversion and `varArgs: false`.
+  - Added utilities to convert JS BigInt to Dart `num` or `BigInt`.
+  - Updated `createWasmRuntime` to return `WasmRuntimeWeb`.
+  - Added extensions for JS function invocation and JSAny type checks and casts.
+
+- `pubspec.yaml`:
+  - Added dependency on `web: ^1.1.1`.
+
+- Tests:
+  - Added new tests `operation3` and `operation4` verifying multi-parameter Dart functions compiled to Wasm and executed correctly.
+
 ## 0.0.54
 
 - Updated minimum Dart SDK constraint to `>=3.10.0 <4.0.0`.

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -35,7 +35,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.0.54';
+  static final String VERSION = '0.1.0';
 
   static int _idCount = 0;
 

--- a/lib/src/languages/wasm/wasm_runner.dart
+++ b/lib/src/languages/wasm/wasm_runner.dart
@@ -70,14 +70,35 @@ class ApolloRunnerWasm extends ApolloRunner {
       _resolveWasmCallParameters(astFunction, allParams);
     }
 
+    final (function: function, varArgs: varArgs) = f;
+
     dynamic res;
     try {
-      res = Function.apply(f, allParams);
+      if (!varArgs) {
+        if (function is Function(List)) {
+          res = Function.apply(function, [allParams]);
+        } else if (function is Function()) {
+          if (allParams.isNotEmpty) {
+            throw WasmModuleExecutionError(
+              functionName,
+              parameters: allParams,
+              function: function,
+              cause:
+                  "Function expects no arguments, but ${allParams.length} were provided: $allParams",
+            );
+          }
+          res = Function.apply(function, []);
+        } else {
+          res = Function.apply(function, allParams);
+        }
+      } else {
+        res = Function.apply(function, allParams);
+      }
     } catch (e) {
       throw WasmModuleExecutionError(
         functionName,
         parameters: allParams,
-        function: f,
+        function: function,
         cause: e,
       );
     }

--- a/lib/src/languages/wasm/wasm_runtime.dart
+++ b/lib/src/languages/wasm/wasm_runtime.dart
@@ -4,7 +4,8 @@ import '../../ast/apollovm_ast_toplevel.dart';
 import 'package:async_extension/async_extension.dart';
 
 import 'wasm_runtime_generic.dart'
-    if (dart.library.html) 'wasm_runtime_browser.dart'
+    if (dart.library.js_interop) 'wasm_runtime_web.dart'
+    if (dart.library.html) 'wasm_runtime_dart_html.dart'
     if (dart.library.io) 'wasm_runtime_io.dart';
 
 /// A WebAssembly (Wasm) Runtime.
@@ -55,6 +56,19 @@ abstract class WasmRuntime {
   }
 }
 
+/// Represents a WebAssembly-exported function with metadata.
+///
+/// Combines a callable Dart function [function] with information about
+/// whether it accepts a variable number of arguments ([varArgs]).
+///
+/// - [function]: The Dart function mapped from a WebAssembly export.
+/// - [varArgs]: Indicates if the function supports variadic arguments
+///   (i.e., can be called with a dynamic number of parameters).
+///
+/// This is typically used when exposing or wrapping WebAssembly functions
+/// in Dart, allowing the runtime to handle invocation semantics correctly.
+typedef WasmModuleFunction<F extends Function> = ({F function, bool varArgs});
+
 /// A WebAssembly (Wasm) Runtime module
 abstract class WasmModule {
   /// The module name.
@@ -66,7 +80,7 @@ abstract class WasmModule {
   Future<WasmModule> copy({String? name});
 
   /// Returns a module function mapped to [F].
-  F? getFunction<F extends Function>(String functionName);
+  WasmModuleFunction<F>? getFunction<F extends Function>(String functionName);
 
   /// Resolves the returned [value] from a called module function.
   Object? resolveReturnedValue(Object? value, ASTFunctionDeclaration? f);

--- a/lib/src/languages/wasm/wasm_runtime_dart_html.dart
+++ b/lib/src/languages/wasm/wasm_runtime_dart_html.dart
@@ -7,12 +7,15 @@ import 'package:wasm_interop/wasm_interop.dart' as browser_wasm;
 import '../../ast/apollovm_ast_toplevel.dart';
 import 'wasm_runtime.dart';
 
-/// [WasmRuntime] implementation for the Browser.
-class WasmRuntimeBrowser extends WasmRuntime {
-  WasmRuntimeBrowser() : super.base();
+/// [WasmRuntime] implementation for the Browser using `dart:html`.
+/// Use `WasmRuntimeWeb` instead.
+@Deprecated("Use `WasmRuntimeWeb` instead.")
+class WasmRuntimeDartHTML extends WasmRuntime {
+  WasmRuntimeDartHTML() : super.base();
 
   @override
-  String get platformVersion => 'Browser: ${window.navigator.userAgent}';
+  String get platformVersion =>
+      'Browser(dart:html): ${window.navigator.userAgent}';
 
   @override
   bool get isSupported => true;
@@ -52,8 +55,10 @@ class WasmModuleBrowser extends WasmModule {
   }
 
   @override
-  F? getFunction<F extends Function>(String functionName) {
-    return instance.functions[functionName]! as F?;
+  WasmModuleFunction<F>? getFunction<F extends Function>(String functionName) {
+    var function = instance.functions[functionName]! as F?;
+    if (function == null) return null;
+    return (function: function, varArgs: true);
   }
 
   @override
@@ -80,5 +85,6 @@ class WasmModuleBrowser extends WasmModule {
 }
 
 WasmRuntime createWasmRuntime() {
-  return WasmRuntimeBrowser();
+  // ignore: deprecated_member_use_from_same_package
+  return WasmRuntimeDartHTML();
 }

--- a/lib/src/languages/wasm/wasm_runtime_generic.dart
+++ b/lib/src/languages/wasm/wasm_runtime_generic.dart
@@ -31,7 +31,8 @@ class WasmModuleGeneric extends WasmModule {
   }
 
   @override
-  F? getFunction<F extends Function>(String functionName) => null;
+  WasmModuleFunction<F>? getFunction<F extends Function>(String functionName) =>
+      null;
 
   @override
   Object? resolveReturnedValue(Object? value, ASTFunctionDeclaration? f) =>

--- a/lib/src/languages/wasm/wasm_runtime_io.dart
+++ b/lib/src/languages/wasm/wasm_runtime_io.dart
@@ -110,11 +110,14 @@ class WasmModuleIO extends WasmModule {
   }
 
   @override
-  F? getFunction<F extends Function>(String functionName) {
+  WasmModuleFunction<F>? getFunction<F extends Function>(String functionName) {
     var f = instance.getFunction(functionName);
     if (f == null) return null;
 
-    return f.inner as F?;
+    var function = f.inner as F?;
+    if (function == null) return null;
+
+    return (function: function, varArgs: true);
   }
 
   @override

--- a/lib/src/languages/wasm/wasm_runtime_web.dart
+++ b/lib/src/languages/wasm/wasm_runtime_web.dart
@@ -1,0 +1,291 @@
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import 'dart:typed_data';
+
+import 'package:web/web.dart' as web;
+
+import '../../ast/apollovm_ast_toplevel.dart';
+import 'wasm_runtime.dart';
+
+/// ===== WebAssembly bindings (extension types) =====
+
+@JS('WebAssembly')
+external _WebAssembly get _webAssembly;
+
+@JS('WebAssembly')
+extension type _WebAssembly(JSObject _) implements JSObject {
+  external JSPromise<_WasmInstantiateResult> instantiate(
+    JSArrayBuffer bytes, [
+    JSAny? imports,
+  ]);
+}
+
+extension type _WasmInstantiateResult(JSObject _) implements JSObject {
+  external _WasmInstance get instance;
+
+  external JSObject get module;
+}
+
+@JS('WebAssembly.Instance')
+extension type _WasmInstance(JSObject _) implements JSObject {
+  external _WasmExports get exports;
+}
+
+extension type _WasmExports(JSObject _) implements JSObject {
+  JSFunction? function(String name) => this[name] as JSFunction?;
+
+  JSNumber? number(String name) => this[name] as JSNumber?;
+
+  JSObject? memory(String name) => this[name] as JSObject?;
+}
+
+@JS('Number')
+external JSNumber _jsNumber(JSAny value);
+
+@JS('Number.isInteger')
+external bool _jsNumberIsInteger(JSNumber n);
+
+@JS('BigInt')
+external JSBigInt _jsBigInt(JSAny value);
+
+extension type JSBigIntX(JSBigInt _) implements JSAny {
+  /// JS constructor: BigInt(value)
+  factory JSBigIntX.from(JSAny value) => JSBigIntX(_jsBigInt(value));
+}
+
+final _maxSafeInteger = JSBigIntX.from(9007199254740991.toJS);
+final _minSafeInteger = JSBigIntX.from((-9007199254740991).toJS);
+
+num? _toSafeNumber(JSBigInt o) {
+  if (o.greaterThan(_maxSafeInteger).toDart ||
+      o.lessThan(_minSafeInteger).toDart) {
+    return null;
+  }
+
+  var n = _jsNumber(o);
+
+  if (_jsNumberIsInteger(n)) {
+    return n.toDartInt;
+  } else {
+    return n.toDartDouble;
+  }
+}
+
+/// ===== Runtime =====
+
+class WasmRuntimeWeb extends WasmRuntime {
+  WasmRuntimeWeb() : super.base();
+
+  @override
+  String get platformVersion =>
+      'Browser(web): ${web.window.navigator.userAgent}';
+
+  @override
+  bool get isSupported => true;
+
+  @override
+  Future<WasmModuleBrowser> loadModuleImpl(
+    String moduleName,
+    Uint8List wasmModuleBinary,
+  ) async {
+    try {
+      final buffer = wasmModuleBinary.buffer.toJS;
+
+      final result = await _webAssembly.instantiate(buffer).toDart;
+
+      final instance = result.instance;
+
+      return WasmModuleBrowser._(moduleName, instance);
+    } catch (e) {
+      throw WasmModuleLoadError(
+        "Can't load wasm module: $moduleName",
+        cause: e,
+      );
+    }
+  }
+}
+
+/// ===== Module =====
+
+class WasmModuleBrowser extends WasmModule {
+  final _WasmInstance _instance;
+
+  WasmModuleBrowser._(super.name, this._instance);
+
+  @override
+  Future<WasmModuleBrowser> copy({String? name}) async {
+    throw UnimplementedError(
+      'Copy requires original wasm bytes (not available from Instance)',
+    );
+  }
+
+  @override
+  WasmModuleFunction<F>? getFunction<F extends Function>(String functionName) {
+    final exports = _instance.exports;
+
+    final fn = exports.function(functionName);
+    if (fn == null) return null;
+
+    Object? function([List? args]) {
+      final JSAny? result;
+      if (args == null || args.isEmpty) {
+        result = fn.callAsFunction(null);
+      } else {
+        final jsArgs = args.map((Object? e) => e?.jsify()).toList();
+        if (jsArgs.isEmpty) {
+          result = fn.callAsFunction(null);
+        } else if (jsArgs.length == 1) {
+          result = fn.callAsFunction(null, jsArgs[0]);
+        } else if (jsArgs.length == 2) {
+          result = fn.callAsFunction(null, jsArgs[0], jsArgs[1]);
+        } else if (jsArgs.length == 3) {
+          result = fn.callAsFunction(null, jsArgs[0], jsArgs[1], jsArgs[2]);
+        } else if (jsArgs.length == 4) {
+          result = fn.callAsFunction(
+            null,
+            jsArgs[0],
+            jsArgs[1],
+            jsArgs[2],
+            jsArgs[3],
+          );
+        } else {
+          result = fn.applyAsFunction(null, jsArgs.toJS);
+        }
+      }
+
+      return result.dartify();
+    }
+
+    return (function: function as F, varArgs: false);
+  }
+
+  @override
+  Object? resolveReturnedValue(Object? value, ASTFunctionDeclaration? f) {
+    if (value == null) return null;
+
+    var jsAny = value.asJSAny;
+
+    if (jsAny.isA<JSBigInt>()) {
+      final jsBig = jsAny as JSBigInt;
+
+      var n = _toSafeNumber(jsBig);
+      if (n != null) {
+        return n;
+      }
+
+      final s = jsBig.toString();
+      final big = BigInt.parse(s);
+      return big;
+    }
+
+    return value;
+  }
+
+  @override
+  String toString() {
+    return 'WasmModuleBrowser{name: $name, instance: $_instance}';
+  }
+}
+
+WasmRuntime createWasmRuntime() {
+  return WasmRuntimeWeb();
+}
+
+extension _JSFunctionUtilExtension on JSFunction {
+  /// Call this [JSFunction] using the JavaScript `.apply` syntax and returns the
+  /// result.
+  ///
+  /// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/apply
+  @JS('apply')
+  external JSAny? applyAsFunction(JSAny? thisArg, [JSArray<JSAny?> argsArray]);
+}
+
+extension _ObjectExtension on Object? {
+  /// Returns `true` if this instance is a [JSAny].
+  /// Returns `null` if it's an ambiguous Dart/JS type.
+  bool? get isJSAny {
+    final self = this;
+    if (self == null) return false;
+
+    // Ambiguous types:
+
+    if (self is String) {
+      // ignore: invalid_runtime_check_with_js_interop_types
+      if (self is JSString) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+
+    if (self is num) {
+      // ignore: invalid_runtime_check_with_js_interop_types
+      if (self is JSNumber) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+
+    if (self is bool) {
+      // ignore: invalid_runtime_check_with_js_interop_types
+      if (self is JSBoolean) {
+        return true;
+      } else {
+        return false;
+      }
+    }
+
+    if (self is Function) {
+      // ignore: invalid_runtime_check_with_js_interop_types
+      if (self is JSFunction) {
+        return null;
+      } else {
+        return false;
+      }
+    }
+
+    if (self is List) {
+      // ignore: invalid_runtime_check_with_js_interop_types
+      if (self is JSArray || self is JSTypedArray) {
+        return null;
+      } else {
+        return false;
+      }
+    }
+
+    if (self is Map) {
+      // ignore: invalid_runtime_check_with_js_interop_types
+      if (self is JSArray || self is JSObject) {
+        return null;
+      } else {
+        return false;
+      }
+    }
+
+    // ignore: invalid_runtime_check_with_js_interop_types
+    return self is JSAny;
+  }
+
+  /// Casts an [Object] to a [JSAny], in a graceful manner.
+  /// See [isJSAny].
+  JSAny? get asJSAny {
+    final self = this;
+    if (self == null) return null;
+
+    var isJSAny = self.isJSAny;
+    if (isJSAny != null) {
+      if (isJSAny) {
+        return self as JSAny;
+      } else {
+        return null;
+      }
+    } else {
+      try {
+        return self as JSAny;
+      } catch (_) {
+        return null;
+      }
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, JavaScript with on-the-fly Wasm compilation.
-version: 0.0.54
+version: 0.1.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 
@@ -29,6 +29,7 @@ dependencies:
   wasm_run: ^0.1.0+2
   crypto: ^3.0.7
   path: ^1.9.1
+  web: ^1.1.1
 
 dev_dependencies:
   lints: ^3.0.0

--- a/test/apollovm_wasm_test.dart
+++ b/test/apollovm_wasm_test.dart
@@ -694,6 +694,73 @@ void main() async {
     );
 
     test(
+      'operation3',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+      
+          double operation3( int v, double r, int balance , double extra ) {
+            var total = v * r ;
+          
+            total = total + extra;
+          
+            if ( total > balance ) {
+              return 0;
+            }
+            
+            return total ;
+          }
+          
+        ''',
+        functionName: 'operation3',
+        executions: {
+          [50, 0.33, 1000, 0.01]: 16.51,
+          [50, 30.0, 1000, 0.02]: 0.0,
+          [50, 30.0, 2000, 0.03]: 1500.03,
+        },
+        expecteWasm: {
+          'test':
+              '0061736D0100000001090160047E7C7E7C017C03020100070E010A6F7065726174696F6E3300000A25012301017C2000B92001A2210420042003A0210420042002B96404404200B90F0B20040F0B',
+        },
+      ),
+    );
+
+    test(
+      'operation4',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+      
+          double operation4( int v, double r, int balance , double extra , double extraRatio ) {
+            var total = v * r ;
+          
+            total = total + (extra * extraRatio);
+          
+            if ( total > balance ) {
+              return 0;
+            }
+            
+            return total ;
+          }
+          
+        ''',
+        functionName: 'operation4',
+        executions: {
+          [50, 0.33, 1000, 0.01, 1]: 16.51,
+          [50, 0.33, 1000, 0.01, 0.5]: 16.505,
+          [50, 30.0, 1000, 0.02, 1]: 0.0,
+          [50, 30.0, 1000, 0.02, 2]: 0.0,
+          [50, 30.0, 2000, 0.03, 1]: 1500.03,
+          [50, 30.0, 2000, 0.03, 2]: 1500.06,
+        },
+        expecteWasm: {
+          'test':
+              '0061736D01000000010A0160057E7C7E7C7C017C03020100070E010A6F7065726174696F6E3400000A28012601017C2000B92001A22105200520032004A2A0210520052002B96404404200B90F0B20050F0B',
+        },
+      ),
+    );
+
+    test(
       'f\$10',
       () => _testWasm(
         language: 'dart',


### PR DESCRIPTION
- `WasmRuntime`:
  - Added `WasmModuleFunction` typedef to represent a WebAssembly-exported function with metadata including the Dart function and a `varArgs` flag.
  - Updated `WasmModule.getFunction` signature to return `WasmModuleFunction<F>?` instead of just `F?`.

- `WasmRunnerWasm`:
  - Updated function invocation logic in `ApolloRunnerWasm` to handle `WasmModuleFunction` with `varArgs` flag.
  - Added special handling for functions with no arguments and functions expecting a single `List` argument.

- `wasm_runtime_generic.dart`:
  - Updated `WasmModuleGeneric.getFunction` to return `null` as `WasmModuleFunction<F>?`.

- `wasm_runtime_io.dart`:
  - Updated `WasmModuleIO.getFunction` to return a `WasmModuleFunction` with `varArgs: true`.

- `wasm_runtime_dart_html.dart`:
  - Deprecated `WasmRuntimeDartHTML` in favor of `WasmRuntimeWeb`.
  - Updated `WasmModuleBrowser.getFunction` to return a `WasmModuleFunction` with `varArgs: true`.
  - Updated `createWasmRuntime` to return `WasmRuntimeDartHTML` with deprecation warning.

- `wasm_runtime_web.dart`:
  - New `WasmRuntimeWeb` implementation using `dart:js_interop` and `web` package.
  - Added JS interop bindings for WebAssembly APIs using extension types.
  - Implemented `WasmModuleBrowser` wrapping `_WasmInstance` with proper JS interop.
  - `getFunction` returns a Dart function wrapping JS function calls with argument conversion and `varArgs: false`.
  - Added utilities to convert JS BigInt to Dart `num` or `BigInt`.
  - Updated `createWasmRuntime` to return `WasmRuntimeWeb`.
  - Added extensions for JS function invocation and JSAny type checks and casts.

- `pubspec.yaml`:
  - Added dependency on `web: ^1.1.1`.

- Tests:
  - Added new tests `operation3` and `operation4` verifying multi-parameter Dart functions compiled to Wasm and executed correctly.