### PR TITLE
Dart subscript assignment: m[k] = v and a[i] = v

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.1.27
 
+- Dart subscript assignment — `m[k] = v` and `a[i] = v` (frontend + interpreter):
+  - The grammar now parses container-entry assignment targets (previously the assignment left-hand side was only a bare variable, so `m[k] = v` / `a[i] = v` failed with a `SyntaxError`). Compound operators (`+=`, `-=`, `*=`, `/=`, `~/=`) are supported, e.g. `m["x"] += 1` for building a frequency map.
+  - New AST node `ASTExpressionVariableEntryAssignment`; new `ASTValue.writeKey`/`writeIndex` write into the underlying `Map`/`List` in place. A `Map` is always written by key (even a numeric one); a `List` by index. Round-trips through the code generators (parse → regenerate → re-parse).
+  - **Empty collection inference fix**: an empty `{}` literal (typed `Map<dynamic,dynamic>`) is now assignable to a typed map such as `Map<String,int>` — `ASTTypeMap.acceptsType` treats a `dynamic` key/value component as a wildcard, matching how lists already ignore their element type for assignment (so `Map<String,int> m = {};` works, like `List<int> a = [];`).
 - Dart `Map` support — frontend + interpreter (read/query; prerequisite for Wasm maps):
   - **Grammar fix**: `Map<K,V>` type annotations now parse. `mapTyped()` was missing the value-type parser (it accepted only `Map<K,>` and read the `,` token as the value type), so every `Map<int,int>` declaration failed with a `SyntaxError`. Key/value types also accept `List<...>` (e.g. `Map<String,List<int>>`).
   - Map literals now infer their key/value types from entries (mirroring list literals) instead of being hardcoded to `Map<dynamic,dynamic>`, so `Map<int,int> m = {1:10}` assigns cleanly. `ASTExpressionMapLiteral.resolveType` returns the `Map` type (it previously returned just the *value* type).

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -835,6 +835,47 @@ abstract class ApolloCodeGenerator
   }
 
   @override
+  StringBuffer generateASTExpressionVariableEntryAssignment(
+    ASTExpressionVariableEntryAssignment expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    generateASTVariable(
+      expression.variable,
+      out: out,
+      indent: indent,
+      headIndented: headIndented,
+    );
+
+    out.write('[');
+    generateASTExpression(
+      expression.keyExpression,
+      out: out,
+      indent: '$indent  ',
+      headIndented: false,
+    );
+    out.write(']');
+
+    var op = getASTAssignmentOperatorText(expression.operator);
+    out.write(' ');
+    out.write(op);
+    out.write(' ');
+    generateASTExpression(
+      expression.expression,
+      out: out,
+      indent: '$indent  ',
+      headIndented: false,
+    );
+
+    return out;
+  }
+
+  @override
   StringBuffer generateASTExpressionVariableDirectOperation(
     ASTExpressionVariableDirectOperation expression, {
     StringBuffer? out,
@@ -988,6 +1029,13 @@ abstract class ApolloCodeGenerator
       );
     } else if (expression is ASTExpressionVariableAssignment) {
       return generateASTExpressionVariableAssignment(
+        expression,
+        out: out,
+        indent: indent,
+        headIndented: headIndented,
+      );
+    } else if (expression is ASTExpressionVariableEntryAssignment) {
+      return generateASTExpressionVariableEntryAssignment(
         expression,
         out: out,
         indent: indent,

--- a/lib/src/apollovm_generator.dart
+++ b/lib/src/apollovm_generator.dart
@@ -212,6 +212,11 @@ abstract class ApolloGenerator<
     O? out,
   });
 
+  O generateASTExpressionVariableEntryAssignment(
+    ASTExpressionVariableEntryAssignment expression, {
+    O? out,
+  }) => throw UnsupportedError("Can't generate entry assignment: $expression");
+
   O generateASTExpressionVariableDirectOperation(
     ASTExpressionVariableDirectOperation expression, {
     O? out,
@@ -245,6 +250,8 @@ abstract class ApolloGenerator<
       return generateASTExpressionVariableAccess(expression, out: out);
     } else if (expression is ASTExpressionVariableAssignment) {
       return generateASTExpressionVariableAssignment(expression, out: out);
+    } else if (expression is ASTExpressionVariableEntryAssignment) {
+      return generateASTExpressionVariableEntryAssignment(expression, out: out);
     } else if (expression is ASTExpressionVariableEntryAccess) {
       return generateASTExpressionVariableEntryAccess(expression, out: out);
     } else if (expression is ASTExpressionLiteral) {

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -1501,6 +1501,104 @@ class ASTExpressionVariableAssignment extends ASTExpression {
   }
 }
 
+/// [ASTExpression] that assigns to a container entry: `m[k] = v` (map) or
+/// `a[i] = v` (list). Supports compound operators (`+=`, `-=`, …).
+class ASTExpressionVariableEntryAssignment extends ASTExpression {
+  ASTVariable variable;
+
+  ASTExpression keyExpression;
+
+  ASTAssignmentOperator operator;
+
+  ASTExpression expression;
+
+  ASTExpressionVariableEntryAssignment(
+    this.variable,
+    this.keyExpression,
+    this.operator,
+    this.expression,
+  );
+
+  @override
+  bool get isComplex => true;
+
+  @override
+  Iterable<ASTNode> get children => [variable, keyExpression, expression];
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+    variable.resolveNode(parentNode);
+    keyExpression.resolveNode(parentNode);
+    expression.resolveNode(parentNode);
+  }
+
+  @override
+  ASTNode? getNodeIdentifier(String name, {ASTNode? requester}) =>
+      parentNode?.getNodeIdentifier(name, requester: requester);
+
+  @override
+  FutureOr<ASTType> resolveType(VMContext? context) =>
+      expression.resolveType(context);
+
+  @override
+  FutureOr<ASTValue> run(
+    VMContext parentContext,
+    ASTRunStatus runStatus,
+  ) async {
+    var context = defineRunContext(parentContext);
+
+    var keyValue = await keyExpression.run(context, runStatus);
+    var value = await expression.run(context, runStatus);
+    var container = await variable.getValue(context);
+
+    // A Map is always accessed by key (even a numeric one); a positional
+    // container (List) by index.
+    var isMap = container.type is ASTTypeMap;
+    var key = await keyValue.getValue(context);
+
+    ASTValue result;
+    if (operator == ASTAssignmentOperator.set) {
+      result = value;
+    } else {
+      var currentRaw = isMap
+          ? await container.readKey(context, key)
+          : await container.readIndex(context, (key as num).toInt());
+      var current = ASTValue.fromValue(currentRaw);
+      result = await switch (operator) {
+        ASTAssignmentOperator.sum => current + value,
+        ASTAssignmentOperator.subtract => current - value,
+        ASTAssignmentOperator.divide => current / value,
+        ASTAssignmentOperator.divideAsInt => current ~/ value,
+        ASTAssignmentOperator.multiply => current * value,
+        ASTAssignmentOperator.set => value,
+      };
+    }
+
+    var resultRaw = await result.getValue(context);
+    if (isMap) {
+      await container.writeKey(context, key, resultRaw);
+    } else {
+      await container.writeIndex(context, (key as num).toInt(), resultRaw);
+    }
+
+    return result;
+  }
+
+  @override
+  String toString({bool asGroup = false}) {
+    var op = switch (operator) {
+      ASTAssignmentOperator.set => '=',
+      ASTAssignmentOperator.sum => '+=',
+      ASTAssignmentOperator.subtract => '-=',
+      ASTAssignmentOperator.multiply => '*=',
+      ASTAssignmentOperator.divide => '/=',
+      ASTAssignmentOperator.divideAsInt => '~/=',
+    };
+    return '$variable[$keyExpression] $op $expression';
+  }
+}
+
 /// [ASTExpression] to directly apply a change to a variable.
 /// - Operators examples: `++` and `--`
 class ASTExpressionVariableDirectOperation extends ASTExpression {

--- a/lib/src/ast/apollovm_ast_type.dart
+++ b/lib/src/ast/apollovm_ast_type.dart
@@ -1356,6 +1356,22 @@ class ASTTypeMap<TK extends ASTType<K>, TV extends ASTType<V>, K, V>
   Iterable<ASTNode> get children => [keyType, valueType];
 
   @override
+  bool acceptsType(ASTType type) {
+    // A `dynamic` key/value component acts as a wildcard, so an empty `{}`
+    // literal (typed `Map<dynamic,dynamic>`) is assignable to a typed map like
+    // `Map<String,int>`. Mirrors how lists ignore their element type here.
+    if (type is ASTTypeMap) {
+      bool accepts(ASTType a, ASTType b) =>
+          a is ASTTypeDynamic || b is ASTTypeDynamic || a.acceptsType(b);
+      if (accepts(keyType, type.keyType) &&
+          accepts(valueType, type.valueType)) {
+        return true;
+      }
+    }
+    return super.acceptsType(type);
+  }
+
+  @override
   FutureOr<ASTValue<Map<K, V>>?> toValue(VMContext context, Object? v) {
     if (v == null) return null;
     if (v is ASTValueMap) return v as ASTValueMap<TK, TV, K, V>;

--- a/lib/src/ast/apollovm_ast_value.dart
+++ b/lib/src/ast/apollovm_ast_value.dart
@@ -142,6 +142,14 @@ abstract class ASTValue<T> with ASTNode implements ASTTypedNode {
     throw UnsupportedError("Can't read key for type: $type");
   }
 
+  FutureOr<void> writeIndex<V>(VMContext context, int index, V value) {
+    throw UnsupportedError("Can't write index for type: $type");
+  }
+
+  FutureOr<void> writeKey<V>(VMContext context, Object? key, V value) {
+    throw UnsupportedError("Can't write key for type: $type");
+  }
+
   FutureOr<int?> size(VMContext context) => null;
 
   FutureOr<ASTValue> operator +(ASTValue other) =>
@@ -347,6 +355,40 @@ class ASTValueStatic<T> extends ASTValue<T> {
 
     throw ApolloVMNullPointerException(
       "Can't read key '$key': type: $type ; value: $value",
+    );
+  }
+
+  @override
+  void writeIndex<V>(VMContext context, int index, V value) {
+    final container = this.value;
+
+    if (container is List) {
+      container[index] = value;
+      return;
+    }
+
+    throw ApolloVMNullPointerException(
+      "Can't write index '$index': type: $type ; value: $container",
+    );
+  }
+
+  @override
+  void writeKey<V>(VMContext context, Object? key, V value) {
+    final container = this.value;
+
+    if (container is Map) {
+      container[key] = value;
+      return;
+    } else if (container is List) {
+      var idx = key is int ? key : int.tryParse('$key');
+      if (idx != null) {
+        container[idx] = value;
+        return;
+      }
+    }
+
+    throw ApolloVMNullPointerException(
+      "Can't write key '$key': type: $type ; value: $container",
     );
   }
 

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -602,6 +602,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
               expressionMapEmptyLiteral() |
               expressionMapLiteral() |
               expressionVariableDirectOperation() |
+              expressionVariableEntryAssignment() |
               expressionVariableAssigment() |
               expressionFunctionInvocation() |
               expressionObjectEntryFunctionInvocation() |
@@ -910,6 +911,18 @@ class DartGrammarDefinition extends DartGrammarLexer {
       (variable() & assigmentOperator() & ref0(expression)).map((v) {
         return ASTExpressionVariableAssignment(v[0], v[1], v[2]);
       });
+
+  Parser<ASTExpressionVariableEntryAssignment>
+  expressionVariableEntryAssignment() =>
+      (variable() &
+              char('[') &
+              ref0(expression) &
+              char(']').trimHidden() &
+              assigmentOperator() &
+              ref0(expression))
+          .map((v) {
+            return ASTExpressionVariableEntryAssignment(v[0], v[2], v[4], v[5]);
+          });
 
   Parser<ASTAssignmentOperator> assigmentOperator() =>
       (char('=') |

--- a/test/apollovm_dart_maps_test.dart
+++ b/test/apollovm_dart_maps_test.dart
@@ -267,4 +267,180 @@ void main() {
       );
     });
   });
+
+  group('Dart maps: subscript assignment m[k] = v', () {
+    test('add a new key', () async {
+      await _testReturn(
+        '''
+        int f() {
+          Map<int,int> m = {1: 10};
+          m[2] = 20;
+          return m[2];
+        }
+      ''',
+        'f',
+        [],
+        20,
+      );
+    });
+
+    test('update an existing key', () async {
+      await _testReturn(
+        '''
+        int f() {
+          Map<int,int> m = {1: 10};
+          m[1] = 99;
+          return m[1];
+        }
+      ''',
+        'f',
+        [],
+        99,
+      );
+    });
+
+    test('set with String key', () async {
+      await _testReturn(
+        '''
+        int f() {
+          Map<String,int> m = {"a": 1};
+          m["b"] = 2;
+          return m["b"];
+        }
+      ''',
+        'f',
+        [],
+        2,
+      );
+    });
+
+    test('set grows length', () async {
+      await _testReturn(
+        '''
+        int f() {
+          Map<int,int> m = {1: 10};
+          m[2] = 20;
+          m[3] = 30;
+          return m.length;
+        }
+      ''',
+        'f',
+        [],
+        3,
+      );
+    });
+
+    test('set with a variable key', () async {
+      await _testReturn(
+        '''
+        int f(int k) {
+          Map<int,int> m = {1: 10};
+          m[k] = 77;
+          return m[k];
+        }
+      ''',
+        'f',
+        [5],
+        77,
+      );
+    });
+
+    test('set a String value', () async {
+      await _testReturn(
+        '''
+        String f() {
+          Map<int,String> m = {1: "a"};
+          m[2] = "b";
+          return m[2];
+        }
+      ''',
+        'f',
+        [],
+        'b',
+      );
+    });
+
+    test('compound += on a key', () async {
+      await _testReturn(
+        '''
+        int f() {
+          Map<int,int> m = {1: 10};
+          m[1] += 5;
+          return m[1];
+        }
+      ''',
+        'f',
+        [],
+        15,
+      );
+    });
+
+    test('build a frequency map', () async {
+      await _testReturn(
+        '''
+        int f() {
+          Map<String,int> m = {};
+          m["x"] = 0;
+          m["x"] += 1;
+          m["x"] += 1;
+          m["x"] += 1;
+          return m["x"];
+        }
+      ''',
+        'f',
+        [],
+        3,
+      );
+    });
+  });
+
+  group('Dart lists: index assignment a[i] = v', () {
+    test('assign by index', () async {
+      await _testReturn(
+        '''
+        int f() {
+          List<int> a = [1, 2, 3];
+          a[1] = 99;
+          return a[1];
+        }
+      ''',
+        'f',
+        [],
+        99,
+      );
+    });
+
+    test('compound += by index', () async {
+      await _testReturn(
+        '''
+        int f() {
+          List<int> a = [1, 2, 3];
+          a[0] += 10;
+          return a[0];
+        }
+      ''',
+        'f',
+        [],
+        11,
+      );
+    });
+
+    test('reverse a list in place', () async {
+      await _testReturn(
+        '''
+        int f() {
+          List<int> a = [1, 2, 3, 4, 5];
+          a[0] = 5;
+          a[1] = 4;
+          a[3] = 2;
+          a[4] = 1;
+          return a[0] + a[4];
+        }
+      ''',
+        'f',
+        [],
+        6,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Second step of the maps work — adds **container-entry assignment** to the Dart frontend + interpreter. This also unlocks **list index assignment** (`a[i] = v`), which was missing for the same reason. The grammar's assignment left-hand side was only a bare `variable()`, so `m[k] = v` and `a[i] = v` failed with a `SyntaxError`.

- **Grammar** — parse `variable[key] op expr` as an assignment target, with all compound operators (`=`, `+=`, `-=`, `*=`, `/=`, `~/=`). Enables idioms like `m["x"] += 1` (frequency maps).
- **AST** — new `ASTExpressionVariableEntryAssignment`; new `ASTValue.writeKey` / `writeIndex` that mutate the underlying `Map`/`List` **in place**. A `Map` is always written by key (even a numeric one); a `List` by index. For compound ops the current entry is read, combined, and written back.
- **Code generators** — dispatch + emit `variable[key] op expr`, so programs round-trip (parse → regenerate → re-parse). The abstract base's default throws `UnsupportedError`; the Wasm implementation lands with the Wasm-maps slice.
- **Empty-collection inference fix** — an empty `{}` literal (typed `Map<dynamic,dynamic>`) is now assignable to a typed map like `Map<String,int>`. `ASTTypeMap.acceptsType` now treats a `dynamic` key/value component as a wildcard — matching how lists already ignore their element type for assignment, so `Map<String,int> m = {};` works just like `List<int> a = [];` (the asymmetry was that `ASTTypeArray` doesn't register `generics` while `ASTTypeMap` does, so maps were strictly checked).

## Tests

`test/apollovm_dart_maps_test.dart` extended (now 27 tests): map set/update/grow, String keys, variable keys, String values, compound `+=`, empty-map frequency counter, and list index assignment (set, compound, in-place reorder). Pass on `-p vm` and `-p chrome`. Full suite green (504), round-trip regeneration verified, `dart analyze --fatal-infos --fatal-warnings` clean, formatted.

## Next

**Wasm map codegen** — now that the frontend fully supports maps (literals, `m[k]` get/set, `.length`/`.keys`/`.values`/`.containsKey`, iteration, params), the Wasm backend can implement them as parity-tested slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)