### PR TITLE
Wasm P3 (part 3): String & bool element lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.1.27
 
+- Wasm collections — `String` & `bool` element lists (P3, part 3):
+  - `List<String>` and `List<bool>` now compile to Wasm: literals, index reads `a[i]`, `for (var e in a)`, `.add`, and the `.first`/`.last`/`.isEmpty`/`.isNotEmpty`/`.length` getters all work (elements stored as i32 — a string pointer or a `0`/`1` boolean). Matches the interpreter on both `wasm_run` and Chrome.
+  - List parameters/returns and maps remain later slices (lists still stay internal, returning scalars/elements).
 - Wasm collections — growable lists `.add` + getters (P3, part 2):
   - List values are now an indirect handle: a 12-byte header `[length:i32][capacity:i32][dataPtr:i32]` pointing at a separately-allocated elements buffer. This makes `.add` aliasing-safe — growing reallocates the data buffer (doubling capacity, `memory.copy`ing existing elements) and updates the header in place, so existing references observe the new length/contents.
   - `list.add(x)` now compiles to Wasm for `int`/`double` lists (including starting from an empty `[]` literal), growing linear memory on demand.
@@ -7,7 +10,7 @@
   - `bool`-returning functions loaded from raw Wasm bytes now decode correctly: the `apollovm_sig` custom section is emitted for `bool` returns (not just String signatures), and the runner maps the i32 `0`/`1` back to a Dart `bool`.
 - Wasm collections — lists, read + iterate (P3, part 1):
   - `int`/`double` list literals compile to linear-memory blocks; index reads `a[i]`, the `.length` getter, and `for (var e in a)` now compile to Wasm (matching the interpreter, on both `wasm_run` and Chrome).
-  - Lists currently stay internal (return scalars); list parameters/returns, `String`/`bool` element lists, and maps are later slices.
+  - Lists currently stay internal (return scalars); list parameters/returns and maps are later slices.
 - Wasm generator — major feature expansion (`ApolloGeneratorWasm`), moving toward full Dart parity:
   - **Loops**: `while` and `for` loops now compile to Wasm (`block`/`loop`/`br_if`/`br`), including `return` from inside a loop. Added the `br` opcode helper and recursion into loop bodies when collecting function locals.
   - **Function calls**: local function invocation (calling other top-level functions, including recursion) via a function-index table threaded through the generator and a `Wasm.call`.

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -992,8 +992,17 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     if (elemType is ASTTypeInt) return _astTypeInt64;
     if (elemType is ASTTypeDouble) return _astTypeDouble64;
     if (elemType is ASTTypeString) return _astTypeString;
+    if (elemType is ASTTypeBool) return _astTypeInt32; // bool as i32
     return elemType;
   }
+
+  /// Element types that compile to Wasm list storage: `int`/`double` (8B) and
+  /// `String`/`bool` (4B i32). Other element types are unsupported.
+  bool _isSupportedElemType(ASTType t) =>
+      t is ASTTypeInt ||
+      t is ASTTypeDouble ||
+      t is ASTTypeString ||
+      t is ASTTypeBool;
 
   @override
   BytesOutput generateASTExpressionListLiteral(
@@ -1017,7 +1026,7 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
           ? rt.componentType
           : ASTTypeDynamic.instance;
     }
-    if (elemType is! ASTTypeInt && elemType is! ASTTypeDouble) {
+    if (!_isSupportedElemType(elemType)) {
       throw UnimplementedError(
         "Wasm list literal of element type $elemType is not supported yet.",
       );

--- a/test/apollovm_wasm_p3_test.dart
+++ b/test/apollovm_wasm_p3_test.dart
@@ -378,4 +378,164 @@ void main() {
       );
     });
   });
+
+  group('Wasm P3: String element lists', () {
+    test('index returns String element', () async {
+      await _testWasmReturn(
+        '''
+        String at() {
+          List<String> a = ["x", "y", "z"];
+          return a[1];
+        }
+      ''',
+        'at',
+        [],
+        'y',
+      );
+    });
+
+    test('add then last', () async {
+      await _testWasmReturn(
+        '''
+        String build() {
+          List<String> a = ["a"];
+          a.add("b");
+          a.add("c");
+          return a.last;
+        }
+      ''',
+        'build',
+        [],
+        'c',
+      );
+    });
+
+    test('add from empty then index', () async {
+      await _testWasmReturn(
+        '''
+        String fromEmpty() {
+          List<String> a = [];
+          a.add("hello");
+          a.add("world");
+          return a[1];
+        }
+      ''',
+        'fromEmpty',
+        [],
+        'world',
+      );
+    });
+
+    test('for-each concatenation', () async {
+      await _testWasmReturn(
+        '''
+        String joined() {
+          List<String> a = ["a", "b", "c"];
+          String s = "";
+          for (var e in a) {
+            s = s + e;
+          }
+          return s;
+        }
+      ''',
+        'joined',
+        [],
+        'abc',
+      );
+    });
+
+    test('length after add', () async {
+      await _testWasmReturn(
+        '''
+        int count() {
+          List<String> a = ["a", "b"];
+          a.add("c");
+          return a.length;
+        }
+      ''',
+        'count',
+        [],
+        3,
+      );
+    });
+
+    test('first getter', () async {
+      await _testWasmReturn(
+        '''
+        String firstS() {
+          List<String> a = ["alpha", "beta"];
+          return a.first;
+        }
+      ''',
+        'firstS',
+        [],
+        'alpha',
+      );
+    });
+
+    test('multi-byte UTF-8 elements', () async {
+      await _testWasmReturn(
+        '''
+        String at() {
+          List<String> a = ["☃", "héllo", "x"];
+          return a[1];
+        }
+      ''',
+        'at',
+        [],
+        'héllo',
+      );
+    });
+  });
+
+  group('Wasm P3: bool element lists', () {
+    test('index returns bool element', () async {
+      await _testWasmReturn(
+        '''
+        bool at() {
+          List<bool> a = [true, false, true];
+          return a[1];
+        }
+      ''',
+        'at',
+        [],
+        false,
+      );
+    });
+
+    test('add then last', () async {
+      await _testWasmReturn(
+        '''
+        bool build() {
+          List<bool> a = [false];
+          a.add(true);
+          return a.last;
+        }
+      ''',
+        'build',
+        [],
+        true,
+      );
+    });
+
+    test('count true via for-each', () async {
+      await _testWasmReturn(
+        '''
+        int countTrue() {
+          List<bool> a = [true, false, true, true];
+          int c = 0;
+          for (var e in a) {
+            if (e) {
+              c = c + 1;
+            }
+          }
+          return c;
+        }
+      ''',
+        'countTrue',
+        [],
+        3,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Extends the Wasm list support (P3, part 3) to **`List<String>` and `List<bool>`**.

The element store/load path already handled i32-sized elements (a string pointer or a `0`/`1` boolean); the only blocker was an `int`/`double`-only guard on the list-literal generator. Relaxing that — plus tracking bool elements as i32 on the virtual stack — makes the whole existing list surface work for String/bool element lists with no new codegen:

- **Literals** `["x", "y"]`, `[true, false]` (including empty `[]` with a declared type).
- **Index reads** `a[i]`.
- **`for (var e in a)`** iteration.
- **`.add`** (grow-aware, via the indirect-handle layout from part 2).
- **Getters** `.first`, `.last`, `.isEmpty`, `.isNotEmpty`, `.length`.

## Tests

New parity tests (interpreter == compiled-and-executed Wasm) covering String-element index/add/for-each-concat/getters (incl. multi-byte UTF-8) and bool-element index/add/for-each. Pass on both `-p vm` (`wasm_run`) and `-p chrome`. Full suite green (466 on vm), `dart analyze --fatal-infos --fatal-warnings` clean, formatted.

## Out of scope (later slices)

List parameters/returns (boundary marshalling), maps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)