### PR TITLE
Wasm: confirm wasm_run lacks WasmGC; add Chrome validation harness + wasm-gc tag

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -47,7 +47,9 @@ jobs:
       - name: wasm_run:setup (install dynamic library)
         run: dart run wasm_run:setup
       - name: Run tests (VM)
-        run: dart test --platform vm --coverage=./coverage
+        # Exclude `wasm-gc` tests: this job uses `wasm_run` (wasmtime 14 /
+        # wasmi 0.31), which does not support the WebAssembly GC proposal.
+        run: dart test --platform vm --exclude-tags wasm-gc --coverage=./coverage
       - name: Generate coverage report
         run: |
           dart pub global activate coverage
@@ -80,7 +82,8 @@ jobs:
       - name: wasm_run:setup (install dynamic library)
         run: dart run wasm_run:setup
       - name: Run tests (exe)
-        run: dart test --compiler exe
+        # `wasm_run` backend has no WebAssembly GC support; skip `wasm-gc` tests.
+        run: dart test --compiler exe --exclude-tags wasm-gc
 
 
   test_chrome:
@@ -97,4 +100,7 @@ jobs:
       - name: Upgrade dependencies
         run: dart pub upgrade
       - name: Run tests (Chrome)
+        # Chrome's engine supports the WebAssembly GC proposal (v119+), so it
+        # runs ALL tests, including `wasm-gc` ones (unlike the wasm_run-based
+        # VM/exe jobs, which exclude that tag).
         run: dart test --platform chrome

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   - **Full Dart `%` semantics**: integer and double modulo now return the Dart-correct non-negative result in `[0, |b|)` for negative operands (sign-corrected via scratch locals); double `%` is computed as `a - trunc(a / b) * b`.
   - **Fix**: compound assignment (`+=`, `-=`, `*=`, …) emitted its operation to a discarded buffer (missing `out`/`context`), producing broken code; now applied to the real output.
 - Tests: added Wasm coverage for every feature above plus a combined integration test (prime counting / sum-of-squares using loops + calls + logic + modulo), all executed against the real compiled-and-run Wasm module.
+- Test infrastructure — WebAssembly GC validation path:
+  - Established a browser (`dart test -p chrome`) parity harness that runs generated Wasm on Chrome's own engine. The native `wasm_run` backend (wasmtime 14 / wasmi 0.31) does not support the WebAssembly GC proposal; Chrome (v119+) does.
+  - Added a `wasm-gc` test tag (`dart_test.yaml`) and a WasmGC capability spike; CI's `wasm_run`-based jobs exclude the tag (`--exclude-tags wasm-gc`) while the Chrome job runs it. This gates the planned dual-target (linear-memory + WasmGC) backend work.
 
 - Bug fixes:
   - Loop `return` propagation: a `return` inside a `for`, `while`, or `for-each` loop was ignored (the loop shadowed `runStatus` with a fresh instance and never broke on return). Returns now propagate and stop iteration correctly.

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -1,0 +1,14 @@
+# Test platform / tag configuration.
+#
+# Tags:
+#   wasm-gc — tests that require the WebAssembly GC proposal. These only run on
+#            engines that support WasmGC (e.g. Chrome 119+). The native
+#            `wasm_run` runtime (wasmtime 14 / wasmi 0.31) does NOT support GC,
+#            so CI that relies on `wasm_run` must EXCLUDE this tag:
+#
+#              dart test -x wasm-gc            # native / wasm_run CI
+#              dart test -p chrome -t wasm-gc  # run only the GC tests in Chrome
+
+tags:
+  wasm-gc:
+    # Requires a WasmGC-capable engine (Chrome). Excluded from wasm_run CI.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -37,6 +37,8 @@ dev_dependencies:
   test: ^1.31.0
   pubspec: ^2.3.0
   xml: ^6.6.1
+  build_web_compilers: ^4.8.0
+  build_runner: ^2.15.0
 
 executables:
   apollovm:

--- a/test/apollovm_wasm_chrome_test.dart
+++ b/test/apollovm_wasm_chrome_test.dart
@@ -1,0 +1,109 @@
+@TestOn('chrome')
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Parity harness that runs in the browser: loads Dart source, executes
+/// [functionName] via the AST interpreter AND via the Wasm module compiled and
+/// run through ApolloVM's web runtime (the browser's own `WebAssembly` engine),
+/// asserting both match. This proves the current linear-memory Wasm output is
+/// accepted and executed by Chrome's engine.
+Future<void> _testWasm(
+  String code,
+  String functionName,
+  Map<List, Object?> executions,
+) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', code, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source");
+
+  var astRunner = vm.createRunner('dart')!;
+  for (var e in executions.entries) {
+    var r = await astRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'AST $functionName(${e.key})',
+    );
+  }
+
+  var storageWasm = vm.generateAllIn<BytesOutput>('wasm');
+  var wasmModules = await storageWasm.allEntries();
+  BytesOutput? compiled;
+  for (var ns in wasmModules.entries) {
+    for (var m in ns.value.entries) {
+      compiled ??= m.value;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var rt = WasmRuntime()..ensureBooted();
+  expect(rt.isSupported, isTrue, reason: 'Browser WasmRuntime unsupported');
+
+  var vmWasm = ApolloVM();
+  var loadOK = await vmWasm.loadCodeUnit(
+    BinaryCodeUnit('wasm', compiled!.output(), id: 'test.wasm', namespace: ''),
+  );
+  expect(loadOK, isTrue, reason: 'Compiled Wasm failed to load in Chrome');
+
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  for (var e in executions.entries) {
+    var r = await wasmRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'CHROME-WASM $functionName(${e.key})',
+    );
+  }
+}
+
+void main() {
+  group('Chrome linear-memory Wasm parity', () {
+    test('int arithmetic', () async {
+      await _testWasm(
+        r'''
+        int calc(int a, int b) {
+          int x = a + b * 2;
+          return x - 1;
+        }
+      ''',
+        'calc',
+        {
+          [3, 4]: 10,
+          [10, 0]: 9,
+        },
+      );
+    });
+
+    test('while loop with accumulator and return', () async {
+      await _testWasm(
+        r'''
+        int sumTo(int n) {
+          int total = 0;
+          int i = 1;
+          while (i <= n) {
+            total = total + i;
+            i = i + 1;
+          }
+          return total;
+        }
+      ''',
+        'sumTo',
+        {
+          [4]: 10,
+          [1]: 1,
+          [0]: 0,
+        },
+      );
+    });
+  });
+}

--- a/test/apollovm_wasm_gc_test.dart
+++ b/test/apollovm_wasm_gc_test.dart
@@ -1,0 +1,77 @@
+@TestOn('chrome')
+@Tags(['wasm-gc'])
+library;
+
+import 'dart:js_interop';
+import 'dart:js_interop_unsafe';
+import 'dart:typed_data';
+
+import 'package:test/test.dart';
+
+// Minimal binding to the browser's WebAssembly.instantiate.
+@JS('WebAssembly.instantiate')
+external JSPromise<JSObject> _instantiate(JSArrayBuffer bytes);
+
+@JS('WebAssembly.validate')
+external bool _validate(JSArrayBuffer bytes);
+
+/// A hand-encoded minimal **WasmGC** module:
+///
+/// ```wat
+/// (module
+///   (type $arr (array (mut i8)))      ;; type 0
+///   (type $f (func (result i32)))     ;; type 1
+///   (func (type 1) (result i32)
+///     i32.const 5
+///     array.new_default 0   ;; ref to a 5-element i8 array (defaults to 0)
+///     array.len)            ;; -> 5
+///   (export "gcLen" (func 0)))
+/// ```
+///
+/// Uses GC opcodes (`array.new_default` = 0xFB 0x07, `array.len` = 0xFB 0x0F)
+/// and the GC array type form (0x5E). A non-GC engine rejects this at compile.
+final _gcModule = Uint8List.fromList([
+  0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00, // magic + version
+  // Type section (id 1)
+  0x01, 0x08, 0x02,
+  0x5e, 0x78, 0x01, //   type 0: (array (mut i8))
+  0x60, 0x00, 0x01, 0x7f, //   type 1: (func (result i32))
+  // Function section (id 3): func 0 -> type 1
+  0x03, 0x02, 0x01, 0x01,
+  // Export section (id 7): "gcLen" = func 0
+  0x07, 0x09, 0x01, 0x05, 0x67, 0x63, 0x4c, 0x65, 0x6e, 0x00, 0x00,
+  // Code section (id 10)
+  0x0a, 0x0b, 0x01, 0x09, 0x00,
+  0x41, 0x05, //   i32.const 5
+  0xfb, 0x07, 0x00, //   array.new_default 0
+  0xfb, 0x0f, //   array.len
+  0x0b, //   end
+]);
+
+void main() {
+  group('WasmGC capability (Chrome)', () {
+    test('Chrome validates a WasmGC module', () {
+      var valid = _validate(_gcModule.buffer.toJS);
+      expect(
+        valid,
+        isTrue,
+        reason: 'Chrome should validate WasmGC bytecode (v119+).',
+      );
+    });
+
+    test('Chrome instantiates and runs a WasmGC module (array.len == 5)', () async {
+      var result = await _instantiate(_gcModule.buffer.toJS).toDart;
+      var instance = result.getProperty('instance'.toJS) as JSObject;
+      var exports = instance.getProperty('exports'.toJS) as JSObject;
+      var gcLen = exports.getProperty('gcLen'.toJS) as JSFunction;
+
+      var r = gcLen.callAsFunction(null) as JSNumber;
+      expect(r.toDartInt, equals(5));
+
+      // Host-interop note: this returns a plain i32 (the array length). Reading
+      // the GC array's *contents* back into Dart/JS is opaque without exported
+      // accessor functions — which is why P2 should marshal aggregate results
+      // through an exported linear memory buffer rather than returning GC refs.
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Answers "does `wasm_run` support WasmGC?" and sets up the testing path for the planned dual-target (linear-memory + WasmGC) Wasm backend.

**Finding: `wasm_run` does NOT support WasmGC.** It bundles **wasmtime 14.0 / wasmi 0.31** (per its README/CHANGELOG) — both predate usable WasmGC. Its `WasmFeatures.garbageCollection` flag is an inert config field on this build, and the bridge can't read GC refs back to Dart. So the native path is **linear-memory only**.

**Chrome can.** ApolloVM's web runtime (`wasm_runtime_web.dart`) already drives the browser's own `WebAssembly` engine via `dart:js_interop`/`package:web`, selected by conditional import. Chrome ships WasmGC by default since **v119** (local Chrome is 149). So `dart test -p chrome` validates/runs both linear and GC modules on Chrome's engine.

## Changes (test/CI only — no `lib/` changes)

- **`dart_test.yaml`** — new **`wasm-gc`** tag for tests requiring a GC-capable engine.
- **`test/apollovm_wasm_chrome_test.dart`** (`@TestOn('chrome')`) — parity smoke: runs existing linear-memory Wasm programs (arithmetic, while-loop) on Chrome's engine and asserts they match the interpreter. Proves the browser harness works end-to-end.
- **`test/apollovm_wasm_gc_test.dart`** (`@Tags(['wasm-gc'])`) — WasmGC capability spike: a hand-encoded GC module (`array.new_default` + `array.len`) that Chrome **validates and runs** (returns 5). Documents the GC host-interop limit that motivates the P2 "marshalling buffer" design.
- **`.github/workflows/dart.yml`** — the `wasm_run`-based **VM and exe** jobs now `--exclude-tags wasm-gc`; the **Chrome** job runs everything (it supports GC).
- **`pubspec.yaml`** — `build_web_compilers` + `build_runner` dev-deps to enable `dart test -p chrome`.

## Verification

- `dart test --platform vm --exclude-tags wasm-gc` → **411 tests pass** (no regression; GC tests excluded).
- `dart test --platform chrome` → **90 tests pass**, including the parity smoke and the WasmGC spike.
- `dart format` / `dart analyze --fatal-infos --fatal-warnings` / `dependency_validator` all clean (matches CI gates).

## Outcome

Confirms the dual-target plan's GC gate: the future WasmGC backend will be validated with `dart test -p chrome`, while the linear backend stays validated with `wasm_run` (`-p vm`). CI won't break on GC tests because the `wasm_run` jobs exclude the `wasm-gc` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)