### PR TITLE
v0.1.12 - Feature: add support for class constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,80 @@
+## 0.1.12
+
+- `ASTInvocableDeclaration`:
+  - Replaced `ASTFunctionDeclaration` with generic `ASTInvocableDeclaration` for function and constructor declarations.
+  - Added `ASTClassConstructorDeclaration` for class constructors with support for `this` parameters.
+  - Added `resolveRuntimeType` method to support runtime type resolution with context and node.
+  - Updated `call` and `run` methods to support async and context-aware execution.
+  - Added `initializeVariables` for constructor variable initialization.
+
+- `ASTParametersDeclaration`:
+  - Made generic over parameter type `P`.
+  - Added `ASTConstructorParametersDeclaration` and `ASTFunctionParametersDeclaration` subclasses.
+  - Updated parameter accessors and type checks to use generic parameter type.
+
+- `ASTParameterDeclaration`:
+  - Added `ASTConstructorParameterDeclaration` with `thisParameter` flag.
+  - Added extensions for filtering `this` parameters.
+
+- `ASTFunctionSet` and `ASTConstructorSet`:
+  - Introduced generic base `ASTInvokableSet` with single and multiple implementations.
+  - Added `ASTConstructorSet` for constructors, similar to function sets.
+
+- `ASTClassNormal`:
+  - Added support for constructors with `ASTConstructorSet`.
+  - Added methods to add, get, and check constructors by name and signature.
+  - Updated `resolveNode` to resolve constructors.
+
+- `ASTRoot`:
+  - Updated `getFunction` to return constructors if matching class name and signature.
+
+- `ASTExpression` and `ASTValue`:
+  - Added `resolveRuntimeType` and `getHashcodeValue` methods for runtime type and value hashing.
+  - Updated equality and hashCode to use `getHashcodeValue`.
+
+- `ASTExpressionFunctionInvocation` and subclasses:
+  - Updated to use `ASTInvocableDeclaration` for function retrieval.
+  - Updated `run` method to support async and context-aware invocation.
+
+- `ASTExpressionObjectGetterAccess`:
+  - Updated getter retrieval and runtime type resolution to support async and context-aware evaluation.
+  - Added `_runGetter` helper for getter invocation.
+
+- `ASTStatementVariableDeclaration`:
+  - Added `unmodifiable` flag.
+  - Updated type resolution and run implementation to use `resolveRuntimeType`.
+
+- `ASTType`:
+  - Added `ASTTypeConstructorThis` singleton for constructor `this` parameter.
+  - Added `resolveRuntimeType` method.
+
+- `ASTVariable`:
+  - Added `resolveRuntimeType` method.
+
+- `CorePackageBase` and `CoreClassMixin`:
+  - Updated external function and class function creation to use `ASTFunctionParametersDeclaration`.
+
+- `CoreClassList`:
+  - Added `first` and `last` getters with runtime component type resolution.
+  - Added empty constructor list and related methods.
+
+- `DartGrammarDefinition` and `Java11GrammarDefinition`:
+  - Added parsing support for class constructors with parameters and optional blocks.
+  - Updated function and constructor parameter parsing to use `ASTFunctionParametersDeclaration` and `ASTConstructorParametersDeclaration`.
+  - Added parsing for `this` constructor parameters.
+
+- `ApolloCodeGeneratorDart` and `ApolloCodeGeneratorJava11`:
+  - Added `generateASTClassConstructorDeclaration` method to generate constructor code.
+  - Updated function parameter generation to use generic parameter declaration.
+
+- `ApolloParserWasm`:
+  - Updated WASM function parsing to use `ASTFunctionParametersDeclaration`.
+
+- `Test`:
+  - Added new test `dart_basic_linearRegression.test.xml` with Dart source for linear regression and forecast.
+  - Added new test `dart_basic_calculateShippingCost.test.xml` for shipping cost calculation.
+  - Updated test runner to include new tests.
+
 ## 0.1.11
 
 - `ASTValueNum`:

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -35,7 +35,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.11';
+  static final String VERSION = '0.1.12';
 
   static int _idCount = 0;
 
@@ -580,7 +580,7 @@ class CodeNamespace {
 
   /// Returns a function with [fName] and [parametersSignature]
   /// (using [context] if needed).
-  ASTFunctionDeclaration? getFunction(
+  ASTInvocableDeclaration? getFunction(
     String fName,
     ASTFunctionSignature parametersSignature,
     VMContext context, {
@@ -737,7 +737,7 @@ class ApolloExternalFunctionMapper {
     String fName,
     Function() f,
   ) {
-    var fParameters = ASTParametersDeclaration(null, null, null);
+    var fParameters = ASTFunctionParametersDeclaration(null, null, null);
 
     var fExternal = ASTExternalFunction(fName, fParameters, fReturn, f);
 
@@ -752,7 +752,7 @@ class ApolloExternalFunctionMapper {
     String pName1,
     Function(T p1) f,
   ) {
-    var fParameters = ASTParametersDeclaration(
+    var fParameters = ASTFunctionParametersDeclaration(
       [ASTFunctionParameterDeclaration(pType1, pName1, 0, false)],
       null,
       null,
@@ -773,7 +773,7 @@ class ApolloExternalFunctionMapper {
     String pName2,
     Function(A p1, B p2) f,
   ) {
-    var fParameters = ASTParametersDeclaration(
+    var fParameters = ASTFunctionParametersDeclaration(
       [
         ASTFunctionParameterDeclaration(pType1, pName1, 0, false),
         ASTFunctionParameterDeclaration(pType2, pName2, 1, false),
@@ -799,7 +799,7 @@ class ApolloExternalFunctionMapper {
     String pName3,
     Function(A p1, B p2) f,
   ) {
-    var fParameters = ASTParametersDeclaration(
+    var fParameters = ASTFunctionParametersDeclaration(
       [
         ASTFunctionParameterDeclaration(pType1, pName1, 0, false),
         ASTFunctionParameterDeclaration(pType2, pName2, 1, false),
@@ -828,7 +828,7 @@ class ApolloExternalFunctionMapper {
     String pName4,
     Function(A p1, B p2) f,
   ) {
-    var fParameters = ASTParametersDeclaration(
+    var fParameters = ASTFunctionParametersDeclaration(
       [
         ASTFunctionParameterDeclaration(pType1, pName1, 0, false),
         ASTFunctionParameterDeclaration(pType2, pName2, 1, false),
@@ -1043,7 +1043,7 @@ class VMContext {
   /// Returns a function of [name] and [parametersSignature]
   ///
   /// If [parent] is defined, will also look in the parent context.
-  ASTFunctionDeclaration? getFunction(
+  ASTInvocableDeclaration? getFunction(
     String name,
     ASTFunctionSignature parametersSignature,
   ) {
@@ -1094,6 +1094,9 @@ class VMContext {
 
     return null;
   }
+
+  @override
+  String toString() => 'VMContext@$block';
 }
 
 /// When an error happens while executing some code ([ASTNode]).

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -115,6 +115,12 @@ abstract class ApolloCodeGenerator
       if (block.fields.isNotEmpty) {
         out.write('\n');
       }
+
+      for (var constructor in block.constructors) {
+        for (var c in constructor.functions) {
+          generateASTClassConstructorDeclaration(c, out: out, indent: indent2);
+        }
+      }
     }
 
     for (var set in block.functions) {
@@ -147,6 +153,13 @@ abstract class ApolloCodeGenerator
   @override
   StringBuffer generateASTClassField(
     ASTClassField field, {
+    StringBuffer? out,
+    String indent = '',
+  });
+
+  @override
+  StringBuffer generateASTClassConstructorDeclaration(
+    ASTClassConstructorDeclaration constructor, {
     StringBuffer? out,
     String indent = '',
   });
@@ -187,11 +200,17 @@ abstract class ApolloCodeGenerator
   }) {
     out ??= newOutput();
 
-    var typeStr = generateASTType(parameter.type);
+    if (parameter is ASTConstructorParameterDeclaration &&
+        parameter.thisParameter) {
+      out.write('this.');
+    } else {
+      var typeStr = generateASTType(parameter.type);
+      out.write(typeStr);
+      out.write(' ');
+    }
 
-    out.write(typeStr);
-    out.write(' ');
     out.write(parameter.name);
+
     return out;
   }
 

--- a/lib/src/apollovm_generator.dart
+++ b/lib/src/apollovm_generator.dart
@@ -72,6 +72,11 @@ abstract class ApolloGenerator<
 
   O generateASTClassField(ASTClassField field, {O? out});
 
+  O generateASTClassConstructorDeclaration(
+    ASTClassConstructorDeclaration constructor, {
+    O? out,
+  });
+
   O generateASTClassFunctionDeclaration(
     ASTClassFunctionDeclaration f, {
     O? out,

--- a/lib/src/apollovm_runner.dart
+++ b/lib/src/apollovm_runner.dart
@@ -162,7 +162,7 @@ abstract class ApolloRunner implements VMTypeResolver {
   ///
   /// - [positionalParameters] and [namedParameters] are used to
   /// determine the method parameters signature.
-  FutureOr<ASTFunctionDeclaration?> getClassMethod(
+  FutureOr<ASTInvocableDeclaration?> getClassMethod(
     String namespace,
     String className,
     String methodName, [
@@ -273,18 +273,18 @@ abstract class ApolloRunner implements VMTypeResolver {
   ///
   /// - [positionalParameters] and [namedParameters] are used to
   /// determine the function parameters signature.
-  FutureOr<ASTFunctionDeclaration?> getFunction(
+  FutureOr<ASTInvocableDeclaration?> getFunction(
     String namespace,
     String functionName, [
     List? positionalParameters,
     Map? namedParameters,
-  ]) async {
+  ]) {
     var codeNamespace = _languageNamespaces.get(namespace);
 
     var codeUnit = codeNamespace.getCodeUnitWithFunction(functionName);
     if (codeUnit == null) return null;
 
-    return await codeUnit.root!.getFunctionWithParameters(
+    return codeUnit.root!.getFunctionWithParameters(
       functionName,
       positionalParameters,
       namedParameters,

--- a/lib/src/ast/apollovm_ast_base.dart
+++ b/lib/src/ast/apollovm_ast_base.dart
@@ -114,6 +114,9 @@ class ASTRunStatus {
 abstract class ASTTypedNode {
   FutureOr<ASTType> resolveType(VMContext? context);
 
+  FutureOr<ASTType> resolveRuntimeType(VMContext context, ASTNode? node) =>
+      resolveType(context);
+
   void associateToType(ASTTypedNode node) {}
 }
 

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -60,7 +60,41 @@ abstract class ASTExpression with ASTNode implements ASTCodeRunner {
   }
 
   @override
+  FutureOr<ASTType> resolveRuntimeType(VMContext context, ASTNode? node) {
+    return resolveType(context).resolveMapped((resolvedType) {
+      if (node == null) return resolvedType;
+
+      if (node is ASTTypedNode) {
+        var typedNode = node as ASTTypedNode;
+
+        return typedNode.resolveRuntimeType(context, null).resolveMapped((
+          nodeType,
+        ) {
+          if (resolvedType != nodeType && resolvedType.acceptsType(nodeType)) {
+            return nodeType;
+          }
+          return resolvedType;
+        });
+      }
+
+      return resolvedType;
+    });
+  }
+
+  @override
   void associateToType(ASTTypedNode node) {}
+
+  FutureOr<Object?> getHashcodeValue(VMContext? context) {
+    if (context != null) {
+      var res = run(
+        context,
+        ASTRunStatus(),
+      ).resolveMapped((result) => result.getValue(context));
+      return res;
+    } else {
+      return '$this';
+    }
+  }
 
   bool get hasLiteralString =>
       children.whereType<ASTExpressionLiteral>().any((e) => e.isLiteralString);
@@ -173,6 +207,11 @@ class ASTExpressionNullValue extends ASTExpression {
   }
 
   @override
+  FutureOr<Object?> getHashcodeValue(VMContext? context) {
+    return null;
+  }
+
+  @override
   String toString({bool asGroup = false}) {
     return 'null';
   }
@@ -243,6 +282,11 @@ class ASTExpressionLiteral extends ASTExpression {
   }
 
   @override
+  FutureOr<Object?> getHashcodeValue(VMContext? context) {
+    return value.getHashcodeValue(context);
+  }
+
+  @override
   String toString({bool asGroup = false}) {
     return '$value';
   }
@@ -302,6 +346,11 @@ class ASTExpressionListLiteral extends ASTExpression {
             });
       });
     });
+  }
+
+  @override
+  FutureOr<Object?> getHashcodeValue(VMContext? context) {
+    return valuesExpressions.map((e) => e.getHashcodeValue(context)).toList();
   }
 
   @override
@@ -383,6 +432,18 @@ class ASTExpressionMapLiteral extends ASTExpression {
         });
       });
     });
+  }
+
+  @override
+  FutureOr<Object?> getHashcodeValue(VMContext? context) {
+    return entriesExpressions
+        .map(
+          (e) => (
+            e.key.getHashcodeValue(context),
+            e.value.getHashcodeValue(context),
+          ),
+        )
+        .toList();
   }
 
   @override
@@ -645,6 +706,39 @@ class ASTExpressionOperation extends ASTExpression {
         {
           var retT1 = expression1.resolveType(context);
           var retT2 = expression2.resolveType(context);
+
+          return retT1.resolveBoth(
+            retT2,
+            (t1, t2) => _resolveTypePair(t1, t2, context),
+          );
+        }
+      case ASTExpressionOperator.divideAsInt:
+        return ASTTypeInt.instance;
+      case ASTExpressionOperator.divideAsDouble:
+        return ASTTypeDouble.instance;
+      case ASTExpressionOperator.equals:
+      case ASTExpressionOperator.notEquals:
+      case ASTExpressionOperator.greater:
+      case ASTExpressionOperator.greaterOrEq:
+      case ASTExpressionOperator.lower:
+      case ASTExpressionOperator.lowerOrEq:
+      case ASTExpressionOperator.and:
+      case ASTExpressionOperator.or:
+        return ASTTypeBool.instance;
+    }
+  }
+
+  @override
+  FutureOr<ASTType> resolveRuntimeType(VMContext context, ASTNode? node) {
+    switch (operator) {
+      case ASTExpressionOperator.add:
+      case ASTExpressionOperator.subtract:
+      case ASTExpressionOperator.multiply:
+      case ASTExpressionOperator.divide:
+      case ASTExpressionOperator.remainder:
+        {
+          var retT1 = expression1.resolveRuntimeType(context, null);
+          var retT2 = expression2.resolveRuntimeType(context, null);
 
           return retT1.resolveBoth(
             retT2,
@@ -1361,22 +1455,19 @@ abstract class ASTExpressionFunctionInvocation extends ASTExpression {
     return _functionSignature!;
   }
 
-  FutureOr<ASTFunctionDeclaration> _getFunction(VMContext parentContext);
+  FutureOr<ASTInvocableDeclaration> _getFunction(VMContext parentContext);
 
   @override
-  FutureOr<ASTValue> run(
-    VMContext parentContext,
-    ASTRunStatus runStatus,
-  ) async {
-    var f = await _getFunction(parentContext);
-
-    var argumentsValues = await _resolveArgumentsValues(
-      parentContext,
-      runStatus,
-      arguments,
-    );
-
-    return f.call(parentContext, positionalParameters: argumentsValues);
+  FutureOr<ASTValue> run(VMContext parentContext, ASTRunStatus runStatus) {
+    return _getFunction(parentContext).resolveMapped((f) {
+      return _resolveArgumentsValues(
+        parentContext,
+        runStatus,
+        arguments,
+      ).resolveMapped((argumentsValues) {
+        return f.call(parentContext, positionalParameters: argumentsValues);
+      });
+    });
   }
 
   @override
@@ -1385,16 +1476,14 @@ abstract class ASTExpressionFunctionInvocation extends ASTExpression {
   }
 }
 
-Future<List<ASTValue>> _resolveArgumentsValues(
+FutureOr<List<ASTValue>> _resolveArgumentsValues(
   VMContext parentContext,
   ASTRunStatus runStatus,
   List<ASTExpression> arguments,
-) async {
-  var argumentsFuture = arguments.map((e) async {
-    return await e.run(parentContext, runStatus);
-  }).toList();
-
-  var argumentsValues = await Future.wait(argumentsFuture);
+) {
+  var argumentsValues = arguments
+      .map((a) => a.run(parentContext, runStatus))
+      .resolveAll();
   return argumentsValues;
 }
 
@@ -1407,7 +1496,7 @@ class ASTExpressionLocalFunctionInvocation
   bool get isComplex => false;
 
   @override
-  ASTFunctionDeclaration _getFunction(VMContext parentContext) {
+  ASTInvocableDeclaration _getFunction(VMContext parentContext) {
     var fSignature = _getASTFunctionSignature();
     var f = parentContext.getFunction(name, fSignature);
 
@@ -1473,7 +1562,9 @@ class ASTExpressionObjectFunctionInvocation
   }
 
   @override
-  FutureOr<ASTFunctionDeclaration> _getFunction(VMContext parentContext) async {
+  FutureOr<ASTInvocableDeclaration> _getFunction(
+    VMContext parentContext,
+  ) async {
     var clazz = await _getFunctionClass(parentContext);
     var fSignature = _getASTFunctionSignature();
 
@@ -1623,45 +1714,101 @@ class ASTExpressionObjectGetterAccess extends ASTExpressionGetterAccess {
 
   ASTClass? _getterClass;
 
-  FutureOr<ASTClass> _getGetterClass(VMContext parentContext) async {
-    if (_getterClass == null) {
-      var clazz = await _getObjectClass(parentContext);
-      _getterClass = clazz;
+  FutureOr<ASTClass> _getGetterClass(VMContext parentContext) {
+    final clazz = _getterClass;
+
+    if (clazz == null) {
+      return _getObjectClass(parentContext).resolveMapped((clazz) {
+        return _getterClass = clazz;
+      });
     }
-    return _getterClass!;
+
+    return clazz;
   }
 
   @override
-  FutureOr<ASTGetterDeclaration> _getGetter(VMContext parentContext) async {
-    var clazz = await _getGetterClass(parentContext);
+  FutureOr<ASTGetterDeclaration> _getGetter(VMContext parentContext) {
+    return _getGetterClass(parentContext).resolveMapped((clazz) {
+      var g = clazz.getGetter(name, parentContext);
+      if (g == null) {
+        return _getVariableValue(parentContext).resolveMapped((obj) {
+          throw ApolloVMRuntimeError(
+            "Can't find class[${clazz.name}] getter[$name] for object: $obj",
+          );
+        });
+      }
 
-    var g = clazz.getGetter(name, parentContext);
-
-    if (g == null) {
-      var obj = await _getVariableValue(parentContext);
-      throw ApolloVMRuntimeError(
-        "Can't find class[${clazz.name}] getter[$name] for object: $obj",
-      );
-    }
-
-    return g;
+      return g;
+    });
   }
 
   @override
-  FutureOr<ASTValue> run(
-    VMContext parentContext,
-    ASTRunStatus runStatus,
-  ) async {
-    var f = await _getGetter(parentContext);
-
-    var obj = await _getVariableValue(parentContext);
-
-    if (f is ASTClassGetterDeclaration) {
-      return f.objectCall(parentContext, obj);
-    } else {
-      // Static getter call:
-      return f.call(parentContext);
+  FutureOr<ASTType> resolveType(VMContext? context) {
+    if (context == null) {
+      return super.resolveType(context);
     }
+
+    return _getVariableValue(context).resolveMapped((obj) {
+      if (obj is ASTClassInstance) {
+        var classContext = obj.createContext(context);
+        return obj.getField(classContext, name).resolveMapped((fieldValue) {
+          if (fieldValue != null) {
+            return fieldValue.type;
+          }
+          return super.resolveType(context);
+        });
+      }
+
+      return super.resolveType(context);
+    });
+  }
+
+  @override
+  FutureOr<ASTType<dynamic>> resolveRuntimeType(
+    VMContext context,
+    ASTNode? node,
+  ) {
+    return _getVariableValue(context).resolveMapped((obj) {
+      if (obj is ASTClassInstance) {
+        var classContext = obj.createContext(context);
+        return obj.getField(classContext, name).resolveMapped((fieldValue) {
+          if (fieldValue != null) {
+            return fieldValue.type;
+          }
+          return super.resolveRuntimeType(context, node);
+        });
+      }
+
+      return super.resolveRuntimeType(context, node);
+    });
+  }
+
+  @override
+  FutureOr<ASTValue> run(VMContext parentContext, ASTRunStatus runStatus) {
+    return _getVariableValue(parentContext).resolveMapped((obj) {
+      if (obj is ASTClassInstance) {
+        var classContext = obj.createContext(parentContext);
+        return obj.getField(classContext, name).resolveMapped((fieldValue) {
+          if (fieldValue != null) {
+            return fieldValue;
+          }
+          return _runGetter(parentContext, obj);
+        });
+      }
+
+      return _runGetter(parentContext, obj);
+    });
+  }
+
+  FutureOr<ASTValue> _runGetter(VMContext parentContext, ASTValue obj) {
+    return _getGetter(parentContext).resolveMapped((g) {
+      if (g is ASTClassGetterDeclaration) {
+        return g.objectCall(parentContext, obj);
+      } else {
+        // Static getter call:
+        return g.call(parentContext);
+      }
+    });
   }
 
   @override

--- a/lib/src/ast/apollovm_ast_statement.dart
+++ b/lib/src/ast/apollovm_ast_statement.dart
@@ -37,6 +37,10 @@ abstract class ASTStatement with ASTNode implements ASTCodeRunner {
   }
 
   @override
+  FutureOr<ASTType> resolveRuntimeType(VMContext context, ASTNode? node) =>
+      resolveType(context);
+
+  @override
   void associateToType(ASTTypedNode node) {}
 }
 
@@ -173,7 +177,7 @@ class ASTBlock extends ASTStatement {
     return set != null;
   }
 
-  ASTFunctionDeclaration? getFunction(
+  ASTInvocableDeclaration? getFunction(
     String fName,
     ASTFunctionSignature parametersSignature,
     VMContext context, {
@@ -568,7 +572,14 @@ class ASTStatementVariableDeclaration<V> extends ASTStatementTyped {
 
   ASTExpression? value;
 
-  ASTStatementVariableDeclaration(this.type, this.name, this.value) {
+  bool unmodifiable;
+
+  ASTStatementVariableDeclaration(
+    this.type,
+    this.name,
+    this.value, {
+    this.unmodifiable = false,
+  }) {
     final value = this.value;
 
     if (value is ASTExpressionListLiteral) {
@@ -625,7 +636,7 @@ class ASTStatementVariableDeclaration<V> extends ASTStatementTyped {
   ) async {
     var value = this.value;
     if (value != null) {
-      return value.resolveType(parentContext).resolveMapped((
+      return value.resolveRuntimeType(parentContext, value).resolveMapped((
         valueResolvedType,
       ) {
         return _runImpl2(
@@ -656,7 +667,7 @@ class ASTStatementVariableDeclaration<V> extends ASTStatementTyped {
   ) async {
     if (!valueResolvedType.canCastToType(variableResolvedType)) {
       throw ApolloVMRuntimeError(
-        "Can't cast variable type ($variableResolvedType) to type: $type",
+        "Can't cast variable type ($variableResolvedType) to type: $valueResolvedType",
       );
     }
 
@@ -664,7 +675,7 @@ class ASTStatementVariableDeclaration<V> extends ASTStatementTyped {
 
     if (!(await initValue.isInstanceOfAsync(variableResolvedType))) {
       throw ApolloVMRuntimeError(
-        "Can't cast initial ($initValue) value to type: $type",
+        "Can't cast initial ($initValue) value to type: $variableResolvedType",
       );
     }
 

--- a/lib/src/ast/apollovm_ast_toplevel.dart
+++ b/lib/src/ast/apollovm_ast_toplevel.dart
@@ -4,12 +4,12 @@
 
 import 'dart:math' as math;
 
-import '../apollovm_utils.dart';
 import 'package:async_extension/async_extension.dart';
 import 'package:collection/collection.dart'
     show IterableExtension, equalsIgnoreAsciiCase, CombinedListView;
 
 import '../apollovm_base.dart';
+import '../apollovm_utils.dart';
 import '../core/apollovm_core_base.dart';
 import 'apollovm_ast_base.dart';
 import 'apollovm_ast_statement.dart';
@@ -65,7 +65,7 @@ class ASTEntryPointBlock extends ASTBlock {
       if (!f.modifiers.isStatic) {
         if (this is ASTClass) {
           var clazz = this as ASTClass;
-          var classContext = clazz._createContext(typeResolver, rootContext);
+          var classContext = clazz.createContext(typeResolver, rootContext);
           var obj = (await clazz.createInstance(
             classContext,
             ASTRunStatus.dummy,
@@ -114,7 +114,7 @@ class ASTEntryPointBlock extends ASTBlock {
     }
   }
 
-  FutureOr<ASTFunctionDeclaration?> getFunctionWithParameters(
+  FutureOr<ASTInvocableDeclaration?> getFunctionWithParameters(
     String entryFunctionName,
     List? positionalParameters,
     Map? namedParameters, {
@@ -163,7 +163,7 @@ class ASTEntryPointBlock extends ASTBlock {
     VMTypeResolver? typeResolver,
   ) async {
     if (_rootContext == null) {
-      var rootContext = _createContext(typeResolver);
+      var rootContext = createContext(typeResolver);
       var rootStatus = ASTRunStatus();
       _rootContext = rootContext;
 
@@ -190,7 +190,7 @@ class ASTEntryPointBlock extends ASTBlock {
     return _rootContext!;
   }
 
-  VMContext _createContext(VMTypeResolver? typeResolver) =>
+  VMContext createContext(VMTypeResolver? typeResolver) =>
       VMContext(this, typeResolver: typeResolver);
 }
 
@@ -207,10 +207,23 @@ abstract class ASTClass<T> extends ASTEntryPointBlock {
   }
 
   @override
-  VMClassContext _createContext(
+  VMClassContext createContext(
     VMTypeResolver? typeResolver, [
     VMContext? parentContext,
   ]) => VMClassContext(this, parent: parentContext, typeResolver: typeResolver);
+
+  List<ASTConstructorSet> get constructors;
+
+  void resolveNodeConstructors(ASTNode? parentNode);
+
+  List<String> get constructorsNames;
+
+  ASTClassConstructorDeclaration? getConstructor(
+    String fName,
+    ASTFunctionSignature? parametersSignature,
+    VMContext context, {
+    bool caseInsensitive = false,
+  });
 
   List<ASTClassField> get fields;
 
@@ -325,6 +338,7 @@ abstract class ASTClass<T> extends ASTEntryPointBlock {
   void resolveNode(ASTNode? parentNode) {
     super.resolveNode(parentNode);
     resolveNodeFields(parentNode);
+    resolveNodeConstructors(parentNode);
   }
 
   void resolveNodeFields(ASTNode? parentNode);
@@ -336,6 +350,27 @@ class ASTClassPrimitive<T> extends ASTClass<T> {
 
   @override
   void set(ASTBlock? other) {}
+
+  @override
+  List<ASTConstructorSet> get constructors => <ASTConstructorSet>[];
+
+  @override
+  List<String> get constructorsNames => <String>[];
+
+  @override
+  ASTClassConstructorDeclaration? getConstructor(
+    String fName,
+    ASTFunctionSignature? parametersSignature,
+    VMContext context, {
+    bool caseInsensitive = false,
+  }) => null;
+
+  @override
+  void resolveNodeConstructors(ASTNode? parentNode) {
+    for (var c in constructors) {
+      c.resolveNode(this);
+    }
+  }
 
   @override
   List<ASTClassField> get fields => <ASTClassField>[];
@@ -451,9 +486,94 @@ class ASTClassNormal extends ASTClass<VMObject> {
     if (other is ASTClassNormal) {
       _fields.clear();
       addAllFields(other._fields.values);
+
+      _constructors.clear();
+      addAllConstructors(other._constructors.values.expand((e) => e.functions));
     }
 
     super.set(other);
+  }
+
+  final Map<String, ASTConstructorSet> _constructors =
+      <String, ASTConstructorSet>{};
+
+  @override
+  List<ASTConstructorSet> get constructors => _constructors.values.toList();
+
+  @override
+  void resolveNodeConstructors(ASTNode? parentNode) {
+    for (var f in _constructors.values) {
+      f.resolveNode(this);
+    }
+  }
+
+  @override
+  List<String> get constructorsNames => _constructors.keys.toList();
+
+  ASTConstructorSet? getConstructorWithName(
+    String name, {
+    bool caseInsensitive = false,
+  }) {
+    var c = _constructors[name];
+
+    if (c == null && caseInsensitive) {
+      for (var entry in _constructors.entries) {
+        if (equalsIgnoreAsciiCase(entry.key, name)) {
+          c = entry.value;
+          break;
+        }
+      }
+    }
+
+    return c;
+  }
+
+  bool containsConstructorWithName(
+    String name, {
+    bool caseInsensitive = false,
+  }) {
+    var set = getConstructorWithName(name, caseInsensitive: caseInsensitive);
+    return set != null;
+  }
+
+  @override
+  ASTClassConstructorDeclaration? getConstructor(
+    String fName,
+    ASTFunctionSignature? parametersSignature,
+    VMContext context, {
+    bool caseInsensitive = false,
+  }) {
+    var set = getConstructorWithName(fName, caseInsensitive: caseInsensitive);
+    if (set == null) return null;
+
+    if (parametersSignature == null) {
+      return set.firstFunction;
+    } else {
+      return set.get(parametersSignature, false);
+    }
+  }
+
+  void addConstructor(ASTClassConstructorDeclaration constructor) {
+    var name = constructor.name;
+    constructor.parentBlock = this;
+
+    var set = _constructors[name];
+    if (set == null) {
+      _constructors[name] = ASTConstructorSetSingle(constructor);
+    } else {
+      var set2 = set.add(constructor);
+      if (!identical(set, set2)) {
+        _constructors[name] = set2;
+      }
+    }
+  }
+
+  void addAllConstructors(
+    Iterable<ASTClassConstructorDeclaration> constructors,
+  ) {
+    for (var constructor in constructors) {
+      addConstructor(constructor);
+    }
   }
 
   final Map<String, ASTClassField> _fields = <String, ASTClassField>{};
@@ -668,7 +788,7 @@ class ASTClassNormal extends ASTClass<VMObject> {
       fieldName = vmObject.getFieldNameIgnoreCase(fieldName) ?? fieldName;
     }
 
-    var prevValue = vmObject.setFieldValue(name, value, context);
+    var prevValue = vmObject.setFieldValue(fieldName, value, context);
     return prevValue?.getValue(context);
   }
 
@@ -692,6 +812,11 @@ class ASTClassNormal extends ASTClass<VMObject> {
 
     var fieldValue = vmObject.removeFieldValue(fieldName, context);
     return fieldValue;
+  }
+
+  @override
+  String toString() {
+    return 'class $name';
   }
 }
 
@@ -722,6 +847,33 @@ class ASTRoot extends ASTEntryPointBlock {
   }
 
   String namespace = '';
+
+  @override
+  ASTInvocableDeclaration? getFunction(
+    String fName,
+    ASTFunctionSignature parametersSignature,
+    VMContext context, {
+    bool caseInsensitive = false,
+  }) {
+    var set = getFunctionWithName(fName, caseInsensitive: caseInsensitive);
+    if (set != null) return set.get(parametersSignature, false);
+
+    var clazz = getClass(fName);
+    if (clazz != null) {
+      var constructor = clazz.getConstructor('', null, context);
+      if (constructor != null &&
+          constructor.matchesParametersTypes(parametersSignature, false)) {
+        return constructor;
+      }
+    }
+
+    var fExternal = context.getMappedExternalFunction(
+      fName,
+      parametersSignature,
+    );
+
+    return fExternal;
+  }
 
   final Map<String, ASTClassNormal> _classes = <String, ASTClassNormal>{};
 
@@ -781,11 +933,13 @@ class ASTRoot extends ASTEntryPointBlock {
 
 /// An AST Parameter declaration.
 class ASTParameterDeclaration<T> with ASTNode implements ASTTypedNode {
-  final ASTType<T> type;
+  ASTType<T> _type;
+
+  ASTType<T> get type => _type;
 
   final String name;
 
-  ASTParameterDeclaration(this.type, this.name);
+  ASTParameterDeclaration(ASTType<T> type, this.name) : _type = type;
 
   @override
   Iterable<ASTNode> get children => [type];
@@ -795,6 +949,10 @@ class ASTParameterDeclaration<T> with ASTNode implements ASTTypedNode {
 
   @override
   FutureOr<ASTType> resolveType(VMContext? context) => type;
+
+  @override
+  FutureOr<ASTType> resolveRuntimeType(VMContext context, ASTNode? node) =>
+      resolveType(context);
 
   FutureOr<ASTValue<T>?> toValue(VMContext context, Object? v) =>
       type.toValue(context, v);
@@ -821,18 +979,71 @@ class ASTParameterDeclaration<T> with ASTNode implements ASTTypedNode {
   }
 }
 
+extension IterableASTParameterDeclarationExtension<
+  P extends ASTParameterDeclaration
+>
+    on Iterable<P> {
+  Iterable<P> withThisParameter() => where(
+    (p) =>
+        p.type is ASTTypeConstructorThis ||
+        (p is ASTConstructorParameterDeclaration && p.thisParameter),
+  );
+}
+
+class ASTConstructorParameterDeclaration<T> extends ASTParameterDeclaration {
+  final int index;
+
+  final bool optional;
+
+  final bool thisParameter;
+
+  ASTConstructorParameterDeclaration(
+    super.type,
+    super.name,
+    this.index,
+    this.optional, {
+    this.thisParameter = false,
+  });
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+
+    if (identical(type, ASTTypeConstructorThis.instance) &&
+        parentNode is ASTClassConstructorDeclaration) {
+      var parentClass = parentNode.parentClass;
+      var field = parentClass?.getField(name);
+      if (field != null) {
+        _type = field.type;
+      }
+    }
+  }
+
+  ASTFunctionParameterDeclaration toASTFunctionParameterDeclaration() =>
+      ASTFunctionParameterDeclaration(type, name, index, optional);
+}
+
+extension IterableASTConstructorParameterDeclarationExtension
+    on Iterable<ASTConstructorParameterDeclaration> {
+  List<ASTFunctionParameterDeclaration> toASTFunctionParameterDeclaration() =>
+      map((e) => e.toASTFunctionParameterDeclaration()).toList();
+}
+
 /// An AST Function Parameter declaration.
 class ASTFunctionParameterDeclaration<T> extends ASTParameterDeclaration<T> {
   final int index;
 
   final bool optional;
 
+  final bool unmodifiable;
+
   ASTFunctionParameterDeclaration(
     super.type,
     super.name,
     this.index,
-    this.optional,
-  );
+    this.optional, {
+    this.unmodifiable = false,
+  });
 }
 
 /// An AST Function Signature.
@@ -970,58 +1181,24 @@ class ASTFunctionSignature with ASTNode {
   }
 }
 
-/// An AST Function Set.
-abstract class ASTFunctionSet with ASTNode {
+/// Base AST Invokable Set.
+abstract class ASTInvokableSet<
+  P extends ASTParameterDeclaration,
+  PS extends ASTParametersDeclaration<P>,
+  F extends ASTInvocableDeclaration<dynamic, P, PS>
+>
+    with ASTNode {
+  String get invokableTypeName;
+
   String get name => firstFunction.name;
 
-  List<ASTFunctionDeclaration> get functions;
+  List<F> get functions;
 
-  ASTFunctionDeclaration get firstFunction;
+  F get firstFunction;
 
-  ASTFunctionDeclaration get(
-    ASTFunctionSignature parametersSignature,
-    bool exactTypes,
-  );
+  F get(ASTFunctionSignature parametersSignature, bool exactTypes);
 
-  ASTFunctionSet add(ASTFunctionDeclaration f);
-}
-
-/// [ASTFunctionSet] implementation, with 1 entry.
-class ASTFunctionSetSingle extends ASTFunctionSet {
-  final ASTFunctionDeclaration f;
-
-  ASTFunctionSetSingle(this.f);
-
-  @override
-  Iterable<ASTNode> get children => [f];
-
-  @override
-  ASTFunctionDeclaration get firstFunction => f;
-
-  @override
-  List<ASTFunctionDeclaration> get functions => [f];
-
-  @override
-  ASTFunctionDeclaration get(
-    ASTFunctionSignature parametersSignature,
-    bool exactTypes,
-  ) {
-    if (f.matchesParametersTypes(parametersSignature, exactTypes)) {
-      return f;
-    }
-
-    throw StateError(
-      'Function \'${f.name}\' parameters signature not compatible: sign:$parametersSignature != f:${f.parameters}',
-    );
-  }
-
-  @override
-  ASTFunctionSet add(ASTFunctionDeclaration f) {
-    var set = ASTFunctionSetMultiple();
-    set.add(this.f);
-    set.add(f);
-    return set;
-  }
+  ASTInvokableSet<P, PS, F> add(F f);
 
   ASTNode? _parentNode;
 
@@ -1032,41 +1209,82 @@ class ASTFunctionSetSingle extends ASTFunctionSet {
   void resolveNode(ASTNode? parentNode) {
     _parentNode = parentNode;
 
-    f.resolveNode(parentNode);
+    resolveFunctionsNodes(parentNode);
 
     cacheDescendantChildren();
   }
+
+  void resolveFunctionsNodes(ASTNode? parentNode);
 
   @override
   ASTNode? getNodeIdentifier(String name, {ASTNode? requester}) =>
       parentNode?.getNodeIdentifier(name, requester: requester);
 }
 
-/// [ASTFunctionSet] implementation, with multiple entries.
-class ASTFunctionSetMultiple extends ASTFunctionSet {
-  final List<ASTFunctionDeclaration> _functions = <ASTFunctionDeclaration>[];
+/// Base [ASTInvokableSet] implementation, with 1 entry.
+abstract class ASTInvokableSetSingle<
+  P extends ASTParameterDeclaration,
+  PS extends ASTParametersDeclaration<P>,
+  F extends ASTInvocableDeclaration<dynamic, P, PS>
+>
+    extends ASTInvokableSet<P, PS, F> {
+  final F f;
+
+  ASTInvokableSetSingle(this.f);
+
+  @override
+  Iterable<ASTNode> get children => [f];
+
+  @override
+  F get firstFunction => f;
+
+  @override
+  List<F> get functions => [f];
+
+  @override
+  F get(ASTFunctionSignature parametersSignature, bool exactTypes) {
+    if (f.matchesParametersTypes(parametersSignature, exactTypes)) {
+      return f;
+    }
+
+    throw StateError(
+      '$invokableTypeName \'${f.name}\' parameters signature not compatible: sign:$parametersSignature != f:${f.parameters}',
+    );
+  }
+
+  @override
+  void resolveFunctionsNodes(ASTNode? parentNode) {
+    f.resolveNode(parentNode);
+  }
+}
+
+/// Base [ASTInvokableSet] implementation, with multiple entries.
+abstract class ASTInvokableSetMultiple<
+  P extends ASTParameterDeclaration,
+  PS extends ASTParametersDeclaration<P>,
+  F extends ASTInvocableDeclaration<dynamic, P, PS>
+>
+    extends ASTInvokableSet<P, PS, F> {
+  final List<F> _functions = <F>[];
 
   @override
   Iterable<ASTNode> get children => [..._functions];
 
   @override
-  ASTFunctionDeclaration get firstFunction => _functions.first;
+  F get firstFunction => _functions.first;
 
   @override
-  List<ASTFunctionDeclaration> get functions => _functions;
+  List<F> get functions => _functions;
 
   @override
-  ASTFunctionDeclaration get(
-    ASTFunctionSignature parametersSignature,
-    bool exactTypes,
-  ) {
+  F get(ASTFunctionSignature parametersSignature, bool exactTypes) {
     for (var f in _functions) {
       if (f.matchesParametersTypes(parametersSignature, exactTypes)) {
         return f;
       }
     }
 
-    ASTFunctionDeclaration? first;
+    F? first;
     for (var f in _functions) {
       first = f;
       break;
@@ -1076,13 +1294,13 @@ class ASTFunctionSetMultiple extends ASTFunctionSet {
       return first;
     }
 
-    throw StateError(
-      "Can't find function '${first?.name}' with signature: $parametersSignature",
+    throw ApolloVMRuntimeError(
+      "Can't find ${invokableTypeName.toLowerCase()} '${first?.name}' with signature: $parametersSignature",
     );
   }
 
   @override
-  ASTFunctionSet add(ASTFunctionDeclaration f) {
+  ASTInvokableSet<P, PS, F> add(F f) {
     _functions.add(f);
 
     _functions.sort((a, b) {
@@ -1094,34 +1312,156 @@ class ASTFunctionSetMultiple extends ASTFunctionSet {
     return this;
   }
 
-  ASTNode? _parentNode;
-
   @override
-  ASTNode? get parentNode => _parentNode;
-
-  @override
-  void resolveNode(ASTNode? parentNode) {
-    _parentNode = parentNode;
-
+  void resolveFunctionsNodes(ASTNode? parentNode) {
     for (var f in _functions) {
       f.resolveNode(parentNode);
     }
-
-    cacheDescendantChildren();
   }
+}
+
+/// Base AST Function Set.
+abstract class ASTFunctionSet
+    extends
+        ASTInvokableSet<
+          ASTFunctionParameterDeclaration,
+          ASTFunctionParametersDeclaration,
+          ASTFunctionDeclaration
+        > {
+  @override
+  String get invokableTypeName => 'Function';
 
   @override
-  ASTNode? getNodeIdentifier(String name, {ASTNode? requester}) =>
-      parentNode?.getNodeIdentifier(name, requester: requester);
+  ASTFunctionSet add(ASTFunctionDeclaration f);
+}
+
+/// [ASTFunctionSet] implementation, with 1 entry.
+class ASTFunctionSetSingle
+    extends
+        ASTInvokableSetSingle<
+          ASTFunctionParameterDeclaration,
+          ASTFunctionParametersDeclaration,
+          ASTFunctionDeclaration
+        >
+    implements ASTFunctionSet {
+  ASTFunctionSetSingle(super.f);
+
+  @override
+  String get invokableTypeName => 'Function';
+
+  @override
+  ASTFunctionSet add(ASTFunctionDeclaration f) {
+    var set = ASTFunctionSetMultiple();
+    set.add(this.f);
+    set.add(f);
+    return set;
+  }
+}
+
+/// [ASTFunctionSet] implementation, with multiple entries.
+class ASTFunctionSetMultiple
+    extends
+        ASTInvokableSetMultiple<
+          ASTFunctionParameterDeclaration,
+          ASTFunctionParametersDeclaration,
+          ASTFunctionDeclaration
+        >
+    implements ASTFunctionSet {
+  @override
+  String get invokableTypeName => 'Function';
+
+  @override
+  ASTFunctionSet add(ASTFunctionDeclaration f) {
+    super.add(f);
+    return this;
+  }
+}
+
+/// Base AST Constructor Set.
+abstract class ASTConstructorSet
+    extends
+        ASTInvokableSet<
+          ASTConstructorParameterDeclaration,
+          ASTConstructorParametersDeclaration,
+          ASTClassConstructorDeclaration
+        > {
+  @override
+  String get invokableTypeName => 'Constructor';
+
+  @override
+  ASTConstructorSet add(ASTClassConstructorDeclaration c);
+}
+
+/// [ASTConstructorSet] implementation, with 1 entry.
+class ASTConstructorSetSingle
+    extends
+        ASTInvokableSetSingle<
+          ASTConstructorParameterDeclaration,
+          ASTConstructorParametersDeclaration,
+          ASTClassConstructorDeclaration
+        >
+    implements ASTConstructorSet {
+  ASTConstructorSetSingle(super.c);
+
+  @override
+  String get invokableTypeName => 'Constructor';
+
+  @override
+  ASTConstructorSet add(ASTClassConstructorDeclaration c) {
+    var set = ASTConstructorSetMultiple();
+    set.add(f);
+    set.add(c);
+    return set;
+  }
+}
+
+/// [ASTConstructorSet] implementation, with multiple entries.
+class ASTConstructorSetMultiple
+    extends
+        ASTInvokableSetMultiple<
+          ASTConstructorParameterDeclaration,
+          ASTConstructorParametersDeclaration,
+          ASTClassConstructorDeclaration
+        >
+    implements ASTConstructorSet {
+  @override
+  String get invokableTypeName => 'Constructor';
+
+  @override
+  // ignore: avoid_renaming_method_parameters
+  ASTConstructorSet add(ASTClassConstructorDeclaration c) {
+    super.add(c);
+    return this;
+  }
+}
+
+/// An AST Constructor Parameters Declaration
+class ASTConstructorParametersDeclaration
+    extends ASTParametersDeclaration<ASTConstructorParameterDeclaration> {
+  ASTConstructorParametersDeclaration(
+    super.positionalParameters, [
+    super.optionalParameters,
+    super.namedParameters,
+  ]);
+}
+
+/// An AST Function Parameters Declaration
+class ASTFunctionParametersDeclaration
+    extends ASTParametersDeclaration<ASTFunctionParameterDeclaration> {
+  ASTFunctionParametersDeclaration(
+    super.positionalParameters, [
+    super.optionalParameters,
+    super.namedParameters,
+  ]);
 }
 
 /// An AST Parameters Declaration
-class ASTParametersDeclaration {
-  List<ASTFunctionParameterDeclaration>? positionalParameters;
+abstract class ASTParametersDeclaration<P extends ASTParameterDeclaration> {
+  List<P>? positionalParameters;
 
-  List<ASTFunctionParameterDeclaration>? optionalParameters;
+  List<P>? optionalParameters;
 
-  List<ASTFunctionParameterDeclaration>? namedParameters;
+  List<P>? namedParameters;
 
   ASTParametersDeclaration(
     this.positionalParameters, [
@@ -1150,7 +1490,7 @@ class ASTParametersDeclaration {
   }
 
   /// Returns a list with all the [positionalParameters], [optionalParameters] and [namedParameters].
-  List<ASTFunctionParameterDeclaration> get allParameters => [
+  List<P> get allParameters => [
     ...?positionalParameters,
     ...?optionalParameters,
     ...?namedParameters,
@@ -1169,7 +1509,7 @@ class ASTParametersDeclaration {
 
   bool get isNotEmpty => !isEmpty;
 
-  ASTFunctionParameterDeclaration? getParameterByIndex(int index) {
+  P? getParameterByIndex(int index) {
     var positionalParametersSize = this.positionalParametersSize;
 
     if (index < positionalParametersSize) {
@@ -1185,7 +1525,7 @@ class ASTParametersDeclaration {
     return null;
   }
 
-  ASTFunctionParameterDeclaration? getParameterByName(String name) {
+  P? getParameterByName(String name) {
     if (namedParameters != null) {
       var p = namedParameters!.firstWhereOrNull((p) => p.name == name);
       if (p != null) return p;
@@ -1257,7 +1597,7 @@ class ASTParametersDeclaration {
   ///
   /// - [exactType]: if true the [param] should be exact to [type].
   static bool parameterAcceptsType(
-    ASTFunctionParameterDeclaration? param,
+    ASTParameterDeclaration? param,
     ASTType? type,
     bool exactType,
   ) {
@@ -1312,7 +1652,7 @@ class ASTClassFunctionDeclaration<T> extends ASTFunctionDeclaration<T> {
   ASTClassFunctionDeclaration(
     this.clazz,
     String name,
-    ASTParametersDeclaration parameters,
+    ASTFunctionParametersDeclaration parameters,
     ASTType<T> returnType, {
     ASTBlock? block,
     ASTModifiers? modifiers,
@@ -1334,13 +1674,19 @@ class ASTClassFunctionDeclaration<T> extends ASTFunctionDeclaration<T> {
   }
 }
 
-/// An AST Function Declaration.
-class ASTFunctionDeclaration<T> extends ASTBlock {
-  /// Name of this function.
+/// An AST of an invocable block declaration.
+/// See [ASTClassConstructorDeclaration] and [ASTFunctionDeclaration].
+abstract class ASTInvocableDeclaration<
+  T,
+  P extends ASTParameterDeclaration,
+  PS extends ASTParametersDeclaration<P>
+>
+    extends ASTBlock {
+  /// Name of this function/constructor.
   final String name;
 
-  /// Parameters of this function.
-  final ASTParametersDeclaration _parameters;
+  /// Parameters.
+  final PS _parameters;
 
   /// The return type of this function.
   final ASTType<T> returnType;
@@ -1348,7 +1694,7 @@ class ASTFunctionDeclaration<T> extends ASTBlock {
   /// Modifiers of this function.
   final ASTModifiers modifiers;
 
-  ASTFunctionDeclaration(
+  ASTInvocableDeclaration(
     this.name,
     this._parameters,
     this.returnType, {
@@ -1396,15 +1742,13 @@ class ASTFunctionDeclaration<T> extends ASTBlock {
     return super.getNodeIdentifier(name, requester: requester);
   }
 
-  ASTParametersDeclaration get parameters => _parameters;
+  PS get parameters => _parameters;
 
   int get parametersSize => _parameters.size;
 
-  ASTFunctionParameterDeclaration? getParameterByIndex(int index) =>
-      _parameters.getParameterByIndex(index);
+  P? getParameterByIndex(int index) => _parameters.getParameterByIndex(index);
 
-  ASTFunctionParameterDeclaration? getParameterByName(String name) =>
-      _parameters.getParameterByName(name);
+  P? getParameterByName(String name) => _parameters.getParameterByName(name);
 
   FutureOr<ASTValue?> getParameterValueByIndex(VMContext context, int index) {
     var p = getParameterByIndex(index);
@@ -1618,7 +1962,7 @@ class ASTFunctionDeclaration<T> extends ASTBlock {
   }
 
   @override
-  ASTValue run(VMContext parentContext, ASTRunStatus runStatus) {
+  FutureOr<ASTValue> run(VMContext parentContext, ASTRunStatus runStatus) {
     throw UnsupportedError(
       "Can't run this block directly! Should use call(...), since this block needs parameters initialization!",
     );
@@ -1634,9 +1978,13 @@ class ASTFunctionDeclaration<T> extends ASTBlock {
   }
 }
 
-extension IterableASTFunctionDeclarationExtension
-    on Iterable<ASTFunctionDeclaration> {
-  ASTFunctionDeclaration? resolveBestMatchBySignature({
+extension IterableASTFunctionDeclarationExtension<
+  P extends ASTParameterDeclaration,
+  PS extends ASTParametersDeclaration<P>,
+  F extends ASTInvocableDeclaration<dynamic, P, PS>
+>
+    on Iterable<F> {
+  F? resolveBestMatchBySignature({
     List? positionalParameters,
     Map? namedParameters,
   }) {
@@ -1658,6 +2006,170 @@ extension IterableASTFunctionDeclarationExtension
           // Fallback to relaxed match (allowing looser type compatibility)
           firstWhereOrNull((f) => f.matchesParametersTypes(fSignature, false));
     }
+  }
+}
+
+/// An AST Function Declaration.
+class ASTFunctionDeclaration<T>
+    extends
+        ASTInvocableDeclaration<
+          T,
+          ASTFunctionParameterDeclaration,
+          ASTFunctionParametersDeclaration
+        > {
+  ASTFunctionDeclaration(
+    super.name,
+    super._parameters,
+    super.returnType, {
+    super.block,
+    super.modifiers,
+  });
+}
+
+/// An AST Function Declaration.
+class ASTClassConstructorDeclaration<T>
+    extends
+        ASTInvocableDeclaration<
+          T,
+          ASTConstructorParameterDeclaration,
+          ASTConstructorParametersDeclaration
+        > {
+  /// The return type of this function.
+  final ASTType<T> classType;
+
+  ASTClassConstructorDeclaration(
+    this.classType,
+    String name,
+    ASTConstructorParametersDeclaration parameters, {
+    super.block,
+    super.modifiers,
+  }) : super(name, parameters, classType);
+
+  ASTClass? _parentClass;
+
+  ASTClass? get parentClass => _parentClass;
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    if (parentNode is ASTClass) {
+      _parentClass = parentNode;
+    }
+
+    super.resolveNode(parentNode);
+  }
+
+  @override
+  ASTType resolveType(VMContext? context) => classType;
+
+  @override
+  FutureOr<ASTClassInstance<ASTValue<T>>> initializeVariables(
+    VMContext context,
+    List? positionalParameters,
+    Map? namedParameters,
+  ) {
+    final parentClass =
+        this.parentClass ??
+        (throw ApolloVMRuntimeError("`parentClass` not defined!"));
+
+    var classContext = parentClass.createContext(context.typeResolver, context);
+
+    return parentClass
+        .createInstance(classContext, ASTRunStatus.dummy)
+        .resolveMapped((obj) {
+          if (obj == null) {
+            throw ApolloVMRuntimeError(
+              "Can't instantiate class `$classType` instance!",
+            );
+          }
+
+          context.declareVariableWithValue(parentClass.type, 'this', obj);
+
+          return super
+              .initializeVariables(
+                context,
+                positionalParameters,
+                namedParameters,
+              )
+              .resolveMapped((_) {
+                return obj as ASTClassInstance<ASTValue<T>>;
+              });
+        });
+  }
+
+  @override
+  FutureOr<ASTValue<T>> call(
+    VMContext parent, {
+    List? positionalParameters,
+    Map? namedParameters,
+  }) async {
+    var context = VMContext(this, parent: parent);
+
+    var prevContext = VMContext.setCurrent(context);
+    try {
+      var obj = await initializeVariables(
+        context,
+        positionalParameters,
+        namedParameters,
+      );
+
+      final parameters = _parameters;
+
+      var constructorParameters = [
+        ...?parameters.positionalParameters?.withThisParameter(),
+        ...?parameters.optionalParameters?.withThisParameter(),
+        ...?parameters.namedParameters?.withThisParameter(),
+      ];
+
+      if (constructorParameters.isNotEmpty) {
+        var classContext = obj.createContext(context);
+        for (var p in constructorParameters.withThisParameter()) {
+          var variable = await context.getVariable(p.name, false);
+          if (variable != null) {
+            var v = await variable.getValue(context);
+            await obj.setField(classContext, p.name, v);
+          } else if (!p.optional) {
+            throw ApolloVMNullPointerException(
+              "Missing required constructor parameter: $p\n"
+              "Constructor: $this",
+            );
+          }
+        }
+      }
+
+      await run(context, ASTRunStatus());
+
+      return obj as ASTValue<T>;
+    } finally {
+      VMContext.setCurrent(prevContext);
+    }
+  }
+
+  @override
+  FutureOr<ASTValue> run(
+    VMContext parentContext,
+    ASTRunStatus runStatus,
+  ) async {
+    var blockContext = defineRunContext(parentContext);
+
+    FutureOr<ASTValue> returnValue = ASTValueVoid.instance;
+
+    for (var stm in statements) {
+      var ret = await stm.run(blockContext, runStatus);
+
+      if (runStatus.returned) {
+        return (runStatus.returnedFutureValue ?? runStatus.returnedValue)!;
+      }
+
+      returnValue = ret;
+    }
+
+    return returnValue;
+  }
+
+  @override
+  String toString() {
+    var block = super.toString();
+    return '$modifiers $classType.$name($_parameters) $block';
   }
 }
 
@@ -1743,7 +2255,7 @@ class ASTGetterDeclaration<T> extends ASTBlock {
     var prevContext = VMContext.setCurrent(context);
     try {
       var result = await super.run(context, ASTRunStatus());
-      return await resolveReturnValue(context, result);
+      return await resolveReturnValue(context, result, result);
     } finally {
       VMContext.setCurrent(prevContext);
     }
@@ -1751,12 +2263,20 @@ class ASTGetterDeclaration<T> extends ASTBlock {
 
   FutureOr<ASTValue<T>> resolveReturnValue(
     VMContext context,
+    ASTNode? node,
     Object? returnValue,
   ) {
-    var ret = returnType.toValue(context, returnValue);
-    return ret.resolveMapped((resolved) {
-      resolved ??= ASTValueVoid.instance as ASTValue<T>;
-      return resolved;
+    return resolveRuntimeType(
+      context,
+      returnValue is ASTNode ? returnValue : node,
+    ).resolveMapped((runtimeReturnType) {
+      var ret = runtimeReturnType is ASTType<T>
+          ? runtimeReturnType.toValue(context, returnValue)
+          : returnType.toValue(context, returnValue);
+      return ret.resolveMapped((resolved) {
+        resolved ??= ASTValueVoid.instance as ASTValue<T>;
+        return resolved;
+      });
     });
   }
 
@@ -1803,9 +2323,9 @@ class ASTExternalGetter<T> extends ASTGetterDeclaration<T> {
 
       if (result is Future) {
         var r = await result;
-        return await resolveReturnValue(context, r);
+        return await resolveReturnValue(context, null, r);
       } else {
-        return await resolveReturnValue(context, result);
+        return await resolveReturnValue(context, null, result);
       }
     } finally {
       VMContext.setCurrent(prevContext);
@@ -1817,37 +2337,61 @@ class ASTExternalGetter<T> extends ASTGetterDeclaration<T> {
 class ASTExternalClassGetter<T> extends ASTClassGetterDeclaration<T> {
   final Function(Object? o) externalFunction;
 
+  final FutureOr<ASTType> Function(VMContext? context, ASTNode? o)?
+  returnTypeResolver;
+
   ASTExternalClassGetter(
     ASTClass super.clazz,
     super.name,
     super.returnType,
-    this.externalFunction,
-  );
+    this.externalFunction, [
+    this.returnTypeResolver,
+  ]);
+
+  @override
+  FutureOr<ASTType<dynamic>> resolveRuntimeType(
+    VMContext context,
+    ASTNode? node,
+  ) {
+    final returnTypeResolver = this.returnTypeResolver;
+    if (returnTypeResolver != null) {
+      return returnTypeResolver(context, node);
+    }
+
+    return super.resolveRuntimeType(context, node);
+  }
 
   @override
   FutureOr<ASTValue<T>> call(
     VMContext parent, {
     List? positionalParameters,
     Map? namedParameters,
-  }) async {
+  }) {
     var classInstance = parent.getClassInstance();
-    var obj = await classInstance!.getValue(parent);
+    return classInstance!.getValue(parent).resolveMapped((obj) {
+      var context = VMContext(this, parent: parent);
 
-    var context = VMContext(this, parent: parent);
-
-    var prevContext = VMContext.setCurrent(context);
-    try {
-      dynamic result = externalFunction(obj);
-
-      if (result is Future) {
-        var r = await result;
-        return await resolveReturnValue(context, r);
-      } else {
-        return await resolveReturnValue(context, result);
+      var prevContext = VMContext.setCurrent(context);
+      try {
+        dynamic result = externalFunction(obj);
+        if (result is Future) {
+          return result
+              .then((r) => resolveReturnValue(context, classInstance, r))
+              .whenComplete(() => VMContext.setCurrent(prevContext));
+        } else {
+          try {
+            return resolveReturnValue(context, classInstance, result);
+          } finally {
+            VMContext.setCurrent(prevContext);
+          }
+        }
+      } catch (_) {
+        if (identical(VMContext.getCurrent(), context)) {
+          VMContext.setCurrent(prevContext);
+        }
+        rethrow;
       }
-    } finally {
-      VMContext.setCurrent(prevContext);
-    }
+    });
   }
 }
 

--- a/lib/src/ast/apollovm_ast_type.dart
+++ b/lib/src/ast/apollovm_ast_type.dart
@@ -209,6 +209,10 @@ class ASTType<V> with ASTNode implements ASTTypedNode {
   FutureOr<ASTType> resolveType(VMContext? context) => this;
 
   @override
+  FutureOr<ASTType> resolveRuntimeType(VMContext context, ASTNode? node) =>
+      resolveType(context);
+
+  @override
   void associateToType(ASTTypedNode node) {}
 
   /// Returns true if this type has generics.
@@ -775,6 +779,70 @@ class ASTTypeObject extends ASTType<Object> {
   }
 }
 
+/// [ASTType] for constructor `this` parameter declaration.
+class ASTTypeConstructorThis extends ASTType<dynamic> {
+  static final ASTTypeConstructorThis instance = ASTTypeConstructorThis._();
+
+  ASTTypeConstructorThis._() : super('this');
+
+  @override
+  Iterable<ASTNode> get children => [];
+
+  @override
+  bool acceptsType(ASTType type) => true;
+
+  ASTType? _resolvedType;
+
+  @override
+  FutureOr<ASTType> resolveType(VMContext? context) {
+    final resolvedType = _resolvedType;
+    if (resolvedType != null) return resolvedType;
+
+    return _resolveTypeImpl(context).resolveMapped((resolvedType) {
+      _resolvedType = resolvedType;
+      return resolvedType;
+    });
+  }
+
+  FutureOr<ASTType> _resolveTypeImpl(VMContext? context) {
+    var associatedNode = _associatedNode;
+    return associatedNode == null ? this : associatedNode.resolveType(context);
+  }
+
+  ASTTypedNode? _associatedNode;
+
+  @override
+  void associateToType(ASTTypedNode node) => _associatedNode = node;
+
+  @override
+  FutureOr<ASTValue<dynamic>> toValue(VMContext context, Object? v) {
+    if (v is ASTValue<dynamic> && v.type == this) {
+      return v;
+    }
+
+    if (v is ASTValue) {
+      return v.getValue(context).resolveMapped((v) {
+        return ASTValueStatic<dynamic>(this, v);
+      });
+    }
+
+    return ASTValueStatic<dynamic>(this, v);
+  }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      super == other && other is ASTTypeInt && runtimeType == other.runtimeType;
+
+  @override
+  int get hashCode => name.hashCode;
+
+  @override
+  String toString() {
+    return 'this';
+  }
+}
+
 /// [ASTType] for `var` declaration.
 class ASTTypeVar extends ASTType<dynamic> {
   static final ASTTypeVar instance = ASTTypeVar();
@@ -846,9 +914,9 @@ class ASTTypeVar extends ASTType<dynamic> {
 
 /// [ASTType] for [dynamic] declaration.
 class ASTTypeDynamic extends ASTType<dynamic> {
-  static final ASTTypeDynamic instance = ASTTypeDynamic();
+  static final ASTTypeDynamic instance = ASTTypeDynamic._();
 
-  ASTTypeDynamic() : super('dynamic');
+  ASTTypeDynamic._() : super('dynamic');
 
   @override
   Iterable<ASTNode> get children => [];

--- a/lib/src/ast/apollovm_ast_value.dart
+++ b/lib/src/ast/apollovm_ast_value.dart
@@ -87,10 +87,22 @@ abstract class ASTValue<T> with ASTNode implements ASTTypedNode {
 
   FutureOr<T> getValueNoContext();
 
+  FutureOr<T> getHashcodeValue(VMContext? context) {
+    if (context != null) {
+      return getValue(context);
+    } else {
+      return getValueNoContext();
+    }
+  }
+
   FutureOr<ASTValue<T>> resolve(VMContext context);
 
   @override
   FutureOr<ASTType> resolveType(VMContext? context) => type;
+
+  @override
+  FutureOr<ASTType> resolveRuntimeType(VMContext context, ASTNode? node) =>
+      resolveType(context);
 
   @override
   void associateToType(ASTTypedNode node) {}
@@ -142,8 +154,8 @@ abstract class ASTValue<T> with ASTNode implements ASTTypedNode {
 
     if (other is ASTValue) {
       var context = VMContext.getCurrent();
-      var v1 = _getValueSafe(context, this);
-      var v2 = _getValueSafe(context, other);
+      var v1 = getHashcodeValue(context);
+      var v2 = other.getHashcodeValue(context);
       return v1 == v2;
     }
     return false;
@@ -152,8 +164,12 @@ abstract class ASTValue<T> with ASTNode implements ASTTypedNode {
   @override
   int get hashCode {
     var context = VMContext.getCurrent();
-    var v1 = _getValueSafe(context, this);
-    return v1.hashCode;
+    try {
+      var v1 = getHashcodeValue(context);
+      return v1.hashCode;
+    } catch (_) {
+      return -1;
+    }
   }
 
   FutureOr<bool> equals(Object other) async {
@@ -868,7 +884,23 @@ class ASTValueArray<T extends ASTType<V>, V> extends ASTValueStatic<List<V>> {
     final value = this.value;
 
     var t = componentType ?? (type as ASTTypeArray).componentType;
-    var v = value is List<V2> ? (value as List<V2>) : value.cast<V2>();
+
+    List<V2> v;
+    if (value is List<V2>) {
+      v = (value as List<V2>);
+    } else {
+      if (V2 == double) {
+        v = value.map<V2>((e) {
+          return e is num
+              ? e.toDouble() as V2
+              : (throw ApolloVMRuntimeError(
+                  "Can't cast `${e.runtimeType}` to `$V2`",
+                ));
+        }).toList();
+      } else {
+        v = value.cast<V2>();
+      }
+    }
 
     return ASTValueArray<T2, V2>(t as T2, v);
   }
@@ -1033,6 +1065,15 @@ class ASTValueStringExpression<T> extends ASTValue<String> {
   );
 
   @override
+  FutureOr<String> getHashcodeValue(VMContext? context) {
+    if (context != null) {
+      return getValue(context);
+    } else {
+      return expression.getHashcodeValue(context).resolveMapped((v) => '$v');
+    }
+  }
+
+  @override
   FutureOr<ASTValueString> resolve(VMContext context) {
     return getValue(context).resolveMapped((s) => ASTValueString(s));
   }
@@ -1065,6 +1106,15 @@ class ASTValueStringVariable<T> extends ASTValue<String> {
   );
 
   @override
+  FutureOr<String> getHashcodeValue(VMContext? context) {
+    if (context != null) {
+      return getValue(context);
+    } else {
+      return '\$${variable.name}';
+    }
+  }
+
+  @override
   FutureOr<ASTValue<String>> resolve(VMContext context) {
     return variable.getValue(context).resolveMapped((value) {
       return value is ASTValue<String> ? value : ASTValueAsString(value);
@@ -1095,6 +1145,12 @@ class ASTValueStringConcatenation extends ASTValue<String> {
   @override
   FutureOr<String> getValueNoContext() {
     var vsFuture = values.map((e) => e.getValueNoContext()).toList();
+    return vsFuture.resolveAllJoined((l) => l.join());
+  }
+
+  @override
+  FutureOr<String> getHashcodeValue(VMContext? context) {
+    var vsFuture = values.map((e) => e.getHashcodeValue(context)).toList();
     return vsFuture.resolveAllJoined((l) => l.join());
   }
 
@@ -1230,6 +1286,10 @@ class ASTClassInstance<V extends ASTValue> extends ASTValue<V> {
     if (type.name != clazz.name) {
       throw StateError('Incompatible class with type: $clazz != $type');
     }
+  }
+
+  VMClassContext createContext(VMContext? parentContext) {
+    return clazz.createContext(parentContext?.typeResolver, parentContext);
   }
 
   @override

--- a/lib/src/ast/apollovm_ast_variable.dart
+++ b/lib/src/ast/apollovm_ast_variable.dart
@@ -23,6 +23,10 @@ abstract class ASTVariable with ASTNode implements ASTTypedNode {
   ASTType? get typeIdentifier => null;
 
   @override
+  FutureOr<ASTType> resolveRuntimeType(VMContext context, ASTNode? node) =>
+      resolveType(context);
+
+  @override
   void associateToType(ASTTypedNode node) {}
 
   FutureOr<ASTVariable> resolveVariable(VMContext context);
@@ -81,6 +85,10 @@ abstract class ASTTypedVariable<T> extends ASTVariable {
 
   @override
   ASTType resolveType(VMContext? context) => type;
+
+  @override
+  FutureOr<ASTType> resolveRuntimeType(VMContext context, ASTNode? node) =>
+      resolveType(context);
 
   @override
   void resolveNode(ASTNode? parentNode) {

--- a/lib/src/core/apollovm_core_base.dart
+++ b/lib/src/core/apollovm_core_base.dart
@@ -2,16 +2,9 @@
 // This code is governed by the Apache License, Version 2.0.
 // Please refer to the LICENSE and AUTHORS files for details.
 
-import 'dart:async';
 import 'dart:math';
 
-import '../apollovm_base.dart';
-import '../ast/apollovm_ast_base.dart';
-import '../ast/apollovm_ast_statement.dart';
-import '../ast/apollovm_ast_toplevel.dart';
-import '../ast/apollovm_ast_type.dart';
-import '../ast/apollovm_ast_value.dart';
-import '../ast/apollovm_ast_variable.dart';
+import 'package:apollovm/apollovm.dart';
 
 class ApolloVMCore {
   static ASTClass<V>? getClass<V>(String className, {List<ASTType>? generics}) {
@@ -48,7 +41,7 @@ abstract class CorePackageBase extends ASTBlock {
   ]) {
     return ASTExternalFunction<R>(
       name,
-      ASTParametersDeclaration([param1], null, null),
+      ASTFunctionParametersDeclaration([param1], null, null),
       returnType,
       externalFunction,
       parameterValueResolver,
@@ -65,7 +58,7 @@ abstract class CorePackageBase extends ASTBlock {
   ]) {
     return ASTExternalFunction<R>(
       name,
-      ASTParametersDeclaration([param1, param2], null, null),
+      ASTFunctionParametersDeclaration([param1, param2], null, null),
       returnType,
       externalFunction,
       parameterValueResolver,
@@ -269,13 +262,16 @@ abstract mixin class CoreClassMixin<T> {
   ASTExternalClassGetter<R> _externalClassGetter<R>(
     String name,
     ASTType<R> returnType,
-    Function(Object? o) externalFunction,
-  ) {
+    Function(Object? o) externalFunction, [
+    FutureOr<ASTType> Function(VMContext? context, ASTNode? o)?
+    returnTypeResolver,
+  ]) {
     return ASTExternalClassGetter<R>(
       astClass,
       name,
       returnType,
       externalFunction,
+      returnTypeResolver,
     );
   }
 
@@ -288,7 +284,7 @@ abstract mixin class CoreClassMixin<T> {
     return ASTExternalClassFunction<R>(
       astClass,
       name,
-      ASTParametersDeclaration(null, null, null),
+      ASTFunctionParametersDeclaration(null, null, null),
       returnType,
       externalFunction,
       parameterValueResolver,
@@ -305,7 +301,7 @@ abstract mixin class CoreClassMixin<T> {
     return ASTExternalClassFunction<R>(
       astClass,
       name,
-      ASTParametersDeclaration([param1], null, null),
+      ASTFunctionParametersDeclaration([param1], null, null),
       returnType,
       externalFunction,
       parameterValueResolver,
@@ -323,7 +319,7 @@ abstract mixin class CoreClassMixin<T> {
     return ASTExternalClassFunction<R>(
       astClass,
       name,
-      ASTParametersDeclaration([param1, param2], null, null),
+      ASTFunctionParametersDeclaration([param1, param2], null, null),
       returnType,
       externalFunction,
       parameterValueResolver,
@@ -339,7 +335,7 @@ abstract mixin class CoreClassMixin<T> {
   ]) {
     return ASTExternalFunction<R>(
       name,
-      ASTParametersDeclaration(null, null, null),
+      ASTFunctionParametersDeclaration(null, null, null),
       returnType,
       externalFunction,
       parameterValueResolver,
@@ -355,7 +351,7 @@ abstract mixin class CoreClassMixin<T> {
   ]) {
     return ASTExternalFunction<R>(
       name,
-      ASTParametersDeclaration([param1], null, null),
+      ASTFunctionParametersDeclaration([param1], null, null),
       returnType,
       externalFunction,
       parameterValueResolver,
@@ -964,6 +960,8 @@ class CoreClassList<T> extends CoreClassBase<List<T>> {
   late final ASTExternalClassGetter _getterLength;
   late final ASTExternalClassGetter _getterIsEmpty;
   late final ASTExternalClassGetter _getterIsNotEmpty;
+  late final ASTExternalClassGetter _getterFirst;
+  late final ASTExternalClassGetter _getterLast;
 
   late final ASTExternalClassFunction _functionAdd;
   late final ASTExternalClassFunction _functionAddAll;
@@ -986,6 +984,21 @@ class CoreClassList<T> extends CoreClassBase<List<T>> {
   late final ASTExternalClassFunction _functionSublist;
 
   late final ASTExternalFunction _functionValueOf;
+
+  FutureOr<ASTType> _resolveComponentType(VMContext? context, ASTNode? node) {
+    if (node is ASTValueArray) {
+      var typeAsync = context != null
+          ? node.resolveRuntimeType(context, null)
+          : node.resolveType(null);
+      return typeAsync.resolveMapped((t) {
+        if (t is ASTTypeArray) {
+          return t.componentType;
+        }
+        return ASTTypeDynamic.instance;
+      });
+    }
+    return ASTTypeDynamic.instance;
+  }
 
   CoreClassList._()
     : super(
@@ -1011,6 +1024,20 @@ class CoreClassList<T> extends CoreClassBase<List<T>> {
       'isNotEmpty',
       ASTTypeBool.instance,
       (Object? o) => o is List ? o.isNotEmpty : null,
+    );
+
+    _getterFirst = _externalClassGetter(
+      'first',
+      ASTTypeDynamic.instance,
+      (Object? o) => o is List ? o.first : null,
+      _resolveComponentType,
+    );
+
+    _getterLast = _externalClassGetter(
+      'last',
+      ASTTypeDynamic.instance,
+      (Object? o) => o is List ? o.last : null,
+      _resolveComponentType,
     );
 
     _functionAdd = _externalClassFunctionArgs1(
@@ -1192,6 +1219,10 @@ class CoreClassList<T> extends CoreClassBase<List<T>> {
         return _getterIsEmpty;
       case 'isNotEmpty':
         return _getterIsNotEmpty;
+      case 'first':
+        return _getterFirst;
+      case 'last':
+        return _getterLast;
     }
 
     throw StateError("Can't find core getter: $coreName.$fName");
@@ -1346,4 +1377,21 @@ class CoreClassList<T> extends CoreClassBase<List<T>> {
   }) {
     throw UnimplementedError();
   }
+
+  @override
+  List<ASTConstructorSet> get constructors => [];
+
+  @override
+  List<String> get constructorsNames => [];
+
+  @override
+  ASTClassConstructorDeclaration? getConstructor(
+    String fName,
+    ASTFunctionSignature? parametersSignature,
+    VMContext context, {
+    bool caseInsensitive = false,
+  }) => null;
+
+  @override
+  void resolveNodeConstructors(ASTNode? parentNode) {}
 }

--- a/lib/src/languages/dart/dart_generator.dart
+++ b/lib/src/languages/dart/dart_generator.dart
@@ -100,6 +100,28 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
   }
 
   @override
+  StringBuffer generateASTClassConstructorDeclaration(
+    ASTClassConstructorDeclaration c, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    var blockCode = generateASTBlock(c, indent: indent, withBrackets: false);
+
+    out.write(indent);
+
+    out.write(c.classType.name);
+    if (c.name.isNotEmpty) {
+      out.write('.');
+      out.write(c.name);
+    }
+    _generateFunctionParamsAndBlock(c, blockCode, out, indent);
+
+    return out;
+  }
+
+  @override
   StringBuffer generateASTClassFunctionDeclaration(
     ASTClassFunctionDeclaration f, {
     StringBuffer? out,
@@ -139,18 +161,34 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
     out.write(typeCode);
     out.write(' ');
     out.write(f.name);
-    out.write('(');
+    _generateFunctionParamsAndBlock(f, blockCode, out, indent);
 
+    return out;
+  }
+
+  void _generateFunctionParamsAndBlock(
+    ASTInvocableDeclaration f,
+    StringBuffer blockCode,
+    StringBuffer out,
+    String indent,
+  ) {
+    out.write('(');
     if (f.parametersSize > 0) {
       generateASTParametersDeclaration(f.parameters, out: out);
     }
+    out.write(')');
 
-    out.write(') {\n');
-    out.write(blockCode);
-    out.write(indent);
-    out.write('}\n\n');
+    var blockStr = blockCode.toString();
+    var emptyBlock = blockStr.trim().isEmpty;
 
-    return out;
+    if (emptyBlock && f is ASTClassConstructorDeclaration) {
+      out.write(';\n\n');
+    } else {
+      out.write(' {\n');
+      out.write(blockCode);
+      out.write(indent);
+      out.write('}\n\n');
+    }
   }
 
   @override
@@ -166,7 +204,7 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
       for (var i = 0; i < positionalParameters.length; ++i) {
         var p = positionalParameters[i];
         if (i > 0) out.write(', ');
-        generateASTFunctionParameterDeclaration(p, out: out);
+        generateASTParameterDeclaration(p, out: out);
       }
     }
 
@@ -176,7 +214,7 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
       for (var i = 0; i < optionalParameters.length; ++i) {
         var p = optionalParameters[i];
         if (i > 0) out.write(', ');
-        generateASTFunctionParameterDeclaration(p, out: out);
+        generateASTParameterDeclaration(p, out: out);
       }
       out.write(']');
     }
@@ -187,7 +225,7 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
       for (var i = 0; i < namedParameters.length; ++i) {
         var p = namedParameters[i];
         if (i > 0) out.write(', ');
-        generateASTFunctionParameterDeclaration(p, out: out);
+        generateASTParameterDeclaration(p, out: out);
       }
       out.write('}');
     }

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -80,19 +80,20 @@ class DartGrammarDefinition extends DartGrammarLexer {
       (functionDeclaration() | classDeclaration()).plus();
 
   Parser<ASTFunctionDeclaration> functionDeclaration() =>
-      (type() & identifier() & parametersDeclaration() & codeBlock()).map((v) {
-        var returnType = v[0];
-        var parameters = v[2];
-        var name = v[1];
-        var block = v[3];
-        return ASTFunctionDeclaration(
-          name,
-          parameters,
-          returnType,
-          block: block,
-          modifiers: ASTModifiers.modifierStatic,
-        );
-      });
+      (type() & identifier() & functionParametersDeclaration() & codeBlock())
+          .map((v) {
+            var returnType = v[0];
+            var parameters = v[2];
+            var name = v[1];
+            var block = v[3];
+            return ASTFunctionDeclaration(
+              name,
+              parameters,
+              returnType,
+              block: block,
+              modifiers: ASTModifiers.modifierStatic,
+            );
+          });
 
   Parser<ASTClassNormal> classDeclaration() =>
       (string('class').trimHidden() & identifier() & classCodeBlock()).map((v) {
@@ -105,7 +106,8 @@ class DartGrammarDefinition extends DartGrammarLexer {
 
   Parser<ASTBlock> classCodeBlock() =>
       (char('{').trimHidden() &
-              (ref0(classFunctionDeclaration) |
+              (ref0(classConstructorDefaultDeclaration) |
+                      ref0(classFunctionDeclaration) |
                       ref0(classFieldDeclaration) |
                       ref0(classFieldDeclarationWithValue))
                   .star() &
@@ -113,22 +115,31 @@ class DartGrammarDefinition extends DartGrammarLexer {
           .map((v) {
             var list = v[1] as List;
             var fields = list.whereType<ASTClassField>().toList();
+            var constructors = list
+                .whereType<ASTClassConstructorDeclaration>()
+                .toList();
             var functions = list.whereType<ASTFunctionDeclaration>().toList();
 
             var block = ASTClassNormal('?', ASTType<VMObject>('?'), null);
 
             block.addAllFields(fields);
+            block.addAllConstructors(constructors);
             block.addAllFunctions(functions);
 
             return block;
           });
 
   Parser<ASTClassField> classFieldDeclaration() =>
-      (type() & identifier() & char(';').trimHidden()).map((v) {
-        var type = v[0] as ASTType;
-        var name = v[1] as String;
-        return ASTClassField(type, name, false);
-      });
+      (finalToken().optional() &
+              type().trimHidden() &
+              identifier().trimHidden() &
+              char(';').trimHidden())
+          .map((v) {
+            var finalValue = v[0] != null;
+            var type = v[1] as ASTType;
+            var name = v[2] as String;
+            return ASTClassField(type, name, finalValue);
+          });
 
   Parser<ASTClassField> classFieldDeclarationWithValue() =>
       (type() &
@@ -144,17 +155,87 @@ class DartGrammarDefinition extends DartGrammarLexer {
             return ASTClassFieldWithInitialValue(type, name, expression, false);
           });
 
+  Parser<ASTClassConstructorDeclaration> classConstructorDefaultDeclaration() =>
+      (identifier() &
+              constructorParametersDeclaration() &
+              (char(';').trim() | codeBlock()))
+          .map((v) {
+            var className = v[0];
+            var parameters = v[1] as ASTConstructorParametersDeclaration;
+            var optionalBlock = v[2];
+            var block = optionalBlock is ASTBlock ? optionalBlock : null;
+            return ASTClassConstructorDeclaration(
+              ASTType(className),
+              '',
+              parameters,
+              block: block,
+            );
+          });
+
+  Parser<ASTConstructorParametersDeclaration>
+  constructorParametersDeclaration() =>
+      (functionEmptyParametersDeclaration() |
+              constructorPositionalParametersDeclaration())
+          .cast<ASTConstructorParametersDeclaration>();
+
+  Parser<ASTConstructorParametersDeclaration>
+  constructorEmptyParametersDeclaration() => (char('(') & char(')')).map((v) {
+    return ASTConstructorParametersDeclaration(null, null, null);
+  });
+
+  Parser<ASTConstructorParametersDeclaration>
+  constructorPositionalParametersDeclaration() =>
+      (char('(') & constructorParametersList() & char(')')).map((v) {
+        return ASTConstructorParametersDeclaration(v[1], null, null);
+      });
+
+  Parser<List<ASTConstructorParameterDeclaration>>
+  constructorParametersList() =>
+      (constructorParameterDeclaration() &
+              (char(',') & constructorParameterDeclaration()).star() &
+              char(',').optional())
+          .map((v) {
+            var params = _expandListDeeply(v);
+            return params
+                .whereType<ASTConstructorParameterDeclaration>()
+                .toList();
+          });
+
+  Parser<ASTConstructorParameterDeclaration>
+  constructorParameterDeclaration() =>
+      (constructorThisParameterDeclaration() |
+              constructorTypedParameterDeclaration())
+          .map((v) => v);
+
+  Parser<ASTConstructorParameterDeclaration>
+  constructorThisParameterDeclaration() =>
+      (thisToken().trim() & char('.') & identifier()).map((v) {
+        return ASTConstructorParameterDeclaration(
+          ASTTypeConstructorThis.instance,
+          v[2],
+          -1,
+          false,
+          thisParameter: true,
+        );
+      });
+
+  Parser<ASTConstructorParameterDeclaration>
+  constructorTypedParameterDeclaration() =>
+      (finalToken().trim().optional() & type().trim() & identifier()).map((v) {
+        return ASTConstructorParameterDeclaration(v[1], v[2], -1, false);
+      });
+
   Parser<ASTFunctionDeclaration> classFunctionDeclaration() =>
       (functionModifiers().optional() &
               type() &
               identifier() &
-              parametersDeclaration() &
+              functionParametersDeclaration() &
               codeBlock())
           .map((v) {
             var modifiers = v[0];
             var returnType = v[1] as ASTType;
             var name = v[2] as String;
-            var parameters = v[3] as ASTParametersDeclaration;
+            var parameters = v[3] as ASTFunctionParametersDeclaration;
             var block = v[4] as ASTBlock;
             return ASTClassFunctionDeclaration(
               null,
@@ -263,17 +344,55 @@ class DartGrammarDefinition extends DartGrammarLexer {
       });
 
   Parser<ASTStatementVariableDeclaration> statementVariableDeclaration() =>
-      (type() &
-              identifier() &
+      (
+          // var definition:
+          (
+              // final Type name:
+              (finalToken().trimHidden() & type() & identifier().trimHidden()) |
+                  // final name:
+                  (finalToken() & identifier().trimHidden()) |
+                  // Type name:
+                  (type() & identifier().trimHidden())
+              // end var definition
+              ) &
               (char('=').trimHidden() & ref0(expression)).optional() &
               char(';').trimHidden())
           .map((v) {
-            var type = v[0] as ASTType;
-            var name = v[1] as String;
-            var valueOpt = v[2];
+            var varDef = v[0] as List;
+
+            bool unmodifiable;
+            ASTType type;
+            String name;
+
+            if (varDef.length == 3) {
+              unmodifiable = true;
+              assert((varDef[0] as Token).value == 'final');
+              type = varDef[1];
+              name = varDef[2];
+            } else if (varDef.length == 2) {
+              final varDef0 = varDef[0];
+              if (varDef0 is Token && varDef0.value == 'final') {
+                unmodifiable = true;
+                type = getTypeByName('final');
+                name = varDef[1];
+              } else {
+                unmodifiable = false;
+                type = varDef[0];
+                name = varDef[1];
+              }
+            } else {
+              throw StateError("Invalid var definition: $varDef");
+            }
+
+            var valueOpt = v[1];
             var value = valueOpt != null ? valueOpt[1] as ASTExpression : null;
             if (value != null) type.associateToType(value);
-            return ASTStatementVariableDeclaration(type, name, value);
+            return ASTStatementVariableDeclaration(
+              type,
+              name,
+              value,
+              unmodifiable: unmodifiable,
+            );
           });
 
   Parser<ASTBranch> branch() =>
@@ -709,30 +828,40 @@ class DartGrammarDefinition extends DartGrammarLexer {
     return ASTScopeVariable(v);
   });
 
-  Parser<ASTParametersDeclaration> parametersDeclaration() =>
-      (emptyParametersDeclaration() | positionalParametersDeclaration())
-          .cast<ASTParametersDeclaration>();
+  Parser<ASTFunctionParametersDeclaration> functionParametersDeclaration() =>
+      (functionEmptyParametersDeclaration() |
+              functionPositionalParametersDeclaration())
+          .cast<ASTFunctionParametersDeclaration>();
 
-  Parser<ASTParametersDeclaration> emptyParametersDeclaration() =>
-      (char('(') & char(')')).map((v) {
-        return ASTParametersDeclaration(null, null, null);
-      });
+  Parser<ASTFunctionParametersDeclaration>
+  functionEmptyParametersDeclaration() => (char('(') & char(')')).map((v) {
+    return ASTFunctionParametersDeclaration(null, null, null);
+  });
 
-  Parser<ASTParametersDeclaration> positionalParametersDeclaration() =>
+  Parser<ASTFunctionParametersDeclaration>
+  functionPositionalParametersDeclaration() =>
       (char('(') & parametersList() & char(')')).map((v) {
-        return ASTParametersDeclaration(v[1], null, null);
+        return ASTFunctionParametersDeclaration(v[1], null, null);
       });
 
   Parser<List<ASTFunctionParameterDeclaration>> parametersList() =>
-      (parameterDeclaration() & (char(',') & parameterDeclaration()).star())
+      (parameterDeclaration() &
+              (char(',') & parameterDeclaration()).star() &
+              char(',').optional())
           .map((v) {
             var params = _expandListDeeply(v);
             return params.whereType<ASTFunctionParameterDeclaration>().toList();
           });
 
   Parser<ASTFunctionParameterDeclaration> parameterDeclaration() =>
-      (type() & identifier()).map((v) {
-        return ASTFunctionParameterDeclaration(v[0], v[1], -1, false);
+      (finalToken().trim().optional() & type().trim() & identifier()).map((v) {
+        return ASTFunctionParameterDeclaration(
+          v[1],
+          v[2],
+          -1,
+          false,
+          unmodifiable: v[0] != null,
+        );
       });
 
   Parser<ASTType> type() =>
@@ -858,6 +987,18 @@ class DartGrammarDefinition extends DartGrammarLexer {
     if (l.isEmpty) return l;
     if (l.length == 1 && l[0] is! List) return l;
 
-    return l.expand((e) => e is List ? _expandListDeeply(e) : [e]).toList();
+    final result = [];
+    _expandInto(l, result);
+    return result;
+  }
+
+  static void _expandInto(List source, List target) {
+    for (final e in source) {
+      if (e is List) {
+        _expandInto(e, target);
+      } else {
+        target.add(e);
+      }
+    }
   }
 }

--- a/lib/src/languages/java/java11/java11_generator.dart
+++ b/lib/src/languages/java/java11/java11_generator.dart
@@ -105,6 +105,24 @@ class ApolloCodeGeneratorJava11 extends ApolloCodeGenerator {
   }
 
   @override
+  StringBuffer generateASTClassConstructorDeclaration(
+    ASTClassConstructorDeclaration c, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    var blockCode = generateASTBlock(c, indent: indent, withBrackets: false);
+
+    out.write(indent);
+
+    out.write(c.classType.name);
+    _generateFunctionParamsAndBlock(c, blockCode, out, indent);
+
+    return out;
+  }
+
+  @override
   StringBuffer generateASTFunctionDeclaration(
     ASTFunctionDeclaration f, {
     StringBuffer? out,
@@ -138,6 +156,17 @@ class ApolloCodeGeneratorJava11 extends ApolloCodeGenerator {
     out.write(typeCode);
     out.write(' ');
     out.write(f.name);
+    _generateFunctionParamsAndBlock(f, blockCode, out, indent);
+
+    return out;
+  }
+
+  void _generateFunctionParamsAndBlock(
+    ASTInvocableDeclaration f,
+    StringBuffer blockCode,
+    StringBuffer out,
+    String indent,
+  ) {
     out.write('(');
 
     if (f.parametersSize > 0) {
@@ -148,8 +177,6 @@ class ApolloCodeGeneratorJava11 extends ApolloCodeGenerator {
     out.write(blockCode);
     out.write(indent);
     out.write('}\n\n');
-
-    return out;
   }
 
   @override
@@ -165,7 +192,7 @@ class ApolloCodeGeneratorJava11 extends ApolloCodeGenerator {
       for (var i = 0; i < positionalParameters.length; ++i) {
         var p = positionalParameters[i];
         if (i > 0) out.write(', ');
-        generateASTFunctionParameterDeclaration(p, out: out);
+        generateASTParameterDeclaration(p, out: out);
       }
     }
 
@@ -174,7 +201,7 @@ class ApolloCodeGeneratorJava11 extends ApolloCodeGenerator {
       for (var i = 0; i < optionalParameters.length; ++i) {
         var p = optionalParameters[i];
         if (i > 0) out.write(', ');
-        generateASTFunctionParameterDeclaration(p, out: out);
+        generateASTParameterDeclaration(p, out: out);
       }
     }
 
@@ -183,7 +210,7 @@ class ApolloCodeGeneratorJava11 extends ApolloCodeGenerator {
       for (var i = 0; i < namedParameters.length; ++i) {
         var p = namedParameters[i];
         if (i > 0) out.write(', ');
-        generateASTFunctionParameterDeclaration(p, out: out);
+        generateASTParameterDeclaration(p, out: out);
       }
     }
 

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -74,7 +74,8 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
 
   Parser<ASTBlock> classCodeBlock() =>
       (char('{').trimHidden() &
-              (ref0(classFunctionDeclaration) |
+              (ref0(classConstructorDefaultDeclaration) |
+                      ref0(classFunctionDeclaration) |
                       ref0(classFieldDeclaration) |
                       ref0(classFieldDeclarationWithValue))
                   .star() &
@@ -82,11 +83,15 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
           .map((v) {
             var list = v[1] as List;
             var fields = list.whereType<ASTClassField>().toList();
+            var constructors = list
+                .whereType<ASTClassConstructorDeclaration>()
+                .toList();
             var functions = list.whereType<ASTFunctionDeclaration>().toList();
 
             var block = ASTClassNormal('?', ASTType<VMObject>('?'), null);
 
             block.addAllFields(fields);
+            block.addAllConstructors(constructors);
             block.addAllFunctions(functions);
 
             return block;
@@ -123,11 +128,79 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
             );
           });
 
+  Parser<ASTClassConstructorDeclaration> classConstructorDefaultDeclaration() =>
+      (identifier() & constructorParametersDeclaration() & codeBlock()).map((
+        v,
+      ) {
+        var className = v[0];
+        var parameters = v[1] as ASTConstructorParametersDeclaration;
+        var block = v[2];
+        return ASTClassConstructorDeclaration(
+          ASTType(className),
+          '',
+          parameters,
+          block: block,
+        );
+      });
+
+  Parser<ASTConstructorParametersDeclaration>
+  constructorParametersDeclaration() =>
+      (functionEmptyParametersDeclaration() |
+              constructorPositionalParametersDeclaration())
+          .cast<ASTConstructorParametersDeclaration>();
+
+  Parser<ASTConstructorParametersDeclaration>
+  constructorEmptyParametersDeclaration() => (char('(') & char(')')).map((v) {
+    return ASTConstructorParametersDeclaration(null, null, null);
+  });
+
+  Parser<ASTConstructorParametersDeclaration>
+  constructorPositionalParametersDeclaration() =>
+      (char('(') & constructorParametersList() & char(')')).map((v) {
+        return ASTConstructorParametersDeclaration(v[1], null, null);
+      });
+
+  Parser<List<ASTConstructorParameterDeclaration>>
+  constructorParametersList() =>
+      (constructorParameterDeclaration() &
+              (char(',') & constructorParameterDeclaration()).star() &
+              char(',').optional())
+          .map((v) {
+            var params = _expandListDeeply(v);
+            return params
+                .whereType<ASTConstructorParameterDeclaration>()
+                .toList();
+          });
+
+  Parser<ASTConstructorParameterDeclaration>
+  constructorParameterDeclaration() =>
+      (constructorThisParameterDeclaration() |
+              constructorTypedParameterDeclaration())
+          .map((v) => v);
+
+  Parser<ASTConstructorParameterDeclaration>
+  constructorThisParameterDeclaration() =>
+      (thisToken().trim() & char('.') & identifier()).map((v) {
+        return ASTConstructorParameterDeclaration(
+          ASTTypeConstructorThis.instance,
+          v[2],
+          -1,
+          false,
+          thisParameter: true,
+        );
+      });
+
+  Parser<ASTConstructorParameterDeclaration>
+  constructorTypedParameterDeclaration() =>
+      (finalToken().trim().optional() & type().trim() & identifier()).map((v) {
+        return ASTConstructorParameterDeclaration(v[1], v[2], -1, false);
+      });
+
   Parser<ASTFunctionDeclaration> classFunctionDeclaration() =>
       (modifiers().optional() &
               type() &
               identifier() &
-              parametersDeclaration() &
+              functionParametersDeclaration() &
               codeBlock())
           .map((List v) {
             var modifiers = v[0];
@@ -620,18 +693,20 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
     return ASTScopeVariable(v);
   });
 
-  Parser<ASTParametersDeclaration> parametersDeclaration() =>
-      (emptyParametersDeclaration() | positionalParametersDeclaration())
-          .cast<ASTParametersDeclaration>();
+  Parser<ASTFunctionParametersDeclaration> functionParametersDeclaration() =>
+      (functionEmptyParametersDeclaration() |
+              functionPositionalParametersDeclaration())
+          .cast<ASTFunctionParametersDeclaration>();
 
-  Parser<ASTParametersDeclaration> emptyParametersDeclaration() =>
-      (char('(') & char(')')).map((v) {
-        return ASTParametersDeclaration(null, null, null);
-      });
+  Parser<ASTFunctionParametersDeclaration>
+  functionEmptyParametersDeclaration() => (char('(') & char(')')).map((v) {
+    return ASTFunctionParametersDeclaration(null, null, null);
+  });
 
-  Parser<ASTParametersDeclaration> positionalParametersDeclaration() =>
+  Parser<ASTFunctionParametersDeclaration>
+  functionPositionalParametersDeclaration() =>
       (char('(') & parametersList() & char(')')).map((v) {
-        return ASTParametersDeclaration(v[1], null, null);
+        return ASTFunctionParametersDeclaration(v[1], null, null);
       });
 
   Parser<List<ASTFunctionParameterDeclaration>> parametersList() =>

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -403,6 +403,15 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   }
 
   @override
+  BytesOutput generateASTClassConstructorDeclaration(
+    ASTClassConstructorDeclaration<dynamic> constructor, {
+    BytesOutput? out,
+  }) {
+    // TODO: implement generateASTClassConstructorDeclaration
+    throw UnimplementedError("generateASTClassConstructorDeclaration");
+  }
+
+  @override
   BytesOutput generateASTClassFunctionDeclaration(
     ASTClassFunctionDeclaration f, {
     BytesOutput? out,
@@ -2239,7 +2248,8 @@ extension _IterableASTFunctionParameterDeclarationExtension
       expand((e) => e.declaredVariables()).toList();
 }
 
-extension _ASTParametersDeclarationExtension on ASTParametersDeclaration {
+extension _ASTParametersDeclarationExtension
+    on ASTFunctionParametersDeclaration {
   List<MapEntry<String, ASTType>> declaredVariables() => [
     ...?positionalParameters?.declaredVariables(),
     ...?optionalParameters?.declaredVariables(),

--- a/lib/src/languages/wasm/wasm_parser.dart
+++ b/lib/src/languages/wasm/wasm_parser.dart
@@ -112,7 +112,7 @@ class ApolloParserWasm extends ApolloCodeParser<Uint8List> {
       if (type == 0) {
         var typeFunction = typeFunctions[index];
 
-        var astParameters = typeFunction.toASTParametersDeclaration();
+        var astParameters = typeFunction.toASTFunctionParametersDeclaration();
 
         var astReturn =
             typeFunction.results.toASTTypes().firstOrNull ??
@@ -147,8 +147,8 @@ class _TypeFunction {
           )
           .toList();
 
-  ASTParametersDeclaration toASTParametersDeclaration() =>
-      ASTParametersDeclaration(toASTFunctionParameterDeclaration());
+  ASTFunctionParametersDeclaration toASTFunctionParametersDeclaration() =>
+      ASTFunctionParametersDeclaration(toASTFunctionParameterDeclaration());
 }
 
 extension _ListIntExtension on List<int> {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, JavaScript with on-the-fly Wasm compilation.
-version: 0.1.11
+version: 0.1.12
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/apollovm_languages_basic_test.dart
+++ b/test/apollovm_languages_basic_test.dart
@@ -3,9 +3,206 @@ import 'package:apollovm/apollovm.dart';
 import 'apollovm_languages_test_definition.dart';
 
 Future<void> main() async {
+  await _tests();
+}
+
+/*
+Future<void> _benchmark() async {
+  for (var i = 0; i < 100; ++i) {
+    await _tests();
+  }
+
+  tearDownAll(() async {
+    await Future.delayed(Duration(hours: 10));
+  });
+}
+ */
+
+Future<void> _tests() async {
   print('BASIC TESTS DEFINITIONS');
 
   var definitions = <TestDefinition>[
+    TestDefinition('dart_basic_linearRegression.test.xml', r'''
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Basic linearRegression(List<double> x, List<double> y)">
+    <source language="dart">
+        <![CDATA[
+class LinearModel {
+   final double m;
+   final double b;
+
+   LinearModel(this.m, this.b);
+}
+
+LinearModel linearRegression(List<int> x, List<double> y) {
+  if (x.length != y.length || x.length < 2) {
+    // Input lists must have same length and >= 2 points:
+    return null;
+  }
+
+  final n = x.length;
+
+  double sumX = 0;
+  double sumY = 0;
+
+  for (int i = 0; i < n; i++) {
+    sumX += x[i];
+    sumY += y[i];
+  }
+
+  final meanX = sumX / n;
+  final meanY = sumY / n;
+
+  double num = 0;
+  double den = 0;
+
+  for (int i = 0; i < n; i++) {
+    final dx = x[i] - meanX;
+    final dy = y[i] - meanY;
+    num += dx * dy;
+    den += dx * dx;
+  }
+
+  if (den == 0) {
+    // Cannot compute regression: zero variance in X:
+    return null;
+  }
+
+  final m = num / den;
+  final b = meanY - m * meanX;
+
+  return LinearModel(m, b);
+}
+
+void forecast(int startX, LinearModel model) {
+  final int days = 10;
+  for (int i = 1; i <= days; i++) {
+    final x = startX + i;
+    final y = model.m * x + model.b;
+    print('Forecast for Day $x: ${y.toStringAsFixed(2)}');
+  }
+}
+
+void main() {
+  // Historical BTC/USD rates
+  final rates = [
+    71428.571429, 71428.571429, 71428.571429, 66666.666667, 71428.571429,
+    71428.571429, 71428.571429, 66666.666667, 66666.666667, 66666.666667,
+    66666.666667, 66666.666667, 66666.666667, 66666.666667, 66666.666667,
+    66666.666667, 71428.571429, 71428.571429, 71428.571429, 76923.076923
+  ];
+
+  // X axis: day index starting at 1
+  final x = <int>[];
+  for (int i = 0; i < rates.length; i++) {
+    x.add(i + 1);
+  }
+
+  print('--- Linear Regression ---');
+
+  final model = linearRegression(x, rates);
+
+  print('Slope (m): ${model.m}');
+  print('Intercept (b): ${model.b}');
+
+  print('\n--- Forecast Next 10 Days ---');
+
+  forecast(x.last, model);
+}
+
+        ]]>
+    </source>
+    <call function="main">
+        []
+    </call>
+    <output>
+         [
+          "--- Linear Regression ---",
+          "Slope (m): 28.367622344360782",
+          "Intercept (b): 69024.48428808422",
+          "\n--- Forecast Next 10 Days ---",
+          "Forecast for Day 21: 1958656.22",
+          "Forecast for Day 22: 1958684.59",
+          "Forecast for Day 23: 1958712.96",
+          "Forecast for Day 24: 1958741.33",
+          "Forecast for Day 25: 1958769.69",
+          "Forecast for Day 26: 1958798.06",
+          "Forecast for Day 27: 1958826.43",
+          "Forecast for Day 28: 1958854.80",
+          "Forecast for Day 29: 1958883.16",
+          "Forecast for Day 30: 1958911.53"
+         ]
+    </output>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  LinearModel linearRegression(List<int> x, List<double> y) {
+    if ((x.length != y.length) || (x.length < 2)) {
+        return null;
+    }
+
+    final n = x.length;
+    double sumX = 0;
+    double sumY = 0;
+    for (int i = 0; i < n ; i++) {
+      sumX += x[i];
+      sumY += y[i];
+    }
+    final meanX = sumX / n;
+    final meanY = sumY / n;
+    double num = 0;
+    double den = 0;
+    for (int i = 0; i < n ; i++) {
+      final dx = x[i] - meanX;
+      final dy = y[i] - meanY;
+      num += dx * dy;
+      den += dx * dx;
+    }
+    if (den == 0) {
+        return null;
+    }
+
+    final m = num / den;
+    final b = meanY - (m * meanX);
+    return LinearModel(m, b);
+  }
+
+  void forecast(int startX, LinearModel model) {
+    int days = 10;
+    for (int i = 1; i <= days ; i++) {
+      final x = startX + i;
+      final y = model.m * (x + model.b);
+      print('Forecast for Day $x: ${y.toStringAsFixed(2)}');
+    }
+  }
+
+  void main() {
+    final rates = <double>[71428.571429, 71428.571429, 71428.571429, 66666.666667, 71428.571429, 71428.571429, 71428.571429, 66666.666667, 66666.666667, 66666.666667, 66666.666667, 66666.666667, 66666.666667, 66666.666667, 66666.666667, 66666.666667, 71428.571429, 71428.571429, 71428.571429, 76923.076923];
+    final x = <int>[];
+    for (int i = 0; i < rates.length ; i++) {
+      x.add(i + 1);
+    }
+    print('--- Linear Regression ---');
+    final model = linearRegression(x, rates);
+    print('Slope (m): ${model.m}');
+    print('Intercept (b): ${model.b}');
+    print('\n--- Forecast Next 10 Days ---');
+    forecast(x.last, model);
+  }
+
+class LinearModel {
+
+  final double m;
+  final double b;
+
+  LinearModel(this.m, this.b);
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>
+    '''),
     TestDefinition('dart_basic_stdv.test.xml', r'''
 <?xml version="1.0" encoding="UTF-8"?>
 <test title="Basic calculateStandardDeviation(List<double> numbers)">
@@ -560,9 +757,9 @@ void main() {
 ]]></source-generated>
 </test>
     '''),
-    TestDefinition('dart_basic_main_print_unnecessary_escape.test.xml', r'''
+    TestDefinition('dart_basic_calculateShippingCost.test.xml', r'''
 <?xml version="1.0" encoding="UTF-8"?>
-<test title="Basic sumOrDouble(int a, int b)">
+<test title="Basic calculateShippingCost(String destination, double weightKg)">
     <source language="dart">
         <![CDATA[
 double calculateShippingCost(String destination, double weightKg) {
@@ -1066,8 +1263,11 @@ class Foo {
   ];
 
   await runTestDefinitions(
-    [definitions[0]],
+    // [definitions[0]],
     // definitions.sublist(1),
-    // definitions,
+    // definitions
+    //     .where((e) => e.fileName.contains('dart_basic_linearRegression'))
+    //     .toList(),
+    definitions,
   );
 }


### PR DESCRIPTION
- `ASTInvocableDeclaration`:
  - Replaced `ASTFunctionDeclaration` with generic `ASTInvocableDeclaration` for function and constructor declarations.
  - Added `ASTClassConstructorDeclaration` for class constructors with support for `this` parameters.
  - Added `resolveRuntimeType` method to support runtime type resolution with context and node.
  - Updated `call` and `run` methods to support async and context-aware execution.
  - Added `initializeVariables` for constructor variable initialization.

- `ASTParametersDeclaration`:
  - Made generic over parameter type `P`.
  - Added `ASTConstructorParametersDeclaration` and `ASTFunctionParametersDeclaration` subclasses.
  - Updated parameter accessors and type checks to use generic parameter type.

- `ASTParameterDeclaration`:
  - Added `ASTConstructorParameterDeclaration` with `thisParameter` flag.
  - Added extensions for filtering `this` parameters.

- `ASTFunctionSet` and `ASTConstructorSet`:
  - Introduced generic base `ASTInvokableSet` with single and multiple implementations.
  - Added `ASTConstructorSet` for constructors, similar to function sets.

- `ASTClassNormal`:
  - Added support for constructors with `ASTConstructorSet`.
  - Added methods to add, get, and check constructors by name and signature.
  - Updated `resolveNode` to resolve constructors.

- `ASTRoot`:
  - Updated `getFunction` to return constructors if matching class name and signature.

- `ASTExpression` and `ASTValue`:
  - Added `resolveRuntimeType` and `getHashcodeValue` methods for runtime type and value hashing.
  - Updated equality and hashCode to use `getHashcodeValue`.

- `ASTExpressionFunctionInvocation` and subclasses:
  - Updated to use `ASTInvocableDeclaration` for function retrieval.
  - Updated `run` method to support async and context-aware invocation.

- `ASTExpressionObjectGetterAccess`:
  - Updated getter retrieval and runtime type resolution to support async and context-aware evaluation.
  - Added `_runGetter` helper for getter invocation.

- `ASTStatementVariableDeclaration`:
  - Added `unmodifiable` flag.
  - Updated type resolution and run implementation to use `resolveRuntimeType`.

- `ASTType`:
  - Added `ASTTypeConstructorThis` singleton for constructor `this` parameter.
  - Added `resolveRuntimeType` method.

- `ASTVariable`:
  - Added `resolveRuntimeType` method.

- `CorePackageBase` and `CoreClassMixin`:
  - Updated external function and class function creation to use `ASTFunctionParametersDeclaration`.

- `CoreClassList`:
  - Added `first` and `last` getters with runtime component type resolution.
  - Added empty constructor list and related methods.

- `DartGrammarDefinition` and `Java11GrammarDefinition`:
  - Added parsing support for class constructors with parameters and optional blocks.
  - Updated function and constructor parameter parsing to use `ASTFunctionParametersDeclaration` and `ASTConstructorParametersDeclaration`.
  - Added parsing for `this` constructor parameters.

- `ApolloCodeGeneratorDart` and `ApolloCodeGeneratorJava11`:
  - Added `generateASTClassConstructorDeclaration` method to generate constructor code.
  - Updated function parameter generation to use generic parameter declaration.

- `ApolloParserWasm`:
  - Updated WASM function parsing to use `ASTFunctionParametersDeclaration`.

- `Test`:
  - Added new test `dart_basic_linearRegression.test.xml` with Dart source for linear regression and forecast.
  - Added new test `dart_basic_calculateShippingCost.test.xml` for shipping cost calculation.
  - Updated test runner to include new tests.