### PR TITLE
Wasm maps (P3 part 8): map parameters & returns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.1.27
 
+- Wasm collections — map parameters & returns (P3, part 8):
+  - Functions can now accept and return whole `Map`s across the host boundary. The runner marshals a Dart `Map` into the module's map layout (header + parallel key/value buffers, via the exported `__alloc`) for `Map` parameters, and decodes a returned map-header pointer back into a Dart `Map`. Covers `int`/`String` keys × `int`/`double`/`String`/`bool` values, including round-tripping and returning a map built with `m[k] = v`.
+  - The `apollovm_sig` custom section now encodes a map type as `[7, <key tag>, <value tag>]`, so raw-byte modules self-describe their key/value types. Element read/write was factored into shared helpers used by both list and map marshalling.
 - Wasm collections — map `.keys` / `.values` + iteration (P3, part 7):
   - `m.keys` and `m.values` now compile to Wasm: each materializes a fresh list by copying the map's parallel key (or value) buffer (which already has the list element layout), so `for (var k in m.keys)` / `for (var v in m.values)` work via the existing list for-each. Matches the interpreter on both `wasm_run` and Chrome.
   - The for-each loop-variable type resolver now derives the element type from the map (`m.keys` → key type, `m.values` → value type) so the loop variable is correctly typed.

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -122,7 +122,7 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   }
 
   /// Type tag used by the `apollovm_sig` custom section.
-  /// 0=void, 1=int, 2=double, 3=bool, 4=String, 5=other, 6=list.
+  /// 0=void, 1=int, 2=double, 3=bool, 4=String, 5=other, 6=list, 7=map.
   static int _typeTag(ASTType t) {
     if (t is ASTTypeVoid) return 0;
     if (t is ASTTypeInt) return 1;
@@ -130,42 +130,58 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     if (t is ASTTypeBool) return 3;
     if (t is ASTTypeString) return 4;
     if (t is ASTTypeArray) return 6;
+    if (t is ASTTypeMap) return 7;
     return 5;
   }
 
   /// Encodes a type as a descriptor for the `apollovm_sig` section. Scalars are
-  /// a single tag byte; a list is `[6, <element tag>]` so the runner can marshal
-  /// the whole collection across the host boundary.
+  /// a single tag byte; a list is `[6, <element tag>]` and a map is
+  /// `[7, <key tag>, <value tag>]` so the runner can marshal the whole
+  /// collection across the host boundary.
   static List<int> _typeDescriptor(ASTType t) {
     if (t is ASTTypeArray) {
       return [6, _typeTag(t.componentType)];
+    }
+    if (t is ASTTypeMap) {
+      return [7, _typeTag(t.keyType), _typeTag(t.valueType)];
     }
     return [_typeTag(t)];
   }
 
   /// Whether the module needs the `apollovm_sig` custom section: any public
   /// function with a return/param the runner must marshal from/to its raw Wasm
-  /// value — a String, a `bool` return, or a list (param or return).
+  /// value — a String, a `bool` return, or a list/map (param or return).
   bool _requiresSignatureSection(WasmModuleContext module) {
     bool needs(ASTType t) =>
-        t is ASTTypeString || t is ASTTypeBool || t is ASTTypeArray;
+        t is ASTTypeString ||
+        t is ASTTypeBool ||
+        t is ASTTypeArray ||
+        t is ASTTypeMap;
     for (var f in module.functions) {
       if (f.modifiers.isPrivate) continue;
       if (needs(f.returnType)) return true;
       for (var p in f.parameters.allParameters) {
-        if (p.type is ASTTypeString || p.type is ASTTypeArray) return true;
+        if (p.type is ASTTypeString ||
+            p.type is ASTTypeArray ||
+            p.type is ASTTypeMap) {
+          return true;
+        }
       }
     }
     return false;
   }
 
   /// Whether any public function has a parameter the host must allocate into
-  /// module memory (a String or a List), requiring an exported `__alloc`.
+  /// module memory (a String, List, or Map), requiring an exported `__alloc`.
   bool _hasMarshalledParam(WasmModuleContext module) {
     for (var f in module.functions) {
       if (f.modifiers.isPrivate) continue;
       for (var p in f.parameters.allParameters) {
-        if (p.type is ASTTypeString || p.type is ASTTypeArray) return true;
+        if (p.type is ASTTypeString ||
+            p.type is ASTTypeArray ||
+            p.type is ASTTypeMap) {
+          return true;
+        }
       }
     }
     return false;

--- a/lib/src/languages/wasm/wasm_runner.dart
+++ b/lib/src/languages/wasm/wasm_runner.dart
@@ -119,20 +119,7 @@ class ApolloRunnerWasm extends ApolloRunner {
       bd.setInt32(header + 8, dataPtr, Endian.little);
 
       for (var i = 0; i < n; ++i) {
-        var addr = dataPtr + i * elemSize;
-        var v = list[i];
-        switch (elemTag) {
-          case _tagInt:
-            _writeI64(bd, addr, v is BigInt ? v.toInt() : (v as num).toInt());
-          case _tagDouble:
-            bd.setFloat64(addr, (v as num).toDouble(), Endian.little);
-          case _tagBool:
-            bd.setInt32(addr, (v as bool) ? 1 : 0, Endian.little);
-          case _tagString:
-            bd.setInt32(addr, strPtrs![i], Endian.little);
-          default:
-            throw StateError("Unsupported Wasm list element tag: $elemTag");
-        }
+        _writeElem(bd, dataPtr + i * elemSize, elemTag, list[i], strPtrs?[i]);
       }
       return header;
     }
@@ -148,18 +135,80 @@ class ApolloRunnerWasm extends ApolloRunner {
       var out = [];
       for (var i = 0; i < n; ++i) {
         var addr = dataPtr + i * elemSize;
-        switch (elemTag) {
-          case _tagInt:
-            out.add(_readI64(bd, addr));
-          case _tagDouble:
-            out.add(bd.getFloat64(addr, Endian.little));
-          case _tagBool:
-            out.add(bd.getInt32(addr, Endian.little) != 0);
-          case _tagString:
-            out.add(decodeString(bd.getInt32(addr, Endian.little)));
-          default:
-            throw StateError("Unsupported Wasm list element tag: $elemTag");
-        }
+        out.add(_readElem(bd, addr, elemTag, decodeString));
+      }
+      return out;
+    }
+
+    // Encodes a Dart [map] into module memory as the generator's map layout
+    // `[len][cap][keysPtr][valuesPtr]` + parallel key/value buffers, returning
+    // the header pointer. Element encodings as for lists.
+    int encodeMap(Map map, int keyTag, int valTag) {
+      var m = loadedModule!;
+      var entries = map.entries.toList();
+      var n = entries.length;
+      var keySize = elemSizeOf(keyTag);
+      var valSize = elemSizeOf(valTag);
+
+      // Pre-allocate String keys/values first (each alloc grows the bump ptr).
+      List<int>? keyStrPtrs;
+      if (keyTag == _tagString) {
+        keyStrPtrs = [
+          for (var e in entries) allocAndWriteString(e.key as String),
+        ];
+      }
+      List<int>? valStrPtrs;
+      if (valTag == _tagString) {
+        valStrPtrs = [
+          for (var e in entries) allocAndWriteString(e.value as String),
+        ];
+      }
+
+      var keysPtr = m.invokeExport('__alloc', [n * keySize]) as int;
+      var valsPtr = m.invokeExport('__alloc', [n * valSize]) as int;
+      var header = m.invokeExport('__alloc', [16]) as int;
+
+      var mem = m.readMemory()!;
+      var bd = ByteData.sublistView(mem);
+      bd.setInt32(header + 0, n, Endian.little);
+      bd.setInt32(header + 4, n, Endian.little);
+      bd.setInt32(header + 8, keysPtr, Endian.little);
+      bd.setInt32(header + 12, valsPtr, Endian.little);
+
+      for (var i = 0; i < n; ++i) {
+        _writeElem(
+          bd,
+          keysPtr + i * keySize,
+          keyTag,
+          entries[i].key,
+          keyStrPtrs?[i],
+        );
+        _writeElem(
+          bd,
+          valsPtr + i * valSize,
+          valTag,
+          entries[i].value,
+          valStrPtrs?[i],
+        );
+      }
+      return header;
+    }
+
+    // Decodes a module-memory map ([header] pointer) into a Dart `Map`.
+    Map decodeMap(int header, int keyTag, int valTag) {
+      var mem = loadedModule!.readMemory()!;
+      var bd = ByteData.sublistView(mem);
+      var n = bd.getInt32(header + 0, Endian.little);
+      var keysPtr = bd.getInt32(header + 8, Endian.little);
+      var valsPtr = bd.getInt32(header + 12, Endian.little);
+      var keySize = elemSizeOf(keyTag);
+      var valSize = elemSizeOf(valTag);
+
+      var out = {};
+      for (var i = 0; i < n; ++i) {
+        var key = _readElem(bd, keysPtr + i * keySize, keyTag, decodeString);
+        var val = _readElem(bd, valsPtr + i * valSize, valTag, decodeString);
+        out[key] = val;
       }
       return out;
     }
@@ -218,6 +267,8 @@ class ApolloRunnerWasm extends ApolloRunner {
           allParams[i] = allocAndWriteString(arg);
         } else if (pt.isList && arg is List) {
           allParams[i] = encodeList(arg, pt.elemTag);
+        } else if (pt.isMap && arg is Map) {
+          allParams[i] = encodeMap(arg, pt.elemTag, pt.valTag);
         }
       }
     }
@@ -290,6 +341,17 @@ class ApolloRunnerWasm extends ApolloRunner {
       var listReturn = astFunction?.returnType is ASTTypeArray
           ? _elemTagOf((astFunction!.returnType as ASTTypeArray).componentType)
           : (sigReturn != null && sigReturn.isList ? sigReturn.elemTag : null);
+      // `Map` return: an i32 pointer to a map header.
+      ({int keyTag, int valTag})? mapReturn;
+      if (astFunction?.returnType is ASTTypeMap) {
+        var mt = astFunction!.returnType as ASTTypeMap;
+        mapReturn = (
+          keyTag: _elemTagOf(mt.keyType),
+          valTag: _elemTagOf(mt.valueType),
+        );
+      } else if (sigReturn != null && sigReturn.isMap) {
+        mapReturn = (keyTag: sigReturn.elemTag, valTag: sigReturn.valTag);
+      }
 
       if (returnsString) {
         res = decodeString(res as int);
@@ -297,6 +359,8 @@ class ApolloRunnerWasm extends ApolloRunner {
         res = (res as num) != 0;
       } else if (listReturn != null) {
         res = decodeList(res as int, listReturn);
+      } else if (mapReturn != null) {
+        res = decodeMap(res as int, mapReturn.keyTag, mapReturn.valTag);
       }
     }
 
@@ -327,6 +391,54 @@ class ApolloRunnerWasm extends ApolloRunner {
     return b.toSigned(64).toInt();
   }
 
+  /// Writes a collection element of [tag] at [addr]. `String` elements use the
+  /// pre-allocated [strPtr]; numerics/bools are written inline.
+  static void _writeElem(
+    ByteData bd,
+    int addr,
+    int tag,
+    Object? value,
+    int? strPtr,
+  ) {
+    switch (tag) {
+      case _tagInt:
+        _writeI64(
+          bd,
+          addr,
+          value is BigInt ? value.toInt() : (value as num).toInt(),
+        );
+      case _tagDouble:
+        bd.setFloat64(addr, (value as num).toDouble(), Endian.little);
+      case _tagBool:
+        bd.setInt32(addr, (value as bool) ? 1 : 0, Endian.little);
+      case _tagString:
+        bd.setInt32(addr, strPtr!, Endian.little);
+      default:
+        throw StateError("Unsupported Wasm element tag: $tag");
+    }
+  }
+
+  /// Reads a collection element of [tag] at [addr].
+  static Object? _readElem(
+    ByteData bd,
+    int addr,
+    int tag,
+    String Function(int) decodeString,
+  ) {
+    switch (tag) {
+      case _tagInt:
+        return _readI64(bd, addr);
+      case _tagDouble:
+        return bd.getFloat64(addr, Endian.little);
+      case _tagBool:
+        return bd.getInt32(addr, Endian.little) != 0;
+      case _tagString:
+        return decodeString(bd.getInt32(addr, Endian.little));
+      default:
+        throw StateError("Unsupported Wasm element tag: $tag");
+    }
+  }
+
   /// Element tag for an AST list-component type (mirrors the generator's
   /// `_typeTag`). Returns `-1` for unsupported element types.
   static int _elemTagOf(ASTType t) {
@@ -343,6 +455,7 @@ class ApolloRunnerWasm extends ApolloRunner {
   static const int _tagBool = 3;
   static const int _tagString = 4;
   static const int _tagList = 6;
+  static const int _tagMap = 7;
 
   /// Per-module signature cache, keyed by the wasm binary's identity.
   final Map<Uint8List, Map<String, _WasmSig>> _signaturesCache = {};
@@ -381,6 +494,11 @@ class ApolloRunnerWasm extends ApolloRunner {
       var tag = b[pos++];
       if (tag == _tagList) {
         return _WasmType(tag, b[pos++]);
+      }
+      if (tag == _tagMap) {
+        var keyTag = b[pos++];
+        var valTag = b[pos++];
+        return _WasmType(tag, keyTag, valTag);
       }
       return _WasmType(tag, -1);
     }
@@ -471,13 +589,17 @@ class ApolloRunnerWasm extends ApolloRunner {
 }
 
 /// A high-level type from the `apollovm_sig` custom section: a [tag] plus, for a
-/// list ([ApolloRunnerWasm._tagList]), the element tag in [elemTag] (else `-1`).
+/// list ([ApolloRunnerWasm._tagList]), the element tag in [elemTag]; for a map
+/// ([ApolloRunnerWasm._tagMap]), [elemTag] is the key tag and [valTag] the value
+/// tag. Unused sub-tags are `-1`.
 class _WasmType {
   final int tag;
   final int elemTag;
-  const _WasmType(this.tag, this.elemTag);
+  final int valTag;
+  const _WasmType(this.tag, this.elemTag, [this.valTag = -1]);
 
   bool get isList => tag == ApolloRunnerWasm._tagList;
+  bool get isMap => tag == ApolloRunnerWasm._tagMap;
 }
 
 /// A parsed public-function signature (return type + parameter types).

--- a/test/apollovm_wasm_maps_test.dart
+++ b/test/apollovm_wasm_maps_test.dart
@@ -552,4 +552,141 @@ void main() {
       );
     });
   });
+
+  group('Wasm maps: parameters', () {
+    test('int-keyed map parameter, index read', () async {
+      await _testWasmReturn(
+        '''
+        int f(Map<int,int> m) {
+          return m[2];
+        }
+      ''',
+        'f',
+        [
+          {1: 10, 2: 20, 3: 30},
+        ],
+        20,
+      );
+    });
+
+    test('String-keyed map parameter, index read', () async {
+      await _testWasmReturn(
+        '''
+        int f(Map<String,int> m) {
+          return m["b"];
+        }
+      ''',
+        'f',
+        [
+          {'a': 1, 'b': 2},
+        ],
+        2,
+      );
+    });
+
+    test('map parameter, sum values via for-each', () async {
+      await _testWasmReturn(
+        '''
+        int f(Map<int,int> m) {
+          int s = 0;
+          for (var v in m.values) {
+            s = s + v;
+          }
+          return s;
+        }
+      ''',
+        'f',
+        [
+          {1: 5, 2: 7, 3: 9},
+        ],
+        21,
+      );
+    });
+  });
+
+  group('Wasm maps: returns', () {
+    test('return int->int map literal', () async {
+      await _testWasmReturn(
+        '''
+        Map<int,int> f() {
+          return {1: 10, 2: 20, 3: 30};
+        }
+      ''',
+        'f',
+        [],
+        {1: 10, 2: 20, 3: 30},
+      );
+    });
+
+    test('return String->int map literal', () async {
+      await _testWasmReturn(
+        '''
+        Map<String,int> f() {
+          return {"a": 1, "b": 2};
+        }
+      ''',
+        'f',
+        [],
+        {'a': 1, 'b': 2},
+      );
+    });
+
+    test('return int->double map', () async {
+      await _testWasmReturn(
+        '''
+        Map<int,double> f() {
+          return {1: 1.5, 2: 2.5};
+        }
+      ''',
+        'f',
+        [],
+        {1: 1.5, 2: 2.5},
+      );
+    });
+
+    test('return String->String map', () async {
+      await _testWasmReturn(
+        '''
+        Map<String,String> f() {
+          return {"hi": "world", "yo": "there"};
+        }
+      ''',
+        'f',
+        [],
+        {'hi': 'world', 'yo': 'there'},
+      );
+    });
+
+    test('build with sets then return', () async {
+      await _testWasmReturn(
+        '''
+        Map<int,int> f() {
+          Map<int,int> m = {};
+          m[1] = 11;
+          m[2] = 22;
+          m[3] = 33;
+          return m;
+        }
+      ''',
+        'f',
+        [],
+        {1: 11, 2: 22, 3: 33},
+      );
+    });
+
+    test('round-trip a map (param in, map out)', () async {
+      await _testWasmReturn(
+        '''
+        Map<int,int> f(Map<int,int> m) {
+          return m;
+        }
+      ''',
+        'f',
+        [
+          {7: 70, 8: 80},
+        ],
+        {7: 70, 8: 80},
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Functions can now **accept and return whole `Map`s** across the host↔Wasm boundary, mirroring the list params/returns slice (#40). Mostly runner-side marshalling plus enriching the self-describing signature section.

- **Map parameters** — the runner encodes a Dart `Map` into the module's map layout (16-byte header `[length][capacity][keysPtr][valuesPtr]` + parallel key/value buffers, allocated via the exported `__alloc`) and passes the header pointer.
- **Map returns** — a returned map-header pointer is decoded back into a Dart `Map`.
- **`apollovm_sig` enrichment** — a map type is now encoded as `[7, <key tag>, <value tag>]`, so raw-byte modules self-describe their key/value types. `_WasmType` carries a value tag; the parser reads it.
- **Refactor** — per-element read/write factored into shared `_writeElem`/`_readElem` helpers used by both list and map marshalling.

Covers `int`/`String` keys × `int`/`double`/`String`/`bool` values, including round-trips and returning a map built with `m[k] = v`.

## Tests

`test/apollovm_wasm_maps_test.dart` extended (now 39 tests): int/String-keyed map parameters (index read, sum-values via for-each), and returns for int→int / String→int / int→double / String→String, build-with-sets-then-return, and a map round-trip (param in → map out). Pass on `-p vm` and `-p chrome`. Full suite green (543), `dart analyze --fatal-infos --fatal-warnings` clean, formatted.

## Out of scope (last map slice)

Compound subscript assignment (`m[k] += v`) — note `m[k] = m[k] + 1` already works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)