### PR TITLE
v0.1.27: bug fixes + raise test coverage to ~71%

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.1.27
+
+- Bug fixes:
+  - Loop `return` propagation: a `return` inside a `for`, `while`, or `for-each` loop was ignored (the loop shadowed `runStatus` with a fresh instance and never broke on return). Returns now propagate and stop iteration correctly.
+  - `ASTType` equality: `ASTTypeBool`, `ASTTypeString`, `ASTTypeObject`, `ASTTypeConstructorThis`, `ASTTypeVar`, `ASTTypeDynamic`, `ASTTypeNull`, and `ASTTypeVoid` mistakenly checked `other is ASTTypeInt`, so equal instances never compared equal. Each now checks its own type.
+  - `ASTTypeMap`: building a map from a flat key/value list read from the (empty) target map instead of the input list, producing an empty map.
+  - Java generator (`_escapeString`): backslashes were not escaped, producing invalid Java string literals (e.g. `"a\b"` instead of `"a\\b"`).
+  - `ASTExpression.literalNumType` returned `ASTNumType.int` for `double` literals.
+  - Corrected the operator symbol shown in `ASTValueString`/`ASTValueNum` comparison/equality error messages.
+
+- Tests:
+  - Increased line coverage from ~64.6% to ~70.9%.
+  - Added regression tests for all the fixes above and extensive unit/integration tests for `ASTValue`, `ASTType`, `ApolloVM`, expressions, the core library, and the Wasm generator.
+
 ## 0.1.26
 
 - `DartGrammarDefinition`:

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -35,7 +35,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.26';
+  static final String VERSION = '0.1.27';
 
   static int _idCount = 0;
 

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -141,7 +141,7 @@ abstract class ASTExpression with ASTNode implements ASTCodeRunner {
       if (valueType is ASTTypeInt) {
         return ASTNumType.int;
       } else if (valueType is ASTTypeDouble) {
-        return ASTNumType.int;
+        return ASTNumType.double;
       } else if (valueType is ASTTypeNum) {
         return ASTNumType.num;
       }

--- a/lib/src/ast/apollovm_ast_statement.dart
+++ b/lib/src/ast/apollovm_ast_statement.dart
@@ -1062,7 +1062,6 @@ class ASTStatementWhileLoop extends ASTStatement {
     ASTRunStatus runStatus,
   ) async {
     var context = VMScopeContext(parentContext.block, parent: parentContext);
-    var runStatus = ASTRunStatus();
 
     var prevContext = VMContext.setCurrent(context);
     try {
@@ -1090,6 +1089,8 @@ class ASTStatementWhileLoop extends ASTStatement {
         await loopBlock.run(loopContext, runStatus);
 
         VMContext.setCurrent(context);
+
+        if (runStatus.returned) break;
       }
     } finally {
       VMContext.setCurrent(prevContext);
@@ -1148,7 +1149,6 @@ class ASTStatementForLoop extends ASTStatement {
     ASTRunStatus runStatus,
   ) async {
     var context = VMScopeContext(parentContext.block, parent: parentContext);
-    var runStatus = ASTRunStatus();
 
     var prevContext = VMContext.setCurrent(context);
     try {
@@ -1178,6 +1178,8 @@ class ASTStatementForLoop extends ASTStatement {
         await loopBlock.run(loopContext, runStatus);
 
         VMContext.setCurrent(context);
+
+        if (runStatus.returned) break;
 
         await continueExpression.run(context, runStatus);
       }
@@ -1259,6 +1261,8 @@ class ASTStatementForEach extends ASTStatement {
         await loopBlock.run(loopContext, runStatus);
 
         VMContext.setCurrent(context);
+
+        if (runStatus.returned) break;
       }
     } finally {
       VMContext.setCurrent(prevContext);

--- a/lib/src/ast/apollovm_ast_type.dart
+++ b/lib/src/ast/apollovm_ast_type.dart
@@ -433,7 +433,9 @@ class ASTTypeBool extends ASTTypePrimitive<bool> {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      super == other && other is ASTTypeInt && runtimeType == other.runtimeType;
+      super == other &&
+          other is ASTTypeBool &&
+          runtimeType == other.runtimeType;
 
   @override
   int get hashCode => name.hashCode;
@@ -742,7 +744,9 @@ class ASTTypeString extends ASTTypePrimitive<String> {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      super == other && other is ASTTypeInt && runtimeType == other.runtimeType;
+      super == other &&
+          other is ASTTypeString &&
+          runtimeType == other.runtimeType;
 
   @override
   int get hashCode => name.hashCode;
@@ -794,7 +798,9 @@ class ASTTypeObject extends ASTType<Object> {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      super == other && other is ASTTypeInt && runtimeType == other.runtimeType;
+      super == other &&
+          other is ASTTypeObject &&
+          runtimeType == other.runtimeType;
 
   @override
   int get hashCode => name.hashCode;
@@ -858,7 +864,9 @@ class ASTTypeConstructorThis extends ASTType<dynamic> {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      super == other && other is ASTTypeInt && runtimeType == other.runtimeType;
+      super == other &&
+          other is ASTTypeConstructorThis &&
+          runtimeType == other.runtimeType;
 
   @override
   int get hashCode => name.hashCode;
@@ -927,7 +935,7 @@ class ASTTypeVar extends ASTType<dynamic> {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      super == other && other is ASTTypeInt && runtimeType == other.runtimeType;
+      super == other && other is ASTTypeVar && runtimeType == other.runtimeType;
 
   @override
   int get hashCode => name.hashCode;
@@ -968,7 +976,9 @@ class ASTTypeDynamic extends ASTType<dynamic> {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      super == other && other is ASTTypeInt && runtimeType == other.runtimeType;
+      super == other &&
+          other is ASTTypeDynamic &&
+          runtimeType == other.runtimeType;
 
   @override
   int get hashCode => name.hashCode;
@@ -1009,7 +1019,9 @@ class ASTTypeNull extends ASTType<Null> {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      super == other && other is ASTTypeInt && runtimeType == other.runtimeType;
+      super == other &&
+          other is ASTTypeNull &&
+          runtimeType == other.runtimeType;
 
   @override
   int get hashCode => name.hashCode;
@@ -1048,7 +1060,9 @@ class ASTTypeVoid extends ASTType<void> {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      super == other && other is ASTTypeInt && runtimeType == other.runtimeType;
+      super == other &&
+          other is ASTTypeVoid &&
+          runtimeType == other.runtimeType;
 
   @override
   int get hashCode => name.hashCode;
@@ -1369,9 +1383,9 @@ class ASTTypeMap<TK extends ASTType<K>, TV extends ASTType<V>, K, V>
       } else if (v.length % 2 == 0) {
         map = {};
         for (var i = 0; i < v.length; i += 2) {
-          var k = map[i];
-          var v = map[i + 1];
-          map[k] = v;
+          var k = v[i];
+          var val = v[i + 1];
+          map[k] = val;
         }
       }
     }

--- a/lib/src/ast/apollovm_ast_value.dart
+++ b/lib/src/ast/apollovm_ast_value.dart
@@ -551,7 +551,7 @@ abstract class ASTValueNum<T extends num> extends ASTValuePrimitive<T> {
       }
 
       throw UnsupportedError(
-        "Can't perform operation '==' in non number values: $value > $v2",
+        "Can't perform operation '==' in non number values: $value == $v2",
       );
     }
     return false;
@@ -819,21 +819,21 @@ class ASTValueString extends ASTValuePrimitive<String> {
   @override
   bool operator <(Object other) {
     throw UnsupportedError(
-      "Can't perform operation '<' in non number values: $this > $other",
+      "Can't perform operation '<' in non number values: $this < $other",
     );
   }
 
   @override
   bool operator >=(Object other) {
     throw UnsupportedError(
-      "Can't perform operation '>=' in non number values: $this > $other",
+      "Can't perform operation '>=' in non number values: $this >= $other",
     );
   }
 
   @override
   bool operator <=(Object other) {
     throw UnsupportedError(
-      "Can't perform operation '<=' in non number values: $this > $other",
+      "Can't perform operation '<=' in non number values: $this <= $other",
     );
   }
 

--- a/lib/src/languages/java/java11/java11_generator.dart
+++ b/lib/src/languages/java/java11/java11_generator.dart
@@ -398,6 +398,7 @@ class ApolloCodeGeneratorJava11 extends ApolloCodeGenerator {
 
   String _escapeString(String str) {
     return str
+        .replaceAll('\\', r'\\')
         .replaceAll('\t', r'\t')
         .replaceAll('"', r'\"')
         .replaceAll('\r', r'\r')

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, JavaScript with on-the-fly Wasm compilation.
-version: 0.1.26
+version: 0.1.27
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/apollovm_ast_type_extra_test.dart
+++ b/test/apollovm_ast_type_extra_test.dart
@@ -1,0 +1,677 @@
+@TestOn('vm')
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Helper to perform intentional cross-type `==` comparisons without
+/// triggering `unrelated_type_equality_checks`.
+bool _eq(ASTType a, ASTType b) => a == b;
+
+void main() {
+  final context = VMScopeContext(ASTBlock(null));
+
+  group('ASTTypeArray basics', () {
+    test('static instances names and generics', () {
+      expect(ASTTypeArray.instanceOfString.name, equals('List'));
+      expect(ASTTypeArray.instanceOfInt.name, equals('List'));
+      expect(ASTTypeArray.instanceOfDouble.name, equals('List'));
+      expect(ASTTypeArray.instanceOfBool.name, equals('List'));
+      expect(ASTTypeArray.instanceOfObject.name, equals('List'));
+      expect(ASTTypeArray.instanceOfDynamic.name, equals('List'));
+
+      expect(ASTTypeArray.instanceOfString.generics, hasLength(1));
+      expect(
+        ASTTypeArray.instanceOfString.elementType,
+        equals(ASTTypeString.instance),
+      );
+      expect(
+        ASTTypeArray.instanceOfInt.componentType,
+        equals(ASTTypeInt.instance),
+      );
+    });
+
+    test('toString includes generics', () {
+      expect(ASTTypeArray.instanceOfString.toString(), equals('List<String>'));
+      expect(ASTTypeArray.instanceOfInt.toString(), equals('List<int>'));
+    });
+
+    test('factory returns shared instances for primitives', () {
+      expect(
+        identical(
+          ASTTypeArray(ASTTypeString.instance),
+          ASTTypeArray.instanceOfString,
+        ),
+        isTrue,
+      );
+      expect(
+        identical(
+          ASTTypeArray(ASTTypeInt.instance),
+          ASTTypeArray.instanceOfInt,
+        ),
+        isTrue,
+      );
+      expect(
+        identical(
+          ASTTypeArray(ASTTypeBool.instance),
+          ASTTypeArray.instanceOfBool,
+        ),
+        isTrue,
+      );
+    });
+
+    test('fromType maps List<T> to array instances', () {
+      expect(
+        ASTTypeArray.fromType(List<String>),
+        equals(ASTTypeArray.instanceOfString),
+      );
+      expect(
+        ASTTypeArray.fromType(List<int>),
+        equals(ASTTypeArray.instanceOfInt),
+      );
+      expect(
+        ASTTypeArray.fromType(List<double>),
+        equals(ASTTypeArray.instanceOfDouble),
+      );
+      expect(
+        ASTTypeArray.fromType(List<bool>),
+        equals(ASTTypeArray.instanceOfBool),
+      );
+      expect(
+        ASTTypeArray.fromType(List<Object>),
+        equals(ASTTypeArray.instanceOfObject),
+      );
+      expect(
+        ASTTypeArray.fromType(List<dynamic>),
+        equals(ASTTypeArray.instanceOfDynamic),
+      );
+      expect(ASTTypeArray.fromType(int), isNull);
+    });
+
+    test('withType factory maps element type', () {
+      var a = ASTTypeArray<ASTTypeString, String>.withType(String);
+      expect(identical(a, ASTTypeArray.instanceOfString), isTrue);
+    });
+
+    test('ASTType.fromType resolves array types', () {
+      expect(
+        ASTType.fromType(List<String>),
+        equals(ASTTypeArray.instanceOfString),
+      );
+    });
+  });
+
+  group('ASTTypeArray toValue / toASTValue', () {
+    test('toValue from native List', () async {
+      ASTValue? v = await ASTTypeArray.instanceOfInt.toValue(context, [
+        1,
+        2,
+        3,
+      ]);
+      expect(v, isNotNull);
+      var list = await v!.getValue(context);
+      expect(list, equals([1, 2, 3]));
+    });
+
+    test('toValue wraps single value into list', () async {
+      ASTValue? v = await ASTTypeArray.instanceOfString.toValue(context, 'x');
+      var list = await v!.getValue(context);
+      expect(list, equals(['x']));
+    });
+
+    test('toValue filters non-matching element types', () async {
+      ASTValue? v = await ASTTypeArray.instanceOfInt.toValue(context, [
+        1,
+        'a',
+        2,
+      ]);
+      var list = await v!.getValue(context);
+      expect(list, equals([1, 2]));
+    });
+
+    test('toValue null returns null', () async {
+      expect(await ASTTypeArray.instanceOfInt.toValue(context, null), isNull);
+    });
+
+    test('toASTValue from List', () {
+      var v = ASTTypeArray.instanceOfString.toASTValue(['a', 'b']);
+      expect(v, isNotNull);
+      expect(v!.getValueNoContext(), equals(['a', 'b']));
+      expect(ASTTypeArray.instanceOfString.toASTValue(null), isNull);
+    });
+  });
+
+  group('ASTTypeArray2D / Array3D', () {
+    test('fromElementType 2D', () {
+      var a2 = ASTTypeArray2D<ASTTypeInt, int>.fromElementType(
+        ASTTypeInt.instance,
+      );
+      expect(a2.name, equals('List'));
+      expect(a2.elementType, equals(ASTTypeInt.instance));
+      expect(a2.toString(), startsWith('List<List<'));
+    });
+
+    test('2D toValue from nested List', () async {
+      // Base-typed so `toValue` returns a `FutureOr` (avoids await_only_futures).
+      ASTType a2 = ASTTypeArray2D<ASTTypeInt, int>.fromElementType(
+        ASTTypeInt.instance,
+      );
+      ASTValue? v = await a2.toValue(context, [
+        [1, 2],
+        [3, 4],
+      ]);
+      expect(v, isNotNull);
+      var list = await v!.getValue(context);
+      expect(
+        list,
+        equals([
+          [1, 2],
+          [3, 4],
+        ]),
+      );
+    });
+
+    test('2D toASTValue', () {
+      var a2 = ASTTypeArray2D<ASTTypeString, String>.fromElementType(
+        ASTTypeString.instance,
+      );
+      var v = a2.toASTValue([
+        ['a'],
+        ['b'],
+      ]);
+      expect(v, isNotNull);
+      expect(a2.toASTValue(null), isNull);
+    });
+
+    test('fromElementType 3D', () {
+      var a3 = ASTTypeArray3D<ASTTypeInt, int>.fromElementType(
+        ASTTypeInt.instance,
+      );
+      expect(a3.name, equals('List'));
+      expect(a3.elementType, equals(ASTTypeInt.instance));
+    });
+
+    test('3D toValue from triple-nested List', () async {
+      ASTType a3 = ASTTypeArray3D<ASTTypeInt, int>.fromElementType(
+        ASTTypeInt.instance,
+      );
+      ASTValue? v = await a3.toValue(context, [
+        [
+          [1, 2],
+        ],
+        [
+          [3],
+        ],
+      ]);
+      expect(v, isNotNull);
+    });
+  });
+
+  group('ASTType.fromNativeValue nested lists', () {
+    test('nested list infers a List array type', () {
+      var t = ASTType.fromNativeValue(<List<int>>[
+        [1],
+        [2],
+      ]);
+      expect(t.name, equals('List'));
+      expect(t, isA<ASTTypeArray>());
+    });
+
+    test('triple-nested list infers a List array type', () {
+      var t = ASTType.fromNativeValue(<List<List<String>>>[
+        [
+          ['a'],
+        ],
+      ]);
+      expect(t.name, equals('List'));
+      expect(t, isA<ASTTypeArray>());
+    });
+
+    test('generic list inference', () {
+      var t = ASTType.fromNativeValue(<num>[1, 2]);
+      expect(t.name, equals('List'));
+      expect(t, isA<ASTTypeArray>());
+    });
+  });
+
+  group('ASTTypeMap', () {
+    test('static instances and names', () {
+      expect(ASTTypeMap.instanceOfStringOfDynamic.name, equals('Map'));
+      expect(
+        ASTTypeMap.instanceOfStringOfDynamic.keyType,
+        equals(ASTTypeString.instance),
+      );
+      expect(
+        ASTTypeMap.instanceOfStringOfDynamic.valueType,
+        equals(ASTTypeDynamic.instance),
+      );
+      expect(
+        ASTTypeMap.instanceOfStringOfString.valueType,
+        equals(ASTTypeString.instance),
+      );
+      expect(
+        ASTTypeMap.instanceOfDynamicOfDynamic.keyType,
+        equals(ASTTypeDynamic.instance),
+      );
+    });
+
+    test('toString includes generics', () {
+      expect(
+        ASTTypeMap.instanceOfStringOfString.toString(),
+        equals('Map<String,String>'),
+      );
+    });
+
+    test('fromType maps Map types', () {
+      expect(
+        ASTTypeMap.fromType(Map<String, dynamic>),
+        equals(ASTTypeMap.instanceOfStringOfDynamic),
+      );
+      expect(
+        ASTTypeMap.fromType(Map<String, String>),
+        equals(ASTTypeMap.instanceOfStringOfString),
+      );
+      expect(
+        ASTTypeMap.fromType(Map<dynamic, dynamic>),
+        equals(ASTTypeMap.instanceOfDynamicOfDynamic),
+      );
+      expect(ASTTypeMap.fromType(int), isNull);
+    });
+
+    test('ASTType.fromType resolves Map types', () {
+      expect(
+        ASTType.fromType(Map<String, String>),
+        equals(ASTTypeMap.instanceOfStringOfString),
+      );
+    });
+
+    test('toValue from real Map', () async {
+      var v = await ASTTypeMap.instanceOfStringOfString.toValue(context, {
+        'a': '1',
+        'b': '2',
+      });
+      expect(v, isNotNull);
+      var map = await v!.getValue(context);
+      expect(map, equals({'a': '1', 'b': '2'}));
+    });
+
+    test('toValue from MapEntry list', () async {
+      var v = await ASTTypeMap.instanceOfStringOfString.toValue(context, [
+        MapEntry('a', '1'),
+        MapEntry('b', '2'),
+      ]);
+      var map = await v!.getValue(context);
+      expect(map, equals({'a': '1', 'b': '2'}));
+    });
+
+    test('toValue from flat pair list', () async {
+      var v = await ASTTypeMap.instanceOfStringOfString.toValue(context, [
+        'a',
+        '1',
+      ]);
+      var map = await v!.getValue(context);
+      expect(map, equals({'a': '1'}));
+    });
+
+    test('toValue null returns null', () async {
+      expect(
+        await ASTTypeMap.instanceOfStringOfString.toValue(context, null),
+        isNull,
+      );
+    });
+
+    test('toASTValue', () {
+      var v = ASTTypeMap.instanceOfStringOfString.toASTValue({'k': 'v'});
+      expect(v, isNotNull);
+      expect(ASTTypeMap.instanceOfStringOfString.toASTValue(null), isNull);
+    });
+  });
+
+  group('ASTTypeFuture', () {
+    test('name and toString', () {
+      var f = ASTTypeFuture<ASTTypeInt, int>(ASTTypeInt.instance);
+      expect(f.name, equals('Future'));
+      expect(f.toString(), equals('Future<int>'));
+    });
+
+    test('toASTValue wraps a value into a Future', () async {
+      var f = ASTTypeFuture<ASTTypeInt, int>(ASTTypeInt.instance);
+      var v = f.toASTValue(42);
+      expect(v, isNotNull);
+      var resolved = await v!.getValueNoContext();
+      expect(resolved, equals(42));
+      expect(f.toASTValue(null), isNull);
+    });
+
+    test('toASTValue wraps an existing Future', () async {
+      var f = ASTTypeFuture<ASTTypeInt, int>(ASTTypeInt.instance);
+      var v = f.toASTValue(Future<int>.value(7));
+      var resolved = await v!.getValueNoContext();
+      expect(resolved, equals(7));
+    });
+
+    test('toValue from Future', () async {
+      var f = ASTTypeFuture<ASTTypeInt, int>(ASTTypeInt.instance);
+      var v = f.toValue(context, Future<int>.value(9));
+      expect(v, isNotNull);
+    });
+  });
+
+  group('ASTTypeFunction', () {
+    test('name and generics', () {
+      var f = ASTTypeFunction(ASTTypeInt.instance, [ASTTypeString.instance]);
+      expect(f.name, equals('Function'));
+      expect(f.generics, isNotNull);
+      expect(f.generics, hasLength(2));
+    });
+
+    test('toValue null returns null', () {
+      var f = ASTTypeFunction();
+      expect(f.toValue(context, null), isNull);
+      expect(f.toASTValue(null), isNull);
+    });
+
+    test('toValue with non-null throws UnsupportedError', () {
+      var f = ASTTypeFunction();
+      expect(() => f.toValue(context, 123), throwsUnsupportedError);
+      expect(() => f.toASTValue(123), throwsUnsupportedError);
+    });
+  });
+
+  group('ASTTypeGenericVariable / Wildcard', () {
+    test('generic variable name and resolveType', () {
+      var g = ASTTypeGenericVariable('T', ASTTypeInt.instance);
+      expect(g.name, equals('T'));
+      expect(g.variableName, equals('T'));
+      expect(g.resolveType(context), equals(ASTTypeInt.instance));
+    });
+
+    test('generic variable without type resolves to Object', () {
+      var g = ASTTypeGenericVariable('E');
+      expect(g.resolveType(context), equals(ASTTypeObject.instance));
+    });
+
+    test('generic variable toValue delegates to resolved type', () async {
+      var g = ASTTypeGenericVariable('T', ASTTypeInt.instance);
+      var v = await g.toValue(context, 5);
+      expect(v, isNotNull);
+      expect(await v!.getValue(context), equals(5));
+    });
+
+    test('wildcard resolveType is Object', () {
+      expect(
+        ASTTypeGenericWildcard.instance.resolveType(context),
+        equals(ASTTypeObject.instance),
+      );
+      expect(ASTTypeGenericWildcard.instance.name, equals('?'));
+    });
+
+    test('acceptsType accepts wildcard argument', () {
+      // `acceptsType` returns true when the argument is the wildcard instance.
+      var t = ASTType('Custom');
+      expect(t.acceptsType(ASTTypeGenericWildcard.instance), isTrue);
+    });
+  });
+
+  group('ASTTypeObject', () {
+    test('toString and acceptsType', () {
+      expect(ASTTypeObject.instance.toString(), equals('Object'));
+      expect(ASTTypeObject.instance.acceptsType(ASTTypeInt.instance), isTrue);
+      expect(
+        ASTTypeObject.instance.acceptsType(ASTTypeString.instance),
+        isTrue,
+      );
+    });
+
+    test('toValue from raw value', () async {
+      var v = await ASTTypeObject.instance.toValue(context, 'hi');
+      expect(v, isNotNull);
+      expect(await v!.getValue(context), equals('hi'));
+    });
+
+    test('toValue null returns null', () async {
+      expect(await ASTTypeObject.instance.toValue(context, null), isNull);
+    });
+
+    test('equality and hashCode', () {
+      expect(_eq(ASTTypeObject.instance, ASTTypeObject()), isTrue);
+      expect(ASTTypeObject.instance.hashCode, equals(ASTTypeObject().hashCode));
+    });
+  });
+
+  group('ASTTypeDynamic', () {
+    test('toString and acceptsType', () {
+      expect(ASTTypeDynamic.instance.toString(), equals('dynamic'));
+      expect(ASTTypeDynamic.instance.acceptsType(ASTTypeInt.instance), isTrue);
+    });
+
+    test('toValue wraps raw value', () async {
+      var v = await ASTTypeDynamic.instance.toValue(context, 123);
+      expect(v, isNotNull);
+      expect(await v.getValue(context), equals(123));
+    });
+  });
+
+  group('ASTTypeVar', () {
+    test('var and final names', () {
+      expect(ASTTypeVar.instance.name, equals('var'));
+      expect(ASTTypeVar.instance.toString(), equals('var'));
+      expect(ASTTypeVar.instanceUnmodifiable.toString(), equals('final'));
+      expect(ASTTypeVar.instanceUnmodifiable.unmodifiable, isTrue);
+    });
+
+    test('acceptsType always true', () {
+      expect(ASTTypeVar.instance.acceptsType(ASTTypeInt.instance), isTrue);
+    });
+
+    test('toValue wraps raw value', () async {
+      var v = await ASTTypeVar.instance.toValue(context, 'data');
+      expect(v, isNotNull);
+      expect(await v.getValue(context), equals('data'));
+    });
+
+    test('resolveType returns self when no associated node', () async {
+      ASTType t = ASTTypeVar();
+      expect(await t.resolveType(context), isA<ASTTypeVar>());
+    });
+  });
+
+  group('ASTTypeNull', () {
+    test('toString and acceptsType', () {
+      expect(ASTTypeNull.instance.toString(), equals('Null'));
+      expect(ASTTypeNull.instance.acceptsType(ASTTypeNull.instance), isTrue);
+      expect(ASTTypeNull.instance.acceptsType(ASTTypeInt.instance), isFalse);
+    });
+
+    test('toValue returns ASTValueNull', () {
+      ASTType nullType = ASTTypeNull.instance;
+      var v = nullType.toValue(context, 'anything');
+      expect(v, isNotNull);
+    });
+
+    test('toASTValue returns null instance', () {
+      expect(ASTTypeNull.instance.toASTValue(null), isNotNull);
+    });
+
+    test('ASTType.from(null) is Null type', () {
+      expect(ASTType.from(null), equals(ASTTypeNull.instance));
+    });
+  });
+
+  group('ASTTypeVoid', () {
+    test('toString and acceptsType', () {
+      expect(ASTTypeVoid.instance.toString(), equals('void'));
+      expect(ASTTypeVoid.instance.acceptsType(ASTTypeVoid.instance), isTrue);
+      expect(ASTTypeVoid.instance.acceptsType(ASTTypeInt.instance), isFalse);
+    });
+
+    test('toValue returns void value', () {
+      ASTType voidType = ASTTypeVoid.instance;
+      expect(voidType.toValue(context, null), isNotNull);
+      expect(ASTTypeVoid.instance.toASTValue(null), isNotNull);
+    });
+  });
+
+  group('ASTTypeConstructorThis', () {
+    test('toString and acceptsType', () {
+      expect(ASTTypeConstructorThis.instance.toString(), equals('this'));
+      expect(
+        ASTTypeConstructorThis.instance.acceptsType(ASTTypeInt.instance),
+        isTrue,
+      );
+    });
+
+    test('toValue wraps raw value', () async {
+      var v = await ASTTypeConstructorThis.instance.toValue(context, 'self');
+      expect(v, isNotNull);
+      expect(await v.getValue(context), equals('self'));
+    });
+
+    test('resolveType returns self when no associated node', () async {
+      ASTType t = ASTTypeConstructorThis.instance;
+      expect(await t.resolveType(context), isA<ASTTypeConstructorThis>());
+    });
+  });
+
+  group('ASTType.from and fromAsync', () {
+    test('from ASTType returns same', () {
+      expect(ASTType.from(ASTTypeInt.instance), equals(ASTTypeInt.instance));
+    });
+
+    test('from native int value', () {
+      expect(ASTType.from(5), equals(ASTTypeInt.instance));
+    });
+
+    test('fromAsync null', () async {
+      expect(await ASTType.fromAsync(null), equals(ASTTypeNull.instance));
+    });
+
+    test('fromAsync ASTType returns same', () async {
+      expect(
+        await ASTType.fromAsync(ASTTypeString.instance),
+        equals(ASTTypeString.instance),
+      );
+    });
+
+    test('fromAsync native value', () async {
+      expect(await ASTType.fromAsync('x'), equals(ASTTypeString.instance));
+      expect(await ASTType.fromAsync(2.5), equals(ASTTypeDouble.instance));
+    });
+  });
+
+  group('acceptsType edge cases', () {
+    test('generics matching same lengths', () {
+      var a = ASTTypeArray.instanceOfInt;
+      expect(a.acceptsType(ASTTypeArray.instanceOfInt), isTrue);
+    });
+
+    test('different name without superType is rejected', () {
+      expect(ASTTypeString.instance.acceptsType(ASTTypeInt.instance), isFalse);
+    });
+
+    test('superType chain accepted', () {
+      var sub = ASTType('Sub', superType: ASTTypeObject.instance);
+      var base = ASTType('Base');
+      // `sub` has Object as superType, and Object accepts `base`, so the
+      // name-mismatch check passes and (no generics) the result is true.
+      expect(base.acceptsType(sub), isTrue);
+
+      // Without a superType, a name mismatch is rejected.
+      var noSuper = ASTType('Other');
+      expect(base.acceptsType(noSuper), isFalse);
+    });
+
+    test('commonType resolves to accepting type', () {
+      expect(
+        ASTTypeObject.instance.commonType(ASTTypeInt.instance),
+        equals(ASTTypeObject.instance),
+      );
+      expect(
+        ASTTypeInt.instance.commonType(ASTTypeInt.instance),
+        equals(ASTTypeInt.instance),
+      );
+      expect(ASTTypeInt.instance.commonType(null), equals(ASTTypeInt.instance));
+    });
+
+    test('canCastToType', () {
+      expect(ASTTypeInt.instance.canCastToType(ASTTypeObject.instance), isTrue);
+      expect(
+        ASTTypeObject.instance.canCastToType(ASTTypeInt.instance),
+        isFalse,
+      );
+    });
+  });
+
+  group('ASTType generic equality / hashCode', () {
+    test('arrays with same component are equal', () {
+      var a = ASTTypeArray(ASTTypeInt.instance);
+      var b = ASTTypeArray.instanceOfInt;
+      expect(_eq(a, b), isTrue);
+      expect(a.hashCode, equals(b.hashCode));
+    });
+
+    test('different component arrays not equal', () {
+      expect(
+        _eq(ASTTypeArray.instanceOfInt, ASTTypeArray.instanceOfString),
+        isFalse,
+      );
+    });
+
+    test('hasGenerics / hasSuperType flags', () {
+      expect(ASTTypeArray.instanceOfInt.hasGenerics, isTrue);
+      expect(ASTTypeInt.instance.hasGenerics, isFalse);
+      var t = ASTType('X', superType: ASTTypeObject.instance);
+      expect(t.hasSuperType, isTrue);
+      expect(ASTTypeInt.instance.hasSuperType, isFalse);
+    });
+  });
+
+  group('ASTNumType enum', () {
+    test('enum values present', () {
+      expect(ASTNumType.values, contains(ASTNumType.int));
+      expect(ASTNumType.values, contains(ASTNumType.double));
+      expect(ASTNumType.values, contains(ASTNumType.num));
+      expect(ASTNumType.values, contains(ASTNumType.nan));
+    });
+  });
+
+  group('ASTTypeNum / Double extra', () {
+    test('num accepts num/int/double', () {
+      expect(ASTTypeNum.instance.acceptsType(ASTTypeNum.instance), isTrue);
+    });
+
+    test('double accepts int', () {
+      expect(ASTTypeDouble.instance.acceptsType(ASTTypeInt.instance), isTrue);
+      expect(
+        ASTTypeDouble.instance.acceptsType(ASTTypeString.instance),
+        isFalse,
+      );
+    });
+
+    test('doubleToString helper', () {
+      expect(ASTTypeDouble.doubleToString(0.0), equals('0.0'));
+      expect(ASTTypeDouble.doubleToString(5), equals('5.0'));
+      expect(ASTTypeDouble.doubleToString(1.5), equals('1.5'));
+    });
+
+    test('double equals strict bits', () {
+      expect(
+        ASTTypeDouble.instance32.equals(ASTTypeDouble.instance64),
+        isFalse,
+      );
+      expect(ASTTypeDouble.instance.equals(ASTTypeDouble.instance32), isTrue);
+      expect(
+        ASTTypeDouble.instance.equals(ASTTypeDouble.instance32, strict: true),
+        isFalse,
+      );
+    });
+
+    test('equalsStrict extension', () {
+      expect(ASTTypeInt.instance.equalsStrict(ASTTypeInt.instance32), isFalse);
+      expect(
+        ASTTypeString.instance.equalsStrict(ASTTypeString.instance),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/apollovm_ast_type_test.dart
+++ b/test/apollovm_ast_type_test.dart
@@ -1,0 +1,158 @@
+@TestOn('vm')
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ASTType.fromType', () {
+    test('maps Dart types to AST types', () {
+      expect(ASTType.fromType(int), equals(ASTTypeInt.instance));
+      expect(ASTType.fromType(double), equals(ASTTypeDouble.instance));
+      expect(ASTType.fromType(bool), equals(ASTTypeBool.instance));
+      expect(ASTType.fromType(String), equals(ASTTypeString.instance));
+      expect(ASTType.fromType(Object), equals(ASTTypeObject.instance));
+    });
+
+    test('returns null for unknown type', () {
+      expect(ASTType.fromType(Duration), isNull);
+    });
+  });
+
+  group('ASTType.fromNativeValue', () {
+    test('infers type from a native value', () {
+      expect(ASTType.fromNativeValue(5), equals(ASTTypeInt.instance));
+      expect(ASTType.fromNativeValue(2.5), equals(ASTTypeDouble.instance));
+      expect(ASTType.fromNativeValue('x'), equals(ASTTypeString.instance));
+      expect(ASTType.fromNativeValue(null), equals(ASTTypeNull.instance));
+    });
+
+    test('infers array types', () {
+      expect(ASTType.fromNativeValue(<String>['a']).name, equals('List'));
+      expect(ASTType.fromNativeValue(<int>[1, 2]).name, equals('List'));
+    });
+  });
+
+  group('toString', () {
+    test('primitive type names', () {
+      expect(ASTTypeInt.instance.toString(), equals('int'));
+      expect(ASTTypeInt(bits: 32).toString(), equals('int(32)'));
+      expect(ASTTypeDouble.instance.toString(), equals('double'));
+      expect(ASTTypeDouble(bits: 64).toString(), equals('double(64)'));
+      expect(ASTTypeNum.instance.toString(), equals('num'));
+      expect(ASTTypeBool.instance.toString(), equals('bool'));
+      expect(ASTTypeString.instance.toString(), equals('String'));
+      expect(ASTTypeObject.instance.toString(), equals('Object'));
+      expect(ASTTypeDynamic.instance.toString(), equals('dynamic'));
+    });
+  });
+
+  group('acceptsType', () {
+    test('int only accepts int', () {
+      expect(ASTTypeInt.instance.acceptsType(ASTTypeInt.instance), isTrue);
+      expect(ASTTypeInt.instance.acceptsType(ASTTypeDouble.instance), isFalse);
+    });
+
+    test('num accepts int and double', () {
+      expect(ASTTypeNum.instance.acceptsType(ASTTypeInt.instance), isTrue);
+      expect(ASTTypeNum.instance.acceptsType(ASTTypeDouble.instance), isTrue);
+      expect(ASTTypeNum.instance.acceptsType(ASTTypeString.instance), isFalse);
+    });
+
+    test('Object and dynamic accept any type', () {
+      expect(ASTTypeObject.instance.acceptsType(ASTTypeInt.instance), isTrue);
+      expect(
+        ASTTypeDynamic.instance.acceptsType(ASTTypeString.instance),
+        isTrue,
+      );
+    });
+  });
+
+  group('toASTValue', () {
+    test('int conversion', () {
+      expect(
+        ASTTypeInt.instance.toASTValue(42)?.getValueNoContext(),
+        equals(42),
+      );
+      expect(
+        ASTTypeInt.instance.toASTValue('7')?.getValueNoContext(),
+        equals(7),
+      );
+      expect(ASTTypeInt.instance.toASTValue(null), isNull);
+    });
+
+    test('double conversion', () {
+      expect(
+        ASTTypeDouble.instance.toASTValue(1.5)?.getValueNoContext(),
+        equals(1.5),
+      );
+    });
+
+    test('bool conversion', () {
+      expect(
+        ASTTypeBool.instance.toASTValue('true')?.getValueNoContext(),
+        isTrue,
+      );
+      expect(ASTTypeBool.instance.toASTValue(null), isNull);
+    });
+
+    test('string conversion', () {
+      expect(
+        ASTTypeString.instance.toASTValue(123)?.getValueNoContext(),
+        equals('123'),
+      );
+    });
+  });
+
+  group('toDefaultValue', () {
+    final context = VMScopeContext(ASTBlock(null));
+
+    test('default values per type', () async {
+      // Call through `ASTType` to use the base `FutureOr<ASTValue?>` signature.
+      ASTType intType = ASTTypeInt.instance;
+      expect(
+        (await intType.toDefaultValue(context))?.getValueNoContext(),
+        equals(0),
+      );
+      expect(
+        (await ASTTypeDouble.instance.toDefaultValue(
+          context,
+        ))?.getValueNoContext(),
+        equals(0.0),
+      );
+      expect(
+        (await ASTTypeBool.instance.toDefaultValue(
+          context,
+        ))?.getValueNoContext(),
+        isFalse,
+      );
+    });
+  });
+
+  group('ASTTypeInt.equals with bits', () {
+    test('bit-width sensitivity', () {
+      expect(ASTTypeInt.instance == ASTTypeInt.instance, isTrue);
+      expect(ASTTypeInt.instance32.equals(ASTTypeInt.instance64), isFalse);
+      // Unspecified bits are compatible unless strict.
+      expect(ASTTypeInt.instance.equals(ASTTypeInt.instance32), isTrue);
+      expect(
+        ASTTypeInt.instance.equals(ASTTypeInt.instance32, strict: true),
+        isFalse,
+      );
+    });
+  });
+
+  group('toValue conversions', () {
+    final context = VMScopeContext(ASTBlock(null));
+
+    test('int from double truncates', () async {
+      var v = await ASTTypeInt.instance.toValue(context, ASTValueDouble(3.9));
+      expect(v?.getValueNoContext(), equals(3));
+    });
+
+    test('int from raw string', () async {
+      var v = await ASTTypeInt.instance.toValue(context, '15');
+      expect(v?.getValueNoContext(), equals(15));
+    });
+  });
+}

--- a/test/apollovm_ast_value_extra_test.dart
+++ b/test/apollovm_ast_value_extra_test.dart
@@ -1,0 +1,412 @@
+@TestOn('vm')
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Helper to route intentional cross-type `==` comparisons through `ASTValue`,
+/// avoiding `unrelated_type_equality_checks` analyzer warnings.
+bool _eq(ASTValue a, Object? b) => a == b;
+
+/// Normalizes a [FutureOr] into a [Future] so `await` is always valid
+/// regardless of the concrete (possibly synchronous) return type.
+Future<T> _await<T>(FutureOr<T> v) async => await v;
+
+void main() {
+  group('ASTValueAsString', () {
+    test('getValueNoContext (int -> toString)', () async {
+      var v = ASTValueAsString(ASTValueInt(42));
+      expect(await _await(v.getValueNoContext()), equals('42'));
+      expect(v.type, isA<ASTTypeString>());
+    });
+
+    test('getValue with context', () async {
+      var context = VMScopeContext(ASTBlock(null));
+      var v = ASTValueAsString(ASTValueInt(7));
+      expect(await v.getValue(context), equals('7'));
+    });
+
+    test('resolve returns ASTValueString', () async {
+      var context = VMScopeContext(ASTBlock(null));
+      var v = ASTValueAsString(ASTValueInt(3));
+      var resolved = await v.resolve(context);
+      expect(resolved, isA<ASTValueString>());
+      expect(await _await(resolved.getValueNoContext()), equals('3'));
+    });
+
+    test('valueToString num + ASTTypeDouble path', () {
+      var s = ASTValueAsString.valueToString(5, ASTTypeDouble.instance);
+      expect(s, equals('5.0'));
+    });
+
+    test('valueToString plain toString path', () {
+      expect(ASTValueAsString.valueToString(5), equals('5'));
+      expect(ASTValueAsString.valueToString('abc'), equals('abc'));
+      expect(ASTValueAsString.valueToString(null), equals('null'));
+    });
+
+    test('valueToString double value through wrapped ASTValueDouble', () async {
+      var v = ASTValueAsString(ASTValueDouble(5));
+      expect(await _await(v.getValueNoContext()), equals('5.0'));
+    });
+
+    test('children contains wrapped value', () {
+      var inner = ASTValueInt(1);
+      var v = ASTValueAsString(inner);
+      expect(v.children, contains(inner));
+    });
+  });
+
+  group('ASTValuesListAsString', () {
+    test('getValueNoContext joins values', () async {
+      var v = ASTValuesListAsString([
+        ASTValueString('a'),
+        ASTValueInt(1),
+        ASTValueDouble(2),
+      ]);
+      expect(await _await(v.getValueNoContext()), equals('a12.0'));
+    });
+
+    test('getValue with context joins values', () async {
+      var context = VMScopeContext(ASTBlock(null));
+      var v = ASTValuesListAsString([ASTValueString('x'), ASTValueInt(9)]);
+      expect(await v.getValue(context), equals('x9'));
+    });
+
+    test('resolve returns ASTValueString', () async {
+      var context = VMScopeContext(ASTBlock(null));
+      var v = ASTValuesListAsString([ASTValueString('hi'), ASTValueInt(5)]);
+      var resolved = await v.resolve(context);
+      expect(resolved, isA<ASTValueString>());
+      expect(await _await(resolved.getValueNoContext()), equals('hi5'));
+    });
+  });
+
+  group('ASTValueStringConcatenation', () {
+    test('getValueNoContext concatenation', () async {
+      var v = ASTValueStringConcatenation([
+        ASTValueString('foo'),
+        ASTValueString('bar'),
+      ]);
+      expect(await _await(v.getValueNoContext()), equals('foobar'));
+    });
+
+    test('getValue with context', () async {
+      var context = VMScopeContext(ASTBlock(null));
+      var v = ASTValueStringConcatenation([
+        ASTValueString('a'),
+        ASTValueString('b'),
+        ASTValueString('c'),
+      ]);
+      expect(await v.getValue(context), equals('abc'));
+    });
+
+    test('toString joins with " + "', () {
+      var v = ASTValueStringConcatenation([
+        ASTValueString('a'),
+        ASTValueString('b'),
+      ]);
+      expect(v.toString(), equals('"a" + "b"'));
+    });
+
+    test('resolve returns ASTValuesListAsString', () async {
+      var context = VMScopeContext(ASTBlock(null));
+      var v = ASTValueStringConcatenation([
+        ASTValueString('x'),
+        ASTValueString('y'),
+      ]);
+      var resolved = await v.resolve(context);
+      expect(await _await(resolved.getValueNoContext()), equals('xy'));
+    });
+  });
+
+  group('ASTValueStringExpression', () {
+    test('getValue with context (literal int)', () async {
+      var context = VMScopeContext(ASTBlock(null));
+      var v = ASTValueStringExpression(ASTExpressionLiteral(ASTValueInt(5)));
+      expect(await v.getValue(context), equals('5'));
+    });
+
+    test('getValueNoContext throws UnsupportedError', () {
+      var v = ASTValueStringExpression(ASTExpressionLiteral(ASTValueInt(5)));
+      expect(() => v.getValueNoContext(), throwsUnsupportedError);
+    });
+
+    test('toString wraps expression', () {
+      var v = ASTValueStringExpression(ASTExpressionLiteral(ASTValueInt(5)));
+      expect(v.toString(), contains('\${'));
+    });
+
+    test('resolve returns ASTValueString', () async {
+      var context = VMScopeContext(ASTBlock(null));
+      var v = ASTValueStringExpression(ASTExpressionLiteral(ASTValueInt(8)));
+      var resolved = await v.resolve(context);
+      expect(resolved, isA<ASTValueString>());
+      expect(await _await(resolved.getValueNoContext()), equals('8'));
+    });
+  });
+
+  group('ASTValueObject', () {
+    test('getValueNoContext returns object', () async {
+      var obj = Object();
+      var v = ASTValueObject(obj);
+      expect(await _await(v.getValueNoContext()), same(obj));
+      expect(v.type, isA<ASTTypeObject>());
+    });
+
+    test('equality by underlying value', () {
+      var v1 = ASTValueObject('same');
+      var v2 = ASTValueObject('same');
+      expect(v1, equals(v2));
+    });
+
+    test('inequality for different objects', () {
+      var v1 = ASTValueObject('a');
+      var v2 = ASTValueObject('b');
+      expect(v1 == v2, isFalse);
+    });
+  });
+
+  group('ASTValueArray', () {
+    test('getValueNoContext returns list', () async {
+      var arr = ASTValueArray<ASTTypeInt, int>(ASTTypeInt.instance, [1, 2, 3]);
+      expect(await _await(arr.getValueNoContext()), equals([1, 2, 3]));
+    });
+
+    test('cast int -> double', () async {
+      var arr = ASTValueArray<ASTTypeInt, int>(ASTTypeInt.instance, [1, 2, 3]);
+      var casted = arr.cast<ASTTypeDouble, double>(
+        componentType: ASTTypeDouble.instance,
+      );
+      var v = await _await(casted.getValueNoContext());
+      expect(v, equals([1.0, 2.0, 3.0]));
+      expect(v, everyElement(isA<double>()));
+    });
+
+    test('equals via equals() method', () async {
+      var a = ASTValueArray<ASTTypeInt, int>(ASTTypeInt.instance, [1, 2]);
+      var b = ASTValueArray<ASTTypeInt, int>(ASTTypeInt.instance, [1, 2]);
+      expect(await a.equals(b), isTrue);
+    });
+
+    test('not equals different list', () async {
+      var a = ASTValueArray<ASTTypeInt, int>(ASTTypeInt.instance, [1, 2]);
+      var b = ASTValueArray<ASTTypeInt, int>(ASTTypeInt.instance, [1, 3]);
+      expect(await a.equals(b), isFalse);
+    });
+  });
+
+  group('ASTValueArray2D', () {
+    test('getValueNoContext returns nested list', () async {
+      var arr = ASTValueArray2D<ASTTypeInt, int>(ASTTypeInt.instance, [
+        [1, 2],
+        [3, 4],
+      ]);
+      expect(
+        await _await(arr.getValueNoContext()),
+        equals([
+          [1, 2],
+          [3, 4],
+        ]),
+      );
+    });
+
+    test('operator== deep equality', () {
+      var a = ASTValueArray2D<ASTTypeInt, int>(ASTTypeInt.instance, [
+        [1, 2],
+        [3, 4],
+      ]);
+      var b = ASTValueArray2D<ASTTypeInt, int>(ASTTypeInt.instance, [
+        [1, 2],
+        [3, 4],
+      ]);
+      expect(a == b, isTrue);
+    });
+
+    test('operator== deep inequality', () {
+      var a = ASTValueArray2D<ASTTypeInt, int>(ASTTypeInt.instance, [
+        [1, 2],
+      ]);
+      var b = ASTValueArray2D<ASTTypeInt, int>(ASTTypeInt.instance, [
+        [9, 9],
+      ]);
+      expect(a == b, isFalse);
+    });
+
+    test('hashCode equal for equal contents', () {
+      var a = ASTValueArray2D<ASTTypeInt, int>(ASTTypeInt.instance, [
+        [1, 2],
+      ]);
+      var b = ASTValueArray2D<ASTTypeInt, int>(ASTTypeInt.instance, [
+        [1, 2],
+      ]);
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+
+  group('ASTValueArray3D', () {
+    test('getValueNoContext returns 3D nested list', () async {
+      var arr = ASTValueArray3D<ASTTypeInt, int>(ASTTypeInt.instance, [
+        [
+          [1, 2],
+          [3],
+        ],
+        [
+          [4],
+        ],
+      ]);
+      expect(
+        await _await(arr.getValueNoContext()),
+        equals([
+          [
+            [1, 2],
+            [3],
+          ],
+          [
+            [4],
+          ],
+        ]),
+      );
+    });
+
+    test('operator== deep equality (inherited)', () {
+      var a = ASTValueArray3D<ASTTypeInt, int>(ASTTypeInt.instance, [
+        [
+          [1],
+        ],
+      ]);
+      var b = ASTValueArray3D<ASTTypeInt, int>(ASTTypeInt.instance, [
+        [
+          [1],
+        ],
+      ]);
+      expect(a == b, isTrue);
+    });
+  });
+
+  group('ASTValueStatic readIndex / readKey / size', () {
+    test('readIndex on a list', () {
+      var context = VMScopeContext(ASTBlock(null));
+      var v = ASTValueStatic<dynamic>(ASTTypeDynamic.instance, [10, 20, 30]);
+      expect(v.readIndex(context, 1), equals(20));
+    });
+
+    test('size on a list', () {
+      var context = VMScopeContext(ASTBlock(null));
+      var v = ASTValueStatic<dynamic>(ASTTypeDynamic.instance, [10, 20, 30]);
+      expect(v.size(context), equals(3));
+    });
+
+    test('readKey on a map', () {
+      var context = VMScopeContext(ASTBlock(null));
+      var v = ASTValueStatic<dynamic>(ASTTypeDynamic.instance, {
+        'a': 1,
+        'b': 2,
+      });
+      expect(v.readKey(context, 'b'), equals(2));
+    });
+
+    test('readIndex on a map (entry value by position)', () {
+      var context = VMScopeContext(ASTBlock(null));
+      var v = ASTValueStatic<dynamic>(ASTTypeDynamic.instance, {
+        'a': 1,
+        'b': 2,
+      });
+      expect(v.readIndex(context, 0), equals(1));
+    });
+
+    test('size on a map returns null (not Iterable)', () {
+      var context = VMScopeContext(ASTBlock(null));
+      var v = ASTValueStatic<dynamic>(ASTTypeDynamic.instance, {'a': 1});
+      expect(v.size(context), isNull);
+    });
+
+    test('readIndex throws for non-collection', () {
+      var context = VMScopeContext(ASTBlock(null));
+      var v = ASTValueStatic<int>(ASTTypeInt.instance, 5);
+      expect(() => v.readIndex(context, 0), throwsA(isA<Exception>()));
+    });
+
+    test('toString format', () {
+      var v = ASTValueStatic<int>(ASTTypeInt.instance, 5);
+      expect(v.toString(), contains('value: 5'));
+    });
+
+    test('equality by value', () {
+      var a = ASTValueStatic<int>(ASTTypeInt.instance, 5);
+      var b = ASTValueStatic<int>(ASTTypeInt.instance, 5);
+      expect(a == b, isTrue);
+      expect(a.hashCode, equals(b.hashCode));
+    });
+  });
+
+  group('ASTValueVar', () {
+    test('getValueNoContext returns stored object', () async {
+      var v = ASTValueVar('hello');
+      expect(await _await(v.getValueNoContext()), equals('hello'));
+      expect(v.type, isA<ASTTypeVar>());
+    });
+  });
+
+  group('ASTValue.fromValue factory', () {
+    test('fromValue int', () async {
+      var v = ASTValue.fromValue<int>(5);
+      expect(v, isA<ASTValueInt>());
+      expect(await _await(v.getValueNoContext()), equals(5));
+    });
+
+    test('fromValue String', () {
+      var v = ASTValue.fromValue<String>('abc');
+      expect(v, isA<ASTValueString>());
+    });
+
+    test('fromValue null', () {
+      var v = ASTValue.fromValue<dynamic>(null);
+      expect(v, isA<ASTValueNull>());
+    });
+
+    test('fromValue double', () {
+      var v = ASTValue.fromValue<double>(1.5);
+      expect(v, isA<ASTValueDouble>());
+    });
+
+    test('fromValue bool', () {
+      var v = ASTValue.fromValue<bool>(true);
+      expect(v, isA<ASTValueBool>());
+    });
+  });
+
+  group('ASTValueBool.from / ASTValueNum.from factories', () {
+    test('ASTValueBool.from num', () async {
+      expect(await _await(ASTValueBool.from(1).getValueNoContext()), isTrue);
+      expect(await _await(ASTValueBool.from(0).getValueNoContext()), isFalse);
+    });
+
+    test('ASTValueBool.from String', () async {
+      expect(
+        await _await(ASTValueBool.from('true').getValueNoContext()),
+        isTrue,
+      );
+    });
+
+    test('ASTValueNum.from int string with decimal -> double', () {
+      var v = ASTValueNum.from('5.0');
+      expect(v, isA<ASTValueDouble>());
+    });
+
+    test('ASTValueNum.from int', () {
+      var v = ASTValueNum.from(5);
+      expect(v, isA<ASTValueInt>());
+    });
+  });
+
+  group('cross-type equality helper', () {
+    test('_eq for ASTValueInt vs ASTValueDouble same value', () {
+      // ASTValueNum compares across int/double when types accept each other.
+      var a = ASTValueInt(5);
+      var b = ASTValueDouble(5);
+      // Route through helper to avoid analyzer unrelated_type warnings.
+      expect(_eq(a, b), isA<bool>());
+    });
+  });
+}

--- a/test/apollovm_ast_value_test.dart
+++ b/test/apollovm_ast_value_test.dart
@@ -1,0 +1,262 @@
+@TestOn('vm')
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Compares two values through the [ASTValue] `==` operator. Routing through a
+/// typed helper keeps the intentional cross-type comparisons (e.g. int vs
+/// double) from tripping the `unrelated_type_equality_checks` lint.
+bool _valEq(ASTValue a, Object? b) => a == b;
+
+void main() {
+  group('ASTValueInt', () {
+    test('arithmetic with int', () {
+      var a = ASTValueInt(7);
+      expect((a + ASTValueInt(3)).getValueNoContext(), equals(10));
+      expect((a - ASTValueInt(2)).getValueNoContext(), equals(5));
+      expect((a * ASTValueInt(3)).getValueNoContext(), equals(21));
+      expect((a ~/ ASTValueInt(2)).getValueNoContext(), equals(3));
+      expect((a % ASTValueInt(4)).getValueNoContext(), equals(3));
+    });
+
+    test('division always yields double', () {
+      var r = ASTValueInt(6) / ASTValueInt(4);
+      expect(r, isA<ASTValueDouble>());
+      expect(r.getValueNoContext(), equals(1.5));
+    });
+
+    test('mixed int/double arithmetic promotes to double', () {
+      expect(
+        (ASTValueInt(2) + ASTValueDouble(0.5)).getValueNoContext(),
+        equals(2.5),
+      );
+      expect((ASTValueInt(5) * ASTValueDouble(2.0)), isA<ASTValueDouble>());
+    });
+
+    test('+ with string concatenates', () {
+      var r = ASTValueInt(42) + ASTValueString('!');
+      expect(r, isA<ASTValueString>());
+      expect(r.getValueNoContext(), equals('42!'));
+    });
+
+    test('unsupported operand throws', () {
+      expect(
+        () => ASTValueInt(1) + ASTValueBool(true),
+        throwsA(isA<UnsupportedValueOperationError>()),
+      );
+      expect(
+        () => ASTValueInt(1) - ASTValueString('x'),
+        throwsA(isA<UnsupportedValueOperationError>()),
+      );
+    });
+
+    test('toString', () {
+      expect(ASTValueInt(5).toString(), equals('(int) 5'));
+    });
+
+    test('negative flag', () {
+      var n = ASTValueInt(5, negative: true);
+      expect(n.value, equals(-5));
+      expect(n.negative, isTrue);
+      expect(n.isZero, isFalse);
+      expect(ASTValueInt(0).isZero, isTrue);
+    });
+  });
+
+  group('ASTValueDouble', () {
+    test('arithmetic', () {
+      var a = ASTValueDouble(2.5);
+      expect((a + ASTValueDouble(0.5)).getValueNoContext(), equals(3.0));
+      expect((a - ASTValueInt(1)).getValueNoContext(), equals(1.5));
+      expect((a * ASTValueInt(2)).getValueNoContext(), equals(5.0));
+      expect((a / ASTValueDouble(2.0)).getValueNoContext(), equals(1.25));
+      expect((a ~/ ASTValueInt(1)).getValueNoContext(), equals(2));
+      expect(
+        (ASTValueDouble(5.5) % ASTValueInt(2)).getValueNoContext(),
+        equals(1.5),
+      );
+    });
+
+    test('~/ yields int', () {
+      expect(ASTValueDouble(7.9) ~/ ASTValueInt(2), isA<ASTValueInt>());
+    });
+
+    test('+ with string concatenates', () {
+      expect(
+        (ASTValueDouble(1.5) + ASTValueString('x')).getValueNoContext(),
+        equals('1.5x'),
+      );
+    });
+
+    test('toString', () {
+      expect(ASTValueDouble(1.5).toString(), equals('(double) 1.5'));
+    });
+  });
+
+  group('ASTValueNum comparisons & equality', () {
+    test('comparison operators', () async {
+      expect(await (ASTValueInt(3) > ASTValueInt(2)), isTrue);
+      expect(await (ASTValueInt(3) < ASTValueInt(2)), isFalse);
+      expect(await (ASTValueInt(3) >= ASTValueInt(3)), isTrue);
+      expect(await (ASTValueInt(2) <= ASTValueDouble(2.0)), isTrue);
+    });
+
+    test('equality across int/double of same value', () {
+      expect(_valEq(ASTValueInt(2), ASTValueDouble(2.0)), isTrue);
+      expect(_valEq(ASTValueInt(2), ASTValueInt(3)), isFalse);
+      expect(ASTValueInt(2).hashCode, equals(ASTValueInt(2).hashCode));
+    });
+
+    test('equals() resolves values', () async {
+      expect(await ASTValueInt(5).equals(ASTValueInt(5)), isTrue);
+      expect(await ASTValueInt(5).equals(ASTValueDouble(5.0)), isTrue);
+      expect(await ASTValueInt(5).equals(ASTValueInt(6)), isFalse);
+    });
+  });
+
+  group('ASTValueNum.from', () {
+    test('parses ints and doubles', () {
+      expect(ASTValueNum.from(10), isA<ASTValueInt>());
+      expect(ASTValueNum.from(1.5), isA<ASTValueDouble>());
+      expect(ASTValueNum.from('7').getValueNoContext(), equals(7));
+      expect(ASTValueNum.from('7.5').getValueNoContext(), equals(7.5));
+    });
+
+    test('string with decimal/exponent intent becomes double', () {
+      expect(ASTValueNum.from('3.0'), isA<ASTValueDouble>());
+      expect(ASTValueNum.from('1e3'), isA<ASTValueDouble>());
+    });
+
+    test('asDouble forces type', () {
+      expect(ASTValueNum.from(4, asDouble: true), isA<ASTValueDouble>());
+      expect(ASTValueNum.from(4.7, asDouble: false), isA<ASTValueInt>());
+      expect(
+        ASTValueNum.from(4.7, asDouble: false).getValueNoContext(),
+        equals(4),
+      );
+    });
+
+    test('invalid input throws', () {
+      expect(() => ASTValueNum.from(true), throwsA(isA<StateError>()));
+    });
+  });
+
+  group('ASTValueBool', () {
+    test('from various inputs', () {
+      expect(ASTValueBool.from(true).getValueNoContext(), isTrue);
+      expect(ASTValueBool.from(0).getValueNoContext(), isFalse);
+      expect(ASTValueBool.from(5).getValueNoContext(), isTrue);
+      expect(ASTValueBool.from('true').getValueNoContext(), isTrue);
+    });
+
+    test('invalid input throws', () {
+      expect(() => ASTValueBool.from([]), throwsA(isA<StateError>()));
+    });
+
+    test('TRUE/FALSE constants', () {
+      expect(ASTValueBool.TRUE.getValueNoContext(), isTrue);
+      expect(ASTValueBool.FALSE.getValueNoContext(), isFalse);
+    });
+  });
+
+  group('ASTValueString', () {
+    test('toString quotes the value', () {
+      expect(ASTValueString('hi').toString(), equals('"hi"'));
+    });
+
+    test('comparison operators throw with the right operator symbol', () {
+      var s = ASTValueString('a');
+      expect(
+        () => s > ASTValueString('b'),
+        throwsA(
+          isA<UnsupportedError>().having(
+            (e) => e.message,
+            'message',
+            contains("'>'"),
+          ),
+        ),
+      );
+      expect(
+        () => s < ASTValueString('b'),
+        throwsA(
+          isA<UnsupportedError>().having(
+            (e) => e.message,
+            'message',
+            allOf(
+              contains("'<'"),
+              isNot(contains("non number values: \"a\" >")),
+            ),
+          ),
+        ),
+      );
+      expect(() => s >= ASTValueString('b'), throwsA(isA<UnsupportedError>()));
+      expect(() => s <= ASTValueString('b'), throwsA(isA<UnsupportedError>()));
+    });
+
+    test('equality by value', () {
+      expect(ASTValueString('x') == ASTValueString('x'), isTrue);
+      expect(ASTValueString('x') == ASTValueString('y'), isFalse);
+    });
+  });
+
+  group('ASTValueNull / ASTValueVoid', () {
+    test('null equality and hashCode', () {
+      expect(ASTValueNull() == ASTValueNull.instance, isTrue);
+      expect(_valEq(ASTValueNull.instance, ASTValueInt(0)), isFalse);
+      expect(ASTValueNull.instance.hashCode, equals(-1));
+      expect(ASTValueNull.instance.toString(), equals('null'));
+    });
+
+    test('void equality and hashCode', () {
+      expect(ASTValueVoid() == ASTValueVoid.instance, isTrue);
+      expect(_valEq(ASTValueVoid.instance, ASTValueNull.instance), isFalse);
+      expect(ASTValueVoid.instance.hashCode, equals(-2));
+      expect(ASTValueVoid.instance.toString(), equals('void'));
+    });
+  });
+
+  group('ASTValueArray', () {
+    final context = VMScopeContext(ASTBlock(null));
+
+    test('readIndex and size', () {
+      var arr = ASTValueArray<ASTTypeInt, int>(ASTTypeInt.instance, [
+        10,
+        20,
+        30,
+      ]);
+      expect(arr.readIndex<int>(context, 1), equals(20));
+      expect(arr.size(context), equals(3));
+      expect(arr.getValueNoContext(), equals([10, 20, 30]));
+    });
+
+    test('equals compares element-wise', () async {
+      var a = ASTValueArray<ASTTypeInt, int>(ASTTypeInt.instance, [1, 2]);
+      var b = ASTValueArray<ASTTypeInt, int>(ASTTypeInt.instance, [1, 2]);
+      var c = ASTValueArray<ASTTypeInt, int>(ASTTypeInt.instance, [1, 3]);
+      expect(await a.equals(b), isTrue);
+      expect(await a.equals(c), isFalse);
+    });
+
+    test('cast converts component type', () {
+      var ints = ASTValueArray<ASTTypeInt, int>(ASTTypeInt.instance, [1, 2, 3]);
+      var doubles = ints.cast<ASTTypeDouble, double>(
+        componentType: ASTTypeDouble.instance,
+      );
+      expect(doubles.getValueNoContext(), equals([1.0, 2.0, 3.0]));
+    });
+  });
+
+  group('ASTValueStatic readKey', () {
+    final context = VMScopeContext(ASTBlock(null));
+
+    test('reads from a map', () {
+      var m = ASTValueMap<ASTTypeString, ASTTypeInt, String, int>(
+        ASTTypeString.instance,
+        ASTTypeInt.instance,
+        {'a': 1, 'b': 2},
+      );
+      expect(m.readKey<int>(context, 'b'), equals(2));
+    });
+  });
+}

--- a/test/apollovm_base_extra_test.dart
+++ b/test/apollovm_base_extra_test.dart
@@ -1,0 +1,479 @@
+@TestOn('vm')
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+const _dartSource = r'''
+class Foo {
+  int x = 10;
+
+  int sum(int a, int b) {
+    int r = a + b;
+    return r;
+  }
+
+  int times(int a, int b) {
+    return a * b;
+  }
+}
+''';
+
+const _dartTopLevel = r'''
+int add(int a, int b) {
+  return a + b;
+}
+''';
+
+const _javaSource = r'''
+class Foo {
+  static int sum(int a, int b) {
+    int r = a + b;
+    return r;
+  }
+
+  static int mul(int a, int b) {
+    int r = a * b;
+    return r;
+  }
+}
+''';
+
+void main() {
+  group('ApolloVM construction', () {
+    test('default construction and id', () {
+      var vm = ApolloVM();
+      expect(vm.id, greaterThan(0));
+      var vm2 = ApolloVM();
+      expect(vm2.id, greaterThan(vm.id));
+    });
+
+    test('VERSION is defined', () {
+      expect(ApolloVM.VERSION, isNotEmpty);
+      expect(ApolloVM.VERSION, matches(RegExp(r'^\d+\.\d+\.\d+$')));
+    });
+
+    test('empty VM has no loaded languages', () {
+      var vm = ApolloVM();
+      expect(vm.loadedCodeLanguages, isEmpty);
+    });
+
+    test('toString includes id and loaded languages', () {
+      var vm = ApolloVM();
+      var s = vm.toString();
+      expect(s, contains('ApolloVM'));
+      expect(s, contains('loadedCodeLanguages'));
+    });
+  });
+
+  group('getParser', () {
+    test('returns parsers for known languages', () {
+      var vm = ApolloVM();
+      expect(vm.getParser('dart'), isNotNull);
+      expect(vm.getParser('java'), isNotNull);
+      expect(vm.getParser('java11'), isNotNull);
+      expect(vm.getParser('wasm'), isNotNull);
+    });
+
+    test('returns null for unknown language', () {
+      var vm = ApolloVM();
+      expect(vm.getParser('cobol'), isNull);
+    });
+  });
+
+  group('createRunner', () {
+    test('creates dart and java runners', () {
+      var vm = ApolloVM();
+      var dartRunner = vm.createRunner('dart');
+      expect(dartRunner, isNotNull);
+      expect(dartRunner!.language, equals('dart'));
+
+      var javaRunner = vm.createRunner('java11');
+      expect(javaRunner, isNotNull);
+      expect(javaRunner!.language, equals('java11'));
+    });
+
+    test('returns null for unknown language', () {
+      var vm = ApolloVM();
+      expect(vm.createRunner('cobol'), isNull);
+    });
+
+    test('runner toString includes language', () {
+      var vm = ApolloVM();
+      var runner = vm.createRunner('dart')!;
+      expect(runner.toString(), contains('dart'));
+    });
+  });
+
+  group('SourceCodeUnit', () {
+    test('properties: language, id, code', () {
+      var cu = SourceCodeUnit('dart', _dartSource, id: 'my_id');
+      expect(cu.language, equals('dart'));
+      expect(cu.id, equals('my_id'));
+      expect(cu.code, equals(_dartSource));
+    });
+
+    test('default id is empty', () {
+      var cu = SourceCodeUnit('dart', _dartSource);
+      expect(cu.id, equals(''));
+    });
+
+    test('lines and getLine', () {
+      var cu = SourceCodeUnit('dart', 'line1\nline2\nline3', id: 'x');
+      expect(cu.lines.length, equals(3));
+      expect(cu.getLine(1), equals('line1'));
+      expect(cu.getLine(2), equals('line2'));
+      expect(cu.getLine(0), isNull);
+      expect(cu.getLine(99), isNull);
+    });
+
+    test('toString', () {
+      var cu = SourceCodeUnit('dart', _dartSource, id: 'x');
+      var s = cu.toString();
+      expect(s, contains('SourceCodeUnit'));
+      expect(s, contains('dart'));
+    });
+
+    test('root is null before loading', () {
+      var cu = SourceCodeUnit('dart', _dartSource, id: 'x');
+      expect(cu.root, isNull);
+    });
+  });
+
+  group('loadCodeUnit', () {
+    test('loads valid Dart source', () async {
+      var vm = ApolloVM();
+      var ok = await vm.loadCodeUnit(
+        SourceCodeUnit('dart', _dartSource, id: 'test'),
+      );
+      expect(ok, isTrue);
+      expect(vm.loadedCodeLanguages, contains('dart'));
+    });
+
+    test('loads valid Java source', () async {
+      var vm = ApolloVM();
+      var ok = await vm.loadCodeUnit(
+        SourceCodeUnit('java11', _javaSource, id: 'test'),
+      );
+      expect(ok, isTrue);
+      expect(vm.loadedCodeLanguages, contains('java11'));
+    });
+
+    test('loading sets the root on the code unit', () async {
+      var vm = ApolloVM();
+      var cu = SourceCodeUnit('dart', _dartSource, id: 'test');
+      await vm.loadCodeUnit(cu);
+      expect(cu.root, isNotNull);
+      expect(cu.namespace, isNotNull);
+    });
+
+    test('loads multiple code units / languages', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(SourceCodeUnit('dart', _dartSource, id: 'a'));
+      await vm.loadCodeUnit(SourceCodeUnit('dart', _dartTopLevel, id: 'b'));
+      await vm.loadCodeUnit(SourceCodeUnit('java11', _javaSource, id: 'c'));
+      expect(vm.loadedCodeLanguages, containsAll(['dart', 'java11']));
+    });
+
+    test(
+      'no-parser language with explicit namespace loads as opaque unit',
+      () async {
+        // With no parser, the unit is stored as-is when a namespace is provided.
+        var vm = ApolloVM();
+        var ok = await vm.loadCodeUnit(
+          SourceCodeUnit(
+            'cobol',
+            'IDENTIFICATION DIVISION.',
+            id: 'x',
+            namespace: 'pkg',
+          ),
+        );
+        expect(ok, isTrue);
+        expect(vm.loadedCodeLanguages, contains('cobol'));
+      },
+    );
+
+    test('no-parser language without namespace throws StateError', () async {
+      var vm = ApolloVM();
+      expect(
+        () => vm.loadCodeUnit(
+          SourceCodeUnit('cobol', 'IDENTIFICATION DIVISION.', id: 'x'),
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('throws SyntaxError on invalid Dart source', () async {
+      var vm = ApolloVM();
+      expect(
+        () => vm.loadCodeUnit(
+          SourceCodeUnit('dart', 'class { this is not valid !!! ', id: 'x'),
+        ),
+        throwsA(isA<SyntaxError>()),
+      );
+    });
+  });
+
+  group('namespaces and class lookup', () {
+    test('getLanguageNamespaces and namespaces list', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(SourceCodeUnit('dart', _dartSource, id: 'test'));
+      var langNs = vm.getLanguageNamespaces('dart');
+      expect(langNs.language, equals('dart'));
+      expect(langNs.namespaces, contains(''));
+      expect(langNs.classesNames, contains('Foo'));
+    });
+
+    test('getNamespace returns CodeNamespace', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(SourceCodeUnit('dart', _dartSource, id: 'test'));
+      var ns = vm.getNamespace('dart', '');
+      expect(ns, isNotNull);
+      expect(ns!.language, equals('dart'));
+      expect(ns.classesNames, contains('Foo'));
+      expect(ns.containsClass('Foo'), isTrue);
+      expect(ns.containsClass('Bar'), isFalse);
+    });
+
+    test('getNamespaceWithName finds across languages', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(SourceCodeUnit('dart', _dartSource, id: 'a'));
+      await vm.loadCodeUnit(SourceCodeUnit('java11', _javaSource, id: 'b'));
+      var nss = vm.getNamespaceWithName('');
+      expect(nss.length, equals(2));
+    });
+
+    test('getNamespaceWithNameAndClass filters by class', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(SourceCodeUnit('dart', _dartSource, id: 'a'));
+      var withFoo = vm.getNamespaceWithNameAndClass('', 'Foo');
+      expect(withFoo, isNotEmpty);
+      var withBar = vm.getNamespaceWithNameAndClass('', 'Bar');
+      expect(withBar, isEmpty);
+    });
+
+    test('getNamespaceWithClass with and without language', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(SourceCodeUnit('dart', _dartSource, id: 'a'));
+      expect(vm.getNamespaceWithClass('Foo'), isNotEmpty);
+      expect(vm.getNamespaceWithClass('Foo', language: 'dart'), isNotEmpty);
+      expect(vm.getNamespaceWithClass('Foo', language: 'java11'), isEmpty);
+      expect(vm.getNamespaceWithClass('Missing'), isEmpty);
+    });
+
+    test('CodeNamespace equality and hashCode', () {
+      var a = CodeNamespace('dart', 'x');
+      var b = CodeNamespace('dart', 'x');
+      var c = CodeNamespace('dart', 'y');
+      expect(a, equals(b));
+      expect(a.hashCode, equals(b.hashCode));
+      expect(a, isNot(equals(c)));
+    });
+
+    test('resolveType resolves loaded class', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(SourceCodeUnit('dart', _dartSource, id: 'a'));
+      var type = await vm
+          .resolveType('Foo', namespace: '', language: 'dart')
+          .asFuture;
+      expect(type, isNotNull);
+      expect(type!.name, equals('Foo'));
+    });
+  });
+
+  group('parseLanguageFromFilePathExtension', () {
+    test('maps known extensions', () {
+      expect(ApolloVM.parseLanguageFromFilePathExtension('a.dart'), 'dart');
+      expect(ApolloVM.parseLanguageFromFilePathExtension('a.java'), 'java11');
+      expect(ApolloVM.parseLanguageFromFilePathExtension('dart'), 'dart');
+      expect(ApolloVM.parseLanguageFromFilePathExtension('java'), 'java11');
+    });
+
+    test('defaults to dart for unknown', () {
+      expect(ApolloVM.parseLanguageFromFilePathExtension('a.xyz'), 'dart');
+    });
+  });
+
+  group('execution: Dart', () {
+    test('executeClassMethod returns computed value', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(SourceCodeUnit('dart', _dartSource, id: 'a'));
+      var runner = vm.createRunner('dart')!;
+      var r = await runner.executeClassMethod(
+        '',
+        'Foo',
+        'sum',
+        positionalParameters: [3, 4],
+      );
+      expect(r.getValueNoContext(), equals(7));
+    });
+
+    test('executeClassMethod times', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(SourceCodeUnit('dart', _dartSource, id: 'a'));
+      var runner = vm.createRunner('dart')!;
+      var r = await runner.executeClassMethod(
+        '',
+        'Foo',
+        'times',
+        positionalParameters: [6, 7],
+      );
+      expect(r.getValueNoContext(), equals(42));
+    });
+
+    test('executeFunction top-level', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(SourceCodeUnit('dart', _dartTopLevel, id: 'a'));
+      var runner = vm.createRunner('dart')!;
+      var r = await runner.executeFunction(
+        '',
+        'add',
+        positionalParameters: [10, 5],
+      );
+      expect(r.getValueNoContext(), equals(15));
+    });
+
+    test('runner.getClass returns loaded class', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(SourceCodeUnit('dart', _dartSource, id: 'a'));
+      var runner = vm.createRunner('dart')!;
+      var clazz = await runner.getClass('Foo');
+      expect(clazz, isNotNull);
+      expect(clazz!.name, equals('Foo'));
+      expect(await runner.getClass('Nope'), isNull);
+    });
+
+    test('runner.getClassMethod resolves method', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(SourceCodeUnit('dart', _dartSource, id: 'a'));
+      var runner = vm.createRunner('dart')!;
+      var method = await runner.getClassMethod('', 'Foo', 'sum', [1, 2]);
+      expect(method, isNotNull);
+    });
+
+    test('externalPrintFunction can be overridden', () async {
+      var vm = ApolloVM();
+      const printSrc = r'''
+class Foo {
+  void hello() {
+    print('hi');
+  }
+}
+''';
+      await vm.loadCodeUnit(SourceCodeUnit('dart', printSrc, id: 'a'));
+      var runner = vm.createRunner('dart')!;
+      var captured = [];
+      runner.externalPrintFunction = (o) => captured.add(o);
+      await runner.executeClassMethod('', 'Foo', 'hello');
+      expect(captured, equals(['hi']));
+    });
+  });
+
+  group('execution: Java', () {
+    test('executeClassMethod static sum', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(SourceCodeUnit('java11', _javaSource, id: 'a'));
+      var runner = vm.createRunner('java11')!;
+      var r = await runner.executeClassMethod(
+        '',
+        'Foo',
+        'sum',
+        positionalParameters: [8, 9],
+      );
+      expect(r.getValueNoContext(), equals(17));
+    });
+
+    test('executeClassMethod static mul', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(SourceCodeUnit('java11', _javaSource, id: 'a'));
+      var runner = vm.createRunner('java11')!;
+      var r = await runner.executeClassMethod(
+        '',
+        'Foo',
+        'mul',
+        positionalParameters: [3, 5],
+      );
+      expect(r.getValueNoContext(), equals(15));
+    });
+  });
+
+  group('code generation', () {
+    test('generateAllCodeIn dart produces reloadable raw source', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(SourceCodeUnit('dart', _dartSource, id: 'test'));
+
+      var codeStorage = vm.generateAllCodeIn('dart');
+      var namespaces = await codeStorage.getNamespaces();
+      expect(namespaces, contains(''));
+
+      var ids = await codeStorage.getNamespaceCodeUnitsIDs('');
+      expect(ids, contains('test'));
+
+      var source = await codeStorage.getNamespaceCodeUnit('', 'test');
+      expect(source, isNotNull);
+      expect(source, contains('class Foo'));
+      expect(source, contains('int sum(int a, int b)'));
+
+      // Round-trip: reload generated source in a fresh VM.
+      var vm2 = ApolloVM();
+      var ok = await vm2.loadCodeUnit(
+        SourceCodeUnit('dart', source!, id: 'test'),
+      );
+      expect(ok, isTrue);
+      var runner = vm2.createRunner('dart')!;
+      var r = await runner.executeClassMethod(
+        '',
+        'Foo',
+        'sum',
+        positionalParameters: [2, 3],
+      );
+      expect(r.getValueNoContext(), equals(5));
+    });
+
+    test('generateAllCodeIn java11 translates Dart -> Java', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(SourceCodeUnit('dart', _dartSource, id: 'test'));
+
+      var codeStorage = vm.generateAllCodeIn('java11');
+      var source = await codeStorage.getNamespaceCodeUnit('', 'test');
+      expect(source, isNotNull);
+      expect(source, contains('class Foo'));
+      expect(source, contains('int sum(int a, int b)'));
+
+      // Round-trip: reload generated Java and run it.
+      var vm2 = ApolloVM();
+      var ok = await vm2.loadCodeUnit(
+        SourceCodeUnit('java11', source!, id: 'test'),
+      );
+      expect(ok, isTrue);
+      var runner = vm2.createRunner('java11')!;
+      var r = await runner.executeClassMethod(
+        '',
+        'Foo',
+        'sum',
+        positionalParameters: [4, 5],
+      );
+      expect(r.getValueNoContext(), equals(9));
+    });
+
+    test('generateAllCodeIn throws for unsupported language', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(SourceCodeUnit('dart', _dartSource, id: 'test'));
+      expect(() => vm.generateAllCodeIn('cobol'), throwsA(isA<StateError>()));
+    });
+
+    test(
+      'createCodeGenerator via generateAllCodeIn round-trips storage',
+      () async {
+        var vm = ApolloVM();
+        await vm.loadCodeUnit(SourceCodeUnit('dart', _dartSource, id: 'test'));
+        // Reuse the storage returned by generateAllCodeIn to confirm it is a
+        // valid ApolloSourceCodeStorage and exposes the code-unit accessors.
+        var storage = vm.generateAllCodeIn('dart');
+        var entries = await storage.allEntries();
+        expect(entries.keys, contains(''));
+        expect(entries['']!.keys, contains('test'));
+      },
+    );
+  });
+}

--- a/test/apollovm_bugfix_test.dart
+++ b/test/apollovm_bugfix_test.dart
@@ -1,0 +1,274 @@
+@TestOn('vm')
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Loads a single Dart [source] and executes [className].[method] with the
+/// given [args], returning the resolved native value and the collected
+/// `print` output.
+Future<({Object? value, List output})> _runDart(
+  String source,
+  String className,
+  String method, {
+  List args = const [],
+}) async {
+  var vm = ApolloVM();
+  var loadOK = await vm.loadCodeUnit(
+    SourceCodeUnit('dart', source, id: 'test'),
+  );
+  expect(loadOK, isTrue, reason: "Can't load Dart source!");
+
+  var runner = vm.createRunner('dart')!;
+
+  var output = [];
+  runner.externalPrintFunction = (o) => output.add(o);
+
+  var astValue = await runner.executeClassMethod(
+    '',
+    className,
+    method,
+    positionalParameters: [args],
+  );
+
+  return (value: astValue.getValueNoContext(), output: output);
+}
+
+void main() {
+  // Regression tests for the loop `return` propagation bug: a `return`
+  // statement inside a loop body used to be ignored because the loop created a
+  // fresh `ASTRunStatus` and never checked it to break out of the iteration.
+  group('Loop return propagation', () {
+    test('return inside a for-loop', () async {
+      var r = await _runDart(
+        r'''
+        class Foo {
+          int findFirst(List<Object> args) {
+            for (var i = 0; i < 10; i++) {
+              if (i == 3) {
+                return i;
+              }
+            }
+            return -1;
+          }
+        }
+      ''',
+        'Foo',
+        'findFirst',
+      );
+
+      expect(r.value, equals(3));
+    });
+
+    test('return inside a for-loop stops side effects', () async {
+      var r = await _runDart(
+        r'''
+        class Foo {
+          int run(List<Object> args) {
+            for (var i = 0; i < 5; i++) {
+              print(i);
+              if (i == 2) {
+                return i;
+              }
+            }
+            return -1;
+          }
+        }
+      ''',
+        'Foo',
+        'run',
+      );
+
+      expect(r.value, equals(2));
+      // Must stop printing right after the return (0, 1, 2 only).
+      expect(r.output, equals([0, 1, 2]));
+    });
+
+    test('return inside a while-loop', () async {
+      var r = await _runDart(
+        r'''
+        class Foo {
+          int firstOver(List<Object> args) {
+            var i = 0;
+            while (i < 100) {
+              if (i > 4) {
+                return i;
+              }
+              i = i + 1;
+            }
+            return -1;
+          }
+        }
+      ''',
+        'Foo',
+        'firstOver',
+      );
+
+      expect(r.value, equals(5));
+    });
+
+    test('return inside a for-each loop stops side effects', () async {
+      var r = await _runDart(
+        r'''
+        class Foo {
+          int find(List<int> args) {
+            for (var e in args) {
+              print(e);
+              if (e == 20) {
+                return e;
+              }
+            }
+            return -1;
+          }
+        }
+      ''',
+        'Foo',
+        'find',
+        args: [10, 20, 30, 40],
+      );
+
+      expect(r.value, equals(20));
+      expect(r.output, equals([10, 20]));
+    });
+
+    test('loop without return still runs to completion', () async {
+      var r = await _runDart(
+        r'''
+        class Foo {
+          int sum(List<Object> args) {
+            var total = 0;
+            for (var i = 1; i <= 4; i++) {
+              total = total + i;
+            }
+            return total;
+          }
+        }
+      ''',
+        'Foo',
+        'sum',
+      );
+
+      expect(r.value, equals(10));
+    });
+  });
+
+  // Regression tests for the `ASTType` equality operators, which previously
+  // (mistakenly) checked `other is ASTTypeInt` for every primitive type,
+  // making instances of e.g. `ASTTypeBool` never equal to each other.
+  group('ASTType equality', () {
+    test('same primitive types are equal', () {
+      expect(ASTTypeBool() == ASTTypeBool.instance, isTrue);
+      expect(ASTTypeString() == ASTTypeString.instance, isTrue);
+      expect(ASTTypeObject() == ASTTypeObject.instance, isTrue);
+      expect(ASTTypeInt() == ASTTypeInt.instance, isTrue);
+      expect(ASTTypeDouble() == ASTTypeDouble.instance, isTrue);
+      expect(ASTTypeNull() == ASTTypeNull.instance, isTrue);
+      expect(ASTTypeVoid() == ASTTypeVoid.instance, isTrue);
+      expect(ASTTypeVar() == ASTTypeVar(), isTrue);
+    });
+
+    test('different primitive types are not equal', () {
+      // Compare through `ASTType` references so the equality check is between
+      // statically-unrelated runtime types (the actual scenario being tested).
+      bool typesEqual(ASTType a, ASTType b) => a == b;
+
+      expect(typesEqual(ASTTypeBool.instance, ASTTypeInt.instance), isFalse);
+      expect(typesEqual(ASTTypeString.instance, ASTTypeInt.instance), isFalse);
+      expect(typesEqual(ASTTypeObject.instance, ASTTypeInt.instance), isFalse);
+      expect(typesEqual(ASTTypeNull.instance, ASTTypeVoid.instance), isFalse);
+      expect(typesEqual(ASTTypeDouble.instance, ASTTypeInt.instance), isFalse);
+    });
+
+    test('equal types share the same hashCode', () {
+      expect(ASTTypeBool().hashCode, equals(ASTTypeBool.instance.hashCode));
+      expect(ASTTypeString().hashCode, equals(ASTTypeString.instance.hashCode));
+    });
+  });
+
+  // Regression test for `ASTTypeMap` building a map from a flat key/value
+  // list: the loop used to read from the (empty) target map instead of the
+  // input list, producing an empty map.
+  group('ASTTypeMap.toValue from flat list', () {
+    test('builds a map from alternating key/value entries (length > 2)', () {
+      var context = VMScopeContext(ASTBlock(null));
+      var astMap = ASTTypeMap.instanceOfStringOfDynamic.toValue(context, [
+        'a',
+        1,
+        'b',
+        2,
+        'c',
+        3,
+      ]);
+
+      expect(astMap, isA<ASTValue>());
+      expect(
+        (astMap as ASTValue).getValueNoContext(),
+        equals({'a': 1, 'b': 2, 'c': 3}),
+      );
+    });
+
+    test('builds a single-entry map from a length-2 list', () {
+      var context = VMScopeContext(ASTBlock(null));
+      var astMap = ASTTypeMap.instanceOfStringOfDynamic.toValue(context, [
+        'x',
+        10,
+      ]);
+
+      expect((astMap as ASTValue).getValueNoContext(), equals({'x': 10}));
+    });
+  });
+
+  // Regression test for Java string escaping: backslashes were not escaped,
+  // producing invalid Java string literals (e.g. `"a\b"` instead of `"a\\b"`).
+  group('Java string escaping', () {
+    test('escapes backslashes when translating Dart to Java', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(
+        SourceCodeUnit('dart', r'''
+          class Foo {
+            void main(List<Object> args) {
+              var p = 'a\\b';
+              print(p);
+            }
+          }
+        ''', id: 'test'),
+      );
+
+      var codeStorage = vm.generateAllCodeIn('java11');
+      var java = (await codeStorage.writeAllSources()).toString();
+
+      expect(java, contains(r'"a\\b"'));
+      expect(java, isNot(contains(r'"a\b"')));
+    });
+  });
+
+  group('apollovm_utils', () {
+    test('toListOfType infers element type', () {
+      expect(<dynamic>['a', 'b'].toListOfType() is List<String>, isTrue);
+      expect(<dynamic>[1, 2, 3].toListOfType() is List<int>, isTrue);
+      expect(<dynamic>[1.1, 2.2].toListOfType() is List<double>, isTrue);
+      expect(<dynamic>[true, false].toListOfType() is List<bool>, isTrue);
+    });
+
+    test('fractionDigitsFromScientificNotation', () {
+      expect((1e-7).fractionDigitsFromScientificNotation(), equals(7));
+      expect((100.0).fractionDigitsFromScientificNotation(), equals(0));
+      expect((1e21).fractionDigitsFromScientificNotation(), equals(0));
+      expect((0.001).fractionDigitsFromScientificNotation(), equals(0));
+    });
+
+    test('lookupValue (case sensitive)', () {
+      var map = {'Key': 1, 'other': 2};
+      expect(map.lookupValue('Key'), equals(1));
+      expect(map.lookupValue('key'), isNull);
+      expect(map.lookupValue('missing'), isNull);
+    });
+
+    test('lookupValue (ignore case)', () {
+      var map = {'Key': 1, 'other': 2};
+      expect(map.lookupValue('key', ignoreCase: true), equals(1));
+      expect(map.lookupValue('OTHER', ignoreCase: true), equals(2));
+      expect(map.lookupValue('missing', ignoreCase: true), isNull);
+    });
+  });
+}

--- a/test/apollovm_features_test.dart
+++ b/test/apollovm_features_test.dart
@@ -1,0 +1,342 @@
+@TestOn('vm')
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Loads a single Dart [source] and runs [className].[method], returning the
+/// resolved native return value and the collected `print` output.
+Future<({Object? value, List output})> runDart(
+  String source,
+  String className,
+  String method, {
+  List args = const [],
+  bool importMath = false,
+}) async {
+  var vm = ApolloVM();
+  var loadOK = await vm.loadCodeUnit(
+    SourceCodeUnit('dart', source, id: 'test'),
+  );
+  expect(loadOK, isTrue, reason: "Can't load Dart source!");
+
+  var runner = vm.createRunner('dart', importCorePackageMath: importMath)!;
+
+  var output = [];
+  runner.externalPrintFunction = (o) => output.add(o);
+
+  var astValue = await runner.executeClassMethod(
+    '',
+    className,
+    method,
+    positionalParameters: [args],
+  );
+
+  return (value: astValue.getValueNoContext(), output: output);
+}
+
+/// Translates a loaded Dart [source] into [language] and returns the single
+/// generated source unit (raw, loadable code — not the multi-source wrapper).
+Future<String> translateDart(String source, String language) async {
+  var vm = ApolloVM();
+  await vm.loadCodeUnit(SourceCodeUnit('dart', source, id: 'test'));
+
+  var codeStorage = vm.generateAllCodeIn(language);
+
+  var buffer = StringBuffer();
+  for (var ns in await codeStorage.getNamespaces()) {
+    for (var id in await codeStorage.getNamespaceCodeUnitsIDs(ns)) {
+      buffer.write(await codeStorage.getNamespaceCodeUnit(ns, id));
+    }
+  }
+  return buffer.toString();
+}
+
+void main() {
+  group('String methods', () {
+    test('case, trim, substring, contains', () async {
+      var r = await runDart(
+        r'''
+        class S {
+          void main(List<Object> args) {
+            var s = '  Hello World  ';
+            var t = s.trim();
+            print(t.toUpperCase());
+            print(t.toLowerCase());
+            print(t.substring(0, 5));
+            print(t.contains('World'));
+          }
+        }
+      ''',
+        'S',
+        'main',
+      );
+
+      expect(r.output, equals(['HELLO WORLD', 'hello world', 'Hello', true]));
+    });
+
+    test('split, replaceAll, startsWith, endsWith, indexOf', () async {
+      var r = await runDart(
+        r'''
+        class S {
+          void main(List<Object> args) {
+            var s = 'a,b,c,b';
+            print(s.split(','));
+            print(s.replaceAll('b', 'X'));
+            print(s.startsWith('a'));
+            print(s.endsWith('b'));
+            print(s.indexOf('b'));
+          }
+        }
+      ''',
+        'S',
+        'main',
+      );
+
+      expect(r.output[0], equals(['a', 'b', 'c', 'b']));
+      expect(r.output[1], equals('a,X,c,X'));
+      expect(r.output[2], isTrue);
+      expect(r.output[3], isTrue);
+      expect(r.output[4], equals(2));
+    });
+
+    test('padLeft / padRight', () async {
+      var r = await runDart(
+        r'''
+        class S {
+          void main(List<Object> args) {
+            var a = '5';
+            print(a.padLeft(3, '0'));
+            print(a.padRight(3, '-'));
+          }
+        }
+      ''',
+        'S',
+        'main',
+      );
+
+      expect(r.output, equals(['005', '5--']));
+    });
+  });
+
+  group('Number methods', () {
+    test('int methods', () async {
+      var r = await runDart(
+        r'''
+        class N {
+          void main(List<Object> args) {
+            var n = -7;
+            var a = 10;
+            var b = 20;
+            print(n.abs());
+            print(n.toDouble());
+            print(a.compareTo(b));
+          }
+        }
+      ''',
+        'N',
+        'main',
+      );
+
+      expect(r.output, equals([7, -7.0, -1]));
+    });
+
+    test('double methods', () async {
+      var r = await runDart(
+        r'''
+        class N {
+          void main(List<Object> args) {
+            var d = 3.567;
+            print(d.toStringAsFixed(2));
+            print(d.round());
+            print(d.floor());
+            print(d.ceil());
+            print(d.truncate());
+          }
+        }
+      ''',
+        'N',
+        'main',
+      );
+
+      expect(r.output, equals(['3.57', 4, 3, 4, 3]));
+    });
+
+    test('int parse', () async {
+      var r = await runDart(
+        r'''
+        class N {
+          int main(List<Object> args) {
+            return int.parse('123') + 1;
+          }
+        }
+      ''',
+        'N',
+        'main',
+      );
+
+      expect(r.value, equals(124));
+    });
+  });
+
+  group('Math functions', () {
+    test('sqrt, pow, abs, max, min', () async {
+      var r = await runDart(
+        r'''
+        import 'dart:math';
+        class M {
+          void main(List<Object> args) {
+            print(sqrt(16));
+            print(pow(2, 10));
+            print(max(3, 9));
+            print(min(3, 9));
+          }
+        }
+      ''',
+        'M',
+        'main',
+        importMath: true,
+      );
+
+      expect(r.output, equals([4.0, 1024, 9, 3]));
+    });
+  });
+
+  group('Control flow', () {
+    test('nested if / else-if / else', () async {
+      var r = await runDart(
+        r'''
+        class C {
+          String main(List<Object> args) {
+            var n = args[0];
+            if (n < 0) {
+              return 'neg';
+            } else if (n == 0) {
+              return 'zero';
+            } else {
+              return 'pos';
+            }
+          }
+        }
+      ''',
+        'C',
+        'main',
+        args: [5],
+      );
+
+      expect(r.value, equals('pos'));
+    });
+
+    test('recursion (factorial)', () async {
+      var r = await runDart(
+        r'''
+        class C {
+          int fact(List<Object> args) {
+            var n = args[0];
+            if (n <= 1) {
+              return 1;
+            }
+            return n * fact([n - 1]);
+          }
+        }
+      ''',
+        'C',
+        'fact',
+        args: [5],
+      );
+
+      expect(r.value, equals(120));
+    });
+
+    test('while loop accumulation', () async {
+      var r = await runDart(
+        r'''
+        class C {
+          int sum(List<Object> args) {
+            var i = 0;
+            var total = 0;
+            while (i < 5) {
+              total = total + i;
+              i = i + 1;
+            }
+            return total;
+          }
+        }
+      ''',
+        'C',
+        'sum',
+      );
+
+      expect(r.value, equals(10));
+    });
+  });
+
+  group('Collections', () {
+    test('list operations', () async {
+      var r = await runDart(
+        r'''
+        class L {
+          void main(List<Object> args) {
+            var list = <int>[1, 2, 3];
+            list.add(4);
+            print(list.length);
+            print(list.first);
+            print(list.last);
+            print(list.isEmpty);
+          }
+        }
+      ''',
+        'L',
+        'main',
+      );
+
+      expect(r.output, equals([4, 1, 4, false]));
+    });
+  });
+
+  group('Translation round-trip', () {
+    const source = r'''
+      class Calc {
+        int sum(List<Object> args) {
+          var a = args[0];
+          var b = args[1];
+          var total = 0;
+          for (var i = a; i <= b; i++) {
+            total = total + i;
+          }
+          return total;
+        }
+      }
+    ''';
+
+    test('runs in Dart', () async {
+      var r = await runDart(source, 'Calc', 'sum', args: [1, 4]);
+      expect(r.value, equals(10));
+    });
+
+    test('generates Java with expected structure', () async {
+      var java = await translateDart(source, 'java11');
+      expect(java, contains('class Calc'));
+      expect(java, contains('for ('));
+    });
+
+    test('regenerated Dart still loads and runs', () async {
+      var dart = await translateDart(source, 'dart');
+      expect(dart, contains('class Calc'));
+
+      var vm = ApolloVM();
+      var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', dart, id: 'regen'));
+      expect(ok, isTrue, reason: 'Regenerated Dart should load');
+
+      var runner = vm.createRunner('dart')!;
+      var astValue = await runner.executeClassMethod(
+        '',
+        'Calc',
+        'sum',
+        positionalParameters: [
+          [1, 4],
+        ],
+      );
+      expect(astValue.getValueNoContext(), equals(10));
+    });
+  });
+}

--- a/test/apollovm_integration_extra_test.dart
+++ b/test/apollovm_integration_extra_test.dart
@@ -1,0 +1,500 @@
+@TestOn('vm')
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Loads a single Dart [source] and runs [className].[method], returning the
+/// resolved native return value and the collected `print` output.
+///
+/// The call arguments [args] are passed as a single positional [List]
+/// (matching the VM's `executeClassMethod` convention), so inside the Dart
+/// code they are read as `args[0]`, `args[1]`, etc.
+Future<({Object? value, List output})> runDart(
+  String source,
+  String className,
+  String method, {
+  List args = const [],
+}) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', source, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source!");
+
+  var runner = vm.createRunner('dart')!;
+  var output = [];
+  runner.externalPrintFunction = (o) => output.add(o);
+
+  var astValue = await runner.executeClassMethod(
+    '',
+    className,
+    method,
+    positionalParameters: [args],
+  );
+  return (value: astValue.getValueNoContext(), output: output);
+}
+
+/// Translates a loaded Dart [source] into [language], returning the raw,
+/// reloadable generated source (concatenation of all generated code units).
+Future<String> translateDart(String source, String language) async {
+  var vm = ApolloVM();
+  await vm.loadCodeUnit(SourceCodeUnit('dart', source, id: 'test'));
+
+  var cs = vm.generateAllCodeIn(language);
+  var buf = StringBuffer();
+  for (var ns in await cs.getNamespaces()) {
+    for (var id in await cs.getNamespaceCodeUnitsIDs(ns)) {
+      buf.write(await cs.getNamespaceCodeUnit(ns, id));
+    }
+  }
+  return buf.toString();
+}
+
+void main() {
+  group('Classes with fields and methods', () {
+    test('method reads instance fields and derives a value', () async {
+      var r = await runDart(
+        r'''
+        class Box {
+          int width = 4;
+          int height = 5;
+          int area() { return width * height; }
+          int run(List a) { return area() + width; }
+        }
+      ''',
+        'Box',
+        'run',
+      );
+
+      expect(r.value, equals(24));
+    });
+
+    test('field-derived describe() combining several methods', () async {
+      var r = await runDart(
+        r'''
+        class Rect {
+          int width = 6;
+          int height = 7;
+          int area() { return width * height; }
+          int perimeter() { return 2 * (width + height); }
+          String describe() {
+            var a = area();
+            var p = perimeter();
+            return 'area=$a perim=$p';
+          }
+        }
+      ''',
+        'Rect',
+        'describe',
+      );
+
+      expect(r.value, equals('area=42 perim=26'));
+    });
+
+    test('field with default initial value read inside method', () async {
+      var r = await runDart(
+        r'''
+        class Account {
+          int balance = 100;
+          int withdraw(List a) {
+            var amount = a[0];
+            return balance - amount;
+          }
+        }
+      ''',
+        'Account',
+        'withdraw',
+        args: [30],
+      );
+
+      expect(r.value, equals(70));
+    });
+
+    test('method calling another method on same instance', () async {
+      var r = await runDart(
+        r'''
+        class Calc {
+          int base = 10;
+          int doubled() { return base * 2; }
+          int tripled() { return base * 3; }
+          int run(List a) { return doubled() + tripled(); }
+        }
+      ''',
+        'Calc',
+        'run',
+      );
+
+      expect(r.value, equals(50));
+    });
+  });
+
+  group('Multiple classes and static methods', () {
+    test('static method calling another static method', () async {
+      var r = await runDart(
+        r'''
+        class Util {
+          static int dbl(int n) { return n * 2; }
+          static int quad(int n) { return dbl(dbl(n)); }
+        }
+        class M { int run(List a) { return Util.quad(3); } }
+      ''',
+        'M',
+        'run',
+      );
+
+      expect(r.value, equals(12));
+    });
+
+    test('static method of one class calling static of another', () async {
+      var r = await runDart(
+        r'''
+        class A { static int twice(int n) { return n * 2; } }
+        class B { static int compute(int n) { return A.twice(n) + 1; } }
+        class M { int run(List a) { return B.compute(10); } }
+      ''',
+        'M',
+        'run',
+      );
+
+      expect(r.value, equals(21));
+    });
+  });
+
+  group('String interpolation', () {
+    test('multiple variables and an embedded expression', () async {
+      var r = await runDart(
+        r'''
+        class M {
+          String run(List a) {
+            var name = 'Bob';
+            var age = 30;
+            return 'Name: $name, Age: $age, Next: ${age + 1}';
+          }
+        }
+      ''',
+        'M',
+        'run',
+      );
+
+      expect(r.value, equals('Name: Bob, Age: 30, Next: 31'));
+    });
+
+    test('interpolation with arithmetic of two variables', () async {
+      var r = await runDart(
+        r'''
+        class M {
+          String run(List a) {
+            var x = 3;
+            var y = 4;
+            return 'sum: ${x + y}';
+          }
+        }
+      ''',
+        'M',
+        'run',
+      );
+
+      expect(r.value, equals('sum: 7'));
+    });
+  });
+
+  group('Boolean and logical operators', () {
+    test('&&, ||, ! combined', () async {
+      var r = await runDart(
+        r'''
+        class M {
+          bool run(List a) {
+            var x = true;
+            var y = false;
+            return (x && !y) || y;
+          }
+        }
+      ''',
+        'M',
+        'run',
+      );
+
+      expect(r.value, isTrue);
+    });
+
+    test('logical conditions selecting a branch', () async {
+      var r = await runDart(
+        r'''
+        class M {
+          String run(List a) {
+            var age = a[0];
+            var member = a[1];
+            if (age >= 18 && member) { return 'full'; }
+            if (age >= 18 || member) { return 'partial'; }
+            return 'none';
+          }
+        }
+      ''',
+        'M',
+        'run',
+        args: [16, true],
+      );
+
+      expect(r.value, equals('partial'));
+    });
+  });
+
+  group('If/else returning values (ternary-like)', () {
+    test('classify number sign via if/else chain', () async {
+      var r = await runDart(
+        r'''
+        class M {
+          String run(List a) {
+            var n = a[0];
+            if (n < 0) { return 'neg'; }
+            else if (n == 0) { return 'zero'; }
+            else { return 'pos'; }
+          }
+        }
+      ''',
+        'M',
+        'run',
+        args: [0],
+      );
+
+      expect(r.value, equals('zero'));
+    });
+
+    test('pick larger of two values', () async {
+      var r = await runDart(
+        r'''
+        class M {
+          int run(List a) {
+            var x = a[0];
+            var y = a[1];
+            if (x > y) { return x; }
+            return y;
+          }
+        }
+      ''',
+        'M',
+        'run',
+        args: [7, 12],
+      );
+
+      expect(r.value, equals(12));
+    });
+  });
+
+  group('Lists', () {
+    test('typed list indexing and add/length', () async {
+      var r = await runDart(
+        r'''
+        class M {
+          void run(List a) {
+            var l = <int>[10, 20, 30];
+            l.add(40);
+            print(l[0]);
+            print(l[3]);
+            print(l.length);
+            print(l.first);
+            print(l.last);
+          }
+        }
+      ''',
+        'M',
+        'run',
+      );
+
+      expect(r.output, equals([10, 40, 4, 10, 40]));
+    });
+
+    test('index loop summing a list', () async {
+      var r = await runDart(
+        r'''
+        class M {
+          int run(List a) {
+            var l = <int>[5, 10, 15, 20];
+            var total = 0;
+            for (var i = 0; i < 4; i++) { total = total + l[i]; }
+            return total;
+          }
+        }
+      ''',
+        'M',
+        'run',
+      );
+
+      expect(r.value, equals(50));
+    });
+
+    test('for-in over typed list', () async {
+      var r = await runDart(
+        r'''
+        class M {
+          int run(List a) {
+            var l = <int>[1, 2, 3, 4];
+            var total = 0;
+            for (var x in l) { total = total + x; }
+            return total;
+          }
+        }
+      ''',
+        'M',
+        'run',
+      );
+
+      expect(r.value, equals(10));
+    });
+
+    test('for-in over string list concatenating', () async {
+      var r = await runDart(
+        r'''
+        class M {
+          String run(List a) {
+            var l = <String>['a', 'b', 'c'];
+            var s = '';
+            for (var x in l) { s = s + x; }
+            return s;
+          }
+        }
+      ''',
+        'M',
+        'run',
+      );
+
+      expect(r.value, equals('abc'));
+    });
+  });
+
+  group('Arithmetic and precedence', () {
+    test('mixed int/double with parentheses', () async {
+      var r = await runDart(
+        r'''
+        class M {
+          double run(List a) {
+            var x = 5;
+            var y = 2.0;
+            return (x + 3) * y - 1;
+          }
+        }
+      ''',
+        'M',
+        'run',
+      );
+
+      expect(r.value, equals(15.0));
+    });
+
+    test('negative numbers, precedence and integer division', () async {
+      var r = await runDart(
+        r'''
+        class M {
+          int run(List a) {
+            return -3 + 4 * 2 - (10 ~/ 3);
+          }
+        }
+      ''',
+        'M',
+        'run',
+      );
+
+      expect(r.value, equals(2));
+    });
+  });
+
+  group('Core String methods', () {
+    test('toUpperCase, substring, replaceAll, contains, split', () async {
+      var r = await runDart(
+        r'''
+        class M {
+          void run(List a) {
+            var s = 'Hello World';
+            print(s.toUpperCase());
+            print(s.substring(0, 5));
+            print(s.replaceAll('o', '0'));
+            print(s.contains('World'));
+            print(s.split(' '));
+          }
+        }
+      ''',
+        'M',
+        'run',
+      );
+
+      expect(r.output[0], equals('HELLO WORLD'));
+      expect(r.output[1], equals('Hello'));
+      expect(r.output[2], equals('Hell0 W0rld'));
+      expect(r.output[3], isTrue);
+      expect(r.output[4], equals(['Hello', 'World']));
+    });
+  });
+
+  group('Core num methods', () {
+    test('toStringAsFixed, round, floor, abs', () async {
+      var r = await runDart(
+        r'''
+        class M {
+          void run(List a) {
+            var d = -3.567;
+            print(d.toStringAsFixed(2));
+            print(d.round());
+            print(d.floor());
+            print(d.abs());
+          }
+        }
+      ''',
+        'M',
+        'run',
+      );
+
+      expect(r.output, equals(['-3.57', -4, -4, 3.567]));
+    });
+  });
+
+  group('Translation coverage', () {
+    const source = r'''
+      class Rect {
+        int width = 6;
+        int height = 7;
+        int area() { return width * height; }
+        String describe() {
+          var a = area();
+          return 'area: $a';
+        }
+      }
+    ''';
+
+    test('runs in Dart producing the described value', () async {
+      var r = await runDart(source, 'Rect', 'describe');
+      expect(r.value, equals('area: 42'));
+    });
+
+    test(
+      'Dart -> Java keeps fields, methods and string concatenation',
+      () async {
+        var java = await translateDart(source, 'java11');
+        expect(java, contains('class Rect'));
+        expect(java, contains('int width = 6'));
+        expect(java, contains('int area()'));
+        // Java generator turns interpolation into string concatenation.
+        expect(java, contains('"area: " + a'));
+      },
+    );
+
+    test('Dart -> Dart round-trips and the regenerated source runs', () async {
+      var dart = await translateDart(source, 'dart');
+      expect(dart, contains('class Rect'));
+      expect(dart, contains('int width = 6'));
+      // Dart generator preserves interpolation.
+      expect(dart, contains(r"'area: $a'"));
+
+      var vm = ApolloVM();
+      var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', dart, id: 'regen'));
+      expect(ok, isTrue, reason: 'Regenerated Dart should load');
+
+      var runner = vm.createRunner('dart')!;
+      var astValue = await runner.executeClassMethod(
+        '',
+        'Rect',
+        'describe',
+        positionalParameters: [const []],
+      );
+      expect(astValue.getValueNoContext(), equals('area: 42'));
+    });
+  });
+}

--- a/test/apollovm_wasm_test.dart
+++ b/test/apollovm_wasm_test.dart
@@ -834,6 +834,375 @@ void main() async {
         },
       ),
     );
+
+    test(
+      'subHeavy1',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int subHeavy1(int a, int b, int c) {
+            int x = a - b - c - 5;
+            return x;
+          }
+
+        ''',
+        functionName: 'subHeavy1',
+        executions: {
+          [100, 20, 30]: 45,
+          [50, 10, 5]: 30,
+        },
+        expecteWasm: {
+          'test':
+              '0061736D0100000001080160037E7E7E017E03020100070D010973756248656176793100000A16011401017E200020017D20027D42057D210320030F0B',
+        },
+      ),
+    );
+
+    test(
+      'cmpLess',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int cmpLess(int a) {
+            if (a < 10) {
+              return 1;
+            }
+            return 0;
+          }
+
+        ''',
+        functionName: 'cmpLess',
+        executions: {
+          [5]: 1,
+          [10]: 0,
+          [20]: 0,
+        },
+        expecteWasm: {
+          'test':
+              '0061736D0100000001060160017E017E03020100070B0107636D704C65737300000A150113002000420A53044042010F0B42000F0042000B',
+        },
+      ),
+    );
+
+    test(
+      'cmpLessEqual',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int cmpLessEqual(int a) {
+            if (a <= 10) {
+              return 1;
+            }
+            return 0;
+          }
+
+        ''',
+        functionName: 'cmpLessEqual',
+        executions: {
+          [5]: 1,
+          [10]: 1,
+          [11]: 0,
+        },
+        expecteWasm: {
+          'test':
+              '0061736D0100000001060160017E017E030201000710010C636D704C657373457175616C00000A150113002000420A57044042010F0B42000F0042000B',
+        },
+      ),
+    );
+
+    test(
+      'cmpGreaterEqual',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int cmpGreaterEqual(int a) {
+            if (a >= 10) {
+              return 1;
+            }
+            return 0;
+          }
+
+        ''',
+        functionName: 'cmpGreaterEqual',
+        executions: {
+          [9]: 0,
+          [10]: 1,
+          [20]: 1,
+        },
+        expecteWasm: {
+          'test':
+              '0061736D0100000001060160017E017E030201000713010F636D7047726561746572457175616C00000A150113002000420A59044042010F0B42000F0042000B',
+        },
+      ),
+    );
+
+    test(
+      'cmpNotEqual',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int cmpNotEqual(int a) {
+            if (a != 5) {
+              return 1;
+            }
+            return 0;
+          }
+
+        ''',
+        functionName: 'cmpNotEqual',
+        executions: {
+          [0]: 1,
+          [5]: 0,
+          [-3]: 1,
+        },
+        expecteWasm: {
+          'test':
+              '0061736D0100000001060160017E017E03020100070F010B636D704E6F74457175616C00000A150113002000420552044042010F0B42000F0042000B',
+        },
+      ),
+    );
+
+    test(
+      'nestedIf1',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int nestedIf1(int a, int b) {
+            if (a > 1) {
+              if (b > 1) {
+                return 1;
+              }
+              return 2;
+            }
+            return 3;
+          }
+
+        ''',
+        functionName: 'nestedIf1',
+        executions: {
+          [5, 5]: 1,
+          [5, 1]: 2,
+          [1, 5]: 3,
+        },
+        expecteWasm: {
+          'test':
+              '0061736D0100000001070160027E7E017E03020100070D01096E657374656449663100000A20011E00200042015504402001420155044042010F0B42020F0B42030F0042000B',
+        },
+      ),
+    );
+
+    test(
+      'ifElseOnly',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int ifElseOnly(int a) {
+            if (a < 1) {
+              return -1;
+            } else {
+              return 1;
+            }
+          }
+
+        ''',
+        functionName: 'ifElseOnly',
+        executions: {
+          [-5]: -1,
+          [5]: 1,
+          [2]: 1,
+        },
+        expecteWasm: {
+          'test':
+              '0061736D0100000001060160017E017E03020100070E010A6966456C73654F6E6C7900000A1601140020004201530440427F0F0542010F0B0042000B',
+        },
+      ),
+    );
+
+    test(
+      'multiIntParams',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int multiIntParams(int a, int b, int c, int d) {
+            int x = a + b;
+            int y = c + d;
+            int z = x * y;
+            return z;
+          }
+
+        ''',
+        functionName: 'multiIntParams',
+        executions: {
+          [1, 2, 3, 4]: 21,
+          [2, 3, 4, 5]: 45,
+        },
+        expecteWasm: {
+          'test':
+              '0061736D0100000001090160047E7E7E7E017E030201000712010E6D756C7469496E74506172616D7300000A22012003017E017E017E200020017C2104200220037C2105200420057E210620060F0B',
+        },
+      ),
+    );
+
+    test(
+      'multiDoubleParams',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          double multiDoubleParams(double a, double b, double c) {
+            double x = a + b;
+            double y = x * c;
+            return y;
+          }
+
+        ''',
+        functionName: 'multiDoubleParams',
+        executions: {
+          [1.5, 2.5, 2.0]: 8.0,
+          [0.0, 0.0, 5.0]: 0.0,
+        },
+        expecteWasm: {
+          'test':
+              '0061736D0100000001080160037C7C7C017C03020100071501116D756C7469446F75626C65506172616D7300000A19011702017C017C20002001A0210320032002A2210420040F0B',
+        },
+      ),
+    );
+
+    test(
+      'mixedParams',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          double mixedParams(int a, double b, int c, double d) {
+            var x = a * b;
+            var y = c * d;
+            return x + y;
+          }
+
+        ''',
+        functionName: 'mixedParams',
+        executions: {
+          [2, 1.5, 3, 2.0]: 9.0,
+          [10, 0.5, 2, 1.5]: 8.0,
+        },
+        expecteWasm: {
+          'test':
+              '0061736D0100000001090160047E7C7E7C017C03020100070F010B6D69786564506172616D7300000A1E011C02017C017C2000B92001A221042002B92003A2210520042005A00F0B',
+        },
+      ),
+    );
+
+    test(
+      'intDivLocal',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int intDivLocal(int a, int b) {
+            int q = a ~/ b;
+            int r = a - (q * b);
+            return r;
+          }
+
+        ''',
+        functionName: 'intDivLocal',
+        executions: {
+          [17, 5]: 2,
+          [20, 4]: 0,
+          [10, 3]: 1,
+        },
+        expecteWasm: {
+          'test':
+              '0061736D0100000001070160027E7E017E03020100070F010B696E744469764C6F63616C00000A1F011D02017E017E2000B92001B9A3B021022000200220017E7D210320030F0B',
+        },
+      ),
+    );
+
+    test(
+      'returnViaLocal',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int returnViaLocal(int a, int b) {
+            int sum = a + b;
+            int diff = a - b;
+            int result = sum * diff;
+            return result;
+          }
+
+        ''',
+        functionName: 'returnViaLocal',
+        executions: {
+          [10, 3]: 91,
+          [5, 5]: 0,
+        },
+        expecteWasm: {
+          'test':
+              '0061736D0100000001070160027E7E017E030201000712010E72657475726E5669614C6F63616C00000A22012003017E017E017E200020017C2102200020017D2103200220037E210420040F0B',
+        },
+      ),
+    );
+
+    test(
+      'doubleCompare',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int doubleCompare(double a, double b) {
+            if (a >= b) {
+              return 1;
+            }
+            return 0;
+          }
+
+        ''',
+        functionName: 'doubleCompare',
+        executions: {
+          [1.5, 1.0]: 1,
+          [1.0, 1.0]: 1,
+          [0.5, 1.0]: 0,
+        },
+        expecteWasm: {
+          'test':
+              '0061736D0100000001070160027C7C017E030201000711010D646F75626C65436F6D7061726500000A150113002000200166044042010F0B42000F0042000B',
+        },
+      ),
+    );
+
+    test(
+      'arithMix1',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int arithMix1(int a, int b) {
+            int x = a * b - a + b;
+            return x;
+          }
+
+        ''',
+        functionName: 'arithMix1',
+        executions: {
+          [3, 4]: 13,
+          [5, 2]: 7,
+        },
+        expecteWasm: {
+          'test':
+              '0061736D0100000001070160027E7E017E03020100070D010961726974684D69783100000A16011401017E200020017E20007D20017C210220020F0B',
+        },
+      ),
+    );
   });
 }
 


### PR DESCRIPTION
## Summary

Audited the project for bugs, fixed several real defects, and raised line coverage from **~64.6% to ~70.9%**. Bumps version to **0.1.27**.

## Bug fixes
- **Loop `return` propagation** — a `return` inside a `for`, `while`, or `for-each` loop was ignored: the loop shadowed `runStatus` with a fresh instance and never broke on return, so the value didn't propagate and iteration continued (extra side effects / wrong result). Confirmed via repro (`findFirst` returned `-1` instead of `3`).
- **`ASTType` equality** — `ASTTypeBool`, `ASTTypeString`, `ASTTypeObject`, `ASTTypeConstructorThis`, `ASTTypeVar`, `ASTTypeDynamic`, `ASTTypeNull`, and `ASTTypeVoid` all checked `other is ASTTypeInt` (copy-paste), so two equal instances never compared equal. Each now checks its own type.
- **`ASTTypeMap` flat-list build** — building a map from a flat key/value list read from the (empty) target map instead of the input list, always producing an empty map.
- **Java string escaping** — `_escapeString` did not escape backslashes, producing invalid Java string literals (`"a\b"` instead of `"a\\b"`).
- **`literalNumType`** — returned `ASTNumType.int` for `double` literals.
- **Error messages** — corrected the operator symbol shown in `ASTValueString`/`ASTValueNum` comparison/equality error messages.

## Tests
- **103 → 385 tests**, all passing; `dart analyze` clean.
- New files: regression tests for every fix above plus unit/integration tests for `ASTValue`, `ASTType`, `ApolloVM`/runner, expressions, the core library, and the Wasm generator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)