### PR TITLE
Wasm maps (P3 part 9): compound subscript assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.1.27
 
+- Wasm collections — compound subscript assignment (P3, part 9):
+  - `m[k] += v` (and `-=`, `*=`, `/=`, `~/=`) and the same for list indices `a[i] += v` now compile to Wasm. Lowered by desugaring `c[k] OP= v` into `c[k] = c[k] OP v`, so it reuses the existing get/set codegen and works for maps (`int`/`String` keys) and lists across `int`/`double` values. Matches the interpreter on both `wasm_run` and Chrome (e.g. a frequency counter can now use `m[w] += 1` directly).
 - Wasm collections — map parameters & returns (P3, part 8):
   - Functions can now accept and return whole `Map`s across the host boundary. The runner marshals a Dart `Map` into the module's map layout (header + parallel key/value buffers, via the exported `__alloc`) for `Map` parameters, and decodes a returned map-header pointer back into a Dart `Map`. Covers `int`/`String` keys × `int`/`double`/`String`/`bool` values, including round-tripping and returning a map built with `m[k] = v`.
   - The `apollovm_sig` custom section now encodes a map type as `[7, <key tag>, <value tag>]`, so raw-byte modules self-describe their key/value types. Element read/write was factored into shared helpers used by both list and map marshalling.

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -2556,10 +2556,29 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     out ??= newOutput();
     context ??= WasmContext();
 
+    // Desugar a compound assignment `c[k] OP= v` into `c[k] = (c[k] OP v)`.
     if (expression.operator != ASTAssignmentOperator.set) {
-      throw UnimplementedError(
-        "Wasm compound entry assignment (`${expression.operator}`) is not "
-        "supported yet.",
+      var binOp = _compoundToOperator(expression.operator);
+      var access = ASTExpressionVariableEntryAccess(
+        expression.variable,
+        expression.keyExpression,
+      );
+      var operation = ASTExpressionOperation(
+        access,
+        binOp,
+        expression.expression,
+      );
+      var desugared = ASTExpressionVariableEntryAssignment(
+        expression.variable,
+        expression.keyExpression,
+        ASTAssignmentOperator.set,
+        operation,
+      );
+      desugared.resolveNode(expression.parentNode);
+      return _generateWasmEntryAssignment(
+        desugared,
+        out: out,
+        context: context,
       );
     }
 
@@ -2582,6 +2601,24 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     throw UnimplementedError(
       "Wasm entry assignment on `$name` ($containerType) is not supported yet.",
     );
+  }
+
+  /// Maps a compound-assignment operator (`+=`, …) to its binary operator.
+  ASTExpressionOperator _compoundToOperator(ASTAssignmentOperator op) {
+    switch (op) {
+      case ASTAssignmentOperator.sum:
+        return ASTExpressionOperator.add;
+      case ASTAssignmentOperator.subtract:
+        return ASTExpressionOperator.subtract;
+      case ASTAssignmentOperator.multiply:
+        return ASTExpressionOperator.multiply;
+      case ASTAssignmentOperator.divide:
+        return ASTExpressionOperator.divide;
+      case ASTAssignmentOperator.divideAsInt:
+        return ASTExpressionOperator.divideAsInt;
+      case ASTAssignmentOperator.set:
+        throw ArgumentError("`set` is not a compound operator");
+    }
   }
 
   /// `a[i] = v`: store `v` at `dataPtr + i*size`.

--- a/test/apollovm_wasm_maps_test.dart
+++ b/test/apollovm_wasm_maps_test.dart
@@ -689,4 +689,119 @@ void main() {
       );
     });
   });
+
+  group('Wasm maps/lists: compound subscript assignment', () {
+    test('map m[k] += v', () async {
+      await _testWasmReturn(
+        '''
+        int f() {
+          Map<int,int> m = {1: 10};
+          m[1] += 5;
+          return m[1];
+        }
+      ''',
+        'f',
+        [],
+        15,
+      );
+    });
+
+    test('map m[k] -= / *=', () async {
+      await _testWasmReturn(
+        '''
+        int f() {
+          Map<int,int> m = {1: 10};
+          m[1] -= 3;
+          m[1] *= 4;
+          return m[1];
+        }
+      ''',
+        'f',
+        [],
+        28,
+      );
+    });
+
+    test('String-keyed map m[k] += v', () async {
+      await _testWasmReturn(
+        '''
+        int f() {
+          Map<String,int> m = {"a": 1};
+          m["a"] += 9;
+          return m["a"];
+        }
+      ''',
+        'f',
+        [],
+        10,
+      );
+    });
+
+    test('double-valued map m[k] += v', () async {
+      await _testWasmReturn(
+        '''
+        double f() {
+          Map<int,double> m = {1: 1.5};
+          m[1] += 2.0;
+          return m[1];
+        }
+      ''',
+        'f',
+        [],
+        3.5,
+      );
+    });
+
+    test('list a[i] += v', () async {
+      await _testWasmReturn(
+        '''
+        int f() {
+          List<int> a = [1, 2, 3];
+          a[0] += 10;
+          return a[0];
+        }
+      ''',
+        'f',
+        [],
+        11,
+      );
+    });
+
+    test('list a[i] *= with variable rhs', () async {
+      await _testWasmReturn(
+        '''
+        int f(int d) {
+          List<int> a = [2, 3];
+          a[1] *= d;
+          return a[1];
+        }
+      ''',
+        'f',
+        [4],
+        12,
+      );
+    });
+
+    test('frequency counter using += ', () async {
+      await _testWasmReturn(
+        '''
+        int f() {
+          List<String> words = ["a", "b", "a", "a", "b"];
+          Map<String,int> m = {};
+          for (var w in words) {
+            if (m.containsKey(w)) {
+              m[w] += 1;
+            } else {
+              m[w] = 1;
+            }
+          }
+          return m["a"];
+        }
+      ''',
+        'f',
+        [],
+        3,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Final map slice: **compound subscript assignment** — `m[k] += v` (and `-=`, `*=`, `/=`, `~/=`), plus the same for list indices `a[i] += v`. These now compile to Wasm.

Lowered by **desugaring** `c[k] OP= v` into `c[k] = c[k] OP v`, so it reuses the existing entry-get and entry-set codegen (no new addressing logic). Works for maps (`int`/`String` keys) and lists across `int`/`double` values.

## Tests

`test/apollovm_wasm_maps_test.dart` extended (now 46 tests): map `+=`/`-=`/`*=`, String-keyed map `+=`, double-valued map `+=`, list `+=`, list `*=` with a variable RHS, and a **frequency counter** that now uses `m[w] += 1` directly (previously needed `m[w] = m[w] + 1`). Pass on `-p vm` and `-p chrome`. Full suite green (550), round-trip regeneration intact, `dart analyze --fatal-infos --fatal-warnings` clean, formatted.

## Map status

With this, the Wasm map surface is complete for the supported types: literals, `m[k]` get/set, compound `m[k] op= v`, `.length`/`.isEmpty`/`.isNotEmpty`, `.containsKey`, `.keys`/`.values`/iteration, and map parameters/returns — for `int`/`String` keys × `int`/`double`/`String`/`bool` values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)