### PR TITLE
Wasm P2 (part 5): String parameters + memory.grow — strings milestone complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   - **Full Dart `%` semantics**: integer and double modulo now return the Dart-correct non-negative result in `[0, |b|)` for negative operands (sign-corrected via scratch locals); double `%` is computed as `a - trunc(a / b) * b`.
   - **Fix**: compound assignment (`+=`, `-=`, `*=`, …) emitted its operation to a discarded buffer (missing `out`/`context`), producing broken code; now applied to the real output.
 - Tests: added Wasm coverage for every feature above plus a combined integration test (prime counting / sum-of-squares using loops + calls + logic + modulo), all executed against the real compiled-and-run Wasm module.
+- Wasm strings — String parameters + `memory.grow` (P2, part 5, completes the strings milestone):
+  - Functions taking `String` parameters now work: the runner encodes the Dart string into module memory (via the exported `__alloc`, guided by the `apollovm_sig` param tags) and passes the i32 pointer. Enables `String echo(String s)`, `String greet(String name)`, etc.
+  - The allocator (both the exported `__alloc` and the inline concat allocator) now **grows linear memory on demand** (`memory.size`/`memory.grow`), so large strings/concatenations no longer trap.
 - Wasm strings — number→string interpolation (P2, part 4):
   - Interpolation of `int`/`double` (`"n=$n"`, `"${a + b}"`) now compiles to Wasm via host imports `env.int_to_str`/`env.double_to_str`; the host formats the number (matching the interpreter; doubles via `ASTTypeDouble.doubleToString`) and writes it into module memory.
   - Adds a synthesized, **exported `__alloc`** bump-allocator function so host imports can allocate strings in the module's memory (reentrant host→module calls), plus value-returning host imports and i64↔BigInt marshalling on the web.

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -66,6 +66,12 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     var functions = root.functions.expand((fs) => fs.functions).toList();
     var module = WasmModuleContext(functions);
 
+    // A public function with a String parameter requires the host to allocate
+    // the argument in module memory, so ensure `__alloc` is exported.
+    if (_hasStringParam(module)) {
+      module.ensureAllocFunction();
+    }
+
     // Body-first: generate the Code section first so that body codegen can
     // register host imports and string literals on [module]; the Type/Import/
     // Memory/Data sections below then reflect what was discovered.
@@ -130,6 +136,16 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     for (var f in module.functions) {
       if (f.modifiers.isPrivate) continue;
       if (f.returnType is ASTTypeString) return true;
+      for (var p in f.parameters.allParameters) {
+        if (p.type is ASTTypeString) return true;
+      }
+    }
+    return false;
+  }
+
+  bool _hasStringParam(WasmModuleContext module) {
+    for (var f in module.functions) {
+      if (f.modifiers.isPrivate) continue;
       for (var p in f.parameters.allParameters) {
         if (p.type is ASTTypeString) return true;
       }
@@ -2947,7 +2963,6 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     var a = context.scratchLocal(_astTypeString, 0);
     var b = context.scratchLocal(_astTypeString, 1);
     var dest = context.scratchLocal(_astTypeString, 2);
-    const hp = WasmModuleContext.heapGlobalIndex;
 
     void getLen(int strLocal) {
       out.write(Wasm.localGet(strLocal));
@@ -2971,11 +2986,9 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     out.write(Wasm32.i32Const(4));
     out.writeByte(Wasm32.i32Add);
 
-    // Bump-allocate: dest = $hp; $hp += size.
-    out.write(Wasm.globalGet(hp));
-    out.write(Wasm.localTee(dest));
-    out.writeByte(Wasm32.i32Add);
-    out.write(Wasm.globalSet(hp));
+    // Allocate (grow-aware): [size] -> [ptr], then dest = ptr.
+    _emitInlineAlloc(out, context);
+    out.write(Wasm.localSet(dest));
 
     // Store total length at dest.
     out.write(Wasm.localGet(dest));
@@ -3008,6 +3021,49 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     context.stackDrop();
     context.stackDrop();
     context.stackPush(_astTypeString, "string concat");
+  }
+
+  /// Grow-aware bump allocation, emitted inline: consumes `[size]` on the stack
+  /// and leaves `[ptr]`, growing the memory if `$hp + size` would overflow.
+  /// (Mirrors the exported `__alloc`; used by string concatenation.)
+  void _emitInlineAlloc(BytesOutput out, WasmContext context) {
+    const hp = WasmModuleContext.heapGlobalIndex;
+    var sz = context.scratchLocal(_astTypeString, 3);
+    var newHp = context.scratchLocal(_astTypeString, 4);
+    var delta = context.scratchLocal(_astTypeString, 5);
+
+    out.write(Wasm.localSet(sz));
+
+    // newHp = $hp + size
+    out.write(Wasm.globalGet(hp));
+    out.write(Wasm.localGet(sz));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localSet(newHp));
+
+    // delta = ceil(newHp / 64KiB) - memory.size
+    out.write(Wasm.localGet(newHp));
+    out.write(Wasm32.i32Const(65535));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm32.i32Const(16));
+    out.writeByte(Wasm32.i32ShiftRightUnsigned);
+    out.write(Wasm.memorySize);
+    out.writeByte(Wasm32.i32Subtract);
+    out.write(Wasm.localSet(delta));
+
+    // if (delta > 0) memory.grow(delta)
+    out.write(Wasm.localGet(delta));
+    out.write(Wasm32.i32Const(0));
+    out.writeByte(Wasm32.i32GreaterThanSigned);
+    out.write(Wasm.ifInstruction(WasmType.voidType));
+    out.write(Wasm.localGet(delta));
+    out.write(Wasm.memoryGrow);
+    out.writeByte(Wasm.drop);
+    out.writeByte(Wasm.end);
+
+    // result = $hp; $hp = newHp  (leaves [ptr])
+    out.write(Wasm.globalGet(hp));
+    out.write(Wasm.localGet(newHp));
+    out.write(Wasm.globalSet(hp));
   }
 
   @override
@@ -3147,13 +3203,46 @@ class WasmModuleContext {
     requiresMemory = true;
     requiresHeapGlobal = true;
 
-    // result = $hp; $hp = $hp + size; return result
+    // i32 __alloc(i32 size):
+    //   newHp = $hp + size
+    //   delta = ceil(newHp / 64KiB) - memory.size; if delta > 0: memory.grow
+    //   result = $hp; $hp = newHp; return result
+    // Locals: 0=size(param), 1=newHp, 2=delta.
     var body = BytesOutput();
-    body.write(Leb128.encodeUnsigned(0), description: "Locals count");
-    body.write(Wasm.globalGet(heapGlobalIndex));
+    // 1 local group of 2 i32 locals.
+    body.write(Leb128.encodeUnsigned(1), description: "Local groups");
+    body.write(Leb128.encodeUnsigned(2), description: "i32 locals");
+    body.writeByte(WasmType.i32Type.value, description: "i32");
+
+    // newHp = $hp + size
     body.write(Wasm.globalGet(heapGlobalIndex));
     body.write(Wasm.localGet(0));
     body.writeByte(Wasm32.i32Add);
+    body.write(Wasm.localSet(1));
+
+    // delta = ((newHp + 65535) >>> 16) - memory.size
+    body.write(Wasm.localGet(1));
+    body.write(Wasm32.i32Const(65535));
+    body.writeByte(Wasm32.i32Add);
+    body.write(Wasm32.i32Const(16));
+    body.writeByte(Wasm32.i32ShiftRightUnsigned);
+    body.write(Wasm.memorySize);
+    body.writeByte(Wasm32.i32Subtract);
+    body.write(Wasm.localSet(2));
+
+    // if (delta > 0) memory.grow(delta) (dropping the previous-size result)
+    body.write(Wasm.localGet(2));
+    body.write(Wasm32.i32Const(0));
+    body.writeByte(Wasm32.i32GreaterThanSigned);
+    body.write(Wasm.ifInstruction(WasmType.voidType));
+    body.write(Wasm.localGet(2));
+    body.write(Wasm.memoryGrow);
+    body.writeByte(Wasm.drop);
+    body.writeByte(Wasm.end);
+
+    // result = $hp; $hp = newHp
+    body.write(Wasm.globalGet(heapGlobalIndex));
+    body.write(Wasm.localGet(1));
     body.write(Wasm.globalSet(heapGlobalIndex));
     body.writeByte(Wasm.end);
 

--- a/lib/src/languages/wasm/wasm_runner.dart
+++ b/lib/src/languages/wasm/wasm_runner.dart
@@ -130,6 +130,19 @@ class ApolloRunnerWasm extends ApolloRunner {
 
     var allParams = [...?positionalParameters, ...?namedParameters?.values];
 
+    // Encode String arguments into module memory (via `__alloc`) BEFORE numeric
+    // parameter resolution, which would otherwise mangle the String values. The
+    // function receives the i32 pointer; String params are identified by the
+    // `apollovm_sig` param tags.
+    var paramTags = _signatures(codeUnit.code)[functionName]?.paramTags;
+    if (paramTags != null) {
+      for (var i = 0; i < allParams.length && i < paramTags.length; ++i) {
+        if (paramTags[i] == _tagString && allParams[i] is String) {
+          allParams[i] = allocAndWriteString(allParams[i] as String);
+        }
+      }
+    }
+
     {
       var astFunction = _getASTFunction(codeUnit, functionName, allParams);
       if (astFunction != null) {

--- a/test/apollovm_wasm_p2_test.dart
+++ b/test/apollovm_wasm_p2_test.dart
@@ -419,4 +419,102 @@ void main() {
       );
     });
   });
+
+  group('Wasm P2: String parameters', () {
+    test('echo (param in, param out)', () async {
+      await _testWasmReturn(
+        '''
+        String echo(String s) {
+          return s;
+        }
+      ''',
+        'echo',
+        ['hello'],
+        'hello',
+      );
+
+      await _testWasmReturn(
+        '''
+        String echo(String s) {
+          return s;
+        }
+      ''',
+        'echo',
+        ['héllo ☃'],
+        'héllo ☃',
+      );
+
+      await _testWasmReturn(
+        '''
+        String echo(String s) {
+          return s;
+        }
+      ''',
+        'echo',
+        [''],
+        '',
+      );
+    });
+
+    test('param + concatenation', () async {
+      await _testWasmReturn(
+        '''
+        String greet(String name) {
+          return "hi " + name + "!";
+        }
+      ''',
+        'greet',
+        ['Bob'],
+        'hi Bob!',
+      );
+    });
+
+    test('param + interpolation', () async {
+      await _testWasmReturn(
+        '''
+        String tag(String s, int n) {
+          return "[\$s:\$n]";
+        }
+      ''',
+        'tag',
+        ['x', 7],
+        '[x:7]',
+      );
+    });
+
+    test('print a String parameter', () async {
+      await _testWasmPrint(
+        '''
+        void show(String s) {
+          print(s);
+          print("got: " + s);
+        }
+      ''',
+        'show',
+        ['yo'],
+        ['yo', 'got: yo'],
+      );
+    });
+  });
+
+  group('Wasm P2: memory.grow', () {
+    test('large allocation grows memory', () async {
+      // Bump-and-leak concat in a loop allocates well past the initial reserve
+      // (64 KiB), forcing `memory.grow`.
+      await _testWasmReturn(
+        '''
+        String repeat(int n) {
+          String s = "";
+          for (int i = 0; i < n; i = i + 1) {
+            s = s + "0123456789";
+          }
+          return s;
+        }
+      ''',
+        'repeat',
+        [200],
+        '0123456789' * 200,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

The **final P2 slice**: `String` **parameters** and **`memory.grow`**. This completes the P2 "linear-memory heap + strings" milestone (parts 1–5: #30, #31, #33, #35, this). Validated on both `wasm_run` (`-p vm`) and Chrome (`-p chrome`) against the interpreter.

## What's new
- **String parameters**: the runner encodes a Dart `String` argument into module memory (via the exported `__alloc`, identified by the `apollovm_sig` **param tags**) and passes the i32 pointer. Encoding happens **before** numeric parameter resolution (which would otherwise mangle the `String` into a number — the bug fixed here). The generator ensures `__alloc` is exported whenever a public function has a `String` parameter. Enables `String echo(String s)`, `greet(String name)`, `print(s)`, param + concat/interpolation.
- **`memory.grow`**: both the exported `__alloc` and the inline concatenation allocator now grow linear memory on demand (`memory.size` + `memory.grow`, ceil-division to pages), so large strings/concatenations no longer trap with out-of-bounds.

## Tests
- New `String parameters` and `memory.grow` groups in `test/apollovm_wasm_p2_test.dart`: `echo`/`greet`/`tag` (String params, incl. multi-byte and empty), `print` of a String param, and a loop concat (`repeat(200)` → ~200 KiB of bump-and-leak) that forces a grow — asserted equal between interpreter and compiled-and-executed Wasm, on `-p vm` and `-p chrome`.
- Full suite: **436 vm** + Chrome green; byte-exact numeric modules unchanged; `dart format`/`analyze --fatal-infos --fatal-warnings`/`dependency_validator` clean.

## P2 strings — done
Strings now work end-to-end in compiled Wasm on both runtimes: literals, `print`, concatenation, interpolation (string + number), String returns, String parameters, and a growable heap. (Known limitation: bump-and-leak — no free/GC; `s[i]` indexing and `.length` are not yet implemented.)

## Next milestones
P3 (lists/maps + `for-each`) and P4 (classes/OOP) build on this allocator + memory + self-describing-signature foundation; the WasmGC strategy slots in behind the same seam (validated via the `wasm-gc` Chrome path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)