### PR TITLE
v0.1.7 - Refactor: CoreClassList generics

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dart-lang/setup-dart@v1
       - name: Dart version
         run: |
@@ -34,7 +34,7 @@ jobs:
   test_vm:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: dart-lang/setup-dart@v1
       - name: Dart version
         run: |
@@ -53,7 +53,7 @@ jobs:
           dart pub global activate coverage
           dart pub global run coverage:format_coverage --packages=.dart_tool/package_config.json --report-on=lib --lcov -o ./coverage/lcov.info -i ./coverage
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,79 @@
+## 0.1.7
+
+- CI:
+  - `.github/workflows/dart.yml`: updated `actions/checkout` from v3 to v6 and `codecov/codecov-action` from v3 to v5.
+
+- `apollovm.dart`:
+  - Exported new utility file `src/apollovm_utils.dart`.
+
+- `apollovm_runner.dart`:
+  - `ApolloRunner`:
+    - `executeClassMethod`: changed to async, added parameter normalization before execution.
+    - Added `normalizeParameters` method to normalize positional and named parameters against AST function declarations.
+    - `executeFunction`: added parameter normalization for top-level functions.
+    - Improved parameter handling for function execution.
+
+- `apollovm_utils.dart` (new):
+  - Added utilities for generic typed list conversion and case-insensitive map key lookup.
+  - Extensions on `List` for typed list creation and on `Map` for case-insensitive key lookup.
+
+- `apollovm_ast_toplevel.dart`:
+  - `ASTFunctionDeclaration`:
+    - Added `normalizeParameters`, `normalizePositionalParameters`, and `normalizeNamedParameters` methods to convert and normalize parameters according to function declarations.
+  - Added extension `IterableASTFunctionDeclarationExtension` with `resolveBestMatchBySignature` to select best matching function overload by parameter signature.
+
+- `apollovm_ast_type.dart`:
+  - `ASTType`:
+    - Added `fromType` factory to create ASTType from Dart `Type`.
+    - Added `toASTValue` method to convert native values to ASTValue according to type.
+  - Added `toASTValue` overrides in primitive and collection types (`ASTTypeBool`, `ASTTypeNum`, `ASTTypeInt`, `ASTTypeDouble`, `ASTTypeString`, `ASTTypeNull`, `ASTTypeVoid`, `ASTTypeArray`, `ASTTypeArray2D`, `ASTTypeMap`, `ASTTypeFuture`).
+  - Added static `fromType` methods for `ASTTypeArray` and `ASTTypeMap` to create instances from Dart generic types.
+  - `ASTTypeArray` and `CoreClassList`:
+    - Added typed singleton instances for common generic types (e.g., `List<String>`, `List<int>`, etc.).
+    - Added factory constructors and `fromType` methods to resolve types generically.
+  - `ASTTypeMap`:
+    - Added `fromType` method for common map generic types.
+  - `ASTTypeFuture`:
+    - Added `toASTValue` override to handle conversion from native or future values.
+
+- `apollovm_ast_value.dart`:
+  - `ASTValue.from` factory:
+    - Added support for `ASTTypeBool` to create `ASTValueBool`.
+
+- `apollovm_core_base.dart`:
+  - `ApolloVMCore.getClass`:
+    - Added optional `generics` parameter.
+    - `List` class resolution now uses `CoreClassList.fromType` with generic type.
+  - `CoreClassList`:
+    - Converted to generic class `CoreClassList<T>`.
+    - Added typed singleton instances for common generic types.
+    - Added `fromType` static method to resolve generic list classes.
+    - Constructor updated to accept generic type and resolve `ASTTypeArray` accordingly.
+
+- `wasm_runner.dart`:
+  - `ApolloRunnerWasm`:
+    - Added parameter normalization before calling Wasm functions.
+
+- `wasm_runtime.dart`:
+  - Added `ensureBooted()` method and `lastBootError` getter to `WasmRuntime` interface.
+
+- `wasm_runtime_dart_html.dart`, `wasm_runtime_generic.dart`, `wasm_runtime_web.dart`:
+  - Implemented `ensureBooted()` as no-op and `lastBootError` as null.
+
+- `wasm_runtime_io.dart`:
+  - Added boot logic with error capture.
+  - Implemented `ensureBooted()` to call boot.
+  - Added `lastBootError` getter.
+
+- Tests (`apollovm_languages_test_definition.dart`):
+  - Updated `_parseJsonList` to return untyped `List` without generic type conversion.
+  - Removed redundant generic list conversion helpers from test file.
+  - Updated tests to call `.toListOfType()` extension for typed list checks.
+
+- Tests (`apollovm_wasm_test.dart`):
+  - Added call to `wasmRuntime.ensureBooted()` before checking support.
+  - On unsupported runtime, print last boot error for diagnostics.
+
 ## 0.1.6
 
 - Added support for external getters in `ApolloVM`:

--- a/lib/apollovm.dart
+++ b/lib/apollovm.dart
@@ -15,6 +15,7 @@ export 'src/apollovm_generated_output.dart';
 export 'src/apollovm_generator.dart';
 export 'src/apollovm_parser.dart';
 export 'src/apollovm_runner.dart';
+export 'src/apollovm_utils.dart';
 export 'src/ast/apollovm_ast_annotation.dart';
 export 'src/ast/apollovm_ast_base.dart';
 export 'src/ast/apollovm_ast_expression.dart';

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -35,7 +35,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.6';
+  static final String VERSION = '0.1.7';
 
   static int _idCount = 0;
 

--- a/lib/src/apollovm_runner.dart
+++ b/lib/src/apollovm_runner.dart
@@ -5,6 +5,7 @@
 import 'package:async_extension/async_extension.dart';
 
 import 'apollovm_base.dart';
+import 'apollovm_utils.dart';
 import 'ast/apollovm_ast_toplevel.dart';
 import 'ast/apollovm_ast_type.dart';
 import 'ast/apollovm_ast_value.dart';
@@ -64,7 +65,7 @@ abstract class ApolloRunner implements VMTypeResolver {
   /// - [methodName] Name of the target method.
   /// - [positionalParameters] Positional parameters to pass to the method.
   /// - [namedParameters] Named parameters to pass to the method.
-  FutureOr<ASTValue> executeClassMethod(
+  Future<ASTValue> executeClassMethod(
     String namespace,
     String className,
     String methodName, {
@@ -87,6 +88,15 @@ abstract class ApolloRunner implements VMTypeResolver {
       );
     }
 
+    var astFunctionSet = clazz.getFunctionWithName(methodName);
+    if (astFunctionSet != null) {
+      (positionalParameters, namedParameters) = normalizeParameters(
+        positionalParameters: positionalParameters,
+        namedParameters: namedParameters,
+        astFunctions: astFunctionSet.functions,
+      );
+    }
+
     var result = await clazz.execute(
       methodName,
       positionalParameters,
@@ -97,6 +107,33 @@ abstract class ApolloRunner implements VMTypeResolver {
       typeResolver: this,
     );
     return result;
+  }
+
+  (List?, Map?) normalizeParameters({
+    List? positionalParameters,
+    Map? namedParameters,
+    List<ASTFunctionDeclaration>? astFunctions,
+  }) {
+    if (astFunctions != null && astFunctions.isNotEmpty) {
+      final astFunction = astFunctions.resolveBestMatchBySignature(
+        positionalParameters: positionalParameters,
+        namedParameters: namedParameters,
+      );
+
+      if (astFunction != null) {
+        (positionalParameters, namedParameters) = astFunction
+            .normalizeParameters(
+              positionalParameters: positionalParameters,
+              namedParameters: namedParameters,
+            );
+
+        return (positionalParameters, namedParameters);
+      }
+    }
+
+    positionalParameters = positionalParameters?.toListOfType();
+
+    return (positionalParameters, namedParameters);
   }
 
   /// Returns an [ASTClassNormal] for [className] in [namespace] (optional).
@@ -199,17 +236,28 @@ abstract class ApolloRunner implements VMTypeResolver {
         positionalParameters: positionalParameters,
         namedParameters: namedParameters,
       );
+    } else {
+      final astRoot = codeUnit.root!;
+
+      var astFunctionSet = astRoot.getFunctionWithName(functionName);
+      if (astFunctionSet != null) {
+        (positionalParameters, namedParameters) = normalizeParameters(
+          positionalParameters: positionalParameters,
+          namedParameters: namedParameters,
+          astFunctions: astFunctionSet.functions,
+        );
+      }
+
+      var result = await astRoot.execute(
+        functionName,
+        positionalParameters,
+        namedParameters,
+        externalFunctionMapper: externalFunctionMapper,
+        typeResolver: this,
+      );
+
+      return result;
     }
-
-    var result = await codeUnit.root!.execute(
-      functionName,
-      positionalParameters,
-      namedParameters,
-      externalFunctionMapper: externalFunctionMapper,
-      typeResolver: this,
-    );
-
-    return result;
   }
 
   /// Returns a function in [namespace] and with name [functionName].

--- a/lib/src/apollovm_utils.dart
+++ b/lib/src/apollovm_utils.dart
@@ -1,0 +1,132 @@
+import 'package:collection/collection.dart';
+
+List _toListWithGenericType<T>(List list) {
+  var l2 = list.map((e) => e is List ? _toListWithGenericType(e) : e).toList();
+
+  var lString = _toListElementsOfType<String>(l2);
+  if (lString != null) return lString;
+
+  var lInt = _toListElementsOfType<int>(l2);
+  if (lInt != null) return lInt;
+
+  var lDouble = _toListElementsOfType<double>(l2);
+  if (lDouble != null) return lDouble;
+
+  var lNum = _toListElementsOfType<num>(l2);
+  if (lNum != null) return lNum;
+
+  var lBoll = _toListElementsOfType<bool>(l2);
+  if (lBoll != null) return lBoll;
+
+  // 1D
+
+  var lListString = _toListElementsOfType<List<String>>(l2);
+  if (lListString != null) return lListString;
+
+  var lListInt = _toListElementsOfType<List<int>>(l2);
+  if (lListInt != null) return lListInt;
+
+  var lListDouble = _toListElementsOfType<List<double>>(l2);
+  if (lListDouble != null) return lListDouble;
+
+  var lListNum = _toListElementsOfType<List<num>>(l2);
+  if (lListNum != null) return lListNum;
+
+  var lListBool = _toListElementsOfType<List<bool>>(l2);
+  if (lListBool != null) return lListBool;
+
+  // 2D
+
+  var lListString2 = _toListElementsOfType<List<List<String>>>(l2);
+  if (lListString2 != null) return lListString2;
+
+  var lListInt2 = _toListElementsOfType<List<List<int>>>(l2);
+  if (lListInt2 != null) return lListInt2;
+
+  var lListDouble2 = _toListElementsOfType<List<List<double>>>(l2);
+  if (lListDouble2 != null) return lListDouble2;
+
+  var lListNum2 = _toListElementsOfType<List<List<num>>>(l2);
+  if (lListNum2 != null) return lListNum2;
+
+  var lListBool2 = _toListElementsOfType<List<List<bool>>>(l2);
+  if (lListBool2 != null) return lListBool2;
+
+  // 3D
+
+  var lListString3 = _toListElementsOfType<List<List<List<String>>>>(l2);
+  if (lListString3 != null) return lListString3;
+
+  var lListInt3 = _toListElementsOfType<List<List<List<int>>>>(l2);
+  if (lListInt3 != null) return lListInt3;
+
+  var lListDouble3 = _toListElementsOfType<List<List<List<double>>>>(l2);
+  if (lListDouble3 != null) return lListDouble3;
+
+  var lListNum3 = _toListElementsOfType<List<List<List<num>>>>(l2);
+  if (lListNum3 != null) return lListNum3;
+
+  var lListBool3 = _toListElementsOfType<List<List<List<bool>>>>(l2);
+  if (lListBool3 != null) return lListBool3;
+
+  //
+
+  var lListObject3 = _toListElementsOfType<List<List<List<Object>>>>(l2);
+  if (lListObject3 != null) return lListObject3;
+
+  var lListObject2 = _toListElementsOfType<List<List<Object>>>(l2);
+  if (lListObject2 != null) return lListObject2;
+
+  var lListObject = _toListElementsOfType<List<Object>>(l2);
+  if (lListObject != null) return lListObject;
+
+  //
+
+  var lObject = _toListElementsOfType<Object>(l2);
+  if (lObject != null) return lObject;
+
+  return l2;
+}
+
+List<T>? _toListElementsOfType<T>(List list) {
+  if (_isListElementsAllOfType<T>(list)) {
+    var l2 = list.cast<T>().toList();
+    return l2;
+  }
+  return null;
+}
+
+bool _isListElementsAllOfType<T>(List list) {
+  if (list is List<T>) return true;
+  return list.whereType<T>().length == list.length;
+}
+
+extension CreateListTypedExtension<T> on List<T> {
+  List<T> createListOfSameType() => <T>[];
+
+  List<List<T>> createListOfSameType2D() => <List<T>>[];
+
+  List<E> toListOfType<E>() => _toListWithGenericType<E>(this) as List<E>;
+}
+
+extension MapGetIgnoreCaseExtension<K, V> on Map<K, V> {
+  V? lookupValue(Object? key, {bool ignoreCase = false}) {
+    if (ignoreCase) {
+      if (containsKey(key)) {
+        return this[key];
+      } else {
+        final keyStr = key?.toString() ?? '';
+
+        for (var e in entries) {
+          if (equalsIgnoreAsciiCase(e.key?.toString() ?? '', keyStr)) {
+            return e.value;
+          }
+        }
+
+        return null;
+      }
+    } else {
+      return this[key];
+    }
+  }
+}

--- a/lib/src/ast/apollovm_ast_toplevel.dart
+++ b/lib/src/ast/apollovm_ast_toplevel.dart
@@ -2,9 +2,12 @@
 // This code is governed by the Apache License, Version 2.0.
 // Please refer to the LICENSE and AUTHORS files for details.
 
+import 'dart:math' as math;
+
+import '../apollovm_utils.dart';
 import 'package:async_extension/async_extension.dart';
 import 'package:collection/collection.dart'
-    show IterableExtension, equalsIgnoreAsciiCase;
+    show IterableExtension, equalsIgnoreAsciiCase, CombinedListView;
 
 import '../apollovm_base.dart';
 import '../core/apollovm_core_base.dart';
@@ -1503,6 +1506,97 @@ class ASTFunctionDeclaration<T> extends ASTBlock {
     return prevFuture.resolveWith(() => i);
   }
 
+  (List?, Map?) normalizeParameters({
+    List? positionalParameters,
+    Map? namedParameters,
+  }) {
+    positionalParameters = normalizePositionalParameters(positionalParameters);
+    namedParameters = normalizeNamedParameters(namedParameters);
+
+    return (positionalParameters, namedParameters);
+  }
+
+  List? normalizePositionalParameters(List? positionalParameters) {
+    if (positionalParameters == null) return null;
+
+    final positionalParametersDeclaration = parameters.positionalParameters;
+
+    final optionalParametersDeclaration = parameters.optionalParameters;
+
+    final positionalParametersLength =
+        positionalParametersDeclaration?.length ?? 0;
+    final optionalParametersLength = optionalParametersDeclaration?.length ?? 0;
+
+    if (positionalParametersLength == 0 && optionalParametersLength == 0) {
+      return null;
+    }
+
+    var lng = math.min(
+      positionalParametersLength + optionalParametersLength,
+      positionalParameters.length,
+    );
+
+    if (lng == 0) return null;
+
+    final allParametersDeclaration = positionalParametersDeclaration == null
+        // Only optional parameters exist (guaranteed non-null here)
+        ? optionalParametersDeclaration!
+        : optionalParametersDeclaration == null
+        // Only positional parameters exist
+        ? positionalParametersDeclaration
+        // Both exist: combine lazily without allocating a merged list
+        : CombinedListView([
+            positionalParametersDeclaration,
+            optionalParametersDeclaration,
+          ]);
+
+    var positionalParameters2 = List.generate(lng, (i) {
+      var p = allParametersDeclaration[i];
+      var v = positionalParameters[i];
+      var astType = p.type;
+
+      var astValue = astType.toASTValue(v);
+      var v2 = astValue?.getValueNoContext();
+      return v2;
+    });
+
+    return positionalParameters2;
+  }
+
+  Map? normalizeNamedParameters(
+    Map? namedParameters, {
+    bool ignoreCase = true,
+  }) {
+    if (namedParameters == null) return null;
+
+    final namedParametersDeclaration = parameters.namedParameters;
+    if (namedParametersDeclaration == null ||
+        namedParametersDeclaration.isEmpty) {
+      return null;
+    }
+
+    var lng = math.min(
+      namedParametersDeclaration.length,
+      namedParameters.length,
+    );
+
+    if (lng == 0) return null;
+
+    var namedParameters2 = Map.fromEntries(
+      List.generate(lng, (i) {
+        var p = namedParametersDeclaration[i];
+        var pName = p.name;
+        var v = namedParameters.lookupValue(pName, ignoreCase: true);
+        var astType = p.type;
+        var astValue = astType.toASTValue(v);
+        var v2 = astValue?.getValueNoContext();
+        return MapEntry(pName, v2);
+      }),
+    );
+
+    return namedParameters2;
+  }
+
   void _initializeOptionalParameters(int i, VMContext context) {
     var parametersSize = this.parametersSize;
 
@@ -1537,6 +1631,33 @@ class ASTFunctionDeclaration<T> extends ASTBlock {
   String toString() {
     var block = super.toString();
     return '$modifiers $returnType $name($_parameters) $block';
+  }
+}
+
+extension IterableASTFunctionDeclarationExtension
+    on Iterable<ASTFunctionDeclaration> {
+  ASTFunctionDeclaration? resolveBestMatchBySignature({
+    List? positionalParameters,
+    Map? namedParameters,
+  }) {
+    final length = this.length;
+
+    if (length == 0) return null;
+
+    if (length == 1) {
+      return first;
+    } else {
+      var fSignature = ASTFunctionSignature.from(
+        positionalParameters,
+        namedParameters,
+      );
+
+      return
+      // Try strict match first (exact parameter type compatibility)
+      firstWhereOrNull((f) => f.matchesParametersTypes(fSignature, true)) ??
+          // Fallback to relaxed match (allowing looser type compatibility)
+          firstWhereOrNull((f) => f.matchesParametersTypes(fSignature, false));
+    }
   }
 }
 

--- a/lib/src/ast/apollovm_ast_type.dart
+++ b/lib/src/ast/apollovm_ast_type.dart
@@ -18,19 +18,43 @@ import 'apollovm_ast_variable.dart';
 
 /// An AST Type.
 class ASTType<V> with ASTNode implements ASTTypedNode {
-  static ASTType from(dynamic o, [VMContext? context]) {
-    if (o == null) return ASTTypeNull.instance;
+  static ASTType? fromType(Type type) {
+    if (type == String) {
+      return ASTTypeString.instance;
+    } else if (type == int) {
+      return ASTTypeInt.instance;
+    } else if (type == double) {
+      return ASTTypeDouble.instance;
+    } else if (type == bool) {
+      return ASTTypeBool.instance;
+    } else if (type == Object) {
+      return ASTTypeObject.instance;
+    } else if (type == dynamic) {
+      return ASTTypeDynamic.instance;
+    }
+
+    var arrayType = ASTTypeArray.fromType(type);
+    if (arrayType != null) return arrayType;
+
+    var mapType = ASTTypeMap.fromType(type);
+    if (mapType != null) return mapType;
+
+    return null;
+  }
+
+  static ASTType<T> from<T>(dynamic o, [VMContext? context]) {
+    if (o == null) return ASTTypeNull.instance as ASTType<T>;
 
     if (o is ASTType) {
-      return o;
+      return o as ASTType<T>;
     }
 
     if (o is ASTValue) {
-      return o.type;
+      return o.type as ASTType<T>;
     }
 
     if (o is ASTTypedVariable) {
-      return o.type;
+      return o.type as ASTType<T>;
     }
 
     if (o is ASTExpressionLiteral) {
@@ -40,13 +64,13 @@ class ASTType<V> with ASTNode implements ASTTypedNode {
     if (o is ASTTypedNode) {
       var resolved = o.resolveType(context ?? VMContext.getCurrent());
       if (resolved is ASTType) {
-        return resolved;
+        return resolved as ASTType<T>;
       } else {
-        return ASTTypeDynamic.instance;
+        return ASTTypeDynamic.instance as ASTType<T>;
       }
     }
 
-    return fromNativeValue(o);
+    return fromNativeValue(o) as ASTType<T>;
   }
 
   static FutureOr<ASTType> fromAsync(dynamic o) {
@@ -172,7 +196,7 @@ class ASTType<V> with ASTNode implements ASTTypedNode {
 
   ASTClass<V> getClass() {
     if (_class == null) {
-      var coreClass = ApolloVMCore.getClass<V>(name);
+      var coreClass = ApolloVMCore.getClass<V>(name, generics: generics);
       if (coreClass == null) {
         throw StateError('Class not set for type: $this');
       }
@@ -255,6 +279,10 @@ class ASTType<V> with ASTNode implements ASTTypedNode {
 
   FutureOr<ASTValue<V>?> toDefaultValue(VMContext context) => null;
 
+  ASTValue<V>? toASTValue(Object? value) {
+    return value == null ? null : ASTValue.from(this, value as V);
+  }
+
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
@@ -335,6 +363,9 @@ abstract class ASTTypePrimitive<T> extends ASTType<T> {
 
   @override
   bool acceptsType(ASTType type);
+
+  @override
+  ASTValue<T>? toASTValue(Object? value);
 }
 
 /// [ASTType] for booleans ([bool]).
@@ -374,6 +405,11 @@ class ASTTypeBool extends ASTTypePrimitive<bool> {
   }
 
   @override
+  ASTValueBool? toASTValue(Object? value) {
+    return value == null ? null : ASTValueBool(parseBool(value) ?? false);
+  }
+
+  @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       super == other && other is ASTTypeInt && runtimeType == other.runtimeType;
@@ -390,11 +426,14 @@ class ASTTypeBool extends ASTTypePrimitive<bool> {
 enum ASTNumType { nan, num, int, double }
 
 /// Base [ASTType] for primitive numbers.
-abstract class ASTTypeNumber<T> extends ASTTypePrimitive<T> {
+abstract class ASTTypeNumber<T extends num> extends ASTTypePrimitive<T> {
   ASTTypeNumber(super.name);
 
   @override
   bool acceptsType(ASTType type);
+
+  @override
+  ASTValueNum<T>? toASTValue(Object? value);
 }
 
 /// [ASTType] for numbers ([num]).
@@ -437,6 +476,19 @@ class ASTTypeNum<T extends num> extends ASTTypeNumber<T> {
   ASTValueNum<T>? _toASTValueNum(dynamic v) {
     var n = parseNum(v);
     if (n == null) return null;
+
+    if (n is int) {
+      return ASTValueInt(n) as ASTValueNum<T>;
+    } else {
+      return ASTValueDouble(n.toDouble()) as ASTValueNum<T>;
+    }
+  }
+
+  @override
+  ASTValueNum<T>? toASTValue(Object? value) {
+    if (value == null) return null;
+
+    var n = parseNum(value) ?? 0;
 
     if (n is int) {
       return ASTValueInt(n) as ASTValueNum<T>;
@@ -511,6 +563,13 @@ class ASTTypeInt extends ASTTypeNum<int> with StrictType {
   }
 
   @override
+  ASTValueInt? toASTValue(Object? value) {
+    if (value == null) return null;
+    var n = parseInt(value) ?? 0;
+    return ASTValueInt(n);
+  }
+
+  @override
   bool operator ==(Object other) => equals(other);
 
   @override
@@ -577,6 +636,13 @@ class ASTTypeDouble extends ASTTypeNum<double> with StrictType {
   }
 
   @override
+  ASTValueDouble? toASTValue(Object? value) {
+    if (value == null) return null;
+    var n = parseDouble(value) ?? 0.0;
+    return ASTValueDouble(n);
+  }
+
+  @override
   bool operator ==(Object other) => equals(other);
 
   @override
@@ -622,6 +688,13 @@ class ASTTypeString extends ASTTypePrimitive<String> {
   @override
   FutureOr<ASTValueString?> toDefaultValue(VMContext context) {
     return null;
+  }
+
+  @override
+  ASTValueString? toASTValue(Object? value) {
+    if (value == null) return null;
+    var s = parseString(value) ?? '';
+    return ASTValueString(s);
   }
 
   @override
@@ -823,6 +896,11 @@ class ASTTypeNull extends ASTType<Null> {
   }
 
   @override
+  ASTValueNull? toASTValue(Object? value) {
+    return ASTValueNull.instance;
+  }
+
+  @override
   bool operator ==(Object other) =>
       identical(this, other) ||
       super == other && other is ASTTypeInt && runtimeType == other.runtimeType;
@@ -853,6 +931,11 @@ class ASTTypeVoid extends ASTType<void> {
 
   @override
   ASTValueVoid toValue(VMContext context, Object? v) {
+    return ASTValueVoid.instance;
+  }
+
+  @override
+  ASTValueVoid? toASTValue(Object? value) {
     return ASTValueVoid.instance;
   }
 
@@ -904,28 +987,83 @@ class ASTTypeGenericWildcard extends ASTTypeGenericVariable {
 /// [ASTType] for an array/List.
 class ASTTypeArray<T extends ASTType<V>, V> extends ASTType<List<V>> {
   static final ASTTypeArray<ASTTypeString, String> instanceOfString =
-      ASTTypeArray<ASTTypeString, String>(ASTTypeString.instance);
+      ASTTypeArray<ASTTypeString, String>._(ASTTypeString.instance);
 
   static final ASTTypeArray<ASTTypeInt, int> instanceOfInt =
-      ASTTypeArray<ASTTypeInt, int>(ASTTypeInt.instance);
+      ASTTypeArray<ASTTypeInt, int>._(ASTTypeInt.instance);
 
   static final ASTTypeArray<ASTTypeDouble, double> instanceOfDouble =
-      ASTTypeArray<ASTTypeDouble, double>(ASTTypeDouble.instance);
+      ASTTypeArray<ASTTypeDouble, double>._(ASTTypeDouble.instance);
 
   static final ASTTypeArray<ASTTypeBool, bool> instanceOfBool =
-      ASTTypeArray<ASTTypeBool, bool>(ASTTypeBool.instance);
+      ASTTypeArray<ASTTypeBool, bool>._(ASTTypeBool.instance);
 
   static final ASTTypeArray<ASTTypeObject, Object> instanceOfObject =
-      ASTTypeArray<ASTTypeObject, Object>(ASTTypeObject.instance);
+      ASTTypeArray<ASTTypeObject, Object>._(ASTTypeObject.instance);
 
   static final ASTTypeArray<ASTTypeDynamic, dynamic> instanceOfDynamic =
-      ASTTypeArray<ASTTypeDynamic, dynamic>(ASTTypeDynamic.instance);
+      ASTTypeArray<ASTTypeDynamic, dynamic>._(ASTTypeDynamic.instance);
+
+  static ASTTypeArray? fromType(Type type) {
+    if (type == List<String>) {
+      return ASTTypeArray.instanceOfString;
+    } else if (type == List<int>) {
+      return ASTTypeArray.instanceOfInt;
+    } else if (type == List<double>) {
+      return ASTTypeArray.instanceOfDouble;
+    } else if (type == List<bool>) {
+      return ASTTypeArray.instanceOfBool;
+    } else if (type == List<Object>) {
+      return ASTTypeArray.instanceOfObject;
+    } else if (type == List<dynamic>) {
+      return ASTTypeArray.instanceOfDynamic;
+    }
+
+    return null;
+  }
 
   final T componentType;
 
   ASTType get elementType => componentType;
 
-  ASTTypeArray(this.componentType) : super('List', generics: [componentType]);
+  ASTTypeArray._(this.componentType) : super('List', generics: [componentType]);
+
+  factory ASTTypeArray(T type) {
+    if (type is ASTTypeString) {
+      return ASTTypeArray.instanceOfString as ASTTypeArray<T, V>;
+    } else if (type is ASTTypeInt) {
+      return ASTTypeArray.instanceOfInt as ASTTypeArray<T, V>;
+    } else if (type is ASTTypeDouble) {
+      return ASTTypeArray.instanceOfDouble as ASTTypeArray<T, V>;
+    } else if (type is ASTTypeBool) {
+      return ASTTypeArray.instanceOfBool as ASTTypeArray<T, V>;
+    } else if (type is ASTTypeObject) {
+      return ASTTypeArray.instanceOfObject as ASTTypeArray<T, V>;
+    } else if (type is ASTTypeDynamic) {
+      return ASTTypeArray.instanceOfDynamic as ASTTypeArray<T, V>;
+    }
+
+    return ASTTypeArray<T, V>._(type);
+  }
+
+  factory ASTTypeArray.withType(Type type) {
+    if (type == String) {
+      return ASTTypeArray.instanceOfString as ASTTypeArray<T, V>;
+    } else if (type == int) {
+      return ASTTypeArray.instanceOfInt as ASTTypeArray<T, V>;
+    } else if (type == double) {
+      return ASTTypeArray.instanceOfDouble as ASTTypeArray<T, V>;
+    } else if (type == bool) {
+      return ASTTypeArray.instanceOfBool as ASTTypeArray<T, V>;
+    } else if (type == Object) {
+      return ASTTypeArray.instanceOfObject as ASTTypeArray<T, V>;
+    } else if (type == dynamic) {
+      return ASTTypeArray.instanceOfDynamic as ASTTypeArray<T, V>;
+    }
+
+    var astType = ASTType.from<V>(type);
+    return ASTTypeArray<T, V>._(astType as T);
+  }
 
   @override
   Iterable<ASTNode> get children => [componentType];
@@ -955,15 +1093,21 @@ class ASTTypeArray<T extends ASTType<V>, V> extends ASTType<List<V>> {
     var value = ASTValueArray<T, V>(componentType, list2);
     return value;
   }
+
+  @override
+  ASTValueArray<T, V>? toASTValue(Object? value) {
+    if (value == null) return null;
+    return _toASTValueArray(value);
+  }
 }
 
 /// [ASTType] a for a 2D array/List.
 class ASTTypeArray2D<T extends ASTType<V>, V>
     extends ASTTypeArray<ASTTypeArray<T, V>, List<V>> {
-  ASTTypeArray2D(super.type);
+  ASTTypeArray2D(super.type) : super._();
 
   factory ASTTypeArray2D.fromElementType(ASTType<V> elementType) {
-    var a1 = ASTTypeArray<T, V>(elementType as T);
+    var a1 = ASTTypeArray<T, V>._(elementType as T);
     return ASTTypeArray2D<T, V>(a1);
   }
 
@@ -979,6 +1123,10 @@ class ASTTypeArray2D<T extends ASTType<V>, V>
       v = (v).getValue(context);
     }
 
+    return _toASTValueArray2D(v);
+  }
+
+  ASTValueArray2D<T, V>? _toASTValueArray2D(Object? v) {
     List list;
     if (v is List) {
       list = v;
@@ -990,6 +1138,12 @@ class ASTTypeArray2D<T extends ASTType<V>, V>
 
     var value = ASTValueArray2D<T, V>(elementType as T, list2);
     return value;
+  }
+
+  @override
+  ASTValueArray2D<T, V>? toASTValue(Object? value) {
+    if (value == null) return null;
+    return _toASTValueArray2D(value);
   }
 }
 
@@ -1054,6 +1208,18 @@ class ASTTypeMap<TK extends ASTType<K>, TV extends ASTType<V>, K, V>
         ASTTypeDynamic.instance,
       );
 
+  static ASTTypeMap? fromType(Type type) {
+    if (type == Map<String, dynamic>) {
+      return ASTTypeMap.instanceOfStringOfDynamic;
+    } else if (type == Map<String, String>) {
+      return ASTTypeMap.instanceOfStringOfString;
+    } else if (type == Map<dynamic, dynamic>) {
+      return ASTTypeMap.instanceOfDynamicOfDynamic;
+    }
+
+    return null;
+  }
+
   final TK keyType;
   final TV valueType;
 
@@ -1111,6 +1277,12 @@ class ASTTypeMap<TK extends ASTType<K>, TV extends ASTType<V>, K, V>
     var value = ASTValueMap<TK, TV, K, V>(keyType, valueType, map2);
     return value;
   }
+
+  @override
+  ASTValueMap<TK, TV, K, V>? toASTValue(Object? value) {
+    if (value == null) return null;
+    return _toASTValueMap(value);
+  }
 }
 
 /// [ASTType] a for a [Future].
@@ -1123,5 +1295,18 @@ class ASTTypeFuture<T extends ASTType<V>, V> extends ASTType<Future<V>> {
   @override
   ASTValueFuture<T, V>? toValue(VMContext context, Object? v) {
     return ASTValueFuture(this, v as Future<V>);
+  }
+
+  @override
+  ASTValueFuture<T, V>? toASTValue(Object? value) {
+    if (value == null) return null;
+    return ASTValueFuture(
+      this,
+      value is Future<V>
+          ? value
+          : (value is Future
+                ? value.then((v) => v as V)
+                : Future.value(value as V)),
+    );
   }
 }

--- a/lib/src/ast/apollovm_ast_value.dart
+++ b/lib/src/ast/apollovm_ast_value.dart
@@ -20,6 +20,8 @@ abstract class ASTValue<T> with ASTNode implements ASTTypedNode {
   factory ASTValue.from(ASTType<T> type, T value) {
     if (value is ASTValue) {
       return value as ASTValue<T>;
+    } else if (type is ASTTypeBool) {
+      return ASTValueBool(value as bool) as ASTValue<T>;
     } else if (type is ASTTypeString) {
       return ASTValueString(value as String) as ASTValue<T>;
     } else if (type is ASTTypeInt) {

--- a/lib/src/core/apollovm_core_base.dart
+++ b/lib/src/core/apollovm_core_base.dart
@@ -12,7 +12,7 @@ import '../ast/apollovm_ast_value.dart';
 import '../ast/apollovm_ast_variable.dart';
 
 class ApolloVMCore {
-  static ASTClass<V>? getClass<V>(String className) {
+  static ASTClass<V>? getClass<V>(String className, {List<ASTType>? generics}) {
     switch (className) {
       case 'String':
         return CoreClassString.instance as ASTClass<V>;
@@ -23,7 +23,7 @@ class ApolloVMCore {
       case 'Double':
         return CoreClassDouble.instance as ASTClass<V>;
       case 'List':
-        return CoreClassList.instance as ASTClass<V>;
+        return CoreClassList.fromType(V) as ASTClass<V>;
       default:
         return null;
     }
@@ -701,8 +701,34 @@ class CoreClassDouble extends CoreClassPrimitive<double> {
   }
 }
 
-class CoreClassList extends CoreClassBase<List<Object>> {
-  static final CoreClassList instance = CoreClassList._();
+class CoreClassList<T> extends CoreClassBase<List<T>> {
+  static final CoreClassList instanceOfObject = CoreClassList<Object>._();
+  static final CoreClassList<String> instanceOfString =
+      CoreClassList<String>._();
+  static final CoreClassList<int> instanceOfInt = CoreClassList<int>._();
+  static final CoreClassList<double> instanceOfDouble =
+      CoreClassList<double>._();
+  static final CoreClassList<bool> instanceOfBool = CoreClassList<bool>._();
+  static final CoreClassList<dynamic> instanceOfDynamic =
+      CoreClassList<dynamic>._();
+
+  static CoreClassList<T>? fromType<T>(Type type) {
+    if (type == List<String>) {
+      return instanceOfString as CoreClassList<T>;
+    } else if (type == List<int>) {
+      return instanceOfInt as CoreClassList<T>;
+    } else if (type == List<double>) {
+      return instanceOfDouble as CoreClassList<T>;
+    } else if (type == List<bool>) {
+      return instanceOfBool as CoreClassList<T>;
+    } else if (type == List<Object>) {
+      return instanceOfObject as CoreClassList<T>;
+    } else if (type == List<dynamic>) {
+      return instanceOfDynamic as CoreClassList<T>;
+    }
+
+    return null;
+  }
 
   late final ASTExternalClassGetter _getterLength;
   late final ASTExternalClassGetter _getterIsEmpty;
@@ -730,7 +756,14 @@ class CoreClassList extends CoreClassBase<List<Object>> {
 
   late final ASTExternalFunction _functionValueOf;
 
-  CoreClassList._() : super(ASTTypeArray.instanceOfObject, 'List') {
+  CoreClassList._()
+    : super(
+        ASTTypeArray.fromType(List<T>) as ASTTypeArray<ASTType<T>, T>? ??
+            (throw ArgumentError(
+              "Can't resolve `ASTTypeArray` for type `$T` (`ASTTypeArray<$T>`)",
+            )),
+        'List',
+      ) {
     _getterLength = _externalClassGetter(
       'length',
       ASTTypeInt.instance,
@@ -985,7 +1018,7 @@ class CoreClassList extends CoreClassBase<List<Object>> {
   }
 
   @override
-  FutureOr<ASTValue<List<Object>>?> createInstance(
+  FutureOr<ASTValue<List<T>>?> createInstance(
     VMClassContext<dynamic> context,
     ASTRunStatus runStatus,
   ) {

--- a/lib/src/core/apollovm_core_base.dart
+++ b/lib/src/core/apollovm_core_base.dart
@@ -601,9 +601,7 @@ class CoreClassDouble extends CoreClassPrimitive<double> {
         0,
         true,
       ),
-      (double self, dynamic digits) => digits == null
-          ? self.toStringAsExponential()
-          : self.toStringAsExponential(digits),
+      (double self, dynamic digits) => self.toStringAsExponential(digits),
     );
 
     _functionToStringAsPrecision = _externalClassFunctionArgs1(
@@ -914,7 +912,7 @@ class CoreClassList<T> extends CoreClassBase<List<T>> {
       'sublist',
       ASTTypeArray.instanceOfObject,
       ASTFunctionParameterDeclaration(ASTTypeInt.instance, 'start', 0, false),
-      ASTFunctionParameterDeclaration(ASTTypeInt.instance, 'end', 1, true),
+      ASTFunctionParameterDeclaration(ASTTypeInt.instance, 'end', 1, false),
       (List o, dynamic start, dynamic end) {
         if (end == null) return o.sublist(start);
         return o.sublist(start, end);

--- a/lib/src/languages/wasm/wasm_runner.dart
+++ b/lib/src/languages/wasm/wasm_runner.dart
@@ -65,6 +65,17 @@ class ApolloRunnerWasm extends ApolloRunner {
 
     var allParams = [...?positionalParameters, ...?namedParameters?.values];
 
+    {
+      var astFunction = _getASTFunction(codeUnit, functionName, allParams);
+      if (astFunction != null) {
+        var (allParamsNormalized, _) = normalizeParameters(
+          positionalParameters: allParams,
+          astFunctions: [astFunction],
+        );
+        allParams = allParamsNormalized ?? [];
+      }
+    }
+
     var astFunction = _getASTFunction(codeUnit, functionName, allParams);
     if (astFunction != null) {
       _resolveWasmCallParameters(astFunction, allParams);

--- a/lib/src/languages/wasm/wasm_runtime.dart
+++ b/lib/src/languages/wasm/wasm_runtime.dart
@@ -21,6 +21,13 @@ abstract class WasmRuntime {
   /// Returns the platform version of the Wasm runtime.
   String get platformVersion;
 
+  /// Ensures that the implementation is booted.
+  void ensureBooted();
+
+  /// Last error while booting the implementation.
+  /// See [ensureBooted].
+  Object? get lastBootError;
+
   /// Returns true if the WebAssembly (Wasm) Runtime is supported in the platform.
   bool get isSupported;
 

--- a/lib/src/languages/wasm/wasm_runtime_dart_html.dart
+++ b/lib/src/languages/wasm/wasm_runtime_dart_html.dart
@@ -18,6 +18,12 @@ class WasmRuntimeDartHTML extends WasmRuntime {
       'Browser(dart:html): ${window.navigator.userAgent}';
 
   @override
+  void ensureBooted() {}
+
+  @override
+  Object? get lastBootError => null;
+
+  @override
   bool get isSupported => true;
 
   @override

--- a/lib/src/languages/wasm/wasm_runtime_generic.dart
+++ b/lib/src/languages/wasm/wasm_runtime_generic.dart
@@ -10,6 +10,12 @@ class WasmRuntimeGeneric extends WasmRuntime {
   String get platformVersion => '?';
 
   @override
+  void ensureBooted() {}
+
+  @override
+  Object? get lastBootError => null;
+
+  @override
   bool get isSupported => false;
 
   @override

--- a/lib/src/languages/wasm/wasm_runtime_io.dart
+++ b/lib/src/languages/wasm/wasm_runtime_io.dart
@@ -16,14 +16,26 @@ class WasmRuntimeIO extends WasmRuntime {
 
   static bool _wasmRunDynLibLoaded = false;
 
+  static Object? _lastBootError;
+
   static void boot() {
     if (_boot) return;
     _boot = true;
 
+    try {
+      var ok = _bootImpl();
+      if (ok) {
+        _wasmRunDynLibLoaded = true;
+      }
+    } catch (e) {
+      _lastBootError = e;
+    }
+  }
+
+  static bool _bootImpl() {
     if (wasm_run.WasmRunLibrary.isReachable()) {
       print('** Loading `wasm_run` dynamic library with default resolver.');
-      _wasmRunDynLibLoaded = true;
-      return;
+      return true;
     }
 
     var libPath = _wasmRunLibraryFilePath();
@@ -31,7 +43,8 @@ class WasmRuntimeIO extends WasmRuntime {
     if (libPath == null) {
       throw StateError(
         "Unable to locate the `wasm_run` dynamic library. "
-        "You can specify the library path using the environment variable `WASM_RUN_LIB_PATH`.",
+        "You can specify the library path using the environment variable `WASM_RUN_LIB_PATH`. "
+        "Run `dart run wasm_run:setup` to install `wasm_run` dynamic library.",
       );
     }
 
@@ -44,13 +57,21 @@ class WasmRuntimeIO extends WasmRuntime {
       throw StateError("Invalid `wasm_run` dynamic library: $libPath");
     }
 
-    _wasmRunDynLibLoaded = true;
+    return true;
   }
 
   WasmRuntimeIO() : super.base();
 
   @override
   String get platformVersion => 'Dart: ${Platform.version}';
+
+  @override
+  void ensureBooted() {
+    boot();
+  }
+
+  @override
+  Object? get lastBootError => _lastBootError;
 
   @override
   bool get isSupported {

--- a/lib/src/languages/wasm/wasm_runtime_web.dart
+++ b/lib/src/languages/wasm/wasm_runtime_web.dart
@@ -81,6 +81,12 @@ class WasmRuntimeWeb extends WasmRuntime {
       'Browser(web): ${web.window.navigator.userAgent}';
 
   @override
+  void ensureBooted() {}
+
+  @override
+  Object? get lastBootError => null;
+
+  @override
   bool get isSupported => true;
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, JavaScript with on-the-fly Wasm compilation.
-version: 0.1.6
+version: 0.1.7
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/apollovm_languages_test_definition.dart
+++ b/test/apollovm_languages_test_definition.dart
@@ -57,24 +57,37 @@ Future<void> runTestDefinitions(List<TestDefinition> testDefinitions) async {
 
   group('Pre Test', () {
     test('_parseJsonList', () async {
-      expect(_parseJsonList('["a","b"]') is List<String>, isTrue);
-      expect(_parseJsonList('["a","b"]') is List<int>, isFalse);
+      expect(
+        _parseJsonList('["a","b"]').toListOfType() is List<String>,
+        isTrue,
+      );
+      expect(_parseJsonList('["a","b"]').toListOfType() is List<int>, isFalse);
 
-      expect(_parseJsonList('[1,2,3]') is List<int>, isTrue);
-      expect(_parseJsonList('[1,2,3]') is List<String>, isFalse);
-
-      expect(_parseJsonList('[1.1, 2.2, 3.3]') is List<double>, isTrue);
-      expect(_parseJsonList('[1.1, 2.2, 3.3]') is List<int>, isFalse);
-
-      expect(_parseJsonList('[ [1,2] , [3,4] ]') is List<List<int>>, isTrue);
+      expect(_parseJsonList('[1,2,3]').toListOfType() is List<int>, isTrue);
+      expect(_parseJsonList('[1,2,3]').toListOfType() is List<String>, isFalse);
 
       expect(
-        _parseJsonList('[ [ [1,2] ] , [ [3,4] ] ]') is List<List<List<int>>>,
+        _parseJsonList('[1.1, 2.2, 3.3]').toListOfType() is List<double>,
+        isTrue,
+      );
+      expect(
+        _parseJsonList('[1.1, 2.2, 3.3]').toListOfType() is List<int>,
+        isFalse,
+      );
+
+      expect(
+        _parseJsonList('[ [1,2] , [3,4] ]').toListOfType() is List<List<int>>,
         isTrue,
       );
 
       expect(
-        _parseJsonList('[ [ [ [1,2] ] ] , [ [ [3,4] ] ] ]')
+        _parseJsonList('[ [ [1,2] ] , [ [3,4] ] ]').toListOfType()
+            is List<List<List<int>>>,
+        isTrue,
+      );
+
+      expect(
+        _parseJsonList('[ [ [ [1,2] ] ] , [ [ [3,4] ] ] ]').toListOfType()
             is List<List<List<List<int>>>>,
         isTrue,
       );
@@ -284,124 +297,5 @@ Future<void> _testCall(
 }
 
 List _parseJsonList(String callParametersJson) {
-  var list = json.decode(callParametersJson) as List;
-  var l2 = _toListWithGenericType(list);
-  return l2;
-}
-
-List _toListWithGenericType<T>(List list) {
-  var l2 = list.map((e) => e is List ? _toListWithGenericType(e) : e).toList();
-
-  var lString = _toListElementsOfType<String>(l2);
-  if (lString != null) return lString;
-
-  var lInt = _toListElementsOfType<int>(l2);
-  if (lInt != null) return lInt;
-
-  var lDouble = _toListElementsOfType<double>(l2);
-  if (lDouble != null) return lDouble;
-
-  var lNum = _toListElementsOfType<num>(l2);
-  if (lNum != null) return lNum;
-
-  var lBoll = _toListElementsOfType<bool>(l2);
-  if (lBoll != null) return lBoll;
-
-  // 1D
-
-  var lListString = _toListElementsOfType<List<String>>(l2);
-  if (lListString != null) return lListString;
-
-  var lListInt = _toListElementsOfType<List<int>>(l2);
-  if (lListInt != null) return lListInt;
-
-  var lListDouble = _toListElementsOfType<List<double>>(l2);
-  if (lListDouble != null) return lListDouble;
-
-  var lListNum = _toListElementsOfType<List<num>>(l2);
-  if (lListNum != null) return lListNum;
-
-  var lListBool = _toListElementsOfType<List<bool>>(l2);
-  if (lListBool != null) return lListBool;
-
-  // 2D
-
-  var lListString2 = _toListElementsOfType<List<List<String>>>(l2);
-  if (lListString2 != null) return lListString2;
-
-  var lListInt2 = _toListElementsOfType<List<List<int>>>(l2);
-  if (lListInt2 != null) return lListInt2;
-
-  var lListDouble2 = _toListElementsOfType<List<List<double>>>(l2);
-  if (lListDouble2 != null) return lListDouble2;
-
-  var lListNum2 = _toListElementsOfType<List<List<num>>>(l2);
-  if (lListNum2 != null) return lListNum2;
-
-  var lListBool2 = _toListElementsOfType<List<List<bool>>>(l2);
-  if (lListBool2 != null) return lListBool2;
-
-  // 3D
-
-  var lListString3 = _toListElementsOfType<List<List<List<String>>>>(l2);
-  if (lListString3 != null) return lListString3;
-
-  var lListInt3 = _toListElementsOfType<List<List<List<int>>>>(l2);
-  if (lListInt3 != null) return lListInt3;
-
-  var lListDouble3 = _toListElementsOfType<List<List<List<double>>>>(l2);
-  if (lListDouble3 != null) return lListDouble3;
-
-  var lListNum3 = _toListElementsOfType<List<List<List<num>>>>(l2);
-  if (lListNum3 != null) return lListNum3;
-
-  var lListBool3 = _toListElementsOfType<List<List<List<bool>>>>(l2);
-  if (lListBool3 != null) return lListBool3;
-
-  //
-
-  var lListObject3 = _toListElementsOfType<List<List<List<Object>>>>(l2);
-  if (lListObject3 != null) return lListObject3;
-
-  var lListObject2 = _toListElementsOfType<List<List<Object>>>(l2);
-  if (lListObject2 != null) return lListObject2;
-
-  var lListObject = _toListElementsOfType<List<Object>>(l2);
-  if (lListObject != null) return lListObject;
-
-  //
-
-  var lObject = _toListElementsOfType<Object>(l2);
-  if (lObject != null) return lObject;
-
-  return l2;
-}
-
-List<T>? _toListElementsOfType<T>(List list) {
-  if (_isListElementsAllOfType<T>(list)) {
-    var l2 = list.cast<T>().toList();
-    return l2;
-  }
-  return null;
-}
-
-bool _isListElementsAllOfType<T>(List list) {
-  if (list is List<T>) return true;
-  return list.whereType<T>().length == list.length;
-}
-
-class TypeHelper<T> {
-  final Type type;
-
-  TypeHelper(this.type);
-
-  List<T> emptyList() => <T>[];
-}
-
-extension ListTypedExtension2<T> on List<T> {
-  List<T> createListOfType() => <T>[];
-
-  List<List<T>> createListOfType2D() => <List<T>>[];
-
-  TypeHelper<T> get typeHelper => TypeHelper<T>(genericType);
+  return json.decode(callParametersJson) as List;
 }

--- a/test/apollovm_wasm_test.dart
+++ b/test/apollovm_wasm_test.dart
@@ -951,6 +951,8 @@ Future<void> _testWasm({
 
   final wasmRuntime = WasmRuntime();
 
+  wasmRuntime.ensureBooted();
+
   if (wasmRuntime.isSupported) {
     print(">> Running compiled Wasm...");
 
@@ -1017,7 +1019,9 @@ Future<void> _testWasm({
       print('>>>>>>>>>>>>>>>>>>>>>>>>>>>>');
     }
   } else {
-    print('** `WasmRuntime` not supported: ${wasmRuntime.platformVersion}');
+    print(
+      '** `WasmRuntime` not supported: ${wasmRuntime.platformVersion}\n** [LAST BOOT ERROR]: ${wasmRuntime.lastBootError}',
+    );
   }
 
   expect(expectedWasmBytes, isNotNull, reason: "Null `expectedWasmBytes`");


### PR DESCRIPTION
- CI:
  - `.github/workflows/dart.yml`: updated `actions/checkout` from v3 to v6 and `codecov/codecov-action` from v3 to v5.

- `apollovm.dart`:
  - Exported new utility file `src/apollovm_utils.dart`.

- `apollovm_runner.dart`:
  - `ApolloRunner`:
    - `executeClassMethod`: changed to async, added parameter normalization before execution.
    - Added `normalizeParameters` method to normalize positional and named parameters against AST function declarations.
    - `executeFunction`: added parameter normalization for top-level functions.
    - Improved parameter handling for function execution.

- `apollovm_utils.dart` (new):
  - Added utilities for generic typed list conversion and case-insensitive map key lookup.
  - Extensions on `List` for typed list creation and on `Map` for case-insensitive key lookup.

- `apollovm_ast_toplevel.dart`:
  - `ASTFunctionDeclaration`:
    - Added `normalizeParameters`, `normalizePositionalParameters`, and `normalizeNamedParameters` methods to convert and normalize parameters according to function declarations.
  - Added extension `IterableASTFunctionDeclarationExtension` with `resolveBestMatchBySignature` to select best matching function overload by parameter signature.

- `apollovm_ast_type.dart`:
  - `ASTType`:
    - Added `fromType` factory to create ASTType from Dart `Type`.
    - Added `toASTValue` method to convert native values to ASTValue according to type.
  - Added `toASTValue` overrides in primitive and collection types (`ASTTypeBool`, `ASTTypeNum`, `ASTTypeInt`, `ASTTypeDouble`, `ASTTypeString`, `ASTTypeNull`, `ASTTypeVoid`, `ASTTypeArray`, `ASTTypeArray2D`, `ASTTypeMap`, `ASTTypeFuture`).
  - Added static `fromType` methods for `ASTTypeArray` and `ASTTypeMap` to create instances from Dart generic types.
  - `ASTTypeArray` and `CoreClassList`:
    - Added typed singleton instances for common generic types (e.g., `List<String>`, `List<int>`, etc.).
    - Added factory constructors and `fromType` methods to resolve types generically.
  - `ASTTypeMap`:
    - Added `fromType` method for common map generic types.
  - `ASTTypeFuture`:
    - Added `toASTValue` override to handle conversion from native or future values.

- `apollovm_ast_value.dart`:
  - `ASTValue.from` factory:
    - Added support for `ASTTypeBool` to create `ASTValueBool`.

- `apollovm_core_base.dart`:
  - `ApolloVMCore.getClass`:
    - Added optional `generics` parameter.
    - `List` class resolution now uses `CoreClassList.fromType` with generic type.
  - `CoreClassList`:
    - Converted to generic class `CoreClassList<T>`.
    - Added typed singleton instances for common generic types.
    - Added `fromType` static method to resolve generic list classes.
    - Constructor updated to accept generic type and resolve `ASTTypeArray` accordingly.

- `wasm_runner.dart`:
  - `ApolloRunnerWasm`:
    - Added parameter normalization before calling Wasm functions.

- `wasm_runtime.dart`:
  - Added `ensureBooted()` method and `lastBootError` getter to `WasmRuntime` interface.

- `wasm_runtime_dart_html.dart`, `wasm_runtime_generic.dart`, `wasm_runtime_web.dart`:
  - Implemented `ensureBooted()` as no-op and `lastBootError` as null.

- `wasm_runtime_io.dart`:
  - Added boot logic with error capture.
  - Implemented `ensureBooted()` to call boot.
  - Added `lastBootError` getter.

- Tests (`apollovm_languages_test_definition.dart`):
  - Updated `_parseJsonList` to return untyped `List` without generic type conversion.
  - Removed redundant generic list conversion helpers from test file.
  - Updated tests to call `.toListOfType()` extension for typed list checks.

- Tests (`apollovm_wasm_test.dart`):
  - Added call to `wasmRuntime.ensureBooted()` before checking support.
  - On unsupported runtime, print last boot error for diagnostics.