### PR TITLE
Wasm P3 (part 4): list parameters & returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 ## 0.1.27
 
+- Wasm collections — list parameters & returns (P3, part 4):
+  - Functions can now accept and return whole lists across the host boundary. The runner marshals a Dart `List` into module memory (header + elements buffer, via the exported `__alloc`) for `List` parameters, and decodes a returned list-header pointer back into a Dart `List`. Covers `int`/`double`/`String`/`bool` element lists, including round-tripping (`List<int> echo(List<int> a)`) and building a result with `.add` before returning it.
+  - The `apollovm_sig` custom section now carries list types as `[6, <element tag>]` (was a single opaque tag), so modules loaded from raw bytes self-describe their list element types; the runner uses 64-bit element reads/writes via `BigInt` so it works on both the Dart VM and dart2js (Chrome).
+  - A `String`/`List` parameter now also forces an exported `__alloc` (previously only String params did), so list-only functions can be fed their arguments.
 - Wasm collections — `String` & `bool` element lists (P3, part 3):
   - `List<String>` and `List<bool>` now compile to Wasm: literals, index reads `a[i]`, `for (var e in a)`, `.add`, and the `.first`/`.last`/`.isEmpty`/`.isNotEmpty`/`.length` getters all work (elements stored as i32 — a string pointer or a `0`/`1` boolean). Matches the interpreter on both `wasm_run` and Chrome.
-  - List parameters/returns and maps remain later slices (lists still stay internal, returning scalars/elements).
+  - Maps remain a later slice.
 - Wasm collections — growable lists `.add` + getters (P3, part 2):
   - List values are now an indirect handle: a 12-byte header `[length:i32][capacity:i32][dataPtr:i32]` pointing at a separately-allocated elements buffer. This makes `.add` aliasing-safe — growing reallocates the data buffer (doubling capacity, `memory.copy`ing existing elements) and updates the header in place, so existing references observe the new length/contents.
   - `list.add(x)` now compiles to Wasm for `int`/`double` lists (including starting from an empty `[]` literal), growing linear memory on demand.

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -66,9 +66,9 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     var functions = root.functions.expand((fs) => fs.functions).toList();
     var module = WasmModuleContext(functions);
 
-    // A public function with a String parameter requires the host to allocate
-    // the argument in module memory, so ensure `__alloc` is exported.
-    if (_hasStringParam(module)) {
+    // A public function with a String or List parameter requires the host to
+    // allocate the argument in module memory, so ensure `__alloc` is exported.
+    if (_hasMarshalledParam(module)) {
       module.ensureAllocFunction();
     }
 
@@ -122,37 +122,50 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   }
 
   /// Type tag used by the `apollovm_sig` custom section.
-  /// 0=void, 1=int, 2=double, 3=bool, 4=String, 5=other.
+  /// 0=void, 1=int, 2=double, 3=bool, 4=String, 5=other, 6=list.
   static int _typeTag(ASTType t) {
     if (t is ASTTypeVoid) return 0;
     if (t is ASTTypeInt) return 1;
     if (t is ASTTypeDouble) return 2;
     if (t is ASTTypeBool) return 3;
     if (t is ASTTypeString) return 4;
+    if (t is ASTTypeArray) return 6;
     return 5;
   }
 
+  /// Encodes a type as a descriptor for the `apollovm_sig` section. Scalars are
+  /// a single tag byte; a list is `[6, <element tag>]` so the runner can marshal
+  /// the whole collection across the host boundary.
+  static List<int> _typeDescriptor(ASTType t) {
+    if (t is ASTTypeArray) {
+      return [6, _typeTag(t.componentType)];
+    }
+    return [_typeTag(t)];
+  }
+
   /// Whether the module needs the `apollovm_sig` custom section: any public
-  /// function that involves a String (param or return) or returns a `bool` —
-  /// i.e. a return/param the runner must decode from its raw Wasm value.
+  /// function with a return/param the runner must marshal from/to its raw Wasm
+  /// value — a String, a `bool` return, or a list (param or return).
   bool _requiresSignatureSection(WasmModuleContext module) {
+    bool needs(ASTType t) =>
+        t is ASTTypeString || t is ASTTypeBool || t is ASTTypeArray;
     for (var f in module.functions) {
       if (f.modifiers.isPrivate) continue;
-      if (f.returnType is ASTTypeString || f.returnType is ASTTypeBool) {
-        return true;
-      }
+      if (needs(f.returnType)) return true;
       for (var p in f.parameters.allParameters) {
-        if (p.type is ASTTypeString) return true;
+        if (p.type is ASTTypeString || p.type is ASTTypeArray) return true;
       }
     }
     return false;
   }
 
-  bool _hasStringParam(WasmModuleContext module) {
+  /// Whether any public function has a parameter the host must allocate into
+  /// module memory (a String or a List), requiring an exported `__alloc`.
+  bool _hasMarshalledParam(WasmModuleContext module) {
     for (var f in module.functions) {
       if (f.modifiers.isPrivate) continue;
       for (var p in f.parameters.allParameters) {
-        if (p.type is ASTTypeString) return true;
+        if (p.type is ASTTypeString || p.type is ASTTypeArray) return true;
       }
     }
     return false;
@@ -180,15 +193,15 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         description: "Function count",
       ),
       ...publics.map((f) {
-        var paramTags = f.parameters.allParameters
-            .map((p) => _typeTag(p.type))
+        var paramDescriptors = f.parameters.allParameters
+            .map((p) => _typeDescriptor(p.type))
             .toList();
         return BytesOutput(
           data: [
             ...Wasm.encodeString(f.name),
-            _typeTag(f.returnType),
-            ...Leb128.encodeUnsigned(paramTags.length),
-            ...paramTags,
+            ..._typeDescriptor(f.returnType),
+            ...Leb128.encodeUnsigned(paramDescriptors.length),
+            ...paramDescriptors.expand((d) => d),
           ],
           description: "Signature `${f.name}`",
         );

--- a/lib/src/languages/wasm/wasm_runner.dart
+++ b/lib/src/languages/wasm/wasm_runner.dart
@@ -89,6 +89,81 @@ class ApolloRunnerWasm extends ApolloRunner {
       return ptr;
     }
 
+    int elemSizeOf(int elemTag) =>
+        (elemTag == _tagInt || elemTag == _tagDouble) ? 8 : 4;
+
+    // Encodes a Dart [list] into module memory as `[len:i32][cap:i32][dataPtr:i32]`
+    // + a separate elements buffer (the generator's indirect list layout), and
+    // returns the header pointer. `int` elements use i64, `double` f64, `bool`
+    // i32 (0/1), `String` an i32 pointer to its own `[len][utf8]` block.
+    int encodeList(List list, int elemTag) {
+      var m = loadedModule!;
+      var n = list.length;
+      var elemSize = elemSizeOf(elemTag);
+
+      // Strings allocate first (each grows the bump pointer); capture pointers.
+      List<int>? strPtrs;
+      if (elemTag == _tagString) {
+        strPtrs = [for (var v in list) allocAndWriteString(v as String)];
+      }
+
+      var dataPtr = m.invokeExport('__alloc', [n * elemSize]) as int;
+      var header = m.invokeExport('__alloc', [12]) as int;
+
+      // Re-read AFTER all allocations: `__alloc` may have grown memory, which
+      // invalidates any earlier view.
+      var mem = m.readMemory()!;
+      var bd = ByteData.sublistView(mem);
+      bd.setInt32(header + 0, n, Endian.little);
+      bd.setInt32(header + 4, n, Endian.little);
+      bd.setInt32(header + 8, dataPtr, Endian.little);
+
+      for (var i = 0; i < n; ++i) {
+        var addr = dataPtr + i * elemSize;
+        var v = list[i];
+        switch (elemTag) {
+          case _tagInt:
+            _writeI64(bd, addr, v is BigInt ? v.toInt() : (v as num).toInt());
+          case _tagDouble:
+            bd.setFloat64(addr, (v as num).toDouble(), Endian.little);
+          case _tagBool:
+            bd.setInt32(addr, (v as bool) ? 1 : 0, Endian.little);
+          case _tagString:
+            bd.setInt32(addr, strPtrs![i], Endian.little);
+          default:
+            throw StateError("Unsupported Wasm list element tag: $elemTag");
+        }
+      }
+      return header;
+    }
+
+    // Decodes a module-memory list ([header] pointer) back into a Dart `List`.
+    List decodeList(int header, int elemTag) {
+      var mem = loadedModule!.readMemory()!;
+      var bd = ByteData.sublistView(mem);
+      var n = bd.getInt32(header + 0, Endian.little);
+      var dataPtr = bd.getInt32(header + 8, Endian.little);
+      var elemSize = elemSizeOf(elemTag);
+
+      var out = [];
+      for (var i = 0; i < n; ++i) {
+        var addr = dataPtr + i * elemSize;
+        switch (elemTag) {
+          case _tagInt:
+            out.add(_readI64(bd, addr));
+          case _tagDouble:
+            out.add(bd.getFloat64(addr, Endian.little));
+          case _tagBool:
+            out.add(bd.getInt32(addr, Endian.little) != 0);
+          case _tagString:
+            out.add(decodeString(bd.getInt32(addr, Endian.little)));
+          default:
+            throw StateError("Unsupported Wasm list element tag: $elemTag");
+        }
+      }
+      return out;
+    }
+
     var hostImports = <String, Map<String, WasmHostFunction>>{
       'env': {
         'print': WasmHostFunction(
@@ -130,15 +205,19 @@ class ApolloRunnerWasm extends ApolloRunner {
 
     var allParams = [...?positionalParameters, ...?namedParameters?.values];
 
-    // Encode String arguments into module memory (via `__alloc`) BEFORE numeric
-    // parameter resolution, which would otherwise mangle the String values. The
-    // function receives the i32 pointer; String params are identified by the
-    // `apollovm_sig` param tags.
-    var paramTags = _signatures(codeUnit.code)[functionName]?.paramTags;
-    if (paramTags != null) {
-      for (var i = 0; i < allParams.length && i < paramTags.length; ++i) {
-        if (paramTags[i] == _tagString && allParams[i] is String) {
-          allParams[i] = allocAndWriteString(allParams[i] as String);
+    // Encode String and List arguments into module memory (via `__alloc`)
+    // BEFORE numeric parameter resolution, which would otherwise mangle them.
+    // The function receives the i32 pointer; param types come from the
+    // `apollovm_sig` descriptors.
+    var paramTypes = _signatures(codeUnit.code)[functionName]?.params;
+    if (paramTypes != null) {
+      for (var i = 0; i < allParams.length && i < paramTypes.length; ++i) {
+        var pt = paramTypes[i];
+        var arg = allParams[i];
+        if (pt.tag == _tagString && arg is String) {
+          allParams[i] = allocAndWriteString(arg);
+        } else if (pt.isList && arg is List) {
+          allParams[i] = encodeList(arg, pt.elemTag);
         }
       }
     }
@@ -194,23 +273,31 @@ class ApolloRunnerWasm extends ApolloRunner {
 
     res = module.resolveReturnedValue(res, astFunction);
 
-    // A `String` return is an i32 pointer into the module's memory; decode it.
-    // The return type comes from the AST when available, else from the module's
-    // `apollovm_sig` custom section (for modules loaded from raw bytes).
-    var returnsString =
-        astFunction?.returnType is ASTTypeString ||
-        _signatures(codeUnit.code)[functionName]?.returnTag == _tagString;
-    if (res != null && returnsString) {
-      res = decodeString(res as int);
-    }
+    // Decode the raw Wasm return into a Dart value. The return type comes from
+    // the AST when available, else from the module's `apollovm_sig` custom
+    // section (for modules loaded from raw bytes).
+    var sigReturn = _signatures(codeUnit.code)[functionName]?.ret;
 
-    // A `bool` return is an i32 (0/1); decode it back to a Dart `bool`. From the
-    // AST when available, else from the `apollovm_sig` custom section.
-    var returnsBool =
-        astFunction?.returnType is ASTTypeBool ||
-        _signatures(codeUnit.code)[functionName]?.returnTag == _tagBool;
-    if (res != null && returnsBool && res is! bool) {
-      res = (res as num) != 0;
+    if (res != null) {
+      // `String` return: an i32 pointer to a `[len][utf8]` block.
+      var returnsString =
+          astFunction?.returnType is ASTTypeString ||
+          sigReturn?.tag == _tagString;
+      // `bool` return: an i32 (0/1).
+      var returnsBool =
+          astFunction?.returnType is ASTTypeBool || sigReturn?.tag == _tagBool;
+      // `List` return: an i32 pointer to a list header.
+      var listReturn = astFunction?.returnType is ASTTypeArray
+          ? _elemTagOf((astFunction!.returnType as ASTTypeArray).componentType)
+          : (sigReturn != null && sigReturn.isList ? sigReturn.elemTag : null);
+
+      if (returnsString) {
+        res = decodeString(res as int);
+      } else if (returnsBool && res is! bool) {
+        res = (res as num) != 0;
+      } else if (listReturn != null) {
+        res = decodeList(res as int, listReturn);
+      }
     }
 
     var astValue = res == null
@@ -220,24 +307,54 @@ class ApolloRunnerWasm extends ApolloRunner {
     return astValue;
   }
 
+  // Reads/writes a little-endian 64-bit int via BigInt, so it works on both the
+  // Dart VM and dart2js (where `ByteData.get/setInt64` throw). Values beyond the
+  // web's 2^53 safe-integer range lose precision on `toInt()` — inherent to web
+  // `int`s, and outside the supported range anyway.
+  static void _writeI64(ByteData bd, int addr, int value) {
+    var b = BigInt.from(value).toUnsigned(64);
+    var mask = BigInt.from(0xff);
+    for (var i = 0; i < 8; ++i) {
+      bd.setUint8(addr + i, ((b >> (8 * i)) & mask).toInt());
+    }
+  }
+
+  static int _readI64(ByteData bd, int addr) {
+    var b = BigInt.zero;
+    for (var i = 0; i < 8; ++i) {
+      b |= BigInt.from(bd.getUint8(addr + i)) << (8 * i);
+    }
+    return b.toSigned(64).toInt();
+  }
+
+  /// Element tag for an AST list-component type (mirrors the generator's
+  /// `_typeTag`). Returns `-1` for unsupported element types.
+  static int _elemTagOf(ASTType t) {
+    if (t is ASTTypeInt) return _tagInt;
+    if (t is ASTTypeDouble) return _tagDouble;
+    if (t is ASTTypeBool) return _tagBool;
+    if (t is ASTTypeString) return _tagString;
+    return -1;
+  }
+
   // High-level type tags from the `apollovm_sig` custom section.
+  static const int _tagInt = 1;
+  static const int _tagDouble = 2;
   static const int _tagBool = 3;
   static const int _tagString = 4;
+  static const int _tagList = 6;
 
   /// Per-module signature cache, keyed by the wasm binary's identity.
-  final Map<Uint8List, Map<String, ({int returnTag, List<int> paramTags})>>
-  _signaturesCache = {};
+  final Map<Uint8List, Map<String, _WasmSig>> _signaturesCache = {};
 
-  Map<String, ({int returnTag, List<int> paramTags})> _signatures(
-    Uint8List wasmBytes,
-  ) => _signaturesCache[wasmBytes] ??= _parseSignatures(wasmBytes);
+  Map<String, _WasmSig> _signatures(Uint8List wasmBytes) =>
+      _signaturesCache[wasmBytes] ??= _parseSignatures(wasmBytes);
 
   /// Parses the `apollovm_sig` custom section (function name -> return/param
-  /// type tags). Returns an empty map if absent.
-  static Map<String, ({int returnTag, List<int> paramTags})> _parseSignatures(
-    Uint8List b,
-  ) {
-    var sigs = <String, ({int returnTag, List<int> paramTags})>{};
+  /// type descriptors). Returns an empty map if absent. Each type is a one-byte
+  /// tag, except a list (`6`) which is followed by its element tag byte.
+  static Map<String, _WasmSig> _parseSignatures(Uint8List b) {
+    var sigs = <String, _WasmSig>{};
     if (b.length < 8) return sigs;
 
     var pos = 8; // skip magic (4) + version (4)
@@ -260,6 +377,14 @@ class ApolloRunnerWasm extends ApolloRunner {
       return s;
     }
 
+    _WasmType readType() {
+      var tag = b[pos++];
+      if (tag == _tagList) {
+        return _WasmType(tag, b[pos++]);
+      }
+      return _WasmType(tag, -1);
+    }
+
     while (pos < b.length) {
       var id = b[pos++];
       var size = readLeb();
@@ -270,11 +395,10 @@ class ApolloRunnerWasm extends ApolloRunner {
           var count = readLeb();
           for (var i = 0; i < count; ++i) {
             var fname = readName();
-            var returnTag = b[pos++];
+            var ret = readType();
             var paramCount = readLeb();
-            var paramTags = b.sublist(pos, pos + paramCount).toList();
-            pos += paramCount;
-            sigs[fname] = (returnTag: returnTag, paramTags: paramTags);
+            var params = [for (var p = 0; p < paramCount; ++p) readType()];
+            sigs[fname] = _WasmSig(ret, params);
           }
         }
       }
@@ -344,4 +468,21 @@ class ApolloRunnerWasm extends ApolloRunner {
       "Ambiguous AST functions. Can't determine function with name `$functionName` and with ${parameters.length} parameters",
     );
   }
+}
+
+/// A high-level type from the `apollovm_sig` custom section: a [tag] plus, for a
+/// list ([ApolloRunnerWasm._tagList]), the element tag in [elemTag] (else `-1`).
+class _WasmType {
+  final int tag;
+  final int elemTag;
+  const _WasmType(this.tag, this.elemTag);
+
+  bool get isList => tag == ApolloRunnerWasm._tagList;
+}
+
+/// A parsed public-function signature (return type + parameter types).
+class _WasmSig {
+  final _WasmType ret;
+  final List<_WasmType> params;
+  const _WasmSig(this.ret, this.params);
 }

--- a/test/apollovm_wasm_p3_test.dart
+++ b/test/apollovm_wasm_p3_test.dart
@@ -538,4 +538,183 @@ void main() {
       );
     });
   });
+
+  group('Wasm P3: list parameters', () {
+    test('sum int list parameter', () async {
+      await _testWasmReturn(
+        '''
+        int sum(List<int> a) {
+          int s = 0;
+          for (var e in a) {
+            s = s + e;
+          }
+          return s;
+        }
+      ''',
+        'sum',
+        [
+          [1, 2, 3, 4],
+        ],
+        10,
+      );
+    });
+
+    test('index into int list parameter', () async {
+      await _testWasmReturn(
+        '''
+        int at(List<int> a, int i) {
+          return a[i];
+        }
+      ''',
+        'at',
+        [
+          [10, 20, 30],
+          2,
+        ],
+        30,
+      );
+    });
+
+    test('double list parameter average', () async {
+      await _testWasmReturn(
+        '''
+        double total(List<double> a) {
+          double s = 0.0;
+          for (var e in a) {
+            s = s + e;
+          }
+          return s;
+        }
+      ''',
+        'total',
+        [
+          [1.5, 2.5, 3.0],
+        ],
+        7.0,
+      );
+    });
+
+    test('String list parameter join', () async {
+      await _testWasmReturn(
+        '''
+        String join(List<String> a) {
+          String s = "";
+          for (var e in a) {
+            s = s + e;
+          }
+          return s;
+        }
+      ''',
+        'join',
+        [
+          ["x", "y", "z"],
+        ],
+        'xyz',
+      );
+    });
+
+    test('mutate list parameter via add', () async {
+      await _testWasmReturn(
+        '''
+        int addAndLen(List<int> a) {
+          a.add(99);
+          return a.length;
+        }
+      ''',
+        'addAndLen',
+        [
+          [1, 2],
+        ],
+        3,
+      );
+    });
+  });
+
+  group('Wasm P3: list returns', () {
+    test('return int list literal', () async {
+      await _testWasmReturn(
+        '''
+        List<int> make() {
+          return [10, 20, 30];
+        }
+      ''',
+        'make',
+        [],
+        [10, 20, 30],
+      );
+    });
+
+    test('return double list literal', () async {
+      await _testWasmReturn(
+        '''
+        List<double> make() {
+          return [1.5, 2.5];
+        }
+      ''',
+        'make',
+        [],
+        [1.5, 2.5],
+      );
+    });
+
+    test('return String list literal', () async {
+      await _testWasmReturn(
+        '''
+        List<String> make() {
+          return ["a", "bb", "ccc"];
+        }
+      ''',
+        'make',
+        [],
+        ['a', 'bb', 'ccc'],
+      );
+    });
+
+    test('return bool list literal', () async {
+      await _testWasmReturn(
+        '''
+        List<bool> make() {
+          return [true, false, true];
+        }
+      ''',
+        'make',
+        [],
+        [true, false, true],
+      );
+    });
+
+    test('return list built with add (incl. realloc)', () async {
+      await _testWasmReturn(
+        '''
+        List<int> doubled(List<int> a) {
+          List<int> r = [];
+          for (var e in a) {
+            r.add(e * 2);
+          }
+          return r;
+        }
+      ''',
+        'doubled',
+        [
+          [1, 2, 3, 4],
+        ],
+        [2, 4, 6, 8],
+      );
+    });
+
+    test('round-trip int list (param in, list out)', () async {
+      await _testWasmReturn(
+        '''
+        List<int> echo(List<int> a) {
+          return a;
+        }
+      ''',
+        'echo',
+        [
+          [7, 8, 9],
+        ],
+        [7, 8, 9],
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Completes the list portion of P3: functions can now **accept and return whole lists** across the host↔Wasm boundary. The Wasm side already represented lists as i32 header pointers (params arrive as i32, returns are i32), so this slice is mostly **runner-side marshalling** plus enriching the self-describing signature section.

- **List parameters.** The runner encodes a Dart `List` into module memory — a 12-byte header `[length][capacity][dataPtr]` plus a separate elements buffer, allocated via the exported `__alloc` — and passes the header pointer. Element encodings: `int`→i64, `double`→f64, `bool`→i32 `0`/`1`, `String`→i32 pointer to its own `[len][utf8]` block.
- **List returns.** A returned list-header pointer is decoded back into a Dart `List`.
- **`apollovm_sig` enrichment.** List types are now encoded as `[6, <element tag>]` (was a single opaque `5`/"other"), so modules loaded from raw bytes self-describe their list element type. The runner's signature parsing was refactored from flat tag bytes to structured type descriptors.
- **Cross-platform 64-bit.** Element i64 reads/writes go through `BigInt` byte assembly, because `ByteData.get/setInt64` throw on dart2js — so list marshalling works on both `wasm_run` (VM) and Chrome.
- **`__alloc` export.** Now forced whenever a public function has a String **or** List parameter (previously String-only), so list-only functions can be fed their arguments.

## Tests

New parity tests (interpreter == compiled-and-executed Wasm): int/double/String list parameters (sum, index, join), mutate-param-via-`.add`, list returns for all element types, build-with-`.add`-then-return (incl. realloc), and an `int` list round-trip (param in → list out). Pass on both `-p vm` and `-p chrome`. Full suite green (477 on vm), `dart analyze --fatal-infos --fatal-warnings` clean, formatted.

## Note

A `List<bool>` **parameter** is not tested: the reference AST interpreter itself rejects it (resolves the Dart literal as `List<Object>`, not assignable to `List<bool>`) — an interpreter-side type-resolution limitation orthogonal to this Wasm slice. `bool` lists remain covered by the element-list tests and by `List<bool>` **returns** (which don't go through parameter matching).

## Out of scope (later slice)

Maps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)