### PR TITLE
Wasm maps (P3 part 7): .keys / .values + iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.1.27
 
+- Wasm collections — map `.keys` / `.values` + iteration (P3, part 7):
+  - `m.keys` and `m.values` now compile to Wasm: each materializes a fresh list by copying the map's parallel key (or value) buffer (which already has the list element layout), so `for (var k in m.keys)` / `for (var v in m.values)` work via the existing list for-each. Matches the interpreter on both `wasm_run` and Chrome.
+  - The for-each loop-variable type resolver now derives the element type from the map (`m.keys` → key type, `m.values` → value type) so the loop variable is correctly typed.
 - Wasm collections — maps with `String` keys (P3, part 6):
   - `Map<String, V>` now compiles to Wasm (`V` = `int`/`double`/`String`/`bool`): literals, `m[k]` get, `m[k] = v` set, `.length`/`.isEmpty`/`.isNotEmpty`, and `.containsKey(k)`. Matches the interpreter on both `wasm_run` and Chrome.
   - String keys are stored as i32 pointers and compared by content via a synthesized `__streq(a, b)` helper (length check + byte loop), so e.g. `containsKey("app")` correctly returns `false` for a map keyed by `"apple"`, and multi-byte UTF-8 keys work.

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -2776,6 +2776,82 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     out.write(Wasm32.i32Store(2, ptrOffset));
   }
 
+  /// `m.keys` / `m.values`: builds a fresh list (`[length][capacity][dataPtr]`)
+  /// by copying the map's key (or value) buffer, and pushes its handle typed as
+  /// `List<keyType>` / `List<valueType>`.
+  BytesOutput _generateMapKeysOrValues(
+    ASTExpressionObjectGetterAccess expression,
+    ({ASTType type, int index}) mapVar, {
+    required bool keys,
+    required BytesOutput out,
+    required WasmContext context,
+  }) {
+    var module = context.module!;
+    module.requiresMemory = true;
+    module.requiresHeapGlobal = true;
+
+    var mapType = _requireMapType(
+      mapVar.type,
+      expression.variable.name,
+      keys ? 'keys' : 'values',
+    );
+    var elemType = keys ? mapType.keyType : mapType.valueType;
+    var elemSize = _elemSize(elemType);
+    var srcOffset = keys ? 8 : 12; // keysPtr / valuesPtr in the map header
+
+    var mapHdr = context.scratchLocal(_astTypeString, 15);
+    var listHdr = context.scratchLocal(_astTypeString, 26);
+    var listData = context.scratchLocal(_astTypeString, 27);
+
+    final s0 = context.stackLength;
+
+    // mapHdr = map header
+    _localVariableGet(out, context, mapVar.index, expression.variable.name);
+    out.write(Wasm.localSet(mapHdr));
+
+    // listHdr = alloc(12) ; listData = alloc(length*elemSize)
+    out.write(Wasm32.i32Const(_listHeaderSize));
+    _emitInlineAlloc(out, context);
+    out.write(Wasm.localSet(listHdr));
+    out.write(Wasm.localGet(mapHdr));
+    out.write(Wasm32.i32Load(2, 0)); // length
+    out.write(Wasm32.i32Const(elemSize));
+    out.writeByte(Wasm32.i32Multiply);
+    _emitInlineAlloc(out, context);
+    out.write(Wasm.localSet(listData));
+
+    // memory.copy(listData, map[srcOffset], length*elemSize)
+    out.write(Wasm.localGet(listData));
+    out.write(Wasm.localGet(mapHdr));
+    out.write(Wasm32.i32Load(2, srcOffset));
+    out.write(Wasm.localGet(mapHdr));
+    out.write(Wasm32.i32Load(2, 0)); // length
+    out.write(Wasm32.i32Const(elemSize));
+    out.writeByte(Wasm32.i32Multiply);
+    out.write(Wasm.memoryCopy);
+
+    // listHdr: length=len@0, capacity=len@4, dataPtr=listData@8
+    out.write(Wasm.localGet(listHdr));
+    out.write(Wasm.localGet(mapHdr));
+    out.write(Wasm32.i32Load(2, 0));
+    out.write(Wasm32.i32Store(2, 0));
+    out.write(Wasm.localGet(listHdr));
+    out.write(Wasm.localGet(mapHdr));
+    out.write(Wasm32.i32Load(2, 0));
+    out.write(Wasm32.i32Store(2, 4));
+    out.write(Wasm.localGet(listHdr));
+    out.write(Wasm.localGet(listData));
+    out.write(Wasm32.i32Store(2, 8));
+
+    out.write(Wasm.localGet(listHdr));
+    context.stackPush(
+      ASTTypeArray(elemType),
+      "${expression.variable.name}.${keys ? 'keys' : 'values'}",
+    );
+    context.assertStackLength(s0 + 1, "After .${keys ? 'keys' : 'values'}");
+    return out;
+  }
+
   /// Lowers a getter access (`a.length`). Slice 1 supports `List.length`.
   BytesOutput _generateWasmGetterAccess(
     ASTExpressionObjectGetterAccess expression, {
@@ -2818,6 +2894,19 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         context.assertStackLength(s0 + 1, "After .$name");
         return out;
       }
+    }
+
+    // `m.keys` / `m.values`: materialize a fresh list (the map's key/value
+    // buffer already has the list element layout), enabling `for (var k in
+    // m.keys)` via the regular list for-each.
+    if (listType is ASTTypeMap && (name == 'keys' || name == 'values')) {
+      return _generateMapKeysOrValues(
+        expression,
+        localVar,
+        keys: name == 'keys',
+        out: out,
+        context: context,
+      );
     }
 
     if (listType is ASTTypeArray) {
@@ -4857,10 +4946,21 @@ extension _ASTStatementExtension on ASTStatement {
     } else if (self is ASTStatementForEach) {
       // The loop variable's type is the iterable's element type (the declared
       // type is usually `var`).
-      var iterType = self.iterableExpression.resolveType(null);
-      var elemType = iterType is ASTTypeArray
-          ? iterType.componentType
-          : self.variableType;
+      var iterExpr = self.iterableExpression;
+      var iterType = iterExpr.resolveType(null);
+      ASTType elemType;
+      if (iterType is ASTTypeArray) {
+        elemType = iterType.componentType;
+      } else if (iterExpr is ASTExpressionObjectGetterAccess &&
+          (iterExpr.name == 'keys' || iterExpr.name == 'values')) {
+        // `for (var k in m.keys)` / `m.values`: element type from the map.
+        var mapType = iterExpr.variable.resolveType(null);
+        elemType = mapType is ASTTypeMap
+            ? (iterExpr.name == 'keys' ? mapType.keyType : mapType.valueType)
+            : self.variableType;
+      } else {
+        elemType = self.variableType;
+      }
       return [
         MapEntry(self.variableName, elemType),
         ...self.loopBlock.declaredVariables(),

--- a/test/apollovm_wasm_maps_test.dart
+++ b/test/apollovm_wasm_maps_test.dart
@@ -457,4 +457,99 @@ void main() {
       );
     });
   });
+
+  group('Wasm maps: .keys / .values iteration', () {
+    test('sum keys (int keys)', () async {
+      await _testWasmReturn(
+        '''
+        int f() {
+          Map<int,int> m = {1: 10, 2: 20, 3: 30};
+          int s = 0;
+          for (var k in m.keys) {
+            s = s + k;
+          }
+          return s;
+        }
+      ''',
+        'f',
+        [],
+        6,
+      );
+    });
+
+    test('sum values (int keys)', () async {
+      await _testWasmReturn(
+        '''
+        int f() {
+          Map<int,int> m = {1: 10, 2: 20, 3: 30};
+          int s = 0;
+          for (var v in m.values) {
+            s = s + v;
+          }
+          return s;
+        }
+      ''',
+        'f',
+        [],
+        60,
+      );
+    });
+
+    test('values reflect prior sets (incl. grow)', () async {
+      await _testWasmReturn(
+        '''
+        int f() {
+          Map<int,int> m = {1: 10};
+          m[2] = 20;
+          m[3] = 30;
+          m[4] = 40;
+          int s = 0;
+          for (var v in m.values) {
+            s = s + v;
+          }
+          return s;
+        }
+      ''',
+        'f',
+        [],
+        100,
+      );
+    });
+
+    test('count keys (String keys)', () async {
+      await _testWasmReturn(
+        '''
+        int f() {
+          Map<String,int> m = {"a": 1, "bb": 2, "ccc": 3};
+          int c = 0;
+          for (var k in m.keys) {
+            c = c + 1;
+          }
+          return c;
+        }
+      ''',
+        'f',
+        [],
+        3,
+      );
+    });
+
+    test('sum values (String keys)', () async {
+      await _testWasmReturn(
+        '''
+        int f() {
+          Map<String,int> m = {"x": 5, "y": 7, "z": 9};
+          int s = 0;
+          for (var v in m.values) {
+            s = s + v;
+          }
+          return s;
+        }
+      ''',
+        'f',
+        [],
+        21,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Adds **`m.keys` / `m.values`** codegen and map iteration to Wasm. Since the map's parallel key/value buffers already use the list element layout, `.keys`/`.values` just **copy a buffer into a fresh list** (`[length][capacity][dataPtr]`), pushed typed as `List<keyType>` / `List<valueType>`. The existing list for-each then handles `for (var k in m.keys)` and `for (var v in m.values)` directly.

- `_generateMapKeysOrValues`: alloc list header + data buffer, `memory.copy` the map's key (or value) buffer, set the list fields.
- Extended the for-each loop-variable **type resolver**: when the iterable is `m.keys`/`m.values`, the loop variable's type is derived from the map (key type / value type) instead of resolving to `var` (which previously broke codegen).

## Tests

`test/apollovm_wasm_maps_test.dart` extended (now 30 tests): sum keys / sum values over int-keyed and String-keyed maps, count keys, and values reflecting prior `m[k] = v` sets including a realloc-grow. Pass on `-p vm` and `-p chrome`. Full suite green (534), `dart analyze --fatal-infos --fatal-warnings` clean, formatted.

## Out of scope (later slices)

Map parameters / returns (host-boundary marshalling), compound subscript assignment (`m[k] += v`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)