### PR TITLE
Wasm P2 (part 3): String-returning functions + self-describing signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   - **Full Dart `%` semantics**: integer and double modulo now return the Dart-correct non-negative result in `[0, |b|)` for negative operands (sign-corrected via scratch locals); double `%` is computed as `a - trunc(a / b) * b`.
   - **Fix**: compound assignment (`+=`, `-=`, `*=`, …) emitted its operation to a discarded buffer (missing `out`/`context`), producing broken code; now applied to the real output.
 - Tests: added Wasm coverage for every feature above plus a combined integration test (prime counting / sum-of-squares using loops + calls + logic + modulo), all executed against the real compiled-and-run Wasm module.
+- Wasm strings — String-returning functions (P2, part 3):
+  - Functions returning `String` now work: the value is an i32 pointer the runner decodes back into a Dart `String`.
+  - Modules are now **self-describing**: a custom `apollovm_sig` section records each public function's high-level return/parameter type tags, so the runner can marshal strings even for modules loaded from raw bytes. Emitted only when a public signature involves a `String` (pure-numeric modules stay byte-identical).
 - Wasm strings — concatenation + bump allocator (P2, part 2):
   - A mutable heap-pointer **Global** (`$hp`) bump allocator; runtime string allocation via `__alloc` + `memory.copy`.
   - String `+`, adjacent string literals, and `$var` interpolation of `String` variables now compile to Wasm (left-folded binary concatenation producing a fresh `[len:i32][utf8]` string). Validated on `wasm_run` and Chrome.

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -101,6 +101,81 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     if (module.hasData) {
       out.writeBytes(generateSectionData(module), description: "Section: Data");
     }
+    // Self-describing high-level signatures (custom section) so the runner can
+    // marshal String returns/params for modules loaded from raw bytes. Only
+    // emitted when a public function involves a String, keeping pure-numeric
+    // modules byte-identical.
+    if (_hasStringSignature(module)) {
+      out.writeBytes(
+        generateSectionCustomSignatures(module),
+        description: "Section: Custom (apollovm_sig)",
+      );
+    }
+
+    return out;
+  }
+
+  /// Type tag used by the `apollovm_sig` custom section.
+  /// 0=void, 1=int, 2=double, 3=bool, 4=String, 5=other.
+  static int _typeTag(ASTType t) {
+    if (t is ASTTypeVoid) return 0;
+    if (t is ASTTypeInt) return 1;
+    if (t is ASTTypeDouble) return 2;
+    if (t is ASTTypeBool) return 3;
+    if (t is ASTTypeString) return 4;
+    return 5;
+  }
+
+  bool _hasStringSignature(WasmModuleContext module) {
+    for (var f in module.functions) {
+      if (f.modifiers.isPrivate) continue;
+      if (f.returnType is ASTTypeString) return true;
+      for (var p in f.parameters.allParameters) {
+        if (p.type is ASTTypeString) return true;
+      }
+    }
+    return false;
+  }
+
+  /// Emits a custom section `apollovm_sig` mapping each public function to its
+  /// high-level return/parameter type tags (see [_typeTag]).
+  BytesOutput generateSectionCustomSignatures(
+    WasmModuleContext module, {
+    BytesOutput? out,
+  }) {
+    out ??= newOutput();
+
+    var publics = module.functions
+        .where((f) => !f.modifiers.isPrivate)
+        .toList();
+
+    var entries = <BytesOutput>[
+      BytesOutput(
+        data: Wasm.encodeString('apollovm_sig'),
+        description: "Custom section name",
+      ),
+      BytesOutput(
+        data: Leb128.encodeUnsigned(publics.length),
+        description: "Function count",
+      ),
+      ...publics.map((f) {
+        var paramTags = f.parameters.allParameters
+            .map((p) => _typeTag(p.type))
+            .toList();
+        return BytesOutput(
+          data: [
+            ...Wasm.encodeString(f.name),
+            _typeTag(f.returnType),
+            ...Leb128.encodeUnsigned(paramTags.length),
+            ...paramTags,
+          ],
+          description: "Signature `${f.name}`",
+        );
+      }),
+    ];
+
+    out.writeByte(0x00, description: "Section Custom ID");
+    out.writeBytesLeb128Block(entries, description: "apollovm_sig");
 
     return out;
   }

--- a/lib/src/languages/wasm/wasm_runner.dart
+++ b/lib/src/languages/wasm/wasm_runner.dart
@@ -152,11 +152,84 @@ class ApolloRunnerWasm extends ApolloRunner {
 
     res = module.resolveReturnedValue(res, astFunction);
 
+    // A `String` return is an i32 pointer into the module's memory; decode it.
+    // The return type comes from the AST when available, else from the module's
+    // `apollovm_sig` custom section (for modules loaded from raw bytes).
+    var returnsString =
+        astFunction?.returnType is ASTTypeString ||
+        _signatures(codeUnit.code)[functionName]?.returnTag == _tagString;
+    if (res != null && returnsString) {
+      res = decodeString(res as int);
+    }
+
     var astValue = res == null
         ? ASTValueNull.instance
         : ASTValue.fromValue(res);
 
     return astValue;
+  }
+
+  // High-level type tags from the `apollovm_sig` custom section.
+  static const int _tagString = 4;
+
+  /// Per-module signature cache, keyed by the wasm binary's identity.
+  final Map<Uint8List, Map<String, ({int returnTag, List<int> paramTags})>>
+  _signaturesCache = {};
+
+  Map<String, ({int returnTag, List<int> paramTags})> _signatures(
+    Uint8List wasmBytes,
+  ) => _signaturesCache[wasmBytes] ??= _parseSignatures(wasmBytes);
+
+  /// Parses the `apollovm_sig` custom section (function name -> return/param
+  /// type tags). Returns an empty map if absent.
+  static Map<String, ({int returnTag, List<int> paramTags})> _parseSignatures(
+    Uint8List b,
+  ) {
+    var sigs = <String, ({int returnTag, List<int> paramTags})>{};
+    if (b.length < 8) return sigs;
+
+    var pos = 8; // skip magic (4) + version (4)
+
+    int readLeb() {
+      var result = 0, shift = 0;
+      while (true) {
+        var byte = b[pos++];
+        result |= (byte & 0x7f) << shift;
+        if ((byte & 0x80) == 0) break;
+        shift += 7;
+      }
+      return result;
+    }
+
+    String readName() {
+      var len = readLeb();
+      var s = utf8.decode(b.sublist(pos, pos + len));
+      pos += len;
+      return s;
+    }
+
+    while (pos < b.length) {
+      var id = b[pos++];
+      var size = readLeb();
+      var sectionEnd = pos + size;
+      if (id == 0) {
+        var name = readName();
+        if (name == 'apollovm_sig') {
+          var count = readLeb();
+          for (var i = 0; i < count; ++i) {
+            var fname = readName();
+            var returnTag = b[pos++];
+            var paramCount = readLeb();
+            var paramTags = b.sublist(pos, pos + paramCount).toList();
+            pos += paramCount;
+            sigs[fname] = (returnTag: returnTag, paramTags: paramTags);
+          }
+        }
+      }
+      pos = sectionEnd;
+    }
+
+    return sigs;
   }
 
   void _resolveWasmCallParameters(

--- a/test/apollovm_wasm_p2_test.dart
+++ b/test/apollovm_wasm_p2_test.dart
@@ -57,6 +57,58 @@ Future<void> _testWasmPrint(
   expect(wasmOut, equals(expectedOutput), reason: 'Wasm print output');
 }
 
+/// Runs [functionName] via the AST interpreter AND the compiled+executed Wasm
+/// module and asserts both return [expectedReturn].
+Future<void> _testWasmReturn(
+  String code,
+  String functionName,
+  List args,
+  Object? expectedReturn,
+) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', code, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source");
+
+  var astRunner = vm.createRunner('dart')!;
+  var astRet = await astRunner.executeFunction(
+    '',
+    functionName,
+    positionalParameters: args,
+  );
+  expect(
+    astRet.getValueNoContext(),
+    expectedReturn,
+    reason: 'interpreter return',
+  );
+
+  var storageWasm = vm.generateAllIn<BytesOutput>('wasm');
+  var wasmModules = await storageWasm.allEntries();
+  BytesOutput? compiled;
+  for (var ns in wasmModules.entries) {
+    for (var m in ns.value.entries) {
+      compiled ??= m.value;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var rt = WasmRuntime()..ensureBooted();
+  if (!rt.isSupported) {
+    fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+  }
+
+  var vmWasm = ApolloVM();
+  await vmWasm.loadCodeUnit(
+    BinaryCodeUnit('wasm', compiled!.output(), id: 'test.wasm', namespace: ''),
+  );
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  var wasmRet = await wasmRunner.executeFunction(
+    '',
+    functionName,
+    positionalParameters: args,
+  );
+  expect(wasmRet.getValueNoContext(), expectedReturn, reason: 'Wasm return');
+}
+
 void main() {
   group('Wasm P2: print(string literal)', () {
     test('single print', () async {
@@ -196,6 +248,91 @@ void main() {
         'run',
         [],
         ['hello world', 'world!'],
+      );
+    });
+  });
+
+  group('Wasm P2: String-returning functions', () {
+    test('return literal', () async {
+      await _testWasmReturn(
+        '''
+        String f() {
+          return "hi";
+        }
+      ''',
+        'f',
+        [],
+        'hi',
+      );
+    });
+
+    test('return concatenation', () async {
+      await _testWasmReturn(
+        '''
+        String f() {
+          return "a" + "b" + "c";
+        }
+      ''',
+        'f',
+        [],
+        'abc',
+      );
+    });
+
+    test('return built from a local', () async {
+      await _testWasmReturn(
+        '''
+        String greet() {
+          String s = "world";
+          return "hello " + s;
+        }
+      ''',
+        'greet',
+        [],
+        'hello world',
+      );
+    });
+
+    test('conditional return (int param, String return)', () async {
+      await _testWasmReturn(
+        '''
+        String sign(int a) {
+          if (a > 0) {
+            return "pos";
+          }
+          return "non-pos";
+        }
+      ''',
+        'sign',
+        [5],
+        'pos',
+      );
+
+      await _testWasmReturn(
+        '''
+        String sign(int a) {
+          if (a > 0) {
+            return "pos";
+          }
+          return "non-pos";
+        }
+      ''',
+        'sign',
+        [-1],
+        'non-pos',
+      );
+    });
+
+    test('return multi-byte UTF-8', () async {
+      await _testWasmReturn(
+        '''
+        String f() {
+          return "héllo ☃";
+        }
+      ''',
+        'f',
+        [],
+        'héllo ☃',
       );
     });
   });


### PR DESCRIPTION
## Summary

Third P2 slice: functions that **return `String`**. Builds on parts 1–2 (#30, #31). Validated on both `wasm_run` (`-p vm`) and Chrome (`-p chrome`) against the interpreter.

## The problem & fix
A compiled `String` function returns an `i32` pointer — but a Wasm module loaded from raw bytes has **no AST**, so the runner couldn't tell an `i32` return was a string pointer vs. a plain int.

Fix: make modules **self-describing**. The generator emits a custom **`apollovm_sig`** section mapping each public function to its high-level return/parameter **type tags** (void/int/double/bool/String). The runner parses it (cached) and decodes `String` returns by reading `[len][utf8]` from exported memory into a Dart `String`.

The custom section is emitted **only when a public signature involves a `String`**, so pure-numeric modules stay **byte-identical** (the existing byte-exact tests are unchanged). It also sets up String **parameter** marshalling for the next slice.

## Tests
- New `String-returning functions` group in `test/apollovm_wasm_p2_test.dart`: return literal / concatenation / built-from-local / conditional (int param, String return) / multi-byte UTF-8 — asserted equal between interpreter and compiled-and-executed Wasm, on `-p vm` and `-p chrome`.
- Full suite: **426 vm** + Chrome green; byte-exact numeric modules unchanged; `dart format`/`analyze --fatal-infos --fatal-warnings`/`dependency_validator` clean.

## Next slices
Number→string interpolation (`env.int_to_str`/`double_to_str`), then `memory.grow` + String **parameters** (encode a Dart string into module memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)