### PR TITLE
Wasm P2 (part 4): number→string interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   - **Full Dart `%` semantics**: integer and double modulo now return the Dart-correct non-negative result in `[0, |b|)` for negative operands (sign-corrected via scratch locals); double `%` is computed as `a - trunc(a / b) * b`.
   - **Fix**: compound assignment (`+=`, `-=`, `*=`, …) emitted its operation to a discarded buffer (missing `out`/`context`), producing broken code; now applied to the real output.
 - Tests: added Wasm coverage for every feature above plus a combined integration test (prime counting / sum-of-squares using loops + calls + logic + modulo), all executed against the real compiled-and-run Wasm module.
+- Wasm strings — number→string interpolation (P2, part 4):
+  - Interpolation of `int`/`double` (`"n=$n"`, `"${a + b}"`) now compiles to Wasm via host imports `env.int_to_str`/`env.double_to_str`; the host formats the number (matching the interpreter; doubles via `ASTTypeDouble.doubleToString`) and writes it into module memory.
+  - Adds a synthesized, **exported `__alloc`** bump-allocator function so host imports can allocate strings in the module's memory (reentrant host→module calls), plus value-returning host imports and i64↔BigInt marshalling on the web.
 - Wasm strings — String-returning functions (P2, part 3):
   - Functions returning `String` now work: the value is an i32 pointer the runner decodes back into a Dart `String`.
   - Modules are now **self-describing**: a custom `apollovm_sig` section records each public function's high-level return/parameter type tags, so the runner can marshal strings even for modules loaded from raw bytes. Emitted only when a public signature involves a `String` (pure-numeric modules stay byte-identical).

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -215,6 +215,29 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       );
     }).toList();
 
+    // Export synthesized functions (e.g. `__alloc`) for host use.
+    var synthBase = importCount + module.functions.length;
+    for (var j = 0; j < module.synthFunctions.length; ++j) {
+      var s = module.synthFunctions[j];
+      if (!s.exported) continue;
+      entries.add(
+        BytesOutput(
+          data: [
+            BytesOutput(
+              data: Wasm.encodeString(s.name),
+              description: "Function name(`${s.name}`)",
+            ),
+            BytesOutput(data: 0x00, description: "Export type(function)"),
+            BytesOutput(
+              data: Leb128.encodeUnsigned(synthBase + j),
+              description: "Function index(${synthBase + j})",
+            ),
+          ],
+          description: "Export synth `${s.name}`",
+        ),
+      );
+    }
+
     // Export the linear memory (as `memory`) so the host can read/write it.
     if (module.requiresMemory) {
       entries.add(
@@ -259,12 +282,15 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     out ??= newOutput();
 
     // Imported-function signatures come first (their type indices 0..K-1),
-    // then the module-defined functions.
+    // then the module-defined functions, then synthesized functions.
     var entries = <BytesOutput>[
       ...module.importedFunctions.map(
         (imp) => _wasmFuncTypeBytes(imp.params, imp.results),
       ),
       ...module.functions.map((f) => f.wasmSignature()),
+      ...module.synthFunctions.map(
+        (s) => _wasmFuncTypeBytes(s.params, s.results),
+      ),
     ];
 
     entries.insert(
@@ -331,11 +357,18 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   }) {
     out ??= newOutput();
 
-    // Each defined function references its type index, offset past the imports.
+    // Each defined function references its type index, offset past the imports;
+    // synthesized functions follow the user functions.
     var importCount = module.importCount;
-    var indexes = module.functions
-        .mapIndexed((i, e) => Leb128.encodeUnsigned(importCount + i))
-        .toList();
+    var n = module.functions.length;
+    var indexes = <List<int>>[
+      ...module.functions.mapIndexed(
+        (i, e) => Leb128.encodeUnsigned(importCount + i),
+      ),
+      ...module.synthFunctions.mapIndexed(
+        (j, s) => Leb128.encodeUnsigned(importCount + n + j),
+      ),
+    ];
 
     indexes.insert(0, Leb128.encodeUnsigned(indexes.length));
 
@@ -454,6 +487,16 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     var entries = module.functions
         .map((f) => generateASTFunctionDeclaration(f, module: module))
         .toList();
+
+    // Synth functions (e.g. `__alloc`) registered during user-body codegen.
+    // Each body is length-prefixed (like user-function bodies).
+    for (var s in module.synthFunctions) {
+      var bodyEntry = newOutput();
+      bodyEntry.writeBytesLeb128Block([
+        s.body,
+      ], description: "Synth body `${s.name}`");
+      entries.add(bodyEntry);
+    }
 
     entries.insert(
       0,
@@ -2622,7 +2665,11 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         context: context,
       );
     } else if (value is ASTValueStringExpression) {
-      return generateASTValueStringExpression(value, out: out);
+      return generateASTValueStringExpression(
+        value,
+        out: out,
+        context: context,
+      );
     } else if (value is ASTValueArray) {
       return generateASTValueArray(value, out: out);
     } else if (value is ASTValueArray2D) {
@@ -2791,9 +2838,25 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   BytesOutput generateASTValueStringExpression(
     ASTValueStringExpression value, {
     BytesOutput? out,
+    WasmContext? context,
   }) {
-    // Number/expression-to-string interpolation lands in a later slice.
-    throw UnimplementedError('generateASTValueStringExpression');
+    out ??= newOutput();
+    context ??= WasmContext();
+
+    generateASTExpression(value.expression, out: out, context: context);
+
+    var t = context.stackGet(0)!.type;
+    if (t is ASTTypeString) {
+      // Already a string handle.
+    } else if (t is ASTTypeInt || t is ASTTypeDouble) {
+      _emitNumberToString(out, context, t);
+    } else {
+      throw UnimplementedError(
+        "Wasm string interpolation of expression type $t is not supported yet.",
+      );
+    }
+
+    return out;
   }
 
   @override
@@ -2808,20 +2871,65 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     var name = value.variable.name;
     var localVar = _getLocalVariable(context, name);
+    var t = localVar.type;
 
-    // For now, only String variables (already an i32 handle) are supported;
-    // number-to-string interpolation lands in a later slice.
-    if (localVar.type is! ASTTypeString) {
+    _localVariableGet(out, context, localVar.index, name);
+
+    if (t is ASTTypeString) {
+      context.stackPush(_astTypeString, "string var: \$$name");
+    } else if (t is ASTTypeInt || t is ASTTypeDouble) {
+      context.stackPush(t, "number var: \$$name");
+      _emitNumberToString(out, context, t);
+    } else {
       throw UnimplementedError(
-        "Wasm interpolation of non-String variable `$name` "
-        "(${localVar.type}) is not supported yet.",
+        "Wasm interpolation of variable `$name` ($t) is not supported yet.",
       );
     }
 
-    _localVariableGet(out, context, localVar.index, name);
-    context.stackPush(_astTypeString, "string var: \$$name");
-
     return out;
+  }
+
+  /// Converts the number on the top of the stack (i64 for int, f64 for double)
+  /// to a string handle via a host import (`env.int_to_str` / `double_to_str`).
+  void _emitNumberToString(
+    BytesOutput out,
+    WasmContext context,
+    ASTType numType,
+  ) {
+    var module = context.module;
+    if (module == null) {
+      throw StateError("Can't convert a number to String without a module.");
+    }
+    module.requiresMemory = true;
+    module.ensureAllocFunction();
+
+    int importIndex;
+    if (numType is ASTTypeInt) {
+      importIndex = module.registerImportedFunction(
+        'env',
+        'int_to_str',
+        const [WasmType.i64Type],
+        const [WasmType.i32Type],
+      );
+    } else if (numType is ASTTypeDouble) {
+      importIndex = module.registerImportedFunction(
+        'env',
+        'double_to_str',
+        const [WasmType.f64Type],
+        const [WasmType.i32Type],
+      );
+    } else {
+      throw UnimplementedError(
+        "Wasm number-to-string for $numType is not supported yet.",
+      );
+    }
+
+    out.write(
+      Wasm.call(importIndex),
+      description: "[OP] call host number-to-string (index $importIndex)",
+    );
+    context.stackDrop();
+    context.stackPush(_astTypeString, "number to string");
   }
 
   /// Concatenates the top two string handles on the stack (`[a, b]`) into a
@@ -2972,6 +3080,26 @@ class WasmImportedFunction {
   WasmImportedFunction(this.module, this.name, this.params, this.results);
 }
 
+/// A generator-synthesized module function (e.g. the `__alloc` bump allocator),
+/// placed in the function index space after the user-defined functions.
+class WasmSynthFunction {
+  final String name;
+  final List<WasmType> params;
+  final List<WasmType> results;
+
+  /// The complete code body: locals vector + instructions + `end`.
+  final BytesOutput body;
+  final bool exported;
+
+  WasmSynthFunction(
+    this.name,
+    this.params,
+    this.results,
+    this.body, {
+    this.exported = false,
+  });
+}
+
 /// Module-level Wasm codegen state shared across all functions: the function
 /// index space (imports + defined functions) and the static data region
 /// (interned string literals).
@@ -3005,6 +3133,40 @@ class WasmModuleContext {
     _importIndexByKey[key] = index;
     requiresMemory = true;
     return index;
+  }
+
+  // --- Synthesized functions (indices importCount + functions.length + j) ---
+
+  final List<WasmSynthFunction> synthFunctions = [];
+  final Set<String> _synthNames = {};
+
+  /// Ensures the exported `__alloc(i32 size) -> i32 ptr` bump-allocator function
+  /// exists. Exported so the host can allocate strings in module memory.
+  void ensureAllocFunction() {
+    if (_synthNames.contains('__alloc')) return;
+    requiresMemory = true;
+    requiresHeapGlobal = true;
+
+    // result = $hp; $hp = $hp + size; return result
+    var body = BytesOutput();
+    body.write(Leb128.encodeUnsigned(0), description: "Locals count");
+    body.write(Wasm.globalGet(heapGlobalIndex));
+    body.write(Wasm.globalGet(heapGlobalIndex));
+    body.write(Wasm.localGet(0));
+    body.writeByte(Wasm32.i32Add);
+    body.write(Wasm.globalSet(heapGlobalIndex));
+    body.writeByte(Wasm.end);
+
+    synthFunctions.add(
+      WasmSynthFunction(
+        '__alloc',
+        const [WasmType.i32Type],
+        const [WasmType.i32Type],
+        body,
+        exported: true,
+      ),
+    );
+    _synthNames.add('__alloc');
   }
 
   /// Resolves the Wasm function index for a module-defined function with [name]

--- a/lib/src/languages/wasm/wasm_runner.dart
+++ b/lib/src/languages/wasm/wasm_runner.dart
@@ -74,6 +74,21 @@ class ApolloRunnerWasm extends ApolloRunner {
       return utf8.decode(mem.sublist(ptr + 4, ptr + 4 + len));
     }
 
+    // Allocates `[len:i32][utf8]` for [s] in the module's memory (via the
+    // exported `__alloc`) and returns its pointer.
+    int allocAndWriteString(String s) {
+      var m = loadedModule!;
+      var bytes = utf8.encode(s);
+      var ptr = m.invokeExport('__alloc', [bytes.length + 4]) as int;
+      var mem = m.readMemory()!;
+      mem[ptr] = bytes.length & 0xff;
+      mem[ptr + 1] = (bytes.length >> 8) & 0xff;
+      mem[ptr + 2] = (bytes.length >> 16) & 0xff;
+      mem[ptr + 3] = (bytes.length >> 24) & 0xff;
+      mem.setRange(ptr + 4, ptr + 4 + bytes.length, bytes);
+      return ptr;
+    }
+
     var hostImports = <String, Map<String, WasmHostFunction>>{
       'env': {
         'print': WasmHostFunction(
@@ -83,6 +98,20 @@ class ApolloRunnerWasm extends ApolloRunner {
             externalPrintFunction(decodeString(args[0] as int));
             return null;
           },
+        ),
+        // Number-to-string, mirroring the interpreter's `'$v'` formatting.
+        'int_to_str': WasmHostFunction(
+          params: const [WasmValueType.i64],
+          results: const [WasmValueType.i32],
+          callback: (args) => allocAndWriteString('${args[0]}'),
+        ),
+        'double_to_str': WasmHostFunction(
+          params: const [WasmValueType.f64],
+          results: const [WasmValueType.i32],
+          // `doubleToString` renders whole doubles as "5.0" deterministically
+          // (plain `toString` yields "5" under dart2js).
+          callback: (args) =>
+              allocAndWriteString(ASTTypeDouble.doubleToString(args[0] as num)),
         ),
       },
     };

--- a/lib/src/languages/wasm/wasm_runtime.dart
+++ b/lib/src/languages/wasm/wasm_runtime.dart
@@ -132,6 +132,11 @@ abstract class WasmModule {
   /// or `null` if the module has no exported memory.
   Uint8List? readMemory() => null;
 
+  /// Invokes an exported function [name] with [args], returning its result.
+  /// Used by host imports that call back into the module (e.g. `__alloc`).
+  Object? invokeExport(String name, List<Object?> args) =>
+      throw UnimplementedError('invokeExport not supported on this platform');
+
   /// Disposes this module instance.
   FutureOr<void> dispose() {}
 }

--- a/lib/src/languages/wasm/wasm_runtime_io.dart
+++ b/lib/src/languages/wasm/wasm_runtime_io.dart
@@ -191,6 +191,15 @@ class WasmModuleIO extends WasmModule {
   Uint8List? readMemory() => instance.getMemory('memory')?.view;
 
   @override
+  Object? invokeExport(String name, List<Object?> args) {
+    var f = instance.getFunction(name);
+    if (f == null) {
+      throw StateError("No exported Wasm function `$name`");
+    }
+    return Function.apply(f.inner, args);
+  }
+
+  @override
   void dispose() {
     instance.dispose();
   }

--- a/lib/src/languages/wasm/wasm_runtime_web.dart
+++ b/lib/src/languages/wasm/wasm_runtime_web.dart
@@ -162,8 +162,12 @@ class WasmRuntimeWeb extends WasmRuntime {
       case WasmValueType.i32:
         return (a as JSNumber).toDartInt;
       case WasmValueType.i64:
-        // i64 arrives as a JS BigInt; passed through (handled by callers).
-        return a;
+        // i64 arrives as a JS BigInt; convert to a Dart int (or BigInt).
+        if (a.isA<JSBigInt>()) {
+          var s = (a as JSBigInt).toString();
+          return int.tryParse(s) ?? BigInt.parse(s);
+        }
+        return (a as JSNumber).toDartInt;
       case WasmValueType.f32:
       case WasmValueType.f64:
         return (a as JSNumber).toDartDouble;
@@ -266,6 +270,24 @@ class WasmModuleBrowser extends WasmModule {
     if (mem == null) return null;
     final buffer = mem.getProperty('buffer'.toJS) as JSArrayBuffer;
     return buffer.toDart.asUint8List();
+  }
+
+  @override
+  Object? invokeExport(String name, List<Object?> args) {
+    final fn = _instance.exports.function(name);
+    if (fn == null) {
+      throw StateError("No exported Wasm function `$name`");
+    }
+    final jsArgs = args.map((Object? e) => e?.jsify()).toList();
+    final JSAny? res;
+    if (jsArgs.isEmpty) {
+      res = fn.callAsFunction(null);
+    } else if (jsArgs.length == 1) {
+      res = fn.callAsFunction(null, jsArgs[0]);
+    } else {
+      res = fn.applyAsFunction(null, jsArgs.toJS);
+    }
+    return res.dartify();
   }
 
   @override

--- a/test/apollovm_wasm_p2_test.dart
+++ b/test/apollovm_wasm_p2_test.dart
@@ -336,4 +336,87 @@ void main() {
       );
     });
   });
+
+  group('Wasm P2: number-to-string interpolation', () {
+    test('int variable interpolation', () async {
+      await _testWasmPrint(
+        '''
+        void run() {
+          int n = 5;
+          int neg = -7;
+          print("n=\$n");
+          print("neg=\$neg");
+        }
+      ''',
+        'run',
+        [],
+        ['n=5', 'neg=-7'],
+      );
+    });
+
+    test('double variable interpolation (incl. whole value)', () async {
+      // `doubleToString` renders whole doubles as "5.0" on both the VM and
+      // dart2js, matching the interpreter's variable-interpolation formatting.
+      await _testWasmPrint(
+        '''
+        void run() {
+          double d = 1.5;
+          double q = 0.25;
+          double w = 5.0;
+          print("d=\$d");
+          print("q=\$q");
+          print("w=\$w");
+        }
+      ''',
+        'run',
+        [],
+        ['d=1.5', 'q=0.25', 'w=5.0'],
+      );
+    });
+
+    test('expression interpolation', () async {
+      await _testWasmPrint(
+        '''
+        void run() {
+          int n = 4;
+          double d = 2.5;
+          print("sum=\${n + n}");
+          print("prod=\${d * 2.5}");
+        }
+      ''',
+        'run',
+        [],
+        ['sum=8', 'prod=6.25'],
+      );
+    });
+
+    test('mixed interpolation', () async {
+      await _testWasmPrint(
+        '''
+        void run() {
+          int n = 3;
+          double d = 2.5;
+          String s = "ok";
+          print("n=\$n d=\$d s=\$s end");
+        }
+      ''',
+        'run',
+        [],
+        ['n=3 d=2.5 s=ok end'],
+      );
+    });
+
+    test('String return with interpolation', () async {
+      await _testWasmReturn(
+        '''
+        String label(int n) {
+          return "n=\$n";
+        }
+      ''',
+        'label',
+        [42],
+        'n=42',
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Fourth P2 slice: **number→string interpolation** (`"n=$n"`, `"${a + b}"`). Builds on parts 1–3 (#30, #31, #33). Validated on both `wasm_run` (`-p vm`) and Chrome (`-p chrome`) against the interpreter.

## How it works
- Interpolation of an `int`/`double` lowers to a host import — `env.int_to_str(i64)→i32` / `env.double_to_str(f64)→i32`. The host formats the number in Dart (matching the interpreter; doubles via `ASTTypeDouble.doubleToString`), allocates `[len][utf8]` in the module's memory, and returns the pointer.
- To let the host allocate, the generator synthesizes an **exported `__alloc(i32)→i32`** bump-allocator function. The function index space and the type/function/export/code sections now account for synthesized functions (after the user functions).
- **Reentrancy**: the host import calls back into the module's `__alloc` while the module is mid-call — verified working on both native and the browser. Added `WasmModule.invokeExport`, value-returning host imports, and i64↔BigInt arg marshalling on the web.
- Lowers `ASTValueStringVariable(number)` and `ASTValueStringExpression(number)`.

## A formatting subtlety (handled)
`dart2js` can't distinguish `5.0` from `5`, so plain `toString()` renders a whole double as `"5"` on the web. Using `ASTTypeDouble.doubleToString` makes the host produce `"5.0"` deterministically on both the VM and dart2js, matching the interpreter's variable-interpolation formatting.

## Tests
- New `number-to-string interpolation` group in `test/apollovm_wasm_p2_test.dart`: int/double variable interpolation (incl. whole `5.0`), expression interpolation, mixed `"n=$n d=$d s=$s"`, and a String-return-with-interpolation — asserted equal between interpreter and compiled-and-executed Wasm, on `-p vm` and `-p chrome`.
- Full suite: **431 vm** + Chrome green; byte-exact numeric modules unchanged; `dart format`/`analyze --fatal-infos --fatal-warnings`/`dependency_validator` clean.

## Next (final P2 slice)
`memory.grow` (grow-on-demand in `__alloc`) + String **parameters** (encode a Dart string into module memory before the call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)