### PR TITLE
Dart Map support: frontend + interpreter (read/query)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## 0.1.27
 
-- Wasm collections — list parameters & returns (P3, part 4):
+- Dart `Map` support — frontend + interpreter (read/query; prerequisite for Wasm maps):
+  - **Grammar fix**: `Map<K,V>` type annotations now parse. `mapTyped()` was missing the value-type parser (it accepted only `Map<K,>` and read the `,` token as the value type), so every `Map<int,int>` declaration failed with a `SyntaxError`. Key/value types also accept `List<...>` (e.g. `Map<String,List<int>>`).
+  - Map literals now infer their key/value types from entries (mirroring list literals) instead of being hardcoded to `Map<dynamic,dynamic>`, so `Map<int,int> m = {1:10}` assigns cleanly. `ASTExpressionMapLiteral.resolveType` returns the `Map` type (it previously returned just the *value* type).
+  - **Map index by key**: `m[k]` now does a key lookup for any `Map` (the access was incorrectly routed to positional/list indexing whenever the key was numeric, so int-keyed maps failed).
+  - New core `Map` class (`CoreClassMap`): getters `.length`/`.isEmpty`/`.isNotEmpty`/`.keys`/`.values` and methods `.containsKey`/`.containsValue`/`.remove`/`.clear`. `.keys`/`.values` resolve to `List<keyType>`/`List<valueType>` so iterating them yields properly-typed elements.
+  - Maps work as function parameters.
+  - Note: map subscript assignment (`m[k] = v`) is a follow-up (the grammar's assignment target is still a bare variable).
   - Functions can now accept and return whole lists across the host boundary. The runner marshals a Dart `List` into module memory (header + elements buffer, via the exported `__alloc`) for `List` parameters, and decodes a returned list-header pointer back into a Dart `List`. Covers `int`/`double`/`String`/`bool` element lists, including round-tripping (`List<int> echo(List<int> a)`) and building a result with `.add` before returning it.
   - The `apollovm_sig` custom section now carries list types as `[6, <element tag>]` (was a single opaque tag), so modules loaded from raw bytes self-describe their list element types; the runner uses 64-bit element reads/writes via `BigInt` so it works on both the Dart VM and dart2js (Chrome).
   - A `String`/`List` parameter now also forces an exported `__alloc` (previously only String params did), so list-only functions can be fed their arguments.

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -389,8 +389,15 @@ class ASTExpressionMapLiteral extends ASTExpression {
       ASTExpression.typeFromExpressions(entriesExpressions.map((e) => e.value));
 
   @override
-  FutureOr<ASTType> resolveType(VMContext? context) =>
-      resolveValueType(context);
+  FutureOr<ASTType> resolveType(VMContext? context) {
+    var kt = keyType, vt = valueType;
+    if (kt != null && vt != null) {
+      return ASTTypeMap(kt, vt);
+    }
+    return resolveKeyType(
+      context,
+    ).resolveBoth(resolveValueType(context), (k, v) => ASTTypeMap(k, v));
+  }
 
   @override
   ASTNode? getNodeIdentifier(String name, {ASTNode? requester}) =>
@@ -495,7 +502,10 @@ class ASTExpressionVariableEntryAccess extends ASTExpression {
 
     return expression.run(context, runStatus).resolveMapped((key) {
       return variable.getValue(context).resolveMapped((value) {
-        if (key is ASTValueNum) {
+        // A Map is always accessed by key, even with a numeric key. Only a
+        // positional container (e.g. a List) uses a numeric index.
+        var isMap = value.type is ASTTypeMap;
+        if (!isMap && key is ASTValueNum) {
           var idx = key.getValue(context).toInt();
           return _run2(context, value, idx: idx, readIndex: true);
         } else {

--- a/lib/src/core/apollovm_core_base.dart
+++ b/lib/src/core/apollovm_core_base.dart
@@ -19,6 +19,8 @@ class ApolloVMCore {
         return CoreClassDouble.instance as ASTClass<V>;
       case 'List':
         return CoreClassList.fromType(V) as ASTClass<V>;
+      case 'Map':
+        return CoreClassMap.instance as ASTClass<V>;
       default:
         return null;
     }
@@ -1543,6 +1545,284 @@ class CoreClassList<T> extends CoreClassBase<List<T>> {
   }) {
     throw UnimplementedError();
   }
+
+  @override
+  List<ASTConstructorSet> get constructors => [];
+
+  @override
+  List<String> get constructorsNames => [];
+
+  @override
+  ASTClassConstructorDeclaration? getConstructor(
+    String fName,
+    ASTFunctionSignature? parametersSignature,
+    VMContext context, {
+    bool caseInsensitive = false,
+  }) => null;
+
+  @override
+  void resolveNodeConstructors(ASTNode? parentNode) {}
+}
+
+/// Core `Map` class: external getters/methods backed by the host Dart [Map].
+class CoreClassMap extends CoreClassBase<Map<dynamic, dynamic>> {
+  static final CoreClassMap instance = CoreClassMap._();
+
+  late final ASTExternalClassGetter _getterLength;
+  late final ASTExternalClassGetter _getterIsEmpty;
+  late final ASTExternalClassGetter _getterIsNotEmpty;
+  late final ASTExternalClassGetter _getterKeys;
+  late final ASTExternalClassGetter _getterValues;
+
+  late final ASTExternalClassFunction _functionContainsKey;
+  late final ASTExternalClassFunction _functionContainsValue;
+  late final ASTExternalClassFunction _functionRemove;
+  late final ASTExternalClassFunction _functionClear;
+  late final ASTExternalClassFunction _functionLength;
+  late final ASTExternalClassFunction _functionIsEmpty;
+  late final ASTExternalClassFunction _functionIsNotEmpty;
+
+  /// Resolves `.keys`/`.values` to `List<keyType>` / `List<valueType>` from the
+  /// actual map value, so iterating them yields properly-typed elements.
+  FutureOr<ASTType> _resolveEntryListType(
+    VMContext? context,
+    ASTNode? node, {
+    required bool keys,
+  }) {
+    if (node is ASTValueMap) {
+      var typeAsync = context != null
+          ? node.resolveRuntimeType(context, null)
+          : node.resolveType(null);
+      return typeAsync.resolveMapped((t) {
+        if (t is ASTTypeMap) {
+          return ASTTypeArray(keys ? t.keyType : t.valueType);
+        }
+        return ASTTypeArray.instanceOfObject;
+      });
+    }
+    return ASTTypeArray.instanceOfObject;
+  }
+
+  CoreClassMap._() : super(ASTTypeMap.instanceOfDynamicOfDynamic, 'Map') {
+    _getterLength = _externalClassGetter(
+      'length',
+      ASTTypeInt.instance,
+      (Object? o) => o is Map ? o.length : null,
+    );
+
+    _getterIsEmpty = _externalClassGetter(
+      'isEmpty',
+      ASTTypeBool.instance,
+      (Object? o) => o is Map ? o.isEmpty : null,
+    );
+
+    _getterIsNotEmpty = _externalClassGetter(
+      'isNotEmpty',
+      ASTTypeBool.instance,
+      (Object? o) => o is Map ? o.isNotEmpty : null,
+    );
+
+    _getterKeys = _externalClassGetter(
+      'keys',
+      ASTTypeArray.instanceOfObject,
+      (Object? o) => o is Map ? o.keys.toList() : null,
+      (context, node) => _resolveEntryListType(context, node, keys: true),
+    );
+
+    _getterValues = _externalClassGetter(
+      'values',
+      ASTTypeArray.instanceOfObject,
+      (Object? o) => o is Map ? o.values.toList() : null,
+      (context, node) => _resolveEntryListType(context, node, keys: false),
+    );
+
+    _functionContainsKey = _externalClassFunctionArgs1(
+      'containsKey',
+      ASTTypeBool.instance,
+      ASTFunctionParameterDeclaration(ASTTypeDynamic.instance, 'key', 0, false),
+      (Map o, dynamic k) => o.containsKey(k),
+    );
+
+    _functionContainsValue = _externalClassFunctionArgs1(
+      'containsValue',
+      ASTTypeBool.instance,
+      ASTFunctionParameterDeclaration(
+        ASTTypeDynamic.instance,
+        'value',
+        0,
+        false,
+      ),
+      (Map o, dynamic v) => o.containsValue(v),
+    );
+
+    _functionRemove = _externalClassFunctionArgs1(
+      'remove',
+      ASTTypeDynamic.instance,
+      ASTFunctionParameterDeclaration(ASTTypeDynamic.instance, 'key', 0, false),
+      (Map o, dynamic k) => o.remove(k),
+    );
+
+    _functionClear = _externalClassFunctionArgs0(
+      'clear',
+      ASTTypeVoid.instance,
+      (Map o) {
+        o.clear();
+        return null;
+      },
+    );
+
+    _functionLength = _externalClassFunctionArgs0(
+      'length',
+      ASTTypeInt.instance,
+      (Map o) => o.length,
+    );
+
+    _functionIsEmpty = _externalClassFunctionArgs0(
+      'isEmpty',
+      ASTTypeBool.instance,
+      (Map o) => o.isEmpty,
+    );
+
+    _functionIsNotEmpty = _externalClassFunctionArgs0(
+      'isNotEmpty',
+      ASTTypeBool.instance,
+      (Map o) => o.isNotEmpty,
+    );
+  }
+
+  @override
+  ASTGetterDeclaration? getGetter(
+    String fName,
+    VMContext context, {
+    bool caseInsensitive = false,
+  }) {
+    switch (fName) {
+      case 'length':
+        return _getterLength;
+      case 'isEmpty':
+        return _getterIsEmpty;
+      case 'isNotEmpty':
+        return _getterIsNotEmpty;
+      case 'keys':
+        return _getterKeys;
+      case 'values':
+        return _getterValues;
+    }
+
+    throw StateError("Can't find core getter: $coreName.$fName");
+  }
+
+  @override
+  ASTFunctionDeclaration? getFunction(
+    String fName,
+    ASTFunctionSignature parametersSignature,
+    VMContext context, {
+    bool caseInsensitive = false,
+  }) {
+    switch (fName) {
+      case 'containsKey':
+        return _functionContainsKey;
+      case 'containsValue':
+        return _functionContainsValue;
+      case 'remove':
+        return _functionRemove;
+      case 'clear':
+        return _functionClear;
+      case 'length':
+        return _functionLength;
+      case 'isEmpty':
+        return _functionIsEmpty;
+      case 'isNotEmpty':
+        return _functionIsNotEmpty;
+      case 'toString':
+        return _functionToString;
+    }
+
+    throw StateError(
+      "Can't find core function: $coreName.$fName( $parametersSignature )",
+    );
+  }
+
+  @override
+  FutureOr<ASTValue<Map<dynamic, dynamic>>?> createInstance(
+    VMClassContext<dynamic> context,
+    ASTRunStatus runStatus,
+  ) => throw UnimplementedError();
+
+  @override
+  List<ASTClassField<dynamic>> get fields => throw UnimplementedError();
+
+  @override
+  List<String> get fieldsNames => throw UnimplementedError();
+
+  @override
+  FutureOr<Map<String, Object>> getFieldsMap({
+    VMContext? context,
+    Map<String, ASTValue<dynamic>>? fieldOverwrite,
+  }) => throw UnimplementedError();
+
+  @override
+  FutureOr<ASTValue<dynamic>?> getInstanceFieldValue(
+    VMContext context,
+    ASTRunStatus runStatus,
+    ASTValue<Map<dynamic, dynamic>> instance,
+    String fieldName, {
+    bool caseInsensitive = false,
+  }) => throw UnimplementedError();
+
+  @override
+  FutureOr<void> initializeInstance(
+    VMClassContext<dynamic> context,
+    ASTRunStatus runStatus,
+    ASTValue<Map<dynamic, dynamic>> instance,
+  ) => throw UnimplementedError();
+
+  @override
+  FutureOr<ASTValue<dynamic>?> removeInstanceFieldValue(
+    VMContext context,
+    ASTRunStatus runStatus,
+    ASTValue<Map<dynamic, dynamic>> instance,
+    String fieldName, {
+    bool caseInsensitive = false,
+  }) => throw UnimplementedError();
+
+  @override
+  void resolveNodeFields(ASTNode? parentNode) {}
+
+  @override
+  FutureOr<void> setInstanceByMap(
+    VMClassContext<dynamic> context,
+    ASTRunStatus runStatus,
+    ASTValue<Map<dynamic, dynamic>> instance,
+    Map<String, ASTValue<dynamic>> value, {
+    bool caseInsensitive = false,
+  }) => throw UnimplementedError();
+
+  @override
+  FutureOr<void> setInstanceByVMObject(
+    VMClassContext<dynamic> context,
+    ASTRunStatus runStatus,
+    ASTValue<Map<dynamic, dynamic>> instance,
+    VMObject value,
+  ) => throw UnimplementedError();
+
+  @override
+  FutureOr<void> setInstanceByValue(
+    VMClassContext<dynamic> context,
+    ASTRunStatus runStatus,
+    ASTValue<Map<dynamic, dynamic>> instance,
+    ASTValue<Map<dynamic, dynamic>> value,
+  ) => throw UnimplementedError();
+
+  @override
+  FutureOr<ASTValue<dynamic>?> setInstanceFieldValue(
+    VMContext context,
+    ASTRunStatus runStatus,
+    ASTValue<Map<dynamic, dynamic>> instance,
+    String fieldName,
+    ASTValue<dynamic> value, {
+    bool caseInsensitive = false,
+  }) => throw UnimplementedError();
 
   @override
   List<ASTConstructorSet> get constructors => [];

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -866,8 +866,10 @@ class DartGrammarDefinition extends DartGrammarLexer {
               char(',').trimHidden().optional() &
               char('}').trimHidden())
           .map((v) {
-            var keyType = (v[0]?[1] as ASTType?) ?? ASTTypeDynamic.instance;
-            var valueType = (v[0]?[3] as ASTType?) ?? ASTTypeDynamic.instance;
+            // Leave the types null when there's no explicit `<K,V>` prefix, so
+            // the literal infers them from its entries (mirrors list literals).
+            var keyType = v[0]?[1] as ASTType?;
+            var valueType = v[0]?[3] as ASTType?;
             var entry0 = (v[2] as List).whereType<ASTExpression>().toList();
             var entriesTail = (v[3] as List?)
                 ?.whereType<List>()
@@ -1050,12 +1052,13 @@ class DartGrammarDefinition extends DartGrammarLexer {
   Parser<ASTTypeMap> mapTyped() =>
       (string('Map') &
               char('<').trim() &
-              simpleType() &
+              (arrayTyped() | simpleType()).cast<ASTType>() &
               char(',').trim() &
+              (arrayTyped() | simpleType()).cast<ASTType>() &
               char('>').trim())
           .map((v) {
             var key = v[2] as ASTType;
-            var val = v[3] as ASTType;
+            var val = v[4] as ASTType;
             return ASTTypeMap(key, val);
           });
 

--- a/test/apollovm_dart_maps_test.dart
+++ b/test/apollovm_dart_maps_test.dart
@@ -1,0 +1,270 @@
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Runs [functionName] via the Dart AST interpreter and asserts the return.
+Future<void> _testReturn(
+  String code,
+  String functionName,
+  List args,
+  Object? expectedReturn,
+) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', code, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source:\n$code");
+
+  var runner = vm.createRunner('dart')!;
+  var ret = await runner.executeFunction(
+    '',
+    functionName,
+    positionalParameters: args,
+  );
+  expect(ret.getValueNoContext(), expectedReturn);
+}
+
+void main() {
+  group('Dart maps: typed declarations + literals', () {
+    test('Map<int,int> declaration parses and runs', () async {
+      await _testReturn(
+        '''
+        int f() {
+          Map<int,int> m = {1: 10, 2: 20};
+          return 1;
+        }
+      ''',
+        'f',
+        [],
+        1,
+      );
+    });
+
+    test('Map<String,int> declaration', () async {
+      await _testReturn(
+        '''
+        int f() {
+          Map<String,int> m = {"a": 1, "b": 2};
+          return m.length;
+        }
+      ''',
+        'f',
+        [],
+        2,
+      );
+    });
+
+    test('Map<String,List<int>> nested value type', () async {
+      await _testReturn(
+        '''
+        int f() {
+          Map<String,List<int>> m = {"a": [1, 2, 3]};
+          return m.length;
+        }
+      ''',
+        'f',
+        [],
+        1,
+      );
+    });
+  });
+
+  group('Dart maps: index read by key', () {
+    test('int key', () async {
+      await _testReturn(
+        '''
+        int f() {
+          Map<int,int> m = {1: 10, 2: 20, 3: 30};
+          return m[2];
+        }
+      ''',
+        'f',
+        [],
+        20,
+      );
+    });
+
+    test('String key', () async {
+      await _testReturn(
+        '''
+        int f() {
+          Map<String,int> m = {"x": 7, "y": 8};
+          return m["y"];
+        }
+      ''',
+        'f',
+        [],
+        8,
+      );
+    });
+
+    test('String value', () async {
+      await _testReturn(
+        '''
+        String f() {
+          Map<int,String> m = {1: "one", 2: "two"};
+          return m[2];
+        }
+      ''',
+        'f',
+        [],
+        'two',
+      );
+    });
+
+    test('index with a variable key', () async {
+      await _testReturn(
+        '''
+        int f(int k) {
+          Map<int,int> m = {1: 10, 2: 20};
+          return m[k];
+        }
+      ''',
+        'f',
+        [2],
+        20,
+      );
+    });
+  });
+
+  group('Dart maps: getters and methods', () {
+    test('.length', () async {
+      await _testReturn(
+        '''
+        int f() {
+          Map<int,int> m = {1: 1, 2: 2, 3: 3, 4: 4};
+          return m.length;
+        }
+      ''',
+        'f',
+        [],
+        4,
+      );
+    });
+
+    test('.isEmpty / .isNotEmpty', () async {
+      await _testReturn(
+        '''
+        bool f() {
+          Map<int,int> m = {1: 1};
+          return m.isNotEmpty;
+        }
+      ''',
+        'f',
+        [],
+        true,
+      );
+    });
+
+    test('.containsKey true', () async {
+      await _testReturn(
+        '''
+        bool f() {
+          Map<String,int> m = {"a": 1, "b": 2};
+          return m.containsKey("b");
+        }
+      ''',
+        'f',
+        [],
+        true,
+      );
+    });
+
+    test('.containsKey false', () async {
+      await _testReturn(
+        '''
+        bool f() {
+          Map<String,int> m = {"a": 1};
+          return m.containsKey("z");
+        }
+      ''',
+        'f',
+        [],
+        false,
+      );
+    });
+
+    test('.containsValue', () async {
+      await _testReturn(
+        '''
+        bool f() {
+          Map<String,int> m = {"a": 1, "b": 2};
+          return m.containsValue(2);
+        }
+      ''',
+        'f',
+        [],
+        true,
+      );
+    });
+  });
+
+  group('Dart maps: keys / values iteration', () {
+    test('sum keys via for-each', () async {
+      await _testReturn(
+        '''
+        int f() {
+          Map<int,int> m = {1: 100, 2: 200, 3: 300};
+          int s = 0;
+          for (var k in m.keys) {
+            s = s + k;
+          }
+          return s;
+        }
+      ''',
+        'f',
+        [],
+        6,
+      );
+    });
+
+    test('sum values via for-each', () async {
+      await _testReturn(
+        '''
+        int f() {
+          Map<int,int> m = {1: 100, 2: 200, 3: 300};
+          int s = 0;
+          for (var v in m.values) {
+            s = s + v;
+          }
+          return s;
+        }
+      ''',
+        'f',
+        [],
+        600,
+      );
+    });
+  });
+
+  group('Dart maps: parameters', () {
+    test('map parameter index read', () async {
+      await _testReturn(
+        '''
+        int f(Map<int,int> m) {
+          return m[1];
+        }
+      ''',
+        'f',
+        [
+          {1: 99},
+        ],
+        99,
+      );
+    });
+
+    test('map parameter length', () async {
+      await _testReturn(
+        '''
+        int f(Map<String,int> m) {
+          return m.length;
+        }
+      ''',
+        'f',
+        [
+          {'a': 1, 'b': 2, 'c': 3},
+        ],
+        3,
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

First step of the maps work (you chose "fix frontend first, then Wasm"). Maps were **unusable end-to-end** — blocked in the grammar, the AST, and the interpreter. This PR makes read/query maps work in the Dart frontend + interpreter, as the prerequisite for Wasm map codegen. **No Wasm codegen yet.**

What was broken and the fix:

- **Grammar** — `mapTyped()` (`dart_grammar.dart`) was missing the value-type parser: it parsed `Map<K,>` and read the `,` token *as* the value type, so every `Map<int,int>` annotation failed with a `SyntaxError`. Now parses `Map<K,V>`, and key/value also accept `List<...>` (e.g. `Map<String,List<int>>`).
- **Type inference** — map literals were hardcoded to `Map<dynamic,dynamic>` (so `Map<int,int> m = {1:10}` failed the assignment cast). They now infer key/value types from their entries, mirroring list literals. `ASTExpressionMapLiteral.resolveType` now returns the `Map` type (it previously returned just the *value* type).
- **Index by key** — `m[k]` was routed to positional/list indexing whenever the key was numeric, so int-keyed maps threw `RangeError`. Access now routes by **container** type: a `Map` is always keyed.
- **Core `Map` class** — there was no `'Map'` case in `ApolloVMCore.getClass` (`Class not set for type: Map`). Added `CoreClassMap` with getters `.length`/`.isEmpty`/`.isNotEmpty`/`.keys`/`.values` and methods `.containsKey`/`.containsValue`/`.remove`/`.clear`. `.keys`/`.values` resolve to `List<keyType>`/`List<valueType>` so iterating them yields properly-typed elements.
- Maps work as **function parameters**.

## Tests

New `test/apollovm_dart_maps_test.dart` — 16 interpreter tests: typed `Map<K,V>` declarations (incl. nested `List` value type), index read by int/String key, `.length`/`.isEmpty`/`.containsKey`/`.containsValue`, `.keys`/`.values` for-each iteration, and map parameters. Pass on both `-p vm` and `-p chrome`. Full suite green (493), `dart analyze --fatal-infos --fatal-warnings` clean, formatted.

## Follow-ups

- **Map subscript assignment** `m[k] = v` (next PR) — the grammar's assignment target is still a bare `variable()`; this also unlocks `a[i] = v` for lists.
- **Wasm map codegen** (after that) — literals, `m[k]` get, `.length`/`.containsKey`, iteration, params/returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)