### PR TITLE
Wasm P0: loops, function calls, logical/modulo/unary operators, booleans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## 0.1.27
 
+- Wasm generator — major feature expansion (`ApolloGeneratorWasm`), moving toward full Dart parity:
+  - **Loops**: `while` and `for` loops now compile to Wasm (`block`/`loop`/`br_if`/`br`), including `return` from inside a loop. Added the `br` opcode helper and recursion into loop bodies when collecting function locals.
+  - **Function calls**: local function invocation (calling other top-level functions, including recursion) via a function-index table threaded through the generator and a `Wasm.call`.
+  - **Operators**: integer modulo `%` (`i64.rem_s`), logical `&&`/`||` (`i32.and`/`i32.or`), logical negation `!` (`i32.eqz`), and unary minus `-` (`f64.neg` / `i64` multiply-by-`-1`).
+  - **Booleans**: `bool` literals and `bool`-typed locals (represented as Wasm `i32`).
+  - **Bug fix**: the `== 0` fast-path (`i64.eqz`) was incorrectly applied to *any* operator with a literal-`0` right operand (e.g. `x > 0` compiled as `x == 0`). It is now restricted to the `equals` operator.
+  - Notes/limitations: `&&`/`||` are non-short-circuit; double `%` and negative-operand integer `%` (Euclidean) are not yet supported.
+- Tests: added Wasm coverage for every feature above plus a combined integration test (prime counting / sum-of-squares using loops + calls + logic + modulo), all executed against the real compiled-and-run Wasm module.
+
 - Bug fixes:
   - Loop `return` propagation: a `return` inside a `for`, `while`, or `for-each` loop was ignored (the loop shadowed `runStatus` with a fresh instance and never broke on return). Returns now propagate and stop iteration correctly.
   - `ASTType` equality: `ASTTypeBool`, `ASTTypeString`, `ASTTypeObject`, `ASTTypeConstructorThis`, `ASTTypeVar`, `ASTTypeDynamic`, `ASTTypeNull`, and `ASTTypeVoid` mistakenly checked `other is ASTTypeInt`, so equal instances never compared equal. Each now checks its own type.

--- a/lib/src/languages/wasm/wasm.dart
+++ b/lib/src/languages/wasm/wasm.dart
@@ -48,6 +48,8 @@ class Wasm {
 
   static const unreachable = 0x00;
 
+  static List<int> br(int i) => <int>[0x0c, ...Leb128.encodeUnsigned(i)];
+
   static List<int> brIf(int i) => <int>[0x0d, ...Leb128.encodeUnsigned(i)];
 
   static List<int> call(int i) => <int>[0x10, ...Leb128.encodeUnsigned(i)];

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -170,7 +170,7 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     out ??= newOutput();
 
     var entries = functions
-        .map((f) => generateASTFunctionDeclaration(f))
+        .map((f) => generateASTFunctionDeclaration(f, functions: functions))
         .toList();
 
     entries.insert(
@@ -498,9 +498,82 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   BytesOutput generateASTExpressionLocalFunctionInvocation(
     ASTExpressionLocalFunctionInvocation expression, {
     BytesOutput? out,
+    WasmContext? context,
   }) {
-    // TODO: implement generateASTExpressionLocalFunctionInvocation
-    throw UnimplementedError('generateASTExpressionLocalFunctionInvocation');
+    out ??= newOutput();
+    context ??= WasmContext();
+
+    var name = expression.name;
+    var arguments = expression.arguments;
+    var argsCount = arguments.length;
+
+    var calleeIndex = context.functionIndex(name, argsCount);
+    if (calleeIndex == null) {
+      throw StateError(
+        "Can't resolve local function `$name` with $argsCount argument(s) "
+        "in the Wasm function index table.",
+      );
+    }
+
+    var callee = context.functionByIndex(calleeIndex)!;
+
+    final stackLng0 = context.stackLength;
+
+    // Evaluate each argument (left-to-right), pushing onto the Wasm stack,
+    // converting each to the callee's declared parameter type.
+    for (var i = 0; i < argsCount; ++i) {
+      var arg = arguments[i];
+
+      var stackLngArg = context.stackLength;
+      generateASTExpression(arg, out: out, context: context);
+      context.assertStackLength(
+        stackLngArg + 1,
+        "After argument[$i] push (call `$name`)",
+      );
+
+      var stackEntry = context.stackGet(0)!;
+      var stackType = stackEntry.type;
+
+      var paramType = callee.parameters.getParameterByIndex(i)?.type;
+      if (paramType != null) {
+        _autoConvertStackTypes(stackType, paramType, out: out, context: context);
+      }
+    }
+
+    context.assertStackLength(
+      stackLng0 + argsCount,
+      "Before call `$name` (all arguments pushed)",
+    );
+
+    out.write(
+      Wasm.call(calleeIndex),
+      description: "[OP] call `$name` (function index: $calleeIndex)",
+    );
+
+    // Update the virtual stack: drop the N arguments and push the return type.
+    for (var i = 0; i < argsCount; ++i) {
+      context.stackDrop();
+    }
+
+    var returnType = callee.returnType;
+    if (!returnType.isVoid) {
+      ASTType resultType;
+      if (returnType is ASTTypeInt) {
+        resultType = _astTypeInt64;
+      } else if (returnType is ASTTypeDouble) {
+        resultType = _astTypeDouble64;
+      } else {
+        resultType = returnType;
+      }
+      context.stackPush(resultType, "call `$name` result: $returnType");
+    }
+
+    context.assertStackLength(
+      stackLng0 + (returnType.isVoid ? 0 : 1),
+      "After call `$name` result",
+    );
+
+    return out;
   }
 
   @override
@@ -1182,9 +1255,14 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     ASTFunctionDeclaration f, {
     BytesOutput? out,
     WasmContext? context,
+    List<ASTFunctionDeclaration>? functions,
   }) {
     out ??= newOutput();
     context ??= WasmContext();
+
+    if (functions != null) {
+      context.functions = functions;
+    }
 
     var outBody = newOutput();
 
@@ -1715,7 +1793,11 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     } else if (expression is ASTExpressionNegative) {
       return generateASTExpressionNegative(expression, out: out);
     } else if (expression is ASTExpressionLocalFunctionInvocation) {
-      return generateASTExpressionLocalFunctionInvocation(expression, out: out);
+      return generateASTExpressionLocalFunctionInvocation(
+        expression,
+        out: out,
+        context: context,
+      );
     } else if (expression is ASTExpressionObjectFunctionInvocation) {
       return generateASTExpressionFunctionInvocation(expression, out: out);
     } else if (expression is ASTExpressionGroupFunctionInvocation) {
@@ -1975,6 +2057,31 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
 /// The Wasm code context.
 class WasmContext {
+  /// The ordered list of functions in the module (defines the Wasm function
+  /// index space). Used to resolve local function invocations to their `call`
+  /// index. See [functionIndex] and [functionByIndex].
+  List<ASTFunctionDeclaration> functions;
+
+  WasmContext({this.functions = const []});
+
+  /// Resolves the Wasm function index for a function with [name] and [arity]
+  /// (number of arguments). Returns `null` if not found.
+  int? functionIndex(String name, int arity) {
+    for (var i = 0; i < functions.length; ++i) {
+      var f = functions[i];
+      if (f.name == name && f.parameters.size == arity) {
+        return i;
+      }
+    }
+    return null;
+  }
+
+  /// Returns the function at the module's function index [index].
+  ASTFunctionDeclaration? functionByIndex(int index) {
+    if (index < 0 || index >= functions.length) return null;
+    return functions[index];
+  }
+
   final Map<String, ({ASTType type, int index})> _localVariables = {};
 
   ({ASTType type, int index})? getLocalVariable(String name) {

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -536,7 +536,12 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
       var paramType = callee.parameters.getParameterByIndex(i)?.type;
       if (paramType != null) {
-        _autoConvertStackTypes(stackType, paramType, out: out, context: context);
+        _autoConvertStackTypes(
+          stackType,
+          paramType,
+          out: out,
+          context: context,
+        );
       }
     }
 
@@ -821,7 +826,11 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     final expression1 = expression.expression1;
     final expression2 = expression.expression2;
 
-    if (expression2 is ASTExpressionLiteral) {
+    // `x == 0` fast-path (`i64.eqz`). Only valid for the `equals` operator:
+    // applying it to `>`, `<`, `!=`, etc. with a literal `0` would silently
+    // compute an equals-to-zero instead of the requested comparison.
+    if (expression.operator == ASTExpressionOperator.equals &&
+        expression2 is ASTExpressionLiteral) {
       var expression2Value = expression2.value;
       if (expression2Value is ASTValueInt && expression2Value.isZero) {
         return generateASTExpressionOperationEqualsToZero(
@@ -1117,10 +1126,6 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
             "i32.or",
           );
         }
-      default:
-        throw UnsupportedError(
-          "Wasm Operator not supported: ${expression.operator.name}",
-        );
     }
 
     context.assertStackLength(stackLng2 - 1, "After operation result");
@@ -1164,7 +1169,10 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     _localVariableGet(out, context, localVar.index, name);
 
-    context.stackPush(localVar.type, 'Local get: ${localVar.index} \$$name');
+    // Booleans are represented as i32 on the Wasm stack, so a `bool` local is
+    // pushed with the i32 type to stay consistent with comparisons/logic.
+    var pushType = localVar.type is ASTTypeBool ? _astTypeInt32 : localVar.type;
+    context.stackPush(pushType, 'Local get: ${localVar.index} \$$name');
 
     context.assertStackLength(
       stackLng0 + 1,
@@ -1656,7 +1664,10 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     out.write(Wasm.brIf(1), description: "[OP] br_if 1 ($description break)");
     context.stackDrop(_astTypeInt32);
 
-    context.assertStackLength(stackLng0, "After $description loop condition br");
+    context.assertStackLength(
+      stackLng0,
+      "After $description loop condition br",
+    );
 
     // Loop body:
     generateASTBlock(loopBlock, out: out, context: context);

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -1282,11 +1282,15 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     } else if (statement is ASTBranch) {
       return generateASTBranch(statement, out: out, context: context);
     } else if (statement is ASTStatementForLoop) {
-      return generateASTStatementForLoop(statement, out: out);
+      return generateASTStatementForLoop(statement, out: out, context: context);
     } else if (statement is ASTStatementForEach) {
       return generateASTStatementForEach(statement, out: out);
     } else if (statement is ASTStatementWhileLoop) {
-      return generateASTStatementWhileLoop(statement, out: out);
+      return generateASTStatementWhileLoop(
+        statement,
+        out: out,
+        context: context,
+      );
     } else if (statement is ASTStatementBlock) {
       return generateASTStatementBlock(statement, out: out);
     } else if (statement is ASTStatementFunctionDeclaration) {
@@ -1373,9 +1377,24 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   BytesOutput generateASTStatementForLoop(
     ASTStatementForLoop forLoop, {
     BytesOutput? out,
+    WasmContext? context,
   }) {
-    // TODO: implement generateASTStatementForLoop
-    throw UnimplementedError('generateASTStatementForLoop');
+    out ??= newOutput();
+    context ??= WasmContext();
+
+    // Emit the init statement BEFORE the loop block:
+    generateASTStatement(forLoop.initStatement, out: out, context: context);
+
+    _generateLoop(
+      out: out,
+      context: context,
+      conditionExpression: forLoop.conditionExpression,
+      loopBlock: forLoop.loopBlock,
+      continueExpression: forLoop.continueExpression,
+      description: "for",
+    );
+
+    return out;
   }
 
   @override
@@ -1391,9 +1410,96 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   BytesOutput generateASTStatementWhileLoop(
     ASTStatementWhileLoop whileLoop, {
     BytesOutput? out,
+    WasmContext? context,
   }) {
-    // TODO: implement generateASTStatementWhileLoop
-    throw UnimplementedError("generateASTStatementWhileLoop");
+    out ??= newOutput();
+    context ??= WasmContext();
+
+    _generateLoop(
+      out: out,
+      context: context,
+      conditionExpression: whileLoop.conditionExpression,
+      loopBlock: whileLoop.loopBlock,
+      continueExpression: null,
+      description: "while",
+    );
+
+    return out;
+  }
+
+  /// Generates the `block`/`loop` structure shared by `while` and `for` loops.
+  ///
+  /// Structure emitted (void block types):
+  /// ```
+  /// block (void)
+  ///   loop (void)
+  ///     <cond>       ; pushes i32
+  ///     i32.eqz      ; !cond
+  ///     br_if 1      ; break out to block
+  ///     <body>
+  ///     <continue>   ; (for-loops only)
+  ///     br 0         ; jump back to loop
+  ///   end
+  /// end
+  /// ```
+  void _generateLoop({
+    required BytesOutput out,
+    required WasmContext context,
+    required ASTExpression conditionExpression,
+    required ASTBlock loopBlock,
+    required ASTExpression? continueExpression,
+    required String description,
+  }) {
+    out.write(
+      Wasm.block(WasmType.voidType),
+      description: "[OP] block ($description loop)",
+    );
+    out.write(
+      Wasm.loop(WasmType.voidType),
+      description: "[OP] loop ($description loop)",
+    );
+
+    final stackLng0 = context.stackLength;
+
+    // Condition: pushes an i32 (boolean).
+    generateASTExpression(conditionExpression, out: out, context: context);
+
+    context.assertStackLength(
+      stackLng0 + 1,
+      "After $description loop condition",
+    );
+    var stackType = context.stackGet(0)!.type;
+    if (stackType != _astTypeInt32) {
+      throw StateError("Stack type error> not a boolean type: $stackType");
+    }
+
+    // Negate the condition: `i32.eqz` consumes 1 i32 and pushes 1 i32
+    // (net zero on the virtual stack).
+    out.writeByte(
+      Wasm32.i32EqualsToZero,
+      description: "[OP] i32.eqz ( !($conditionExpression) )",
+    );
+
+    // Break out of the `block` (label 1) when the condition is false:
+    out.write(Wasm.brIf(1), description: "[OP] br_if 1 ($description break)");
+    context.stackDrop(_astTypeInt32);
+
+    context.assertStackLength(stackLng0, "After $description loop condition br");
+
+    // Loop body:
+    generateASTBlock(loopBlock, out: out, context: context);
+
+    // Continue expression (for-loops only), e.g. `i++`:
+    if (continueExpression != null) {
+      generateASTExpression(continueExpression, out: out, context: context);
+    }
+
+    // Jump back to the top of the `loop` (label 0). Any leaked operand-stack
+    // values are unwound by this branch (loop is void).
+    out.write(Wasm.br(0), description: "[OP] br 0 ($description continue)");
+
+    out.writeByte(Wasm.end, description: "[OP] loop end ($description)");
+    out.writeByte(Wasm.end, description: "[OP] block end ($description)");
   }
 
   @override
@@ -2306,6 +2412,13 @@ extension _ASTStatementExtension on ASTStatement {
         ...self.blocksElseIf.declaredVariables(),
         ...?self.blockElse?.declaredVariables(),
       ];
+    } else if (self is ASTStatementForLoop) {
+      return [
+        ...self.initStatement.declaredVariablesTypes(),
+        ...self.loopBlock.declaredVariables(),
+      ];
+    } else if (self is ASTStatementWhileLoop) {
+      return self.loopBlock.declaredVariables();
     }
 
     return [];

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -525,18 +525,75 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   BytesOutput generateASTExpressionNegation(
     ASTExpressionNegation expression, {
     BytesOutput? out,
+    WasmContext? context,
   }) {
-    // TODO: implement generateASTExpressionNegation
-    throw UnimplementedError('generateASTExpressionNegation');
+    out ??= newOutput();
+    context ??= WasmContext();
+
+    final stackLng0 = context.stackLength;
+
+    generateASTExpression(expression.expression, out: out, context: context);
+
+    context.assertStackLength(stackLng0 + 1, "After negation operand");
+
+    var stackType = context.stackGet(0)!.type;
+    if (stackType != _astTypeInt32) {
+      throw StateError(
+        "Logical negation `!` needs a boolean (i32) value: $stackType",
+      );
+    }
+
+    out.writeByte(
+      Wasm32.i32EqualsToZero,
+      description: "[OP] operator: not (i32.eqz)",
+    );
+    context.stackOperationUnary(_astTypeInt32, "i32.eqz (not)");
+
+    context.assertStackLength(stackLng0 + 1, "After negation result");
+
+    return out;
   }
 
   @override
   BytesOutput generateASTExpressionNegative(
     ASTExpressionNegative expression, {
     BytesOutput? out,
+    WasmContext? context,
   }) {
-    // TODO: implement generateASTExpressionNegative
-    throw UnimplementedError('generateASTExpressionNegative');
+    out ??= newOutput();
+    context ??= WasmContext();
+
+    final stackLng0 = context.stackLength;
+
+    generateASTExpression(expression.expression, out: out, context: context);
+
+    context.assertStackLength(stackLng0 + 1, "After negative operand");
+
+    var stackType = context.stackGet(0)!.type;
+
+    if (stackType == _astTypeDouble64 || stackType == _astTypeDouble) {
+      out.writeByte(
+        Wasm64.f64Negation,
+        description: "[OP] operator: negative (f64.neg)",
+      );
+      // Unary: top stays f64 (stack length unchanged).
+    } else {
+      // No `i64.neg` opcode: negate via `x * -1`.
+      out.write(
+        Wasm64.i64Const(-1),
+        description: "[OP] push constant(i64): -1 (negate)",
+      );
+      context.stackPush(_astTypeInt64, "negate -1");
+      out.writeByte(
+        Wasm64.i64Multiply,
+        description: "[OP] operator: negative (i64.mul -1)",
+      );
+      context.stackOperationBinary(_astTypeInt64, "i64.mul (negate)");
+    }
+
+    context.assertStackLength(stackLng0 + 1, "After negative result");
+
+    return out;
   }
 
   ASTTypeDouble _fixStackOpsAsFloat64(
@@ -948,6 +1005,43 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
             Wasm64.i64LessThanOrEqualsSigned,
             "lowerEquals(i64)",
             "i64.lowerOrEqualsSigned",
+          );
+        }
+      case ASTExpressionOperator.remainder:
+        {
+          // Dart `%` on doubles has no direct Wasm f64 opcode (and i64.rem_s
+          // gives a truncated remainder, matching Dart only for non-negative
+          // operands). Support the common integer, non-negative case.
+          if (stackType2 == _astTypeDouble64 || stackType2 == _astTypeDouble) {
+            throw UnsupportedError(
+              "Wasm Operator not supported for double: remainder (%)",
+            );
+          }
+          writeOperation(
+            _astTypeInt64,
+            Wasm64.i64RemainderSigned,
+            "remainder(i64)",
+            "i64.rem_s",
+          );
+        }
+      case ASTExpressionOperator.and:
+        {
+          // Non-short-circuit logical AND on i32 booleans (0/1).
+          writeOperation(
+            _astTypeInt32,
+            Wasm32.i32BitwiseAnd,
+            "and(i32)",
+            "i32.and",
+          );
+        }
+      case ASTExpressionOperator.or:
+        {
+          // Non-short-circuit logical OR on i32 booleans (0/1).
+          writeOperation(
+            _astTypeInt32,
+            Wasm32.i32BitwiseOr,
+            "or(i32)",
+            "i32.or",
           );
         }
       default:
@@ -1711,9 +1805,17 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     } else if (expression is ASTExpressionMapLiteral) {
       return generateASTExpressionMapLiteral(expression, out: out);
     } else if (expression is ASTExpressionNegation) {
-      return generateASTExpressionNegation(expression, out: out);
+      return generateASTExpressionNegation(
+        expression,
+        out: out,
+        context: context,
+      );
     } else if (expression is ASTExpressionNegative) {
-      return generateASTExpressionNegative(expression, out: out);
+      return generateASTExpressionNegative(
+        expression,
+        out: out,
+        context: context,
+      );
     } else if (expression is ASTExpressionLocalFunctionInvocation) {
       return generateASTExpressionLocalFunctionInvocation(expression, out: out);
     } else if (expression is ASTExpressionObjectFunctionInvocation) {
@@ -1776,6 +1878,8 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       return generateASTValueInt(value, out: out, context: context);
     } else if (value is ASTValueDouble) {
       return generateASTValueDouble(value, out: out, context: context);
+    } else if (value is ASTValueBool) {
+      return generateASTValueBool(value, out: out, context: context);
     } else if (value is ASTValueNull) {
       return generateASTValueNull(value, out: out);
     } else if (value is ASTValueVar) {
@@ -1858,6 +1962,25 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     out.write(Wasm64.i64Const(v), description: "[OP] push constant(i64): $v");
     context.stackPush(_astTypeInt64, "int literal: $v");
+
+    return out;
+  }
+
+  BytesOutput generateASTValueBool(
+    ASTValueBool value, {
+    BytesOutput? out,
+    WasmContext? context,
+  }) {
+    out ??= newOutput();
+    context ??= WasmContext();
+
+    var v = value.value;
+
+    out.write(
+      Wasm32.i32Const(v ? 1 : 0),
+      description: "[OP] push constant(bool/i32): $v",
+    );
+    context.stackPush(_astTypeInt32, "bool literal: $v");
 
     return out;
   }
@@ -2218,6 +2341,8 @@ extension _ASTTypeExtension on ASTType {
       return WasmType.i64Type;
     } else if (this is ASTTypeDouble) {
       return WasmType.f64Type;
+    } else if (this is ASTTypeBool) {
+      return WasmType.i32Type;
     } else if (this is ASTTypeVoid) {
       return WasmType.voidType;
     } else if (name == 'void') {

--- a/test/apollovm_wasm_ops_test.dart
+++ b/test/apollovm_wasm_ops_test.dart
@@ -2,7 +2,6 @@
 library;
 
 import 'package:apollovm/apollovm.dart';
-import 'package:data_serializer/data_serializer.dart';
 import 'package:test/test.dart';
 
 /// Compiles [code] to Wasm, executes [functionName] both via the AST
@@ -25,7 +24,11 @@ Future<void> _testWasm(
       functionName,
       positionalParameters: e.key,
     );
-    expect(r.getValueNoContext(), e.value, reason: 'AST $functionName(${e.key})');
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'AST $functionName(${e.key})',
+    );
   }
 
   // 2) Compile to Wasm.
@@ -73,21 +76,26 @@ Future<void> _testWasm(
 void main() {
   group('Wasm OPS: modulo', () {
     test('integer remainder (non-negative)', () async {
-      await _testWasm(r'''
+      await _testWasm(
+        r'''
         int mod(int a, int b) {
           return a % b;
         }
-      ''', 'mod', {
-        [17, 5]: 2,
-        [20, 4]: 0,
-        [9, 10]: 9,
-      });
+      ''',
+        'mod',
+        {
+          [17, 5]: 2,
+          [20, 4]: 0,
+          [9, 10]: 9,
+        },
+      );
     });
   });
 
   group('Wasm OPS: logical && / ||', () {
     test('logical AND with bool locals', () async {
-      await _testWasm(r'''
+      await _testWasm(
+        r'''
         int land(int a, int b) {
           bool x = a > 5;
           bool y = b > 5;
@@ -96,15 +104,19 @@ void main() {
           }
           return 0;
         }
-      ''', 'land', {
-        [6, 6]: 1,
-        [6, 1]: 0,
-        [1, 6]: 0,
-      });
+      ''',
+        'land',
+        {
+          [6, 6]: 1,
+          [6, 1]: 0,
+          [1, 6]: 0,
+        },
+      );
     });
 
     test('logical OR', () async {
-      await _testWasm(r'''
+      await _testWasm(
+        r'''
         int lor(int a) {
           bool x = a > 5 || a < 2;
           if (x) {
@@ -112,17 +124,21 @@ void main() {
           }
           return 0;
         }
-      ''', 'lor', {
-        [6]: 1,
-        [1]: 1,
-        [4]: 0,
-      });
+      ''',
+        'lor',
+        {
+          [6]: 1,
+          [1]: 1,
+          [4]: 0,
+        },
+      );
     });
   });
 
   group('Wasm OPS: logical negation !', () {
     test('not on a bool', () async {
-      await _testWasm(r'''
+      await _testWasm(
+        r'''
         int neg(int a) {
           bool x = a > 5;
           if (!x) {
@@ -130,43 +146,122 @@ void main() {
           }
           return 0;
         }
-      ''', 'neg', {
-        [1]: 1,
-        [6]: 0,
-      });
+      ''',
+        'neg',
+        {
+          [1]: 1,
+          [6]: 0,
+        },
+      );
     });
   });
 
   group('Wasm OPS: unary minus', () {
     test('negate int', () async {
-      await _testWasm(r'''
+      await _testWasm(
+        r'''
         int negI(int a) {
-          int b = -a;
-          return b;
+          return -a;
         }
-      ''', 'negI', {
-        [5]: -5,
-        [-3]: 3,
-        [0]: 0,
-      });
+      ''',
+        'negI',
+        {
+          [5]: -5,
+          [-3]: 3,
+          [0]: 0,
+        },
+      );
     });
 
     test('negate double', () async {
-      await _testWasm(r'''
+      await _testWasm(
+        r'''
         double negD(double a) {
-          double b = -a;
-          return b;
+          return -a;
         }
-      ''', 'negD', {
-        [2.5]: -2.5,
-        [-4.0]: 4.0,
-      });
+      ''',
+        'negD',
+        {
+          [2.5]: -2.5,
+          [-4.0]: 4.0,
+        },
+      );
+    });
+  });
+
+  group('Wasm integration (loops + calls + logic + modulo)', () {
+    test(
+      'prime counting: while loop + function call + % + comparisons',
+      () async {
+        await _testWasm(
+          r'''
+        int isPrime(int n) {
+          if (n < 2) {
+            return 0;
+          }
+          int i = 2;
+          while (i < n) {
+            if (n % i == 0) {
+              return 0;
+            }
+            i = i + 1;
+          }
+          return 1;
+        }
+
+        int countPrimes(int max) {
+          int count = 0;
+          int k = 2;
+          while (k <= max) {
+            if (isPrime(k) > 0) {
+              count = count + 1;
+            }
+            k = k + 1;
+          }
+          return count;
+        }
+      ''',
+          'countPrimes',
+          {
+            [10]: 4,
+            [20]: 8,
+            [1]: 0,
+          },
+        );
+      },
+    );
+
+    test('for loop + function call + logical AND', () async {
+      await _testWasm(
+        r'''
+        int sq(int x) {
+          return x * x;
+        }
+
+        int sumSquaresMiddle(int n) {
+          int total = 0;
+          for (int i = 1; i <= n; i = i + 1) {
+            if (i > 1 && i < n) {
+              total = total + sq(i);
+            }
+          }
+          return total;
+        }
+      ''',
+        'sumSquaresMiddle',
+        {
+          [5]: 29,
+          [3]: 4,
+          [2]: 0,
+        },
+      );
     });
   });
 
   group('Wasm OPS: bool literals', () {
     test('true/false literals in conditions', () async {
-      await _testWasm(r'''
+      await _testWasm(
+        r'''
         int useTrue(int a) {
           bool b = true;
           if (b) {
@@ -174,11 +269,15 @@ void main() {
           }
           return 0;
         }
-      ''', 'useTrue', {
-        [0]: 1,
-      });
+      ''',
+        'useTrue',
+        {
+          [0]: 1,
+        },
+      );
 
-      await _testWasm(r'''
+      await _testWasm(
+        r'''
         int useFalse(int a) {
           bool b = false;
           if (b) {
@@ -186,9 +285,12 @@ void main() {
           }
           return 0;
         }
-      ''', 'useFalse', {
-        [0]: 0,
-      });
+      ''',
+        'useFalse',
+        {
+          [0]: 0,
+        },
+      );
     });
   });
 }

--- a/test/apollovm_wasm_ops_test.dart
+++ b/test/apollovm_wasm_ops_test.dart
@@ -1,0 +1,194 @@
+@TestOn('vm')
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:data_serializer/data_serializer.dart';
+import 'package:test/test.dart';
+
+/// Compiles [code] to Wasm, executes [functionName] both via the AST
+/// interpreter and the compiled+executed Wasm module, and asserts every
+/// execution matches the expected result in [executions].
+Future<void> _testWasm(
+  String code,
+  String functionName,
+  Map<List, Object?> executions,
+) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', code, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source");
+
+  // 1) AST interpreter.
+  var astRunner = vm.createRunner('dart')!;
+  for (var e in executions.entries) {
+    var r = await astRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(r.getValueNoContext(), e.value, reason: 'AST $functionName(${e.key})');
+  }
+
+  // 2) Compile to Wasm.
+  var storageWasm = vm.generateAllIn<BytesOutput>('wasm');
+  var wasmModules = await storageWasm.allEntries();
+
+  BytesOutput? compiled;
+  for (var ns in wasmModules.entries) {
+    for (var m in ns.value.entries) {
+      compiled ??= m.value;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var rt = WasmRuntime()..ensureBooted();
+  if (!rt.isSupported) {
+    fail(
+      'Wasm runtime not supported — cannot validate compiled bytes '
+      '(run `dart run wasm_run:setup`).',
+    );
+  }
+
+  // 3) Load + execute the compiled Wasm.
+  var vmWasm = ApolloVM();
+  var loadOK = await vmWasm.loadCodeUnit(
+    BinaryCodeUnit('wasm', compiled!.output(), id: 'test.wasm', namespace: ''),
+  );
+  expect(loadOK, isTrue, reason: 'Compiled Wasm failed to load');
+
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  for (var e in executions.entries) {
+    var r = await wasmRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'WASM $functionName(${e.key})',
+    );
+  }
+}
+
+void main() {
+  group('Wasm OPS: modulo', () {
+    test('integer remainder (non-negative)', () async {
+      await _testWasm(r'''
+        int mod(int a, int b) {
+          return a % b;
+        }
+      ''', 'mod', {
+        [17, 5]: 2,
+        [20, 4]: 0,
+        [9, 10]: 9,
+      });
+    });
+  });
+
+  group('Wasm OPS: logical && / ||', () {
+    test('logical AND with bool locals', () async {
+      await _testWasm(r'''
+        int land(int a, int b) {
+          bool x = a > 5;
+          bool y = b > 5;
+          if (x && y) {
+            return 1;
+          }
+          return 0;
+        }
+      ''', 'land', {
+        [6, 6]: 1,
+        [6, 1]: 0,
+        [1, 6]: 0,
+      });
+    });
+
+    test('logical OR', () async {
+      await _testWasm(r'''
+        int lor(int a) {
+          bool x = a > 5 || a < 2;
+          if (x) {
+            return 1;
+          }
+          return 0;
+        }
+      ''', 'lor', {
+        [6]: 1,
+        [1]: 1,
+        [4]: 0,
+      });
+    });
+  });
+
+  group('Wasm OPS: logical negation !', () {
+    test('not on a bool', () async {
+      await _testWasm(r'''
+        int neg(int a) {
+          bool x = a > 5;
+          if (!x) {
+            return 1;
+          }
+          return 0;
+        }
+      ''', 'neg', {
+        [1]: 1,
+        [6]: 0,
+      });
+    });
+  });
+
+  group('Wasm OPS: unary minus', () {
+    test('negate int', () async {
+      await _testWasm(r'''
+        int negI(int a) {
+          int b = -a;
+          return b;
+        }
+      ''', 'negI', {
+        [5]: -5,
+        [-3]: 3,
+        [0]: 0,
+      });
+    });
+
+    test('negate double', () async {
+      await _testWasm(r'''
+        double negD(double a) {
+          double b = -a;
+          return b;
+        }
+      ''', 'negD', {
+        [2.5]: -2.5,
+        [-4.0]: 4.0,
+      });
+    });
+  });
+
+  group('Wasm OPS: bool literals', () {
+    test('true/false literals in conditions', () async {
+      await _testWasm(r'''
+        int useTrue(int a) {
+          bool b = true;
+          if (b) {
+            return 1;
+          }
+          return 0;
+        }
+      ''', 'useTrue', {
+        [0]: 1,
+      });
+
+      await _testWasm(r'''
+        int useFalse(int a) {
+          bool b = false;
+          if (b) {
+            return 1;
+          }
+          return 0;
+        }
+      ''', 'useFalse', {
+        [0]: 0,
+      });
+    });
+  });
+}

--- a/test/apollovm_wasm_test.dart
+++ b/test/apollovm_wasm_test.dart
@@ -1203,6 +1203,127 @@ void main() async {
         },
       ),
     );
+
+    test(
+      'call simple (function calling function)',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int sq(int x) {
+            return x * x;
+          }
+
+          int f(int a) {
+            return sq(a) + 1;
+          }
+
+        ''',
+        functionName: 'f',
+        executions: {
+          [3]: 10,
+          [5]: 26,
+        },
+      ),
+    );
+
+    test(
+      'call chain (3-function chain)',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int a(int x) {
+            return x + 1;
+          }
+
+          int b(int x) {
+            return a(x) * 2;
+          }
+
+          int c(int x) {
+            return b(x) - 3;
+          }
+
+        ''',
+        functionName: 'c',
+        executions: {
+          [5]: 9,
+          [10]: 19,
+        },
+      ),
+    );
+
+    test(
+      'call mixed int/double params',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          double half(double v) {
+            return v / 2.0;
+          }
+
+          double g(int n) {
+            return half(n) + 1.0;
+          }
+
+        ''',
+        functionName: 'g',
+        executions: {
+          [4]: 3.0,
+          [10]: 6.0,
+        },
+      ),
+    );
+
+    test(
+      'call recursion (factorial)',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int fact(int n) {
+            if (n < 2) {
+              return 1;
+            }
+            return n * fact(n - 1);
+          }
+
+        ''',
+        functionName: 'fact',
+        executions: {
+          [0]: 1,
+          [1]: 1,
+          [5]: 120,
+          [6]: 720,
+        },
+      ),
+    );
+
+    test(
+      'call recursion (sum-to-n)',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int sumTo(int n) {
+            if (n < 1) {
+              return 0;
+            }
+            return n + sumTo(n - 1);
+          }
+
+        ''',
+        functionName: 'sumTo',
+        executions: {
+          [0]: 0,
+          [1]: 1,
+          [5]: 15,
+          [10]: 55,
+        },
+      ),
+    );
   });
 }
 
@@ -1393,14 +1514,16 @@ Future<void> _testWasm({
     );
   }
 
-  expect(expectedWasmBytes, isNotNull, reason: "Null `expectedWasmBytes`");
-
-  print('<< EXPECTED WASM: HEX>>\n${hex.encode(expectedWasmBytes!)}');
-
   var output = compiledWasm?.output();
   print('<< GENERATED WASM: HEX>>\n${hex.encode(output!)}');
 
-  expect(output, expectedWasmBytes);
+  // Only assert exact bytes when an expected Wasm was provided.
+  // When called without `expecteWasm`, the test just compiles + runs + asserts
+  // the execution results above.
+  if (expectedWasmBytes != null) {
+    print('<< EXPECTED WASM: HEX>>\n${hex.encode(expectedWasmBytes)}');
+    expect(output, expectedWasmBytes);
+  }
 }
 
 /*

--- a/test/apollovm_wasm_test.dart
+++ b/test/apollovm_wasm_test.dart
@@ -1203,6 +1203,129 @@ void main() async {
         },
       ),
     );
+
+    test(
+      'whileSum',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int whileSum(int n) {
+            int sum = 0;
+            int i = 0;
+            while (i <= n) {
+              sum = sum + i;
+              i = i + 1;
+            }
+            return sum;
+          }
+
+        ''',
+        functionName: 'whileSum',
+        executions: {
+          [0]: 0,
+          [5]: 15,
+          [10]: 55,
+        },
+      ),
+    );
+
+    test(
+      'forSum',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int forSum(int n) {
+            int sum = 0;
+            for (int i = 1; i <= n; i = i + 1) {
+              sum = sum + i;
+            }
+            return sum;
+          }
+
+        ''',
+        functionName: 'forSum',
+        executions: {
+          [0]: 0,
+          [4]: 10,
+          [5]: 15,
+        },
+      ),
+    );
+
+    test(
+      'forFactorial',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int forFactorial(int n) {
+            int p = 1;
+            for (int i = 1; i <= n; i = i + 1) {
+              p = p * i;
+            }
+            return p;
+          }
+
+        ''',
+        functionName: 'forFactorial',
+        executions: {
+          [1]: 1,
+          [4]: 24,
+          [5]: 120,
+        },
+      ),
+    );
+
+    test(
+      'nestedLoop',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int nestedLoop(int a, int b) {
+            int count = 0;
+            for (int i = 1; i <= a; i = i + 1) {
+              for (int j = 1; j <= b; j = j + 1) {
+                count = count + 1;
+              }
+            }
+            return count;
+          }
+
+        ''',
+        functionName: 'nestedLoop',
+        executions: {
+          [3, 4]: 12,
+          [2, 5]: 10,
+        },
+      ),
+    );
+
+    test(
+      'doubleAccumLoop',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          double doubleAccumLoop(int n) {
+            double acc = 0.0;
+            for (int i = 0; i < n; i = i + 1) {
+              acc = acc + 0.5;
+            }
+            return acc;
+          }
+
+        ''',
+        functionName: 'doubleAccumLoop',
+        executions: {
+          [0]: 0.0,
+          [4]: 2.0,
+          [10]: 5.0,
+        },
+      ),
+    );
   });
 }
 
@@ -1393,14 +1516,14 @@ Future<void> _testWasm({
     );
   }
 
-  expect(expectedWasmBytes, isNotNull, reason: "Null `expectedWasmBytes`");
-
-  print('<< EXPECTED WASM: HEX>>\n${hex.encode(expectedWasmBytes!)}');
-
   var output = compiledWasm?.output();
   print('<< GENERATED WASM: HEX>>\n${hex.encode(output!)}');
 
-  expect(output, expectedWasmBytes);
+  // Only assert exact bytes when an expectation was provided.
+  if (expectedWasmBytes != null) {
+    print('<< EXPECTED WASM: HEX>>\n${hex.encode(expectedWasmBytes)}');
+    expect(output, expectedWasmBytes);
+  }
 }
 
 /*


### PR DESCRIPTION
## Summary

Expands the **Wasm generator** toward full Dart parity by implementing the P0 feature set plus local function invocation (#8 from the gap analysis). Every feature is verified by compiling the Dart source to Wasm **and executing the compiled module** (via the `wasm_run` runtime), asserting the result matches the AST interpreter.

Ships under **0.1.27** (the current unpublished version — no version skip, per pub.dev).

## Features implemented

- **Loops** — `while` and `for` compile to `block`/`loop`/`br_if`/`br`, including `return` from inside a loop. Added the `br` (0x0c) opcode helper and made local-variable collection recurse into loop bodies/init.
- **Function calls (#8)** — local function invocation (calling other top-level functions, **including recursion**) via a function-index table threaded through the generator + `Wasm.call`.
- **Operators** — integer modulo `%` (`i64.rem_s`), logical `&&`/`||` (`i32.and`/`i32.or`), logical negation `!` (`i32.eqz`), unary minus `-` (`f64.neg` / `i64` ×`-1`).
- **Booleans** — `bool` literals and `bool`-typed locals (represented as Wasm `i32`).

## Bug fix

The `== 0` fast-path (`i64.eqz`) was applied to **any** operator with a literal-`0` right operand, so e.g. `x > 0` compiled to `x == 0` (inverted). Now restricted to the `equals` operator. This was caught by the new prime-counting integration test.

## Tests

- New `test/apollovm_wasm_ops_test.dart` (operators, unary, booleans, and a combined loops+calls+logic+modulo integration test — prime counting / sum-of-squares).
- New `while`/`for` and function-call cases in `test/apollovm_wasm_test.dart`.
- Full suite green (404 project tests; 65 Wasm tests run against the real compiled+executed module). `dart analyze` clean.

## Known limitations (next steps)

- `&&`/`||` are non-short-circuit (both operands evaluated).
- Double `%` and negative-operand (Euclidean) integer `%` are not yet supported.
- Strings, lists, maps, classes remain unimplemented (P2+ in the gap analysis — require linear memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)