### PR TITLE
v0.1.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## 0.1.9
+
+- `ASTExpressionListLiteral`:
+  - `resolveType`: updated to return `ASTTypeArray` of the specified type or deduced common element type.
+  - `children`: fixed to include `type` correctly.
+
+- `ASTStatementVariableDeclaration`:
+  - Constructor enhanced to handle `ASTExpressionListLiteral` values with type adjustments or cast exceptions.
+
+- `ASTStatementForEach`:
+  - Added `variableType` field.
+  - Constructor updated to accept `variableType`.
+
+- `ASTType`:
+  - Added `commonType` method to find common compatible type between two types.
+
+- `ASTTypeArray`:
+  - `toValue`: improved to cast `ASTValueArray` to correct generic type if needed.
+
+- `ASTValueArray`:
+  - Added `cast` method to convert to another generic type with optional component type.
+
+- Dart grammar (`dart_grammar.dart`):
+  - `statementForEach` parser updated to parse explicit variable type before variable name.
+  - `expressionListLiteral` parser updated to infer common element type if not specified.
+
+- Java11 grammar (`java11_grammar.dart`):
+  - `statementForEach` parser updated to parse explicit variable type before variable name.
+
+- Tests:
+  - Added Dart test for `findMax(List<int> numbers)` function with multiple test cases including empty list handling.
+
 ## 0.1.8
 
 - `ASTStatementForEach`:
@@ -19,14 +51,6 @@
 
 - Java language grammar (`java11_grammar.dart`):
   - Added parser `statementForEach` to parse Java-style for-each loops (`for (Type var : iterable) { ... }`).
-
-- WebAssembly generator (`wasm_generator.dart`):
-  - Added stub `generateASTStatementForEach` method throwing `UnimplementedError`.
-  - Updated `generateASTStatement` to dispatch to `generateASTStatementForEach`.
-
-- Tests (`apollovm_languages_basic_test.dart`):
-  - Added new Dart test `dart_basic_findMax.test.xml` demonstrating usage of for-each loop to find max in a list.
-  - Test includes source, call, expected output, and generated source code verification.
 
 ## 0.1.7
 

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -35,7 +35,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.8';
+  static final String VERSION = '0.1.9';
 
   static int _idCount = 0;
 

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -235,8 +235,16 @@ class ASTExpressionListLiteral extends ASTExpression {
   Iterable<ASTNode> get children => [?type, ...valuesExpressions];
 
   @override
-  FutureOr<ASTType> resolveType(VMContext? context) =>
-      ASTExpression.typeFromExpressions(valuesExpressions);
+  FutureOr<ASTType> resolveType(VMContext? context) {
+    final type = this.type;
+    if (type != null) {
+      return ASTTypeArray(type);
+    }
+
+    return ASTExpression.typeFromExpressions(
+      valuesExpressions,
+    ).resolveMapped((elementsType) => ASTTypeArray(elementsType));
+  }
 
   @override
   ASTNode? getNodeIdentifier(String name, {ASTNode? requester}) =>

--- a/lib/src/ast/apollovm_ast_statement.dart
+++ b/lib/src/ast/apollovm_ast_statement.dart
@@ -563,7 +563,36 @@ class ASTStatementVariableDeclaration<V> extends ASTStatementTyped {
 
   ASTExpression? value;
 
-  ASTStatementVariableDeclaration(this.type, this.name, this.value);
+  ASTStatementVariableDeclaration(this.type, this.name, this.value) {
+    final value = this.value;
+
+    if (value is ASTExpressionListLiteral) {
+      var valueComponentType = value.type;
+      if (valueComponentType != null) {
+        // Resolve the type of the list literal:
+        var valueType = value.resolveType(null);
+
+        // If the resolved type is valid but NOT directly assignable
+        // to the declared variable type, attempt to fix or reject it
+        if (valueType is ASTType && !type.acceptsType(valueType)) {
+          var typeGenerics = type.generics?.firstOrNull;
+          if (typeGenerics != null && valueType.acceptsType(type)) {
+            var value2 = ASTExpressionListLiteral(
+              typeGenerics,
+              value.valuesExpressions,
+            );
+            // Replace the original value with the adjusted one
+            this.value = value2;
+          } else {
+            // Types are incompatible → fail fast
+            throw ApolloVMCastException(
+              "Can't cast value type ($valueType) to variable type ($type)",
+            );
+          }
+        }
+      }
+    }
+  }
 
   @override
   Iterable<ASTNode> get children => [type, ?value];
@@ -943,11 +972,13 @@ class ASTStatementForLoop extends ASTStatement {
 }
 
 class ASTStatementForEach extends ASTStatement {
+  final ASTType variableType;
   final String variableName;
   final ASTExpression iterableExpression;
   final ASTBlock loopBlock;
 
   ASTStatementForEach(
+    this.variableType,
     this.variableName,
     this.iterableExpression,
     this.loopBlock,

--- a/lib/src/ast/apollovm_ast_type.dart
+++ b/lib/src/ast/apollovm_ast_type.dart
@@ -261,6 +261,18 @@ class ASTType<V> with ASTNode implements ASTTypedNode {
     return true;
   }
 
+  ASTType? commonType(ASTType? other) {
+    if (other == null || identical(this, other)) return this;
+
+    if (acceptsType(other)) {
+      return this;
+    } else if (other.acceptsType(this)) {
+      return other;
+    }
+
+    return null;
+  }
+
   FutureOr<ASTValue<V>?> toValue(VMContext context, Object? v) {
     if (v == null) return null;
 
@@ -1071,7 +1083,13 @@ class ASTTypeArray<T extends ASTType<V>, V> extends ASTType<List<V>> {
   @override
   FutureOr<ASTValueArray<T, V>?> toValue(VMContext context, Object? v) {
     if (v == null) return null;
-    if (v is ASTValueArray) return v as ASTValueArray<T, V>;
+
+    if (v is ASTValueArray) {
+      if (v is ASTValueArray<T, V>) {
+        return v;
+      }
+      return v.cast<T, V>(componentType: componentType);
+    }
 
     if (v is ASTValue) {
       return v.getValue(context).resolveMapped(_toASTValueArray);

--- a/lib/src/ast/apollovm_ast_value.dart
+++ b/lib/src/ast/apollovm_ast_value.dart
@@ -839,6 +839,15 @@ class ASTValueVoid extends ASTValueStatic<void> {
 class ASTValueArray<T extends ASTType<V>, V> extends ASTValueStatic<List<V>> {
   ASTValueArray(T type, List<V> value) : super(ASTTypeArray<T, V>(type), value);
 
+  ASTValueArray<T2, V2> cast<T2 extends ASTType<V2>, V2>({T2? componentType}) {
+    final value = this.value;
+
+    var t = componentType ?? (type as ASTTypeArray).componentType;
+    var v = value is List<V2> ? (value as List<V2>) : value.cast<V2>();
+
+    return ASTValueArray<T2, V2>(t as T2, v);
+  }
+
   static final ListEquality _listEquality = const ListEquality();
 
   @override

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -211,23 +211,25 @@ class DartGrammarDefinition extends DartGrammarLexer {
   Parser<ASTStatementForEach> statementForEach() =>
       (string('for').trimHidden() &
               char('(').trimHidden() &
-              ref0(_forEachVariableDecl) &
+              type().trimHidden() &
+              ref0(identifier).trimHidden() &
               string('in').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
               codeBlock())
           .map((v) {
-            var variableName = v[2]; // from _forEachVariableDecl
-            var iterableExp = v[4];
-            var block = v[6];
+            var variableType = v[2];
+            var variableName = v[3];
+            var iterableExp = v[5];
+            var block = v[7];
 
-            return ASTStatementForEach(variableName, iterableExp, block);
+            return ASTStatementForEach(
+              variableType,
+              variableName,
+              iterableExp,
+              block,
+            );
           });
-
-  Parser<String> _forEachVariableDecl() =>
-      ((string('var') | string('final')).trimHidden().optional() &
-              ref0(identifier))
-          .map((v) => v[1]);
 
   Parser<ASTStatementReturn> statementReturn() =>
       (string('return').trimHidden() &
@@ -578,13 +580,29 @@ class DartGrammarDefinition extends DartGrammarLexer {
               char(',').trimHidden().optional() &
               char(']').trimHidden())
           .map((v) {
-            var type = (v[0]?[1] as ASTType?) ?? ASTTypeDynamic.instance;
+            var type = v[0]?[1] as ASTType?;
             var v0 = v[2];
             var tail = (v[3] as List?) ?? [];
 
-            var vs = tail.expand((e) => e).whereType<ASTExpression>().toList();
+            var vs = <ASTExpression>[
+              v0,
+              ...tail.expand((e) => e).whereType<ASTExpression>(),
+            ];
 
-            return ASTExpressionListLiteral(type, [v0, ...vs]);
+            if (type == null) {
+              var vsTypeResolving = vs.map((e) => e.resolveType(null)).toList();
+              var vsTypes = vsTypeResolving.whereType<ASTType>().toList();
+              if (vsTypes.length == vsTypeResolving.length) {
+                var commonType = vsTypes.isEmpty
+                    ? ASTTypeDynamic.instance
+                    : vsTypes.reduce(
+                        (a, b) => a.commonType(b) ?? ASTTypeDynamic.instance,
+                      );
+                type = commonType;
+              }
+            }
+
+            return ASTExpressionListLiteral(type, vs);
           });
 
   Parser<ASTExpressionMapLiteral> expressionMapEmptyLiteral() =>

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -211,17 +211,24 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
   Parser<ASTStatementForEach> statementForEach() =>
       (string('for').trimHidden() &
               char('(').trimHidden() &
+              type().trimHidden() &
               ref0(identifier) &
               char(':').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
               codeBlock())
           .map((v) {
+            var variableType = v[2];
             var variableName = v[3];
             var iterableExp = v[5];
             var block = v[7];
 
-            return ASTStatementForEach(variableName, iterableExp, block);
+            return ASTStatementForEach(
+              variableType,
+              variableName,
+              iterableExp,
+              block,
+            );
           });
 
   Parser<ASTStatementReturn> statementReturn() =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, JavaScript with on-the-fly Wasm compilation.
-version: 0.1.8
+version: 0.1.9
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/apollovm_languages_basic_test.dart
+++ b/test/apollovm_languages_basic_test.dart
@@ -8,7 +8,107 @@ Future<void> main() async {
   var definitions = <TestDefinition>[
     TestDefinition('dart_basic_findMax.test.xml', r'''
 <?xml version="1.0" encoding="UTF-8"?>
-<test title="Basic sumOfEvens(List<int> numbers)">
+<test title="Basic findMax(List<int> numbers)">
+    <source language="dart">
+        <![CDATA[
+ void findMax(List<int> numbers) {
+  if (numbers.isEmpty) {
+    print("The list is empty.");
+    return;
+  }
+
+  // Start by assuming the first element is the maximum
+  var max = numbers[0];
+
+  // Iterate through the rest of the list to find the actual maximum
+  for (var number in numbers) {
+    if (number > max) {
+      max = number;
+    }
+  }
+
+  print('The list is: $numbers');
+  print('The maximum number in the list is: $max');
+}
+
+void main() {
+  // Test Case 1: Positive and negative numbers
+  List<int> data1 = [10, 5, 22, 8, 30, 9];
+  findMax(data1);
+  print('---');
+   
+  // Test Case 2: List with only one element
+  List<int> data2 = [42];
+  findMax(data2);
+  print('---');
+  
+  // Test Case 3: Empty list (edge case handling)
+  List<int> data3 = <int>[];
+  findMax(data3);
+  
+  // Test Case 4: Empty list (not typed)
+  List<int> data4 = [];
+  findMax(data4);  
+}
+
+        ]]>
+    </source>
+    <call function="main">
+        []
+    </call>
+    <output>
+        [
+          "The list is: [10, 5, 22, 8, 30, 9]",
+          "The maximum number in the list is: 30",
+          "---",
+          "The list is: [42]",
+          "The maximum number in the list is: 42",
+          "---",
+          "The list is empty.",
+          "The list is empty."
+        ]
+    </output>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  void findMax(List<int> numbers) {
+    if (numbers.isEmpty) {
+        print('The list is empty.');
+        return;
+    }
+
+    var max = numbers[0];
+    for (var number in numbers) {
+      if (number > max) {
+          max = number;
+      }
+
+    }
+    print('The list is: $numbers');
+    print('The maximum number in the list is: $max');
+  }
+
+  void main() {
+    List<int> data1 = <int>[10, 5, 22, 8, 30, 9];
+    findMax(data1);
+    print('---');
+    List<int> data2 = <int>[42];
+    findMax(data2);
+    print('---');
+    List<int> data3 = <int>[];
+    findMax(data3);
+    List<int> data4 = <int>[];
+    findMax(data4);
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>
+    '''),
+    TestDefinition('dart_basic_findMax.test.xml', r'''
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Basic findMax(List<int> numbers)">
     <source language="dart">
         <![CDATA[
 int findMax(List<int> numbers) {
@@ -121,7 +221,7 @@ int sumOfEvens(List<int> numbers) {
     '''),
     TestDefinition('dart_basic_fizzBuzz.test.xml', r'''
 <?xml version="1.0" encoding="UTF-8"?>
-<test title="Basic sumOrDouble(int a, int b)">
+<test title="Basic fizzBuzz(int n)">
     <source language="dart">
         <![CDATA[
 void fizzBuzz(int n) {
@@ -815,5 +915,9 @@ class Foo {
     '''),
   ];
 
-  await runTestDefinitions([definitions[0]]);
+  await runTestDefinitions(
+    // [definitions[0]],
+    //definitions.sublist(1)
+    definitions,
+  );
 }


### PR DESCRIPTION
- `ASTExpressionListLiteral`:
  - `resolveType`: updated to return `ASTTypeArray` of the specified type or deduced common element type.
  - `children`: fixed to include `type` correctly.

- `ASTStatementVariableDeclaration`:
  - Constructor enhanced to handle `ASTExpressionListLiteral` values with type adjustments or cast exceptions.

- `ASTStatementForEach`:
  - Added `variableType` field.
  - Constructor updated to accept `variableType`.

- `ASTType`:
  - Added `commonType` method to find common compatible type between two types.

- `ASTTypeArray`:
  - `toValue`: improved to cast `ASTValueArray` to correct generic type if needed.

- `ASTValueArray`:
  - Added `cast` method to convert to another generic type with optional component type.

- Dart grammar (`dart_grammar.dart`):
  - `statementForEach` parser updated to parse explicit variable type before variable name.
  - `expressionListLiteral` parser updated to infer common element type if not specified.

- Java11 grammar (`java11_grammar.dart`):
  - `statementForEach` parser updated to parse explicit variable type before variable name.

- Tests:
  - Added Dart test for `findMax(List<int> numbers)` function with multiple test cases including empty list handling.