### PR TITLE
v0.1.17 - Feature: added import manager (ApolloImportManager)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+## 0.1.17
+
+- Added `ApolloImportManager` to manage package/library imports and resolve core packages.
+- `VMContext`:
+  - Made sealed class.
+  - Added `importManager` field and `import` method to support import resolution and delegation to parent contexts.
+  - Updated function and external function lookup to consider imported functions.
+- Added `VMScopeContext` as a final subclass of `VMContext` for scoped runtime contexts.
+- Updated `VMClassContext` and other runtime contexts to be final and use `VMScopeContext` for nested scopes.
+- `ASTStatementImport`:
+  - New AST node to represent import statements.
+  - Supports running import in a context, throwing on failure.
+- `ASTRoot`:
+  - Supports tracking and running import statements.
+  - Considers imported functions in function resolution.
+- `ApolloRunner`:
+  - Added `importManager` field and initialization with default import manager.
+  - Supports auto-import of `dart:math` core package.
+  - Passes `importManager` to execution and function lookup calls.
+- `CorePackageBase` and `CorePackageMath`:
+  - Added `path` getter for core package identification.
+- Code generators (`dart`, `java11`, `wasm`):
+  - Added support for generating import statements (`ASTStatementImport`).
+- Dart and Java11 grammar:
+  - Added parsing of import statements into `ASTStatementImport`.
+- Test framework:
+  - Added support for `auto-import-dart-math` attribute in test XML.
+  - Tests updated to import `dart:math` and use `pow` function.
+- Various runtime and AST classes:
+  - Updated to use `VMScopeContext` instead of base `VMContext` for nested scopes.
+  - Updated `VMObject` field value methods to use `VMScopeContext`.
+- Minor fixes and improvements in import handling, context management, and code generation.
+
 ## 0.1.16
 
 - `DartGrammarDefinition`:

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -35,7 +35,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.16';
+  static final String VERSION = '0.1.17';
 
   static int _idCount = 0;
 
@@ -695,6 +695,62 @@ class BinaryCodeUnit extends CodeUnit<Uint8List> {
   }
 }
 
+/// A package/library import manager.
+class ApolloImportManager {
+  FutureOr<bool> import(String path) {
+    var corePackage = resolveCorePackage(path);
+    if (corePackage != null) {
+      return importCorePackage(corePackage);
+    }
+    return false;
+  }
+
+  CorePackageBase? resolveCorePackage(String path) {
+    switch (path) {
+      case 'dart:math':
+        return CorePackageMath();
+    }
+    return null;
+  }
+
+  bool importCorePackage(CorePackageBase corePackage) {
+    final path = corePackage.path;
+    for (var f in corePackage.exportedFunctions) {
+      addFunction(path, f);
+    }
+    return true;
+  }
+
+  final Map<String, ASTFunctionSet> _functions = {};
+
+  /// Returns a mapped functions with [fName] and optional [parametersSignature].
+  ASTFunctionDeclaration<R>? getImportedFunction<R>(
+    VMContext context,
+    String fName, [
+    ASTFunctionSignature? parametersSignature,
+  ]) {
+    var fSet = _functions[fName];
+    if (fSet == null) return null;
+
+    if (parametersSignature != null) {
+      return fSet.get(parametersSignature, false) as ASTFunctionDeclaration<R>;
+    } else {
+      return fSet.firstFunction as ASTFunctionDeclaration<R>;
+    }
+  }
+
+  void addFunction(String path, ASTFunctionDeclaration f) {
+    var fName = f.name;
+    var fSet = _functions[fName];
+
+    if (fSet == null) {
+      _functions[fName] = ASTFunctionSetSingle(f);
+    } else {
+      _functions[fName] = fSet.add(f);
+    }
+  }
+}
+
 /// A mapper for a function that is external to the [ApolloVM].
 ///
 /// Used to map normal Dart functions to the [ApolloVM] instance.
@@ -875,7 +931,7 @@ class ApolloExternalGetterMapper {
 /// A runtime context, for classes, of the VM.
 ///
 /// Implements the object instance reference of a running class.
-class VMClassContext<T> extends VMContext {
+final class VMClassContext<T> extends VMContext {
   /// The class of this context.
   ASTClass<T> clazz;
 
@@ -907,11 +963,23 @@ abstract class VMTypeResolver {
   });
 }
 
-/// A runtime context of the VM.
+/// A runtime context, for current scope, of the VM.
+///
+/// See [VMContext]
+final class VMScopeContext extends VMContext {
+  VMScopeContext(
+    super.block, {
+    super.parent,
+    super.typeResolver,
+    super.importManager,
+  });
+}
+
+/// Base class for a runtime context of the VM.
 ///
 /// Any code executed inside the VM has a context, that holds blocks
 /// variables, functions and classes instances.
-class VMContext {
+sealed class VMContext {
   static VMContext? _current;
 
   /// Static setter for the current [VMContext].
@@ -939,11 +1007,35 @@ class VMContext {
   /// The [root] should have a defined [typeResolver].
   VMTypeResolver get typeResolver => _typeResolver ??= parent!.typeResolver;
 
+  /// The import manager.
+  ApolloImportManager? importManager;
+
+  /// The external function mapper.
+  ApolloExternalFunctionMapper? externalFunctionMapper;
+
   /// The runtime block of this context.
   final ASTBlock block;
 
-  VMContext(this.block, {this.parent, VMTypeResolver? typeResolver})
-    : _typeResolver = typeResolver;
+  VMContext(
+    this.block, {
+    this.parent,
+    VMTypeResolver? typeResolver,
+    this.importManager,
+  }) : _typeResolver = typeResolver;
+
+  FutureOr<bool> import(String path) {
+    final parent = this.parent;
+    final importManager = this.importManager;
+
+    if (importManager != null) {
+      return importManager.import(path).resolveMapped((ok) {
+        if (ok) return true;
+        return parent == null ? false : parent.import(path);
+      });
+    }
+
+    return parent == null ? false : parent.import(path);
+  }
 
   final Map<String, ASTTypedVariable> _variables = {};
 
@@ -1047,12 +1139,26 @@ class VMContext {
     String name,
     ASTFunctionSignature parametersSignature,
   ) {
-    var f = block.getFunction(name, parametersSignature, this);
-    if (f != null) return f;
-    return parent?.getFunction(name, parametersSignature);
+    for (VMContext? current = this; current != null; current = current.parent) {
+      final f = current.block.getFunction(name, parametersSignature, current);
+      if (f != null) return f;
+    }
+    return null;
   }
 
-  ApolloExternalFunctionMapper? externalFunctionMapper;
+  ASTFunctionDeclaration<R>? getImportedFunction<R>(
+    String fName, [
+    ASTFunctionSignature? parametersSignature,
+  ]) {
+    for (VMContext? current = this; current != null; current = current.parent) {
+      final im = current.importManager;
+      if (im == null) continue;
+
+      final f = im.getImportedFunction<R>(current, fName, parametersSignature);
+      if (f != null) return f;
+    }
+    return null;
+  }
 
   /// Returns an [ASTExternalFunction] of [fName] and [parametersSignature].
   ///
@@ -1061,19 +1167,17 @@ class VMContext {
     String fName, [
     ASTFunctionSignature? parametersSignature,
   ]) {
-    if (externalFunctionMapper != null) {
-      var f = externalFunctionMapper!.getMappedFunction(
-        this,
+    for (VMContext? current = this; current != null; current = current.parent) {
+      final mapper = current.externalFunctionMapper;
+      if (mapper == null) continue;
+
+      final f = mapper.getMappedFunction<R>(
+        current,
         fName,
         parametersSignature,
       );
-      if (f != null) return f as ASTExternalFunction<R>;
+      if (f != null) return f;
     }
-
-    if (parent != null) {
-      return parent!.getMappedExternalFunction(fName, parametersSignature);
-    }
-
     return null;
   }
 
@@ -1145,7 +1249,7 @@ class VMObject extends ASTValue<dynamic> {
 
   /// Returns a [Map] with fields names and values.
   Map<String, ASTValue> getFieldsValues([VMContext? context]) {
-    context ??= VMContext(ASTBlock(null));
+    context ??= VMScopeContext(ASTBlock(null));
 
     var fieldsValues = <String, ASTValue>{};
 
@@ -1172,7 +1276,7 @@ class VMObject extends ASTValue<dynamic> {
   ASTValue? getFieldValue(String fieldName, [VMContext? context]) {
     var prev = _fieldsValues[fieldName];
     if (prev == null) return null;
-    context ??= VMContext(ASTBlock(null));
+    context ??= VMScopeContext(ASTBlock(null));
     var value = prev.getValue(context);
     return value;
   }
@@ -1181,7 +1285,7 @@ class VMObject extends ASTValue<dynamic> {
   ASTValue? removeFieldValue(String fieldName, [VMContext? context]) {
     var prev = _fieldsValues.remove(fieldName);
     if (prev == null) return null;
-    context ??= VMContext(ASTBlock(null));
+    context ??= VMScopeContext(ASTBlock(null));
     var value = prev.getValue(context);
     return value;
   }

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -81,6 +81,14 @@ abstract class ApolloCodeGenerator
   }) {
     out ??= newOutput();
 
+    var imports = root.imports;
+    if (imports.isNotEmpty) {
+      for (var import in imports) {
+        generateASTStatementImport(import, out: out);
+      }
+      out.write('\n');
+    }
+
     generateASTBlock(root, out: out, withBrackets: false);
 
     for (var clazz in root.classes) {
@@ -141,6 +149,13 @@ abstract class ApolloCodeGenerator
 
     return out;
   }
+
+  @override
+  StringBuffer generateASTStatementImport(
+    ASTStatementImport import, {
+    StringBuffer? out,
+    String indent = '',
+  });
 
   @override
   StringBuffer generateASTClass(

--- a/lib/src/apollovm_generator.dart
+++ b/lib/src/apollovm_generator.dart
@@ -39,6 +39,8 @@ abstract class ApolloGenerator<
       return generateASTExpression(node, out: out);
     } else if (node is ASTRoot) {
       return generateASTRoot(node, out: out);
+    } else if (node is ASTStatementImport) {
+      return generateASTStatementImport(node, out: out);
     } else if (node is ASTClassNormal) {
       return generateASTClass(node, out: out);
     } else if (node is ASTBlock) {
@@ -67,6 +69,8 @@ abstract class ApolloGenerator<
   }
 
   O generateASTBlock(ASTBlock block, {O? out});
+
+  O generateASTStatementImport(ASTStatementImport import, {O? out});
 
   O generateASTClass(ASTClassNormal clazz, {O? out});
 

--- a/lib/src/apollovm_runner.dart
+++ b/lib/src/apollovm_runner.dart
@@ -9,7 +9,6 @@ import 'apollovm_utils.dart';
 import 'ast/apollovm_ast_toplevel.dart';
 import 'ast/apollovm_ast_type.dart';
 import 'ast/apollovm_ast_value.dart';
-import 'core/apollovm_core_base.dart';
 
 @Deprecated("Renamed to `ApolloRunner`")
 typedef ApolloLanguageRunner = ApolloRunner;
@@ -27,17 +26,33 @@ abstract class ApolloRunner implements VMTypeResolver {
 
   late LanguageNamespaces _languageNamespaces;
 
+  ApolloImportManager? importManager;
+
   ApolloExternalFunctionMapper? externalFunctionMapper;
 
   final bool importCorePackageMath;
 
   ApolloRunner(this.apolloVM, {this.importCorePackageMath = false}) {
     _languageNamespaces = apolloVM.getLanguageNamespaces(language);
+    importManager = createDefaultApolloImportManager();
     externalFunctionMapper = createDefaultApolloExternalFunctionMapper();
   }
 
   /// Returns a copy of this instance.
   ApolloRunner copy();
+
+  ApolloImportManager? createDefaultApolloImportManager() {
+    var apolloImportManager = ApolloImportManager();
+
+    if (importCorePackageMath) {
+      var ok = apolloImportManager.import('dart:math') as bool;
+      if (!ok) {
+        throw ApolloVMRuntimeError("Can't auto import `dart:math`");
+      }
+    }
+
+    return apolloImportManager;
+  }
 
   /// The default [ApolloExternalFunctionMapper] for this target language runner.
   ///
@@ -52,12 +67,6 @@ abstract class ApolloRunner implements VMTypeResolver {
       'o',
       (o) => externalPrintFunction(o),
     );
-
-    if (importCorePackageMath) {
-      for (var f in CorePackageMath().exportedFunctions) {
-        externalFunctionMapper.addExternalFunction(f);
-      }
-    }
 
     return externalFunctionMapper;
   }
@@ -112,6 +121,7 @@ abstract class ApolloRunner implements VMTypeResolver {
       namedParameters,
       classInstanceObject: classInstanceObject,
       classInstanceFields: classInstanceFields,
+      importManager: importManager,
       externalFunctionMapper: externalFunctionMapper,
       typeResolver: this,
     );
@@ -176,6 +186,7 @@ abstract class ApolloRunner implements VMTypeResolver {
       methodName,
       positionalParameters,
       namedParameters,
+      importManager: importManager,
       externalFunctionMapper: externalFunctionMapper,
       typeResolver: this,
     );
@@ -261,6 +272,7 @@ abstract class ApolloRunner implements VMTypeResolver {
         functionName,
         positionalParameters,
         namedParameters,
+        importManager: importManager,
         externalFunctionMapper: externalFunctionMapper,
         typeResolver: this,
       );
@@ -288,6 +300,7 @@ abstract class ApolloRunner implements VMTypeResolver {
       functionName,
       positionalParameters,
       namedParameters,
+      importManager: importManager,
       externalFunctionMapper: externalFunctionMapper,
       typeResolver: this,
     );

--- a/lib/src/ast/apollovm_ast_statement.dart
+++ b/lib/src/ast/apollovm_ast_statement.dart
@@ -44,6 +44,48 @@ abstract class ASTStatement with ASTNode implements ASTCodeRunner {
   void associateToType(ASTTypedNode node) {}
 }
 
+/// [ASTStatement] to import a package/library.
+class ASTStatementImport extends ASTStatement {
+  final String path;
+
+  final String? prefix;
+
+  ASTStatementImport(this.path, {this.prefix});
+
+  @override
+  Iterable<ASTNode> get children => [];
+
+  @override
+  FutureOr<ASTValueVoid> run(VMContext parentContext, ASTRunStatus runStatus) {
+    return parentContext.import(path).resolveMapped((ok) {
+      if (!ok) {
+        throw ApolloVMRuntimeError("Can't import: $path");
+      }
+      return runStatus.returnVoid();
+    });
+  }
+
+  @override
+  FutureOr<ASTType> resolveType(VMContext? context) => ASTTypeVoid.instance;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ASTStatementImport &&
+          runtimeType == other.runtimeType &&
+          path == other.path &&
+          prefix == other.prefix;
+
+  @override
+  int get hashCode => Object.hash(path, prefix);
+
+  @override
+  String toString() {
+    final prefix = this.prefix;
+    return ['import "$path"', if (prefix != null) ' as $prefix', ';'].join();
+  }
+}
+
 /// An AST Block of code (statements).
 class ASTBlock extends ASTStatement {
   ASTBlock? parentBlock;
@@ -185,6 +227,9 @@ class ASTBlock extends ASTStatement {
   }) {
     var set = getFunctionWithName(fName, caseInsensitive: caseInsensitive);
     if (set != null) return set.get(parametersSignature, false);
+
+    var fImported = context.getImportedFunction(fName, parametersSignature);
+    if (fImported != null) return fImported;
 
     var fExternal = context.getMappedExternalFunction(
       fName,
@@ -927,7 +972,7 @@ class ASTStatementWhileLoop extends ASTStatement {
     VMContext parentContext,
     ASTRunStatus runStatus,
   ) async {
-    var context = VMContext(parentContext.block, parent: parentContext);
+    var context = VMScopeContext(parentContext.block, parent: parentContext);
     var runStatus = ASTRunStatus();
 
     var prevContext = VMContext.setCurrent(context);
@@ -949,7 +994,7 @@ class ASTStatementWhileLoop extends ASTStatement {
           }
         }
 
-        var loopContext = VMContext(parentContext.block, parent: context);
+        var loopContext = VMScopeContext(parentContext.block, parent: context);
 
         VMContext.setCurrent(loopContext);
 
@@ -1013,7 +1058,7 @@ class ASTStatementForLoop extends ASTStatement {
     VMContext parentContext,
     ASTRunStatus runStatus,
   ) async {
-    var context = VMContext(parentContext.block, parent: parentContext);
+    var context = VMScopeContext(parentContext.block, parent: parentContext);
     var runStatus = ASTRunStatus();
 
     var prevContext = VMContext.setCurrent(context);
@@ -1037,7 +1082,7 @@ class ASTStatementForLoop extends ASTStatement {
           }
         }
 
-        var loopContext = VMContext(parentContext.block, parent: context);
+        var loopContext = VMScopeContext(parentContext.block, parent: context);
 
         VMContext.setCurrent(loopContext);
 
@@ -1092,7 +1137,7 @@ class ASTStatementForEach extends ASTStatement {
     VMContext parentContext,
     ASTRunStatus runStatus,
   ) async {
-    var context = VMContext(parentContext.block, parent: parentContext);
+    var context = VMScopeContext(parentContext.block, parent: parentContext);
     var prevContext = VMContext.setCurrent(context);
 
     try {
@@ -1112,7 +1157,7 @@ class ASTStatementForEach extends ASTStatement {
       for (var element in iterable) {
         var astElement = await elementType.toValue(parentContext, element);
 
-        var loopContext = VMContext(parentContext.block, parent: context);
+        var loopContext = VMScopeContext(parentContext.block, parent: context);
 
         loopContext.declareVariableWithValue(
           elementType,

--- a/lib/src/ast/apollovm_ast_toplevel.dart
+++ b/lib/src/ast/apollovm_ast_toplevel.dart
@@ -2,6 +2,7 @@
 // This code is governed by the Apache License, Version 2.0.
 // Please refer to the LICENSE and AUTHORS files for details.
 
+import 'dart:collection';
 import 'dart:math' as math;
 
 import 'package:async_extension/async_extension.dart';
@@ -25,15 +26,23 @@ class ASTEntryPointBlock extends ASTBlock {
     String entryFunctionName,
     List? positionalParameters,
     Map? namedParameters, {
+    ApolloImportManager? importManager,
     ApolloExternalFunctionMapper? externalFunctionMapper,
     VMObject? classInstanceObject,
     Map<String, ASTValue>? classInstanceFields,
     VMTypeResolver? typeResolver,
   }) async {
     var rootContext = await _initializeEntryPointBlock(
+      importManager,
       externalFunctionMapper,
       typeResolver,
     );
+
+    ApolloImportManager? prevImportManager;
+    if (importManager != null) {
+      prevImportManager = rootContext.importManager;
+      rootContext.importManager = importManager;
+    }
 
     ApolloExternalFunctionMapper? prevExternalFunctionMapper;
     if (externalFunctionMapper != null) {
@@ -105,6 +114,11 @@ class ASTEntryPointBlock extends ASTBlock {
       );
     } finally {
       VMContext.setCurrent(prevContext);
+
+      if (identical(rootContext.importManager, importManager)) {
+        rootContext.importManager = prevImportManager;
+      }
+
       if (identical(
         rootContext.externalFunctionMapper,
         externalFunctionMapper,
@@ -118,13 +132,21 @@ class ASTEntryPointBlock extends ASTBlock {
     String entryFunctionName,
     List? positionalParameters,
     Map? namedParameters, {
+    ApolloImportManager? importManager,
     ApolloExternalFunctionMapper? externalFunctionMapper,
     VMTypeResolver? typeResolver,
   }) async {
     var rootContext = await _initializeEntryPointBlock(
+      importManager,
       externalFunctionMapper,
       typeResolver,
     );
+
+    ApolloImportManager? prevImportManager;
+    if (importManager != null) {
+      prevImportManager = rootContext.importManager;
+      rootContext.importManager = importManager;
+    }
 
     ApolloExternalFunctionMapper? prevExternalFunctionMapper;
     if (externalFunctionMapper != null) {
@@ -147,6 +169,11 @@ class ASTEntryPointBlock extends ASTBlock {
       }
     } finally {
       VMContext.setCurrent(prevContext);
+
+      if (identical(rootContext.importManager, importManager)) {
+        rootContext.importManager = prevImportManager;
+      }
+
       if (identical(
         rootContext.externalFunctionMapper,
         externalFunctionMapper,
@@ -159,6 +186,7 @@ class ASTEntryPointBlock extends ASTBlock {
   VMContext? _rootContext;
 
   Future<VMContext> _initializeEntryPointBlock(
+    ApolloImportManager? importManager,
     ApolloExternalFunctionMapper? externalFunctionMapper,
     VMTypeResolver? typeResolver,
   ) async {
@@ -166,6 +194,12 @@ class ASTEntryPointBlock extends ASTBlock {
       var rootContext = createContext(typeResolver);
       var rootStatus = ASTRunStatus();
       _rootContext = rootContext;
+
+      ApolloImportManager? prevImportManager;
+      if (importManager != null) {
+        prevImportManager = rootContext.importManager;
+        rootContext.importManager = importManager;
+      }
 
       ApolloExternalFunctionMapper? prevExternalFunctionMapper;
       if (externalFunctionMapper != null) {
@@ -179,6 +213,10 @@ class ASTEntryPointBlock extends ASTBlock {
       } finally {
         VMContext.setCurrent(prevContext);
 
+        if (identical(rootContext.importManager, importManager)) {
+          rootContext.importManager = prevImportManager;
+        }
+
         if (identical(
           rootContext.externalFunctionMapper,
           externalFunctionMapper,
@@ -191,7 +229,7 @@ class ASTEntryPointBlock extends ASTBlock {
   }
 
   VMContext createContext(VMTypeResolver? typeResolver) =>
-      VMContext(this, typeResolver: typeResolver);
+      VMScopeContext(this, typeResolver: typeResolver);
 }
 
 /// AST base of a Class.
@@ -263,7 +301,7 @@ abstract class ASTClass<T> extends ASTEntryPointBlock {
     var map = Map<String, Object>.fromEntries(fieldsEntries);
 
     if (fieldOverwrite != null && fieldOverwrite.isNotEmpty) {
-      context ??= VMContext(ASTBlock(null));
+      context ??= VMScopeContext(ASTBlock(null));
       for (var entry in fieldOverwrite.entries) {
         var value = await entry.value.getValue(context);
         map[entry.key] = value ?? Null;
@@ -848,6 +886,12 @@ class ASTRoot extends ASTEntryPointBlock {
 
   String namespace = '';
 
+  final Set<ASTStatementImport> _imports = {};
+
+  Set<ASTStatementImport> get imports => UnmodifiableSetView(_imports);
+
+  void addImport(ASTStatementImport import) => _imports.add(import);
+
   @override
   ASTInvocableDeclaration? getFunction(
     String fName,
@@ -866,6 +910,9 @@ class ASTRoot extends ASTEntryPointBlock {
         return constructor;
       }
     }
+
+    var fImported = context.getImportedFunction(fName, parametersSignature);
+    if (fImported != null) return fImported;
 
     var fExternal = context.getMappedExternalFunction(
       fName,
@@ -929,6 +976,22 @@ class ASTRoot extends ASTEntryPointBlock {
 
   ASTClassNormal? getClassWithMethod(String methodName) => _classes.values
       .firstWhereOrNull((c) => c.containsFunctionWithName(methodName));
+
+  @override
+  FutureOr<ASTValue> run(
+    VMContext parentContext,
+    ASTRunStatus runStatus,
+  ) async {
+    var imports = _imports;
+
+    if (imports.isNotEmpty) {
+      for (var import in imports) {
+        await import.run(parentContext, runStatus);
+      }
+    }
+
+    return super.run(parentContext, runStatus);
+  }
 }
 
 /// An AST Parameter declaration.
@@ -1777,7 +1840,7 @@ abstract class ASTInvocableDeclaration<
     List? positionalParameters,
     Map? namedParameters,
   }) async {
-    var context = VMContext(this, parent: parent);
+    var context = VMScopeContext(this, parent: parent);
 
     var prevContext = VMContext.setCurrent(context);
     try {
@@ -2102,7 +2165,7 @@ class ASTClassConstructorDeclaration<T>
     List? positionalParameters,
     Map? namedParameters,
   }) async {
-    var context = VMContext(this, parent: parent);
+    var context = VMScopeContext(this, parent: parent);
 
     var prevContext = VMContext.setCurrent(context);
     try {
@@ -2250,7 +2313,7 @@ class ASTGetterDeclaration<T> extends ASTBlock {
   }
 
   FutureOr<ASTValue<T>> call(VMContext parent) async {
-    var context = VMContext(this, parent: parent);
+    var context = VMScopeContext(this, parent: parent);
 
     var prevContext = VMContext.setCurrent(context);
     try {
@@ -2315,7 +2378,7 @@ class ASTExternalGetter<T> extends ASTGetterDeclaration<T> {
 
   @override
   FutureOr<ASTValue<T>> call(VMContext parent) async {
-    var context = VMContext(this, parent: parent);
+    var context = VMScopeContext(this, parent: parent);
 
     var prevContext = VMContext.setCurrent(context);
     try {
@@ -2369,7 +2432,7 @@ class ASTExternalClassGetter<T> extends ASTClassGetterDeclaration<T> {
   }) {
     var classInstance = parent.getClassInstance();
     return classInstance!.getValue(parent).resolveMapped((obj) {
-      var context = VMContext(this, parent: parent);
+      var context = VMScopeContext(this, parent: parent);
 
       var prevContext = VMContext.setCurrent(context);
       try {
@@ -2428,7 +2491,7 @@ class ASTExternalFunction<T> extends ASTFunctionDeclaration<T> {
     List? positionalParameters,
     Map? namedParameters,
   }) async {
-    var context = VMContext(this, parent: parent);
+    var context = VMScopeContext(this, parent: parent);
 
     var prevContext = VMContext.setCurrent(context);
     try {
@@ -2532,7 +2595,7 @@ class ASTExternalClassFunction<T> extends ASTClassFunctionDeclaration<T> {
     var classInstance = parent.getClassInstance();
     var obj = await classInstance!.getValue(parent);
 
-    var context = VMContext(this, parent: parent);
+    var context = VMScopeContext(this, parent: parent);
 
     var prevContext = VMContext.setCurrent(context);
     try {

--- a/lib/src/ast/apollovm_ast_variable.dart
+++ b/lib/src/ast/apollovm_ast_variable.dart
@@ -141,7 +141,7 @@ class ASTClassFieldWithInitialValue<T> extends ASTClassField<T> {
   }
 
   FutureOr<ASTValue> getInitialValueNoContext() {
-    var context = VMContext(ASTBlock(null));
+    var context = VMScopeContext(ASTBlock(null));
     var runStatus = ASTRunStatus();
     return _initialValueExpression.run(context, runStatus);
   }

--- a/lib/src/core/apollovm_core_base.dart
+++ b/lib/src/core/apollovm_core_base.dart
@@ -28,6 +28,8 @@ class ApolloVMCore {
 abstract class CorePackageBase extends ASTBlock {
   String get packageName;
 
+  String get path;
+
   CorePackageBase() : super(null);
 
   List<ASTExternalFunction> get exportedFunctions;
@@ -69,6 +71,9 @@ abstract class CorePackageBase extends ASTBlock {
 class CorePackageMath extends CorePackageBase {
   @override
   String get packageName => 'dart:math';
+
+  @override
+  String get path => 'dart:math';
 
   late final ASTExternalFunction _functionPow;
   late final ASTExternalFunction _functionSqrt;

--- a/lib/src/languages/dart/dart_generator.dart
+++ b/lib/src/languages/dart/dart_generator.dart
@@ -7,6 +7,7 @@ import 'package:collection/collection.dart';
 import '../../apollovm_code_generator.dart';
 import '../../apollovm_code_storage.dart';
 import '../../ast/apollovm_ast_expression.dart';
+import '../../ast/apollovm_ast_statement.dart';
 import '../../ast/apollovm_ast_toplevel.dart';
 import '../../ast/apollovm_ast_type.dart';
 import '../../ast/apollovm_ast_value.dart';
@@ -44,6 +45,28 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
       default:
         return functionName;
     }
+  }
+
+  @override
+  StringBuffer generateASTStatementImport(
+    ASTStatementImport import, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    final path = import.path;
+    final prefix = import.prefix;
+
+    out ??= newOutput();
+
+    out.write('import ');
+    out.write("'$path'");
+    if (prefix != null) {
+      out.write(' as ');
+      out.write(prefix);
+    }
+    out.write(';\n');
+
+    return out;
   }
 
   @override

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -54,12 +54,19 @@ class DartGrammarDefinition extends DartGrammarLexer {
   Parser<ASTRoot> compilationUnit() =>
       (ref0(hashbangLexicalToken).optional() &
               //ref0(libraryDirective).optional() &
-              //ref0(importDirective).star() &
+              ref0(statementImport).star() &
               ref0(topLevelDefinition).star())
           .map((v) {
-            var topDef = v[1] as List;
+            var imports = v[1] as List;
+            var topDef = v[2] as List;
 
             var root = ASTRoot();
+
+            for (var import in imports) {
+              if (import is ASTStatementImport) {
+                root.addImport(import);
+              }
+            }
 
             for (var defList in topDef) {
               for (var def in defList) {
@@ -93,6 +100,18 @@ class DartGrammarDefinition extends DartGrammarLexer {
               block: block,
               modifiers: ASTModifiers.modifierStatic,
             );
+          });
+
+  Parser<ASTStatementImport> statementImport() =>
+      (importToken().trimHidden() &
+              stringLexicalToken() &
+              char(';').trimHidden())
+          .map((v) {
+            var parsedPath = v[1] as ParsedString;
+            var path =
+                parsedPath.literalString ??
+                (throw StateError("Invalid import parsed path: $parsedPath"));
+            return ASTStatementImport(path);
           });
 
   Parser<ASTClassNormal> classDeclaration() =>

--- a/lib/src/languages/java/java11/java11_generator.dart
+++ b/lib/src/languages/java/java11/java11_generator.dart
@@ -6,6 +6,7 @@ import '../../../apollovm_code_generator.dart';
 import '../../../apollovm_code_storage.dart';
 import '../../../apollovm_parser.dart';
 import '../../../ast/apollovm_ast_expression.dart';
+import '../../../ast/apollovm_ast_statement.dart';
 import '../../../ast/apollovm_ast_toplevel.dart';
 import '../../../ast/apollovm_ast_type.dart';
 import '../../../ast/apollovm_ast_value.dart';
@@ -45,6 +46,23 @@ class ApolloCodeGeneratorJava11 extends ApolloCodeGenerator {
       default:
         return functionName;
     }
+  }
+
+  @override
+  StringBuffer generateASTStatementImport(
+    ASTStatementImport import, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    final path = import.path;
+
+    out ??= newOutput();
+
+    out.write('import ');
+    out.write(path);
+    out.write(';\n');
+
+    return out;
   }
 
   @override

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -391,6 +391,15 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   }
 
   @override
+  BytesOutput generateASTStatementImport(
+    ASTStatementImport import, {
+    BytesOutput? out,
+  }) {
+    // TODO: implement generateASTStatementImport
+    throw UnimplementedError("generateASTStatementImport");
+  }
+
+  @override
   BytesOutput generateASTClass(ASTClassNormal clazz, {BytesOutput? out}) {
     // TODO: implement generateASTClass
     throw UnimplementedError('generateASTClass');

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, JavaScript with on-the-fly Wasm compilation.
-version: 0.1.16
+version: 0.1.17
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/apollovm_languages_basic_test.dart
+++ b/test/apollovm_languages_basic_test.dart
@@ -27,6 +27,8 @@ Future<void> _tests() async {
 <test title="Basic main()">
     <source language="dart">
         <![CDATA[
+import 'dart:math';
+
 double calculateStdDev(List<double> values) {        
   if (values == null || values.isEmpty) {
     return 0.0;
@@ -40,7 +42,7 @@ double calculateStdDev(List<double> values) {
 
   double sqDiffSum = 0;
   for (var value in values) {
-    sqDiffSum += (value - mean) * (value - mean);
+    sqDiffSum += pow(value - mean, 2);
   }
   double variance = sqDiffSum / values.length;
   return sqrt(variance);
@@ -64,6 +66,8 @@ void main() {
     <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
 <<<< NAMESPACE="" >>>>
 <<<< CODE_UNIT_START="/test" >>>>
+import 'dart:math';
+
   double calculateStdDev(List<double> values) {
     if ((values == null) || values.isEmpty) {
         return 0.0;
@@ -76,7 +80,7 @@ void main() {
     double mean = sum / values.length;
     double sqDiffSum = 0;
     for (var value in values) {
-      sqDiffSum += (value - mean) * (value - mean);
+      sqDiffSum += pow(value - mean, 2);
     }
     double variance = sqDiffSum / values.length;
     return sqrt(variance);
@@ -96,7 +100,7 @@ void main() {
     TestDefinition('dart_basic_exchange_rates.test.xml', r'''
 <?xml version="1.0" encoding="UTF-8"?>
 <test title="Basic main()">
-    <source language="dart">
+    <source language="dart" auto-import-dart-math="true">
         <![CDATA[
 
 void main() {
@@ -591,6 +595,8 @@ class LinearModel {
 <test title="Basic calculateStandardDeviation(List<double> numbers)">
     <source language="dart">
         <![CDATA[
+import "dart:math" ;
+
 double calculateStandardDeviation(List<double> numbers) {
   if (numbers == null || numbers.length < 2) {
     return 0.0; // Cannot calculate std dev for less than 2 points
@@ -637,6 +643,8 @@ void main() {
     <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
 <<<< NAMESPACE="" >>>>
 <<<< CODE_UNIT_START="/test" >>>>
+import 'dart:math';
+
   double calculateStandardDeviation(List<double> numbers) {
     if ((numbers == null) || (numbers.length < 2)) {
         return 0.0;
@@ -1646,11 +1654,11 @@ class Foo {
   ];
 
   await runTestDefinitions(
-    [definitions[0]],
+    // [definitions[0]],
     // definitions.sublist(1),
     // definitions
     //     .where((e) => e.fileName.contains('dart_basic_linearRegression'))
     //     .toList(),
-    // definitions,
+    definitions,
   );
 }

--- a/test/apollovm_languages_test_definition.dart
+++ b/test/apollovm_languages_test_definition.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 
 import 'package:apollovm/apollovm.dart';
 import 'package:collection/collection.dart';
+import 'package:swiss_knife/swiss_knife.dart';
 import 'package:test/test.dart';
 import 'package:xml/xml.dart';
 
@@ -23,6 +24,9 @@ class TestDefinition implements Comparable<TestDefinition> {
   XmlElement get source => rootElement.findElements('source').first;
 
   String get language => source.getAttribute('language')!;
+
+  bool get autoImportDartMath =>
+      parseBool(source.getAttribute('auto-import-dart-math')) ?? false;
 
   String get sourceCode => source.innerText;
 
@@ -104,8 +108,9 @@ Future<void> runTestDefinitions(List<TestDefinition> testDefinitions) async {
             '\n======================================================================\n',
           );
 
-          var language = testDefinition.language;
-          var sourcesGenerated = testDefinition.sourcesGenerated;
+          final language = testDefinition.language;
+          final autoImportDartMath = testDefinition.autoImportDartMath;
+          final sourcesGenerated = testDefinition.sourcesGenerated;
 
           print('FILE: ${testDefinition.fileName}');
           print('');
@@ -113,6 +118,7 @@ Future<void> runTestDefinitions(List<TestDefinition> testDefinitions) async {
           print('TEST: ${testDefinition.title}');
 
           print('  - language: $language ');
+          print('  - autoImportDartMath: $autoImportDartMath ');
           print('  - sourcesGenerated: ${sourcesGenerated.length}');
           print('');
           print('SOURCE:');
@@ -132,7 +138,10 @@ Future<void> runTestDefinitions(List<TestDefinition> testDefinitions) async {
 
           expect(loadOK, isTrue, reason: "Error loading '$language ' code!");
 
-          var runner = vm.createRunner(language, importCorePackageMath: true)!;
+          var runner = vm.createRunner(
+            language,
+            importCorePackageMath: autoImportDartMath,
+          )!;
 
           var calls = testDefinition.calls;
           var outputs = testDefinition.outputs;


### PR DESCRIPTION
- Added `ApolloImportManager` to manage package/library imports and resolve core packages.
- `VMContext`:
  - Made sealed class.
  - Added `importManager` field and `import` method to support import resolution and delegation to parent contexts.
  - Updated function and external function lookup to consider imported functions.
- Added `VMScopeContext` as a final subclass of `VMContext` for scoped runtime contexts.
- Updated `VMClassContext` and other runtime contexts to be final and use `VMScopeContext` for nested scopes.
- `ASTStatementImport`:
  - New AST node to represent import statements.
  - Supports running import in a context, throwing on failure.
- `ASTRoot`:
  - Supports tracking and running import statements.
  - Considers imported functions in function resolution.
- `ApolloRunner`:
  - Added `importManager` field and initialization with default import manager.
  - Supports auto-import of `dart:math` core package.
  - Passes `importManager` to execution and function lookup calls.
- `CorePackageBase` and `CorePackageMath`:
  - Added `path` getter for core package identification.
- Code generators (`dart`, `java11`, `wasm`):
  - Added support for generating import statements (`ASTStatementImport`).
- Dart and Java11 grammar:
  - Added parsing of import statements into `ASTStatementImport`.
- Test framework:
  - Added support for `auto-import-dart-math` attribute in test XML.
  - Tests updated to import `dart:math` and use `pow` function.
- Various runtime and AST classes:
  - Updated to use `VMScopeContext` instead of base `VMContext` for nested scopes.
  - Updated `VMObject` field value methods to use `VMScopeContext`.
- Minor fixes and improvements in import handling, context management, and code generation.