### PR TITLE
Wasm polish: short-circuit && / ||, full Dart % semantics, compound-assignment fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@
   - **Operators**: integer modulo `%` (`i64.rem_s`), logical `&&`/`||` (`i32.and`/`i32.or`), logical negation `!` (`i32.eqz`), and unary minus `-` (`f64.neg` / `i64` multiply-by-`-1`).
   - **Booleans**: `bool` literals and `bool`-typed locals (represented as Wasm `i32`).
   - **Bug fix**: the `== 0` fast-path (`i64.eqz`) was incorrectly applied to *any* operator with a literal-`0` right operand (e.g. `x > 0` compiled as `x == 0`). It is now restricted to the `equals` operator.
-  - Notes/limitations: `&&`/`||` are non-short-circuit; double `%` and negative-operand integer `%` (Euclidean) are not yet supported.
+  - **Short-circuit `&&` / `||`**: now compile to an `if/else` so the right operand is only evaluated when needed. The AST interpreter was also made short-circuiting, so interpreted and compiled execution stay consistent (and match Dart).
+  - **Full Dart `%` semantics**: integer and double modulo now return the Dart-correct non-negative result in `[0, |b|)` for negative operands (sign-corrected via scratch locals); double `%` is computed as `a - trunc(a / b) * b`.
+  - **Fix**: compound assignment (`+=`, `-=`, `*=`, …) emitted its operation to a discarded buffer (missing `out`/`context`), producing broken code; now applied to the real output.
 - Tests: added Wasm coverage for every feature above plus a combined integration test (prime counting / sum-of-squares using loops + calls + logic + modulo), all executed against the real compiled-and-run Wasm module.
 
 - Bug fixes:

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -974,6 +974,30 @@ class ASTExpressionOperation extends ASTExpression {
   FutureOr<ASTValue> run(VMContext parentContext, ASTRunStatus runStatus) {
     var context = defineRunContext(parentContext);
 
+    final operator = this.operator;
+
+    // Short-circuit logical operators: only evaluate the right operand when the
+    // left does not already determine the result. This matches Dart semantics
+    // and keeps the interpreter consistent with the Wasm compiler.
+    if (operator == ASTExpressionOperator.and ||
+        operator == ASTExpressionOperator.or) {
+      return expression1.run(context, runStatus).resolveMapped((val1) {
+        return _toBoolean(val1, context).resolveMapped((b1) {
+          if (operator == ASTExpressionOperator.and) {
+            if (!b1) return ASTValueBool.FALSE;
+          } else {
+            if (b1) return ASTValueBool.TRUE;
+          }
+          return expression2.run(context, runStatus).resolveMapped((val2) {
+            return _toBoolean(
+              val2,
+              context,
+            ).resolveMapped((b2) => ASTValueBool(b2));
+          });
+        });
+      });
+    }
+
     var retVal2 = expression2.run(context, runStatus);
     var retVal1 = expression1.run(context, runStatus);
 

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -814,6 +814,65 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     return out;
   }
 
+  /// Generates a short-circuiting logical `&&` / `||` as an `if/else` that
+  /// yields an i32 boolean, so the right operand is only evaluated when needed:
+  /// - `a && b`  ->  `a ? b : false`
+  /// - `a || b`  ->  `a ? true : b`
+  BytesOutput generateASTExpressionLogicalShortCircuit(
+    ASTExpressionOperation expression, {
+    BytesOutput? out,
+    WasmContext? context,
+  }) {
+    out ??= newOutput();
+    context ??= WasmContext();
+
+    final isAnd = expression.operator == ASTExpressionOperator.and;
+    final stackLng0 = context.stackLength;
+
+    // Left operand (i32 boolean).
+    generateASTExpression(expression.expression1, out: out, context: context);
+    context.assertStackLength(stackLng0 + 1, "After logical left operand");
+
+    var leftType = context.stackGet(0)!.type;
+    if (leftType != _astTypeInt32) {
+      throw StateError("Logical operand is not a boolean (i32): $leftType");
+    }
+
+    // `if` consumes the left boolean and yields an i32 result.
+    out.write(
+      Wasm.ifInstruction(WasmType.i32Type),
+      description: "[OP] logical ${isAnd ? '&&' : '||'} (short-circuit)",
+    );
+    context.stackDrop(_astTypeInt32);
+
+    // `then` branch value.
+    if (isAnd) {
+      generateASTExpression(expression.expression2, out: out, context: context);
+    } else {
+      out.write(Wasm32.i32Const(1), description: "[OP] push true");
+      context.stackPush(_astTypeInt32, "logical true");
+    }
+    // The two branches are mutually exclusive: drop the `then` result from the
+    // virtual stack before generating the `else` branch.
+    context.stackDrop();
+
+    out.writeByte(Wasm.elseInstruction, description: "[OP] logical else");
+
+    // `else` branch value.
+    if (isAnd) {
+      out.write(Wasm32.i32Const(0), description: "[OP] push false");
+      context.stackPush(_astTypeInt32, "logical false");
+    } else {
+      generateASTExpression(expression.expression2, out: out, context: context);
+    }
+
+    out.writeByte(Wasm.end, description: "[OP] logical end");
+
+    context.assertStackLength(stackLng0 + 1, "After logical short-circuit");
+
+    return out;
+  }
+
   @override
   BytesOutput generateASTExpressionOperation(
     ASTExpressionOperation expression, {
@@ -839,6 +898,17 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
           context: context,
         );
       }
+    }
+
+    // Short-circuit logical operators must NOT eagerly evaluate the right
+    // operand, so they are handled before the generic operand evaluation below.
+    if (expression.operator == ASTExpressionOperator.and ||
+        expression.operator == ASTExpressionOperator.or) {
+      return generateASTExpressionLogicalShortCircuit(
+        expression,
+        out: out,
+        context: context,
+      );
     }
 
     final stackLng0 = context.stackLength;
@@ -1091,41 +1161,20 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         }
       case ASTExpressionOperator.remainder:
         {
-          // Dart `%` on doubles has no direct Wasm f64 opcode (and i64.rem_s
-          // gives a truncated remainder, matching Dart only for non-negative
-          // operands). Support the common integer, non-negative case.
-          if (stackType2 == _astTypeDouble64 || stackType2 == _astTypeDouble) {
-            throw UnsupportedError(
-              "Wasm Operator not supported for double: remainder (%)",
-            );
+          // Dart `%` always yields a non-negative result in `[0, |b|)`, which
+          // differs from Wasm's truncated `i64.rem_s` / the f64 formula for
+          // negative operands; the helpers apply the sign correction.
+          if (stackType2 == _astTypeDouble) {
+            _writeDoubleModulo(out, context);
+          } else {
+            _writeIntModulo(out, context);
           }
-          writeOperation(
-            _astTypeInt64,
-            Wasm64.i64RemainderSigned,
-            "remainder(i64)",
-            "i64.rem_s",
-          );
         }
-      case ASTExpressionOperator.and:
-        {
-          // Non-short-circuit logical AND on i32 booleans (0/1).
-          writeOperation(
-            _astTypeInt32,
-            Wasm32.i32BitwiseAnd,
-            "and(i32)",
-            "i32.and",
-          );
-        }
-      case ASTExpressionOperator.or:
-        {
-          // Non-short-circuit logical OR on i32 booleans (0/1).
-          writeOperation(
-            _astTypeInt32,
-            Wasm32.i32BitwiseOr,
-            "or(i32)",
-            "i32.or",
-          );
-        }
+      default:
+        // `and`/`or` are handled before operand evaluation (short-circuit).
+        throw UnsupportedError(
+          "Wasm Operator not supported: ${expression.operator.name}",
+        );
     }
 
     context.assertStackLength(stackLng2 - 1, "After operation result");
@@ -1140,6 +1189,81 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         "Stack status error> `f64.divide` needs 2 f64 values in the top of the stack",
       );
     }
+  }
+
+  /// Emits Dart integer `%` for `[a, b]` on the stack (both i64).
+  ///
+  /// `i64.rem_s` yields a truncated remainder (sign of the dividend), but Dart
+  /// `%` is always in `[0, |b|)`. So: `r = a rem b; if (r < 0) r += |b|`,
+  /// computed branchlessly with `select` and two scratch locals.
+  void _writeIntModulo(BytesOutput out, WasmContext context) {
+    var bs = context.scratchLocal(_astTypeInt64, 0);
+    var rs = context.scratchLocal(_astTypeInt64, 1);
+
+    out.write(Wasm.localTee(bs), description: "[OP] % keep b");
+    out.writeByte(Wasm64.i64RemainderSigned, description: "[OP] i64.rem_s");
+    out.write(Wasm.localTee(rs), description: "[OP] % keep r");
+
+    // |b| = (b < 0) ? -b : b
+    out.write(Wasm64.i64Const(0));
+    out.write(Wasm.localGet(bs));
+    out.writeByte(Wasm64.i64Subtract, description: "[OP] -b");
+    out.write(Wasm.localGet(bs));
+    out.write(Wasm.localGet(bs));
+    out.write(Wasm64.i64Const(0));
+    out.writeByte(Wasm64.i64LessThanSigned, description: "[OP] b < 0");
+    out.writeByte(Wasm.select, description: "[OP] |b|");
+
+    // addend = (r < 0) ? |b| : 0
+    out.write(Wasm64.i64Const(0));
+    out.write(Wasm.localGet(rs));
+    out.write(Wasm64.i64Const(0));
+    out.writeByte(Wasm64.i64LessThanSigned, description: "[OP] r < 0");
+    out.writeByte(Wasm.select, description: "[OP] addend");
+
+    out.writeByte(Wasm64.i64Add, description: "[OP] r + addend (Dart %)");
+
+    context.stackOperationBinary(_astTypeInt64, "i64 Dart modulo");
+  }
+
+  /// Emits Dart double `%` for `[a, b]` on the stack (both f64).
+  ///
+  /// f64 has no remainder opcode: `r = a - trunc(a / b) * b`, then the same
+  /// non-negative correction `if (r < 0) r += |b|`. Uses three scratch locals.
+  void _writeDoubleModulo(BytesOutput out, WasmContext context) {
+    var af = context.scratchLocal(_astTypeDouble64, 0);
+    var bf = context.scratchLocal(_astTypeDouble64, 1);
+    var rf = context.scratchLocal(_astTypeDouble64, 2);
+
+    out.write(Wasm.localSet(bf), description: "[OP] % save b");
+    out.write(Wasm.localSet(af), description: "[OP] % save a");
+
+    // r = a - trunc(a / b) * b
+    out.write(Wasm.localGet(af));
+    out.write(Wasm.localGet(af));
+    out.write(Wasm.localGet(bf));
+    out.writeByte(Wasm64.f64Divide, description: "[OP] a / b");
+    out.writeByte(
+      Wasm64.f64TruncateToF64Signed,
+      description: "[OP] trunc(a / b)",
+    );
+    out.write(Wasm.localGet(bf));
+    out.writeByte(Wasm64.f64Multiply, description: "[OP] trunc(a / b) * b");
+    out.writeByte(Wasm64.f64Subtract, description: "[OP] a - ...");
+    out.write(Wasm.localTee(rf), description: "[OP] % keep r");
+
+    // addend = (r < 0) ? |b| : 0
+    out.write(Wasm.localGet(bf));
+    out.writeByte(Wasm64.f64Absolute, description: "[OP] |b|");
+    out.write(Wasm64.f64Const(0.0));
+    out.write(Wasm.localGet(rf));
+    out.write(Wasm64.f64Const(0.0));
+    out.writeByte(Wasm64.f64LessThan, description: "[OP] r < 0");
+    out.writeByte(Wasm.select, description: "[OP] addend");
+
+    out.writeByte(Wasm64.f64Add, description: "[OP] r + addend (Dart %)");
+
+    context.stackOperationBinary(_astTypeDouble64, "f64 Dart modulo");
   }
 
   @override
@@ -1219,6 +1343,8 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
               expOp,
               expression.expression,
             ),
+            out: out,
+            context: context,
           );
         }
     }
@@ -1383,16 +1509,54 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     var localVariables = f.statements.declaredVariables();
 
+    // Register declared locals before generating the body (which references
+    // them, and may also allocate scratch locals).
+    for (var v in localVariables) {
+      context.addLocalVariable(v.key, v.value);
+    }
+
+    // Generate the body first, into its own buffer: body generation may
+    // allocate scratch locals (e.g. for `%`), which must be declared in the
+    // preamble below.
+    var bodyCode = newOutput();
+
+    for (var stm in f.statements) {
+      generateASTStatement(stm, out: bodyCode, context: context);
+    }
+
+    var returnType = f.returnType;
+
+    if (!returnType.isVoid && context.stackLength == 0) {
+      // Notify that the function can't reach the end.
+      bodyCode.writeByte(
+        Wasm.unreachable,
+        description: "[OP] Unreachable function end",
+      );
+
+      if (returnType is ASTTypeInt) {
+        bodyCode.write(
+          Wasm64.i64Const(0),
+          description: "Unreachable default return",
+        );
+      } else if (returnType is ASTTypeDouble) {
+        bodyCode.write(
+          Wasm64.f64Const(0),
+          description: "Unreachable default return",
+        );
+      }
+    }
+
+    // Preamble: declared locals followed by any scratch locals (in index
+    // order), then the generated body.
+    var scratchTypes = context.scratchLocalTypes;
+
     outBody.write(
-      Leb128.encodeUnsigned(localVariables.length),
+      Leb128.encodeUnsigned(localVariables.length + scratchTypes.length),
       description: "Local variables count",
     );
 
     for (var v in localVariables) {
       var astType = v.value;
-
-      context.addLocalVariable(v.key, astType);
-
       outBody.write(
         Leb128.encodeUnsigned(1),
         description: "Declared variable count",
@@ -1404,31 +1568,18 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       );
     }
 
-    for (var stm in f.statements) {
-      generateASTStatement(stm, out: outBody, context: context);
-    }
-
-    var returnType = f.returnType;
-
-    if (!returnType.isVoid && context.stackLength == 0) {
-      // Notify that the function can't reach the end.
-      outBody.writeByte(
-        Wasm.unreachable,
-        description: "[OP] Unreachable function end",
+    for (var astType in scratchTypes) {
+      outBody.write(
+        Leb128.encodeUnsigned(1),
+        description: "Scratch variable count",
       );
-
-      if (returnType is ASTTypeInt) {
-        outBody.write(
-          Wasm64.i64Const(0),
-          description: "Unreachable default return",
-        );
-      } else if (returnType is ASTTypeDouble) {
-        outBody.write(
-          Wasm64.f64Const(0),
-          description: "Unreachable default return",
-        );
-      }
+      outBody.writeByte(
+        astType.wasmCode,
+        description: "Scratch variable type(${astType.wasmType.name})",
+      );
     }
+
+    outBody.writeBytes(bodyCode);
 
     context.assertReturnsLength(return0 + 1);
     context.returnsDrop(f.returnType);
@@ -2367,6 +2518,27 @@ class WasmContext {
     var entry = (type: type, index: _localVariables.length);
     _localVariables[name] = entry;
     return entry.index;
+  }
+
+  /// Scratch (temporary) local types, in the order they were allocated. These
+  /// are declared in the function preamble after the regular locals.
+  final List<ASTType> scratchLocalTypes = [];
+
+  final Map<String, int> _scratchCache = {};
+
+  /// Allocates (or reuses) a scratch local of [type] identified by [slot].
+  /// Reused across the function so repeated operations don't keep allocating.
+  /// Must be called while generating the function body (before the preamble is
+  /// emitted), so [generateASTFunctionDeclaration] can declare them.
+  int scratchLocal(ASTType type, int slot) {
+    var key = '${type.wasmType.value}#$slot';
+    var cached = _scratchCache[key];
+    if (cached != null) return cached;
+
+    var index = addLocalVariable('\$scratch_$key', type);
+    scratchLocalTypes.add(type);
+    _scratchCache[key] = index;
+    return index;
   }
 
   final ListQueue<({ASTType type, String description})> _stack = ListQueue();

--- a/test/apollovm_wasm_polish_test.dart
+++ b/test/apollovm_wasm_polish_test.dart
@@ -1,0 +1,222 @@
+@TestOn('vm')
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Compiles [code] to Wasm, executes [functionName] both via the AST
+/// interpreter and the compiled+executed Wasm module, asserting every
+/// execution in [executions] matches.
+Future<void> _testWasm(
+  String code,
+  String functionName,
+  Map<List, Object?> executions,
+) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', code, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source");
+
+  var astRunner = vm.createRunner('dart')!;
+  for (var e in executions.entries) {
+    var r = await astRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'AST $functionName(${e.key})',
+    );
+  }
+
+  var storageWasm = vm.generateAllIn<BytesOutput>('wasm');
+  var wasmModules = await storageWasm.allEntries();
+  BytesOutput? compiled;
+  for (var ns in wasmModules.entries) {
+    for (var m in ns.value.entries) {
+      compiled ??= m.value;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var rt = WasmRuntime()..ensureBooted();
+  if (!rt.isSupported) {
+    fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+  }
+
+  var vmWasm = ApolloVM();
+  var loadOK = await vmWasm.loadCodeUnit(
+    BinaryCodeUnit('wasm', compiled!.output(), id: 'test.wasm', namespace: ''),
+  );
+  expect(loadOK, isTrue, reason: 'Compiled Wasm failed to load');
+
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  for (var e in executions.entries) {
+    var r = await wasmRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'WASM $functionName(${e.key})',
+    );
+  }
+}
+
+void main() {
+  group('Wasm compound assignment', () {
+    test('+= -= *= on int', () async {
+      await _testWasm(
+        r'''
+        int addAssign(int a) {
+          int x = a;
+          x += 5;
+          return x;
+        }
+      ''',
+        'addAssign',
+        {
+          [10]: 15,
+          [0]: 5,
+        },
+      );
+
+      await _testWasm(
+        r'''
+        int mulSubAssign(int a) {
+          int x = a;
+          x *= 3;
+          x -= 1;
+          return x;
+        }
+      ''',
+        'mulSubAssign',
+        {
+          [4]: 11,
+          [2]: 5,
+        },
+      );
+    });
+
+    test('+= in a loop accumulator', () async {
+      await _testWasm(
+        r'''
+        int sum(int n) {
+          int total = 0;
+          for (int i = 1; i <= n; i = i + 1) {
+            total += i;
+          }
+          return total;
+        }
+      ''',
+        'sum',
+        {
+          [4]: 10,
+          [1]: 1,
+        },
+      );
+    });
+  });
+
+  group('Wasm short-circuit && / ||', () {
+    test('&& does not evaluate the right side when left is false', () async {
+      // If `&&` were non-short-circuit, `100 ~/ d` with d==0 would trap.
+      await _testWasm(
+        r'''
+        int safeAnd(int a, int d) {
+          if (d != 0 && a ~/ d > 1) {
+            return 1;
+          }
+          return 0;
+        }
+      ''',
+        'safeAnd',
+        {
+          [10, 0]: 0,
+          [10, 2]: 1,
+          [10, 20]: 0,
+        },
+      );
+    });
+
+    test('|| does not evaluate the right side when left is true', () async {
+      await _testWasm(
+        r'''
+        int safeOr(int a, int d) {
+          if (d == 0 || a ~/ d > 1) {
+            return 1;
+          }
+          return 0;
+        }
+      ''',
+        'safeOr',
+        {
+          [10, 0]: 1,
+          [10, 2]: 1,
+          [10, 20]: 0,
+        },
+      );
+    });
+
+    test('chained && / || logic values', () async {
+      await _testWasm(
+        r'''
+        int logic(int a, int b) {
+          bool r = a > 0 && b > 0 || a < 0;
+          if (r) {
+            return 1;
+          }
+          return 0;
+        }
+      ''',
+        'logic',
+        {
+          [1, 1]: 1,
+          [1, 0]: 0,
+          [-1, 0]: 1,
+          [0, 5]: 0,
+        },
+      );
+    });
+  });
+
+  group('Wasm modulo (Dart semantics, incl. negatives)', () {
+    test('integer % matches Dart for negative operands', () async {
+      await _testWasm(
+        r'''
+        int mod(int a, int b) {
+          return a % b;
+        }
+      ''',
+        'mod',
+        {
+          [17, 5]: 2,
+          [-7, 3]: 2,
+          [7, -3]: 1,
+          [-7, -3]: 2,
+          [0, 4]: 0,
+          [9, 10]: 9,
+        },
+      );
+    });
+
+    test('double % matches Dart', () async {
+      await _testWasm(
+        r'''
+        double modD(double a, double b) {
+          return a % b;
+        }
+      ''',
+        'modD',
+        {
+          [5.5, 2.0]: 1.5,
+          [-5.5, 2.0]: 0.5,
+          [5.5, -2.0]: 1.5,
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Quick follow-up that closes the rough edges left after the Wasm P0 work. Ships under **0.1.27** (unpublished).

## Changes

- **Short-circuit `&&` / `||`** — now compile to an `if/else` that yields an i32 boolean, so the right operand is only evaluated when the left doesn't already decide the result. The **AST interpreter was also made short-circuiting** (it previously evaluated both operands eagerly), so interpreted and compiled execution stay consistent and both match Dart. Verified with a division-by-zero guard (`d != 0 && a ~/ d > 1`) that would trap if eager.
- **Full Dart `%` semantics** — integer and double modulo now return Dart's always-non-negative result in `[0, |b|)` for negative operands:
  - integer: `i64.rem_s` + branchless sign correction (`if (r < 0) r += |b|`) via `select` and scratch locals;
  - double: `a - trunc(a / b) * b` + the same correction.
  - Added **scratch-local** support to `WasmContext` and refactored the function preamble (body generated first, then declared + scratch locals emitted). Byte-identical output for functions that use no scratch locals (all existing byte-exact tests unchanged).
- **Compound-assignment fix** — `+=`/`-=`/`*=`/… emitted its operation to a *discarded* buffer (the call omitted `out`/`context`), producing broken Wasm. Now applied to the real output.

## Tests

- New `test/apollovm_wasm_polish_test.dart`: compound assignment, short-circuit safety, and modulo (incl. negative ints and doubles) — all run against the **compiled-and-executed** Wasm module and compared to the interpreter.
- Full suite green: **411 project tests**, **72 Wasm tests**; `dart analyze` clean.

## Remaining (next milestone)

Linear-memory foundation (P2) → strings, lists, maps, classes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)