### PR TITLE
Add async/await support (Dart run/translate, JS translate)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,18 @@
     host awaits a real Dart `Future`, then re-invokes the export which rewinds
     and resumes. Demonstrates multi-frame state preservation, exactly-once
     prologue execution, and two concurrent computations interleaving by host
-    delay. Generator integration (general bodies, multiple await points,
-    `br_table` resume dispatch, a real Asyncify stack) is the follow-up.
+    delay.
+  - Wasm **Asyncify code generation (v1)**: the generator now emits the
+    unwind/rewind state machine for an `async` function with a single
+    statement-level `await` of an external (host) call — a fixed low-memory
+    Asyncify control region (`WasmModuleContext`), a rewind-dispatch prologue
+    (`br_if`), live-local spill/restore, and a suspend epilogue. Validated
+    against the live runtime in `test/apollovm_wasm_asyncify_codegen_test.dart`
+    (real suspension, pre/post-await local preservation, concurrent
+    interleaving). Anything more complex (multiple awaits, awaits in control
+    flow, awaiting a module function => multi-frame) falls back to the
+    synchronous-collapse path. Driving it through `ApolloRunnerWasm` and a
+    `br_table` multi-await/multi-frame transform are the follow-ups.
   - Kotlin async/await translation is deferred and fails loudly via
     `UnsupportedSyntaxError` (the eventual mapping is `suspend fun` + coroutines).
   - Tests: `test/apollovm_async_test.dart` (parse, real-suspension ordering,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## 0.1.30
+
+- `async`/`await` support (real asynchrony) — Dart parse/run/translate and
+  JavaScript translation:
+  - AST: new `ASTModifiers.isAsync`, new `ASTExpressionAwait` expression, and a
+    new abstract `generateASTExpressionAwait` generator hook. Reuses the
+    existing `ASTTypeFuture`/`ASTValueFuture` (added `ASTTypeFuture.futureValueType`).
+  - Runtime: an `async` function returns a first-class future *immediately*
+    (a non-awaited call yields an `ASTValueFuture` that can be stored and
+    awaited later); `await` suspends on real Dart `Future`s, including those
+    returned by external functions declared with a `Future<...>` return type.
+    `ASTEntryPointBlock.execute` awaits the entry future before tearing down the
+    entry-point context (external mapper, current context).
+  - Dart grammar: parses the `async` body keyword (after the parameter list) and
+    the `await` prefix expression; `Future<T>` types parse to `ASTTypeFuture`;
+    the `await`/`async` contextual keywords no longer shadow identifiers
+    (e.g. `awaiter`) or get read as a type name.
+  - Code generation: Dart emits `... ) async {` and `await `; JavaScript emits
+    `async function` / `async name(` and `await `.
+  - Kotlin and Wasm async/await translation is deferred and fails loudly via
+    `UnsupportedSyntaxError` (Wasm has a `TODO(async)` documenting the intended
+    state-machine/host-yield lowering).
+  - Tests in `test/apollovm_async_test.dart` cover parse, real-suspension
+    ordering, await chains, top-level async, the identifier guard, and
+    Dart/JS/Kotlin translation.
+
 ## 0.1.29
 
 - Lua language support (parse, run, and translate):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,8 +38,14 @@
     (real suspension, pre/post-await local preservation, concurrent
     interleaving). Anything more complex (multiple awaits, awaits in control
     flow, awaiting a module function => multi-frame) falls back to the
-    synchronous-collapse path. Driving it through `ApolloRunnerWasm` and a
-    `br_table` multi-await/multi-frame transform are the follow-ups.
+    synchronous-collapse path.
+  - Wasm Asyncify **runner integration**: `ApolloRunnerWasm.executeFunction`
+    now detects real-suspension `async` functions (flagged in `apollovm_sig`)
+    and drives their unwind/rewind loop, awaiting a real Dart `Future` from a
+    host function registered via the new `ApolloRunnerWasm.mapWasmAsyncFunction`
+    API. So real-suspension async/await works end-to-end through the VM
+    (`test/apollovm_wasm_asyncify_runner_test.dart`). A `br_table`
+    multi-await/multi-frame transform is the remaining follow-up.
   - Kotlin async/await translation is deferred and fails loudly via
     `UnsupportedSyntaxError` (the eventual mapping is `suspend fun` + coroutines).
   - Tests: `test/apollovm_async_test.dart` (parse, real-suspension ordering,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,15 +31,18 @@
     delay.
   - Wasm **Asyncify code generation**: the generator emits the unwind/rewind
     state machine for an `async` function whose `await`s are statement-level
-    calls to external (host) functions — a fixed low-memory Asyncify control
-    region (`WasmModuleContext`), live-local spill/restore, a suspend epilogue,
-    and **`br_table` resume dispatch supporting multiple `await` points** in one
-    function (statements may interleave; locals survive every suspension).
-    Validated against the live runtime in
-    `test/apollovm_wasm_asyncify_codegen_test.dart` (real suspension, multi-
-    await, pre/post-await local preservation, concurrent interleaving). More
-    complex shapes (awaits nested in control flow, awaiting a module function =>
-    multi-frame) fall back to the synchronous-collapse path.
+    calls — a low-memory Asyncify control region (`WasmModuleContext`) with a
+    LIFO **frame stack**, live-local spill/restore, `br_table` resume dispatch
+    supporting **multiple `await` points** in one function, and **multi-frame
+    unwinding**: an `async` function may `await` another module `async` function
+    (an *internal* frame) as well as a host import (a *leaf*). The unwind
+    propagates up every frame on the call stack to the host and rewinds back
+    down (an eligibility fixed-point decides which async functions transform;
+    the rest use synchronous-collapse). Validated against the live runtime in
+    `test/apollovm_wasm_asyncify_codegen_test.dart` and the multi-frame /
+    mixed-await cases in `test/apollovm_wasm_asyncify_runner_test.dart`. Shapes
+    that still fall back to synchronous-collapse: awaits nested in control flow,
+    multiple awaits in one statement, and async recursion.
   - Wasm Asyncify **runner integration**: `ApolloRunnerWasm.executeFunction`
     now detects real-suspension `async` functions (flagged in `apollovm_sig`)
     and drives their unwind/rewind loop, awaiting a real Dart `Future` from a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,16 @@
   - Wasm: async/await compiles via **synchronous collapse** — the backend runs
     synchronously, so `Future<T>` collapses to `T` (`effectiveReturnType`) and
     `await` is a value pass-through. Compute-style async Dart compiles to Wasm
-    and matches the AST interpreter. Real suspension (Asyncify/JSPI) remains a
-    `TODO(async)`.
+    and matches the AST interpreter.
+  - Wasm real-suspension **Asyncify prototype**
+    (`test/apollovm_wasm_asyncify_prototype_test.dart`): a hand-assembled
+    two-frame module proves real suspension against the live `WasmRuntime` — a
+    running call unwinds to the host (saving live locals to linear memory), the
+    host awaits a real Dart `Future`, then re-invokes the export which rewinds
+    and resumes. Demonstrates multi-frame state preservation, exactly-once
+    prologue execution, and two concurrent computations interleaving by host
+    delay. Generator integration (general bodies, multiple await points,
+    `br_table` resume dispatch, a real Asyncify stack) is the follow-up.
   - Kotlin async/await translation is deferred and fails loudly via
     `UnsupportedSyntaxError` (the eventual mapping is `suspend fun` + coroutines).
   - Tests: `test/apollovm_async_test.dart` (parse, real-suspension ordering,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,16 +29,17 @@
     and resumes. Demonstrates multi-frame state preservation, exactly-once
     prologue execution, and two concurrent computations interleaving by host
     delay.
-  - Wasm **Asyncify code generation (v1)**: the generator now emits the
-    unwind/rewind state machine for an `async` function with a single
-    statement-level `await` of an external (host) call — a fixed low-memory
-    Asyncify control region (`WasmModuleContext`), a rewind-dispatch prologue
-    (`br_if`), live-local spill/restore, and a suspend epilogue. Validated
-    against the live runtime in `test/apollovm_wasm_asyncify_codegen_test.dart`
-    (real suspension, pre/post-await local preservation, concurrent
-    interleaving). Anything more complex (multiple awaits, awaits in control
-    flow, awaiting a module function => multi-frame) falls back to the
-    synchronous-collapse path.
+  - Wasm **Asyncify code generation**: the generator emits the unwind/rewind
+    state machine for an `async` function whose `await`s are statement-level
+    calls to external (host) functions — a fixed low-memory Asyncify control
+    region (`WasmModuleContext`), live-local spill/restore, a suspend epilogue,
+    and **`br_table` resume dispatch supporting multiple `await` points** in one
+    function (statements may interleave; locals survive every suspension).
+    Validated against the live runtime in
+    `test/apollovm_wasm_asyncify_codegen_test.dart` (real suspension, multi-
+    await, pre/post-await local preservation, concurrent interleaving). More
+    complex shapes (awaits nested in control flow, awaiting a module function =>
+    multi-frame) fall back to the synchronous-collapse path.
   - Wasm Asyncify **runner integration**: `ApolloRunnerWasm.executeFunction`
     now detects real-suspension `async` functions (flagged in `apollovm_sig`)
     and drives their unwind/rewind loop, awaiting a real Dart `Future` from a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,12 +17,16 @@
     (e.g. `awaiter`) or get read as a type name.
   - Code generation: Dart emits `... ) async {` and `await `; JavaScript emits
     `async function` / `async name(` and `await `.
-  - Kotlin and Wasm async/await translation is deferred and fails loudly via
-    `UnsupportedSyntaxError` (Wasm has a `TODO(async)` documenting the intended
-    state-machine/host-yield lowering).
-  - Tests in `test/apollovm_async_test.dart` cover parse, real-suspension
-    ordering, await chains, top-level async, the identifier guard, and
-    Dart/JS/Kotlin translation.
+  - Wasm: async/await compiles via **synchronous collapse** — the backend runs
+    synchronously, so `Future<T>` collapses to `T` (`effectiveReturnType`) and
+    `await` is a value pass-through. Compute-style async Dart compiles to Wasm
+    and matches the AST interpreter. Real suspension (Asyncify/JSPI) remains a
+    `TODO(async)`.
+  - Kotlin async/await translation is deferred and fails loudly via
+    `UnsupportedSyntaxError` (the eventual mapping is `suspend fun` + coroutines).
+  - Tests: `test/apollovm_async_test.dart` (parse, real-suspension ordering,
+    await chains, top-level async, identifier guard, Dart/JS/Kotlin translation)
+    and `test/apollovm_wasm_async_test.dart` (AST-vs-compiled-Wasm parity).
 
 ## 0.1.29
 

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -44,7 +44,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.29';
+  static final String VERSION = '0.1.30';
 
   static int _idCount = 0;
 

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -1090,6 +1090,13 @@ abstract class ApolloCodeGenerator
         indent: indent,
         headIndented: headIndented,
       );
+    } else if (expression is ASTExpressionAwait) {
+      return generateASTExpressionAwait(
+        expression,
+        out: out,
+        indent: indent,
+        headIndented: headIndented,
+      );
     } else if (expression is ASTExpressionLocalFunctionInvocation) {
       return generateASTExpressionLocalFunctionInvocation(
         expression,
@@ -1358,6 +1365,34 @@ abstract class ApolloCodeGenerator
       indent: indent,
       headIndented: false,
     );
+
+    return out;
+  }
+
+  /// Generates an `await` expression. Shared by languages that use the
+  /// `await` keyword (Dart, JavaScript). Languages without it (e.g. Kotlin,
+  /// Wasm) should override this to fail loudly.
+  @override
+  StringBuffer generateASTExpressionAwait(
+    ASTExpressionAwait expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write('await ');
+
+    // Parenthesize a complex operand so `await a + b` is not emitted (which
+    // would re-parse as `(await a) + b`).
+    final inner = expression.expression;
+    final group = inner.isComplex;
+
+    if (group) out.write('(');
+    generateASTExpression(inner, out: out, indent: indent, headIndented: false);
+    if (group) out.write(')');
 
     return out;
   }

--- a/lib/src/apollovm_generator.dart
+++ b/lib/src/apollovm_generator.dart
@@ -264,6 +264,8 @@ abstract class ApolloGenerator<
       return generateASTExpressionNegation(expression, out: out);
     } else if (expression is ASTExpressionNegative) {
       return generateASTExpressionNegative(expression, out: out);
+    } else if (expression is ASTExpressionAwait) {
+      return generateASTExpressionAwait(expression, out: out);
     } else if (expression is ASTExpressionLocalFunctionInvocation) {
       return generateASTExpressionLocalFunctionInvocation(expression, out: out);
     } else if (expression is ASTExpressionObjectFunctionInvocation) {
@@ -300,6 +302,8 @@ abstract class ApolloGenerator<
   O generateASTExpressionNegation(ASTExpressionNegation expression, {O? out});
 
   O generateASTExpressionNegative(ASTExpressionNegative expression, {O? out});
+
+  O generateASTExpressionAwait(ASTExpressionAwait expression, {O? out});
 
   O generateASTExpressionGroupFunctionInvocation(
     ASTExpressionGroupFunctionInvocation expression, {

--- a/lib/src/ast/apollovm_ast_base.dart
+++ b/lib/src/ast/apollovm_ast_base.dart
@@ -138,6 +138,7 @@ class ASTModifiers {
     isStatic: true,
     isFinal: true,
   );
+  static final ASTModifiers modifierAsync = ASTModifiers(isAsync: true);
 
   final bool isStatic;
 
@@ -147,11 +148,15 @@ class ASTModifiers {
 
   final bool isPublic;
 
+  /// If `true` this is an asynchronous element (`async` function).
+  final bool isAsync;
+
   ASTModifiers({
     this.isStatic = false,
     this.isFinal = false,
     this.isPrivate = false,
     this.isPublic = false,
+    this.isAsync = false,
   }) {
     if (isPrivate && isPublic) {
       throw StateError("Can't be private and public at the same time!");
@@ -163,12 +168,14 @@ class ASTModifiers {
     bool? isFinal,
     bool? isPrivate,
     bool? isPublic,
+    bool? isAsync,
   }) {
     return ASTModifiers(
       isStatic: isStatic ?? this.isStatic,
       isFinal: isFinal ?? this.isFinal,
       isPrivate: isPrivate ?? this.isPrivate,
       isPublic: isPublic ?? this.isPublic,
+      isAsync: isAsync ?? this.isAsync,
     );
   }
 
@@ -177,6 +184,7 @@ class ASTModifiers {
     if (isPrivate) 'private',
     if (isStatic) 'static',
     if (isFinal) 'final',
+    if (isAsync) 'async',
   ];
 
   @override

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -817,6 +817,59 @@ class ASTExpressionNegative extends ASTExpression {
   }
 }
 
+/// [ASTExpression] that awaits another [expression] (`await x`).
+///
+/// At runtime it resolves [expression] and, if the resolved value is a
+/// [ASTValueFuture] or backed by a native Dart [Future], suspends until it
+/// completes and yields the underlying value. Awaiting a non-future value is
+/// the identity (returns the value as-is), matching Dart semantics.
+class ASTExpressionAwait extends ASTExpression {
+  ASTExpression expression;
+
+  ASTExpressionAwait(this.expression);
+
+  @override
+  bool get isComplex => true;
+
+  @override
+  Iterable<ASTNode> get children => [expression];
+
+  @override
+  FutureOr<ASTType> resolveType(VMContext? context) {
+    return expression.resolveType(context).resolveMapped((t) {
+      return t is ASTTypeFuture ? t.futureValueType : t;
+    });
+  }
+
+  @override
+  FutureOr<ASTValue> run(VMContext parentContext, ASTRunStatus runStatus) {
+    var context = defineRunContext(parentContext);
+
+    return expression.run(context, runStatus).resolveMapped((val) {
+      // Case 1: a VM-level future value.
+      if (val is ASTValueFuture) {
+        return val.future.then((v) => ASTValue.fromValue(v));
+      }
+
+      // Case 2: an `ASTValue` whose underlying value is a native Dart `Future`
+      // (e.g. returned by an external function).
+      var raw = val.getValue(context);
+      if (raw is Future) {
+        return raw.then((v) => ASTValue.fromValue(v));
+      }
+
+      // Case 3: awaiting a non-future value is the identity.
+      return val;
+    });
+  }
+
+  @override
+  String toString({bool asGroup = false}) {
+    var s = 'await $expression';
+    return asGroup ? '($s)' : s;
+  }
+}
+
 /// [ASTExpression] for an operation between 2 expressions.
 class ASTExpressionOperation extends ASTExpression {
   ASTExpression expression1;

--- a/lib/src/ast/apollovm_ast_toplevel.dart
+++ b/lib/src/ast/apollovm_ast_toplevel.dart
@@ -107,11 +107,23 @@ class ASTEntryPointBlock extends ASTBlock {
         }
       }
 
-      return await f.call(
+      var result = await f.call(
         context,
         positionalParameters: positionalParameters,
         namedParameters: namedParameters,
       );
+
+      // If the entry function is `async` it returns a first-class future
+      // *immediately*; await its completion here, while the entry-point
+      // context (external function mapper, current context, etc.) is still
+      // alive — otherwise the deferred body would run after the `finally`
+      // below has torn it down.
+      if (result is ASTValueFuture) {
+        var resolved = await result.future;
+        return ASTValue.fromValue(resolved);
+      }
+
+      return result;
     } finally {
       VMContext.setCurrent(prevContext);
 
@@ -1844,7 +1856,21 @@ abstract class ASTInvocableDeclaration<
     VMContext parent, {
     List? positionalParameters,
     Map? namedParameters,
-  }) async {
+  }) {
+    // An `async` function returns a first-class future *immediately*, without
+    // awaiting its body, so a non-awaited call can be stored in a `Future<T>`
+    // variable and awaited later (real asynchrony).
+    if (modifiers.isAsync) {
+      return _callAsync(parent, positionalParameters, namedParameters);
+    }
+    return _callBody(parent, positionalParameters, namedParameters);
+  }
+
+  Future<ASTValue<T>> _callBody(
+    VMContext parent,
+    List? positionalParameters,
+    Map? namedParameters,
+  ) async {
     var context = VMScopeContext(this, parent: parent);
 
     var prevContext = VMContext.setCurrent(context);
@@ -1853,6 +1879,49 @@ abstract class ASTInvocableDeclaration<
 
       var result = await super.run(context, ASTRunStatus());
       return await resolveReturnValue(context, result);
+    } finally {
+      VMContext.setCurrent(prevContext);
+    }
+  }
+
+  /// The type the `async` body resolves to (the `T` of `Future<T>`, or the
+  /// declared return type itself when it isn't a `Future<...>`).
+  ASTType get _asyncInnerReturnType {
+    ASTType rt = returnType;
+    return rt is ASTTypeFuture ? rt.futureValueType : rt;
+  }
+
+  ASTValue<T> _callAsync(
+    VMContext parent,
+    List? positionalParameters,
+    Map? namedParameters,
+  ) {
+    var context = VMScopeContext(this, parent: parent);
+    var innerType = _asyncInnerReturnType;
+    var bodyFuture = _runAsyncBody(
+      context,
+      positionalParameters,
+      namedParameters,
+      innerType,
+    );
+    return ASTValueFuture(innerType, bodyFuture) as ASTValue<T>;
+  }
+
+  Future<dynamic> _runAsyncBody(
+    VMContext context,
+    List? positionalParameters,
+    Map? namedParameters,
+    ASTType innerType,
+  ) async {
+    var prevContext = VMContext.setCurrent(context);
+    try {
+      await initializeVariables(context, positionalParameters, namedParameters);
+
+      var result = await super.run(context, ASTRunStatus());
+      // Resolve to the inner (unwrapped) value carried by the `Future`.
+      var astValue = await innerType.toValue(context, result);
+      astValue ??= ASTValueVoid.instance;
+      return await astValue.getValue(context);
     } finally {
       VMContext.setCurrent(prevContext);
     }
@@ -2593,6 +2662,12 @@ class ASTExternalFunction<T> extends ASTFunctionDeclaration<T> {
       }
 
       if (result is Future) {
+        // If the external function is declared to return a `Future<...>`, keep
+        // it as a first-class future (don't eager-await) so callers can await
+        // it on demand.
+        if (returnType is ASTTypeFuture) {
+          return await resolveReturnValue(context, result);
+        }
         var r = await result;
         return await resolveReturnValue(context, r);
       } else {

--- a/lib/src/ast/apollovm_ast_type.dart
+++ b/lib/src/ast/apollovm_ast_type.dart
@@ -1431,6 +1431,14 @@ class ASTTypeMap<TK extends ASTType<K>, TV extends ASTType<V>, K, V>
 class ASTTypeFuture<T extends ASTType<V>, V> extends ASTType<Future<V>> {
   ASTTypeFuture(T type) : super('Future', generics: [type]);
 
+  /// The type of the value the [Future] resolves to (the `T` in `Future<T>`).
+  ASTType get futureValueType {
+    var generics = this.generics;
+    return (generics != null && generics.isNotEmpty)
+        ? generics.first
+        : ASTTypeDynamic.instance;
+  }
+
   @override
   Iterable<ASTNode> get children => [];
 

--- a/lib/src/languages/dart/dart_generator.dart
+++ b/lib/src/languages/dart/dart_generator.dart
@@ -201,6 +201,10 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
     }
     out.write(')');
 
+    if (f is ASTFunctionDeclaration && f.modifiers.isAsync) {
+      out.write(' async');
+    }
+
     var blockStr = blockCode.toString();
     var emptyBlock = blockStr.trim().isEmpty;
 

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -600,9 +600,8 @@ class DartGrammarDefinition extends DartGrammarLexer {
           });
 
   Parser<ASTExpressionAwait> expressionAwait() =>
-      (awaitToken() & (ref0(expressionNoOperation) | ref0(expressionGroup))).map(
-        (v) => ASTExpressionAwait(v[1] as ASTExpression),
-      );
+      (awaitToken() & (ref0(expressionNoOperation) | ref0(expressionGroup)))
+          .map((v) => ASTExpressionAwait(v[1] as ASTExpression));
 
   Parser<ASTExpression> expressionNoOperation() =>
       (expressionAwait() |

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -95,18 +95,20 @@ class DartGrammarDefinition extends DartGrammarLexer {
       (type().optional() &
               identifier() &
               functionParametersDeclaration() &
+              asyncToken().optional() &
               codeBlock())
           .map((v) {
             var returnType = v[0] as ASTType? ?? ASTTypeDynamic.instance;
             var parameters = v[2];
             var name = v[1];
-            var block = v[3];
+            var isAsync = v[3] != null;
+            var block = v[4];
             return ASTFunctionDeclaration(
               name,
               parameters,
               returnType,
               block: block,
-              modifiers: ASTModifiers.modifierStatic,
+              modifiers: ASTModifiers(isStatic: true, isAsync: isAsync),
             );
           });
 
@@ -260,13 +262,18 @@ class DartGrammarDefinition extends DartGrammarLexer {
               type().optional() &
               identifier() &
               functionParametersDeclaration() &
+              asyncToken().optional() &
               codeBlock())
           .map((v) {
-            var modifiers = v[0];
+            var modifiers =
+                (v[0] as ASTModifiers?) ?? ASTModifiers.modifiersNone;
+            if (v[4] != null) {
+              modifiers = modifiers.copyWith(isAsync: true);
+            }
             var returnType = v[1] as ASTType? ?? ASTTypeDynamic.instance;
             var name = v[2] as String;
             var parameters = v[3] as ASTFunctionParametersDeclaration;
-            var block = v[4] as ASTBlock;
+            var block = v[5] as ASTBlock;
             return ASTClassFunctionDeclaration(
               null,
               name,
@@ -592,8 +599,14 @@ class DartGrammarDefinition extends DartGrammarLexer {
             return op;
           });
 
+  Parser<ASTExpressionAwait> expressionAwait() =>
+      (awaitToken() & (ref0(expressionNoOperation) | ref0(expressionGroup))).map(
+        (v) => ASTExpressionAwait(v[1] as ASTExpression),
+      );
+
   Parser<ASTExpression> expressionNoOperation() =>
-      (expressionNegate() |
+      (expressionAwait() |
+              expressionNegate() |
               expressionLiteral() |
               expressionGroupFunctionInvocation() |
               expressionGroup() |
@@ -987,16 +1000,31 @@ class DartGrammarDefinition extends DartGrammarLexer {
           });
 
   Parser<ASTType> type() =>
-      (arrayTyped() |
+      (futureTyped() |
+              arrayTyped() |
               arrayTypeDynamic() |
               mapTyped() |
               mapTypeDynamic() |
               simpleType())
           .cast<ASTType>();
 
-  Parser<ASTType> simpleType() => identifier().map((v) {
-    return getTypeByName(v);
-  });
+  Parser<ASTTypeFuture> futureTyped() =>
+      (string('Future') &
+              char('<').trimHidden() &
+              ref0(type) &
+              char('>').trimHidden())
+          .map((v) {
+            var t = v[2] as ASTType;
+            return ASTTypeFuture(t);
+          });
+
+  Parser<ASTType> simpleType() =>
+      // Guard against the `await` contextual keyword being read as a type name
+      // (so `await x;` parses as an await expression, not a `await x` variable
+      // declaration).
+      (awaitToken().not() & identifier()).map((v) {
+        return getTypeByName(v[1] as String);
+      });
 
   Parser<ASTTypeArray> arrayTyped() =>
       (array3DTyped() | array2DTyped() | array1DTyped()).cast<ASTTypeArray>();

--- a/lib/src/languages/dart/dart_grammar_lexer.dart
+++ b/lib/src/languages/dart/dart_grammar_lexer.dart
@@ -116,6 +116,17 @@ abstract class DartGrammarLexer extends BaseGrammarLexer {
 
   Parser typedefToken() => ref1(token, 'typedef');
 
+  // `async`/`await` are contextual keywords: they must match as whole words so
+  // identifiers like `awaiter` are not read as `await` + `er`.
+  Parser asyncToken() => _keywordToken('async');
+
+  Parser awaitToken() => _keywordToken('await');
+
+  Parser _keywordToken(String word) =>
+      (string(word) & ref0(identifierPartLexicalToken).not())
+          .map((v) => v[0])
+          .trim(ref0(hiddenStuffWhitespace));
+
   Parser hexNumberLexicalToken() =>
       string('0x') & ref0(hexDigitLexicalToken).plus() |
       string('0X') & ref0(hexDigitLexicalToken).plus();

--- a/lib/src/languages/javascript/es/javascript_generator.dart
+++ b/lib/src/languages/javascript/es/javascript_generator.dart
@@ -159,6 +159,9 @@ class ApolloCodeGeneratorJavaScript extends ApolloCodeGenerator {
     var blockCode = generateASTBlock(f, indent: indent, withBrackets: false);
 
     out.write(indent);
+    if (f.modifiers.isAsync) {
+      out.write('async ');
+    }
     out.write('function ');
     out.write(f.name);
     _generateFunctionParamsAndBlock(f, blockCode, out, indent);
@@ -180,6 +183,10 @@ class ApolloCodeGeneratorJavaScript extends ApolloCodeGenerator {
 
     if (f.modifiers.isStatic) {
       out.write('static ');
+    }
+
+    if (f.modifiers.isAsync) {
+      out.write('async ');
     }
 
     out.write(f.name);

--- a/lib/src/languages/kotlin/kotlin_generator.dart
+++ b/lib/src/languages/kotlin/kotlin_generator.dart
@@ -4,6 +4,7 @@
 
 import '../../apollovm_code_generator.dart';
 import '../../apollovm_code_storage.dart';
+import '../../apollovm_parser.dart';
 import '../../ast/apollovm_ast_expression.dart';
 import '../../ast/apollovm_ast_statement.dart';
 import '../../ast/apollovm_ast_toplevel.dart';
@@ -172,6 +173,13 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
   ) {
     out ??= newOutput();
 
+    if (f.modifiers.isAsync) {
+      // Kotlin async maps to `suspend fun` + coroutines, not yet implemented.
+      throw UnsupportedSyntaxError(
+        "Kotlin async/await translation not yet supported (function: '${f.name}')",
+      );
+    }
+
     var blockCode = generateASTBlock(f, indent: indent, withBrackets: false);
 
     out.write(indent);
@@ -181,6 +189,18 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
     _generateFunctionParamsAndBlock(f, blockCode, out, indent, f.returnType);
 
     return out;
+  }
+
+  @override
+  StringBuffer generateASTExpressionAwait(
+    ASTExpressionAwait expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    throw UnsupportedSyntaxError(
+      'Kotlin async/await translation not yet supported',
+    );
   }
 
   void _generateFunctionParamsAndBlock(

--- a/lib/src/languages/wasm/wasm.dart
+++ b/lib/src/languages/wasm/wasm.dart
@@ -78,6 +78,15 @@ class Wasm {
 
   static List<int> brIf(int i) => <int>[0x0d, ...Leb128.encodeUnsigned(i)];
 
+  /// `br_table`: branch to `targets[operand]` (relative block depths), or
+  /// [defaultTarget] when the operand is out of range.
+  static List<int> brTable(List<int> targets, int defaultTarget) => <int>[
+    0x0e,
+    ...Leb128.encodeUnsigned(targets.length),
+    for (var t in targets) ...Leb128.encodeUnsigned(t),
+    ...Leb128.encodeUnsigned(defaultTarget),
+  ];
+
   static List<int> call(int i) => <int>[0x10, ...Leb128.encodeUnsigned(i)];
 
   static const drop = 0x1a;

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -12,7 +12,6 @@ import 'package:data_serializer/data_serializer.dart';
 import '../../apollovm_code_storage.dart';
 import '../../apollovm_generated_output.dart';
 import '../../apollovm_generator.dart';
-import '../../apollovm_parser.dart';
 import '../../ast/apollovm_ast_expression.dart';
 import '../../ast/apollovm_ast_statement.dart';
 import '../../ast/apollovm_ast_toplevel.dart';
@@ -160,7 +159,7 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         t is ASTTypeMap;
     for (var f in module.functions) {
       if (f.modifiers.isPrivate) continue;
-      if (needs(f.returnType)) return true;
+      if (needs(f.effectiveReturnType)) return true;
       for (var p in f.parameters.allParameters) {
         if (p.type is ASTTypeString ||
             p.type is ASTTypeArray ||
@@ -216,7 +215,7 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         return BytesOutput(
           data: [
             ...Wasm.encodeString(f.name),
-            ..._typeDescriptor(f.returnType),
+            ..._typeDescriptor(f.effectiveReturnType),
             ...Leb128.encodeUnsigned(paramDescriptors.length),
             ...paramDescriptors.expand((d) => d),
           ],
@@ -1264,7 +1263,7 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       context.stackDrop();
     }
 
-    var returnType = callee.returnType;
+    var returnType = callee.effectiveReturnType;
     if (!returnType.isVoid) {
       ASTType resultType;
       if (returnType is ASTTypeInt) {
@@ -1613,17 +1612,29 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     return out;
   }
 
-  // TODO(async): Lower `await`/`async` to a resumable continuation (state
-  // machine) that yields to the host event loop (e.g. Asyncify or JSPI).
-  // Wasm has no native async/await, so this is deferred.
+  // The Wasm backend executes synchronously, so a `Future<T>` value is always
+  // already available: `await expr` compiles to just `expr` (a value
+  // pass-through), and an `async` function is compiled as a normal function
+  // returning the unwrapped `T` (see `effectiveReturnType`). This yields
+  // correct results for compute-style async code.
+  //
+  // TODO(async): real suspension — lower `await`/`async` to a resumable
+  // continuation (state machine) that yields to the host event loop
+  // (e.g. Asyncify or JSPI). That requires runtime support the synchronous
+  // `WasmRuntime` does not yet have.
   @override
   BytesOutput generateASTExpressionAwait(
     ASTExpressionAwait expression, {
     BytesOutput? out,
     WasmContext? context,
   }) {
-    throw UnsupportedSyntaxError(
-      'Wasm async/await generation not yet supported',
+    out ??= newOutput();
+    context ??= WasmContext();
+
+    return generateASTExpression(
+      expression.expression,
+      out: out,
+      context: context,
     );
   }
 
@@ -3017,23 +3028,20 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     out ??= newOutput();
     context ??= WasmContext();
 
-    if (f.modifiers.isAsync) {
-      // See generateASTExpressionAwait: Wasm async is deferred.
-      throw UnsupportedSyntaxError(
-        "Wasm async/await generation not yet supported (function: '${f.name}')",
-      );
-    }
-
     if (module != null) {
       context.module = module;
     }
 
     var outBody = newOutput();
 
+    // For an `async` function the declared `Future<T>` collapses to `T` (Wasm
+    // executes synchronously); compile it as a normal function returning `T`.
+    var effectiveReturnType = f.effectiveReturnType;
+
     var return0 = context.returnsLength;
     context.returnsPush(
-      f.returnType,
-      "Function `${f.name}` return: ${f.returnType}",
+      effectiveReturnType,
+      "Function `${f.name}` return: $effectiveReturnType",
     );
     context.assertReturnsLength(return0 + 1);
 
@@ -3060,7 +3068,7 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       generateASTStatement(stm, out: bodyCode, context: context);
     }
 
-    var returnType = f.returnType;
+    var returnType = effectiveReturnType;
 
     if (!returnType.isVoid && context.stackLength == 0) {
       // Notify that the function can't reach the end.
@@ -3118,7 +3126,7 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     outBody.writeBytes(bodyCode);
 
     context.assertReturnsLength(return0 + 1);
-    context.returnsDrop(f.returnType);
+    context.returnsDrop(effectiveReturnType);
     context.assertReturnsLength(return0);
 
     outBody.writeByte(Wasm.end, description: "Code body end");
@@ -4948,6 +4956,20 @@ extension on Iterable<ASTFunctionParameterDeclaration> {
 }
 
 extension _ASTFunctionDeclarationExtension on ASTFunctionDeclaration {
+  /// The effective Wasm return type. For an `async` function the declared
+  /// `Future<T>` collapses to `T`, because the Wasm backend executes
+  /// synchronously — a future's value is always already available, so
+  /// `await` is a value pass-through and an `async` function is compiled as a
+  /// normal function returning `T`. (Real suspension would require Asyncify or
+  /// JSPI; see the `TODO(async)` on `generateASTExpressionAwait`.)
+  ASTType get effectiveReturnType {
+    var rt = returnType;
+    if (modifiers.isAsync && rt is ASTTypeFuture) {
+      return rt.futureValueType;
+    }
+    return rt;
+  }
+
   List<int> get parametersTypesWasmCode {
     final parameters = this.parameters;
 
@@ -4979,6 +5001,8 @@ extension _ASTFunctionDeclarationExtension on ASTFunctionDeclaration {
     } else {
       out.writeByte(0, description: "No parameters");
     }
+
+    var returnType = effectiveReturnType;
 
     if (!returnType.isVoid) {
       out.write([

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -501,12 +501,8 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       data: [
         BytesOutput(data: 0x00, description: "Data kind(active, mem 0)"),
         BytesOutput(
-          data: [
-            ...Wasm32.i32Const(WasmModuleContext.dataBaseOffset),
-            Wasm.end,
-          ],
-          description:
-              "Offset expr (i32.const ${WasmModuleContext.dataBaseOffset})",
+          data: [...Wasm32.i32Const(module.dataBaseOffset), Wasm.end],
+          description: "Offset expr (i32.const ${module.dataBaseOffset})",
         ),
         BytesOutput(
           data: [...Leb128.encodeUnsigned(bytes.length), ...bytes],
@@ -3032,6 +3028,23 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       context.module = module;
     }
 
+    // Real `async`/`await` suspension (Asyncify): if this async function has a
+    // single statement-level `await` of an external (host) call, emit the
+    // unwind/rewind state machine so it can really suspend. Anything more
+    // complex falls back to the synchronous-collapse path below.
+    if (f.modifiers.isAsync && module != null) {
+      var match = _matchAsyncify(f, module);
+      if (match != null) {
+        return _generateAsyncifyFunction(
+          f,
+          match,
+          out: out,
+          context: context,
+          module: module,
+        );
+      }
+    }
+
     var outBody = newOutput();
 
     // For an `async` function the declared `Future<T>` collapses to `T` (Wasm
@@ -3133,6 +3146,250 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     out.writeBytesLeb128Block([outBody], description: "Function body");
 
+    return out;
+  }
+
+  /// Detects the v1 Asyncify shape: an `async` function with exactly one
+  /// `await`, where the await is a top-level statement (`T v = await call(...)`
+  /// or `await call(...)`) and `call` is an external (host) function. Returns
+  /// `null` (=> synchronous-collapse fallback) for anything more complex
+  /// (multiple awaits, awaits nested in control flow, awaiting a module
+  /// function, or a `var`-typed result the Wasm backend can't infer).
+  _AsyncifyMatch? _matchAsyncify(
+    ASTFunctionDeclaration f,
+    WasmModuleContext module,
+  ) {
+    final awaits = <ASTExpressionAwait>[];
+    for (var s in f.statements) {
+      awaits.addAll(s.descendantChildren.whereType<ASTExpressionAwait>());
+    }
+    if (awaits.length != 1) return null;
+
+    final aw = awaits.first;
+    final inner = aw.expression;
+    if (inner is! ASTExpressionLocalFunctionInvocation) return null;
+
+    final name = inner.name;
+    final args = inner.arguments;
+    if (name == 'print') return null;
+    // A module function would require multi-frame unwind (v2).
+    if (module.functionIndex(name, args.length) != null) return null;
+
+    final stmts = f.statements;
+    for (var i = 0; i < stmts.length; i++) {
+      final s = stmts[i];
+      if (s is ASTStatementVariableDeclaration && identical(s.value, aw)) {
+        if (s.type is ASTTypeVar) return null; // explicit type required
+        return _AsyncifyMatch(i, name, args, s.name, s.type);
+      }
+      if (s is ASTStatementExpression && identical(s.expression, aw)) {
+        return _AsyncifyMatch(i, name, args, null, null);
+      }
+    }
+    return null; // await not a top-level statement
+  }
+
+  /// Emits the Asyncify state machine for a [match]ed async function: a rewind
+  /// dispatch prologue, the pre-await segment + suspend (spill live locals,
+  /// set state, return), and the post-await resume segment. The host driver
+  /// re-invokes the export to rewind. See
+  /// `test/apollovm_wasm_asyncify_*` and `WasmModuleContext` for the layout.
+  BytesOutput _generateAsyncifyFunction(
+    ASTFunctionDeclaration f,
+    _AsyncifyMatch match, {
+    required BytesOutput out,
+    required WasmContext context,
+    required WasmModuleContext module,
+  }) {
+    module.requiresAsyncify = true;
+    module.requiresMemory = true;
+
+    const stateOff = WasmModuleContext.asyncifyStateOffset;
+    const resultOff = WasmModuleContext.asyncifyResultOffset;
+    int slotOf(int i) => WasmModuleContext.asyncifyLocalsOffset + i * 8;
+
+    final returnType = f.effectiveReturnType;
+    final return0 = context.returnsLength;
+    context.returnsPush(returnType, "async `${f.name}` -> $returnType");
+
+    // Register params, then declared locals (preamble/index order), then the
+    // `$resume` control local. Collect every user local for spill/restore.
+    final userLocals = <({int index, ASTType type})>[];
+    for (var v in f.parameters.declaredVariables()) {
+      userLocals.add((
+        index: context.addLocalVariable(v.key, v.value),
+        type: v.value,
+      ));
+    }
+    final declaredLocals = f.statements.declaredVariables();
+    for (var v in declaredLocals) {
+      userLocals.add((
+        index: context.addLocalVariable(v.key, v.value),
+        type: v.value,
+      ));
+    }
+    final resumeIdx = context.addLocalVariable(
+      '\$asyncify_resume',
+      _astTypeInt32,
+    );
+
+    List<int> spill(int idx, ASTType t, int slot) {
+      final k = t.wasmType;
+      return [
+        ...Wasm32.i32Const(0),
+        ...Wasm.localGet(idx),
+        if (k == WasmType.f64Type)
+          ...Wasm64.f64Store(FloatAlign.align3, slot)
+        else if (k == WasmType.i32Type)
+          ...Wasm32.i32Store(2, slot)
+        else
+          ...Wasm64.i64Store(3, slot),
+      ];
+    }
+
+    List<int> restore(int idx, ASTType t, int slot) {
+      final k = t.wasmType;
+      return [
+        ...Wasm32.i32Const(0),
+        if (k == WasmType.f64Type)
+          ...Wasm64.f64Load(FloatAlign.align3, slot)
+        else if (k == WasmType.i32Type)
+          ...Wasm32.i32Load(2, slot)
+        else
+          ...Wasm64.i64Load(3, slot),
+        ...Wasm.localSet(idx),
+      ];
+    }
+
+    List<int> defaultConst(ASTType t) {
+      final k = t.wasmType;
+      if (k == WasmType.voidType) return const [];
+      if (k == WasmType.f64Type) return Wasm64.f64Const(0);
+      if (k == WasmType.i32Type) return Wasm32.i32Const(0);
+      return Wasm64.i64Const(0);
+    }
+
+    final body = newOutput();
+
+    // --- prologue: if rewinding, restore locals, clear state, resume=1 ---
+    body.write([
+      ...Wasm32.i32Const(0),
+      ...Wasm32.i32Load(2, stateOff),
+      ...Wasm32.i32Const(2),
+      Wasm32.i32Equals,
+      ...Wasm.ifInstruction(WasmType.voidType),
+    ]);
+    for (var i = 0; i < userLocals.length; i++) {
+      body.write(restore(userLocals[i].index, userLocals[i].type, slotOf(i)));
+    }
+    body.write([
+      ...Wasm32.i32Const(0),
+      ...Wasm32.i32Const(0),
+      ...Wasm32.i32Store(2, stateOff),
+      ...Wasm32.i32Const(1),
+      ...Wasm.localSet(resumeIdx),
+      Wasm.elseInstruction,
+      ...Wasm32.i32Const(0),
+      ...Wasm.localSet(resumeIdx),
+      Wasm.end,
+    ]);
+
+    // --- block $L0: on rewind, skip the pre-await segment and the suspend ---
+    body.write([
+      ...Wasm.block(WasmType.voidType),
+      ...Wasm.localGet(resumeIdx),
+      ...Wasm.brIf(0),
+    ]);
+
+    // Pre-await segment.
+    for (var i = 0; i < match.awaitStmtIndex; i++) {
+      generateASTStatement(f.statements[i], out: body, context: context);
+    }
+
+    // The await: evaluate args, register & call the suspending host import.
+    final argTypes = <WasmType>[];
+    for (var arg in match.args) {
+      generateASTExpression(arg, out: body, context: context);
+      argTypes.add(context.stackGet(0)!.type.wasmType);
+    }
+    final importIndex = module.registerImportedFunction(
+      'env',
+      match.calleeName,
+      argTypes,
+      const [],
+    );
+    body.write(Wasm.call(importIndex));
+    for (var _ in match.args) {
+      context.stackDrop();
+    }
+
+    // Suspend: spill live locals, mark unwound, return a default value.
+    for (var i = 0; i < userLocals.length; i++) {
+      body.write(spill(userLocals[i].index, userLocals[i].type, slotOf(i)));
+    }
+    body.write([
+      ...Wasm32.i32Const(0),
+      ...Wasm32.i32Const(1),
+      ...Wasm32.i32Store(2, stateOff),
+      ...defaultConst(returnType),
+    ]);
+    body.writeByte(Wasm.functionReturn);
+    body.writeByte(Wasm.end); // end $L0 (rewind target)
+
+    // Resume: deliver the host-provided result into the result variable.
+    if (match.resultVarName != null) {
+      final rv = context.getLocalVariable(match.resultVarName!)!;
+      final k = match.resultType!.wasmType;
+      body.write([
+        ...Wasm32.i32Const(0),
+        if (k == WasmType.f64Type)
+          ...Wasm64.f64Load(FloatAlign.align3, resultOff)
+        else if (k == WasmType.i32Type)
+          ...Wasm32.i32Load(2, resultOff)
+        else
+          ...Wasm64.i64Load(3, resultOff),
+        ...Wasm.localSet(rv.index),
+      ]);
+    }
+
+    // Post-await segment (includes the `return`).
+    for (var i = match.awaitStmtIndex + 1; i < f.statements.length; i++) {
+      generateASTStatement(f.statements[i], out: body, context: context);
+    }
+
+    // Safety net (mirrors the synchronous path): a non-void function that can
+    // fall through gets an unreachable default.
+    if (!returnType.isVoid && context.stackLength == 0) {
+      body.writeByte(Wasm.unreachable);
+      body.write(defaultConst(returnType));
+    }
+
+    // --- assemble: locals preamble + body + end ---
+    final outBody = newOutput();
+    final scratchTypes = context.scratchLocalTypes;
+    outBody.write(
+      Leb128.encodeUnsigned(declaredLocals.length + 1 + scratchTypes.length),
+      description: "Local variables count",
+    );
+    for (var v in declaredLocals) {
+      outBody.write(Leb128.encodeUnsigned(1));
+      outBody.writeByte(v.value.wasmCode);
+    }
+    outBody.write(Leb128.encodeUnsigned(1), description: "\$asyncify_resume");
+    outBody.writeByte(WasmType.i32Type.value);
+    for (var t in scratchTypes) {
+      outBody.write(Leb128.encodeUnsigned(1));
+      outBody.writeByte(t.wasmCode);
+    }
+    outBody.writeBytes(body);
+    outBody.writeByte(Wasm.end, description: "Code body end");
+
+    context.returnsDrop(returnType);
+    context.assertReturnsLength(return0);
+
+    out.writeBytesLeb128Block([
+      outBody,
+    ], description: "Async function (asyncify)");
     return out;
   }
 
@@ -4576,11 +4833,37 @@ class WasmModuleContext {
     return functions[i];
   }
 
+  // --- Asyncify control region (real `async`/`await` suspension) ---
+  //
+  // When an `async` function is compiled with real suspension (Asyncify), a
+  // small fixed region of low linear memory holds the suspension state. The
+  // host driver and the generated code agree on these absolute offsets. Offset
+  // `0` stays reserved as the null pointer.
+  //
+  //   ASY_STATE  (i32 @ 8): 0=normal, 1=unwound(suspended), 2=rewinding
+  //   ASY_RESULT (i64 @16): the awaited value, written back by the host
+  //   ASY_LOCALS (i64[] @24): spilled live locals across the suspension
+
+  static const int asyncifyBase = 8;
+  static const int asyncifyStateOffset = 8;
+  static const int asyncifyResultOffset = 16;
+  static const int asyncifyLocalsOffset = 24;
+
+  /// Bytes reserved for the Asyncify control region (state + result + spilled
+  /// locals). 256 bytes => up to 29 spilled i64 locals.
+  static const int asyncifyRegionSize = 256;
+
+  /// Whether the module compiled at least one real-suspension `async` function
+  /// and therefore reserves the Asyncify control region.
+  bool requiresAsyncify = false;
+
   // --- Static data region (interned string literals) ---
 
   /// Base offset of the static data region in linear memory. Offset `0` is
-  /// reserved as a null pointer.
-  static const int dataBaseOffset = 8;
+  /// reserved as a null pointer; when Asyncify is used the static data is
+  /// shifted up past the control region so its fixed offsets never collide.
+  int get dataBaseOffset =>
+      requiresAsyncify ? (asyncifyBase + asyncifyRegionSize) : 8;
 
   final BytesBuilder _data = BytesBuilder();
   final Map<String, int> _literalPointers = {};
@@ -4953,6 +5236,33 @@ extension _ASTTypeNumExtension on ASTTypeNum {
 
 extension on Iterable<ASTFunctionParameterDeclaration> {
   Iterable<int> toWasmCodes() => map((p) => p.type.wasmCode);
+}
+
+/// A matched v1 Asyncify shape (see `_matchAsyncify`): the single statement-
+/// level `await` of an external call that drives the suspension.
+class _AsyncifyMatch {
+  /// Index of the await statement within the function's statements.
+  final int awaitStmtIndex;
+
+  /// Name of the awaited external (host) function.
+  final String calleeName;
+
+  /// Argument expressions passed to the awaited call.
+  final List<ASTExpression> args;
+
+  /// Local that receives the awaited result on resume (`null` if discarded).
+  final String? resultVarName;
+
+  /// Declared type of [resultVarName] (`null` when there is no result var).
+  final ASTType? resultType;
+
+  _AsyncifyMatch(
+    this.awaitStmtIndex,
+    this.calleeName,
+    this.args,
+    this.resultVarName,
+    this.resultType,
+  );
 }
 
 extension _ASTFunctionDeclarationExtension on ASTFunctionDeclaration {

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -12,6 +12,7 @@ import 'package:data_serializer/data_serializer.dart';
 import '../../apollovm_code_storage.dart';
 import '../../apollovm_generated_output.dart';
 import '../../apollovm_generator.dart';
+import '../../apollovm_parser.dart';
 import '../../ast/apollovm_ast_expression.dart';
 import '../../ast/apollovm_ast_statement.dart';
 import '../../ast/apollovm_ast_toplevel.dart';
@@ -1612,6 +1613,20 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     return out;
   }
 
+  // TODO(async): Lower `await`/`async` to a resumable continuation (state
+  // machine) that yields to the host event loop (e.g. Asyncify or JSPI).
+  // Wasm has no native async/await, so this is deferred.
+  @override
+  BytesOutput generateASTExpressionAwait(
+    ASTExpressionAwait expression, {
+    BytesOutput? out,
+    WasmContext? context,
+  }) {
+    throw UnsupportedSyntaxError(
+      'Wasm async/await generation not yet supported',
+    );
+  }
+
   ASTTypeDouble _fixStackOpsAsFloat64(
     ASTType stackType1,
     ASTType stackType2,
@@ -3002,6 +3017,13 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     out ??= newOutput();
     context ??= WasmContext();
 
+    if (f.modifiers.isAsync) {
+      // See generateASTExpressionAwait: Wasm async is deferred.
+      throw UnsupportedSyntaxError(
+        "Wasm async/await generation not yet supported (function: '${f.name}')",
+      );
+    }
+
     if (module != null) {
       context.module = module;
     }
@@ -3768,6 +3790,8 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         out: out,
         context: context,
       );
+    } else if (expression is ASTExpressionAwait) {
+      return generateASTExpressionAwait(expression, out: out, context: context);
     } else if (expression is ASTExpressionLocalFunctionInvocation) {
       return generateASTExpressionLocalFunctionInvocation(
         expression,

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -152,6 +152,9 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   /// function with a return/param the runner must marshal from/to its raw Wasm
   /// value — a String, a `bool` return, or a list/map (param or return).
   bool _requiresSignatureSection(WasmModuleContext module) {
+    // Real-suspension async functions need the section so the runner knows to
+    // drive their unwind/rewind loop.
+    if (module.asyncifyFunctionNames.isNotEmpty) return true;
     bool needs(ASTType t) =>
         t is ASTTypeString ||
         t is ASTTypeBool ||
@@ -223,6 +226,23 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         );
       }),
     ];
+
+    // Trailing, backward-compatible block: the names of Asyncify (real-
+    // suspension) functions the runner must drive. Only emitted when present,
+    // so non-async modules stay byte-identical; older readers stop after the
+    // entries above and ignore it.
+    var asyncNames = module.asyncifyFunctionNames;
+    if (asyncNames.isNotEmpty) {
+      entries.add(
+        BytesOutput(
+          data: [
+            ...Leb128.encodeUnsigned(asyncNames.length),
+            for (var n in asyncNames) ...Wasm.encodeString(n),
+          ],
+          description: "Asyncify functions",
+        ),
+      );
+    }
 
     out.writeByte(0x00, description: "Section Custom ID");
     out.writeBytesLeb128Block(entries, description: "apollovm_sig");
@@ -3203,6 +3223,7 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   }) {
     module.requiresAsyncify = true;
     module.requiresMemory = true;
+    module.asyncifyFunctionNames.add(f.name);
 
     const stateOff = WasmModuleContext.asyncifyStateOffset;
     const resultOff = WasmModuleContext.asyncifyResultOffset;
@@ -4856,6 +4877,10 @@ class WasmModuleContext {
   /// Whether the module compiled at least one real-suspension `async` function
   /// and therefore reserves the Asyncify control region.
   bool requiresAsyncify = false;
+
+  /// Names of functions compiled with the Asyncify transform (real suspension).
+  /// Surfaced in the `apollovm_sig` section so the runner drives them.
+  final Set<String> asyncifyFunctionNames = {};
 
   // --- Static data region (interned string literals) ---
 

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -3169,44 +3169,50 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     return out;
   }
 
-  /// Detects the v1 Asyncify shape: an `async` function with exactly one
-  /// `await`, where the await is a top-level statement (`T v = await call(...)`
-  /// or `await call(...)`) and `call` is an external (host) function. Returns
-  /// `null` (=> synchronous-collapse fallback) for anything more complex
-  /// (multiple awaits, awaits nested in control flow, awaiting a module
-  /// function, or a `var`-typed result the Wasm backend can't infer).
+  /// Detects the Asyncify shape: an `async` function whose every `await` is a
+  /// top-level statement (`T v = await call(...)` or `await call(...)`) of an
+  /// external (host) call. Returns the ordered list of await points, or `null`
+  /// (=> synchronous-collapse fallback) for anything more complex (an await
+  /// nested in control flow or another expression, multiple awaits in one
+  /// statement, awaiting a module function => multi-frame, or a `var`-typed
+  /// result the Wasm backend can't infer).
   _AsyncifyMatch? _matchAsyncify(
     ASTFunctionDeclaration f,
     WasmModuleContext module,
   ) {
-    final awaits = <ASTExpressionAwait>[];
-    for (var s in f.statements) {
-      awaits.addAll(s.descendantChildren.whereType<ASTExpressionAwait>());
-    }
-    if (awaits.length != 1) return null;
-
-    final aw = awaits.first;
-    final inner = aw.expression;
-    if (inner is! ASTExpressionLocalFunctionInvocation) return null;
-
-    final name = inner.name;
-    final args = inner.arguments;
-    if (name == 'print') return null;
-    // A module function would require multi-frame unwind (v2).
-    if (module.functionIndex(name, args.length) != null) return null;
-
     final stmts = f.statements;
+    final points = <_AwaitPoint>[];
+
     for (var i = 0; i < stmts.length; i++) {
       final s = stmts[i];
+      final awaitsInS = s.descendantChildren
+          .whereType<ASTExpressionAwait>()
+          .toList();
+      if (awaitsInS.isEmpty) continue;
+      if (awaitsInS.length != 1) return null; // >1 await in one statement
+
+      final aw = awaitsInS.first;
+      final inner = aw.expression;
+      if (inner is! ASTExpressionLocalFunctionInvocation) return null;
+
+      final name = inner.name;
+      final args = inner.arguments;
+      if (name == 'print') return null;
+      // A module function would require multi-frame unwind.
+      if (module.functionIndex(name, args.length) != null) return null;
+
       if (s is ASTStatementVariableDeclaration && identical(s.value, aw)) {
         if (s.type is ASTTypeVar) return null; // explicit type required
-        return _AsyncifyMatch(i, name, args, s.name, s.type);
-      }
-      if (s is ASTStatementExpression && identical(s.expression, aw)) {
-        return _AsyncifyMatch(i, name, args, null, null);
+        points.add(_AwaitPoint(i, name, args, s.name, s.type));
+      } else if (s is ASTStatementExpression && identical(s.expression, aw)) {
+        points.add(_AwaitPoint(i, name, args, null, null));
+      } else {
+        return null; // await not a clean top-level statement
       }
     }
-    return null; // await not a top-level statement
+
+    if (points.isEmpty) return null;
+    return _AsyncifyMatch(points);
   }
 
   /// Emits the Asyncify state machine for a [match]ed async function: a rewind
@@ -3290,9 +3296,65 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       return Wasm64.i64Const(0);
     }
 
+    const resumeOff = WasmModuleContext.asyncifyResumeOffset;
+    final points = match.awaits;
+    final k = points.length;
+    final stmts = f.statements;
+
+    // Loads the host-provided result of [p] into its result variable.
+    List<int> loadResultInto(_AwaitPoint p) {
+      if (p.resultVarName == null) return const [];
+      final rv = context.getLocalVariable(p.resultVarName!)!;
+      final rk = p.resultType!.wasmType;
+      return [
+        ...Wasm32.i32Const(0),
+        if (rk == WasmType.f64Type)
+          ...Wasm64.f64Load(FloatAlign.align3, resultOff)
+        else if (rk == WasmType.i32Type)
+          ...Wasm32.i32Load(2, resultOff)
+        else
+          ...Wasm64.i64Load(3, resultOff),
+        ...Wasm.localSet(rv.index),
+      ];
+    }
+
     final body = newOutput();
 
-    // --- prologue: if rewinding, restore locals, clear state, resume=1 ---
+    // Emits an await: evaluate args, call the suspending host import, then
+    // suspend — spill locals, record the resume index, flag unwound, return.
+    void emitAwait(_AwaitPoint p, int resumeValue) {
+      final argTypes = <WasmType>[];
+      for (var arg in p.args) {
+        generateASTExpression(arg, out: body, context: context);
+        argTypes.add(context.stackGet(0)!.type.wasmType);
+      }
+      final importIndex = module.registerImportedFunction(
+        'env',
+        p.calleeName,
+        argTypes,
+        const [],
+      );
+      body.write(Wasm.call(importIndex));
+      for (var _ in p.args) {
+        context.stackDrop();
+      }
+      for (var i = 0; i < userLocals.length; i++) {
+        body.write(spill(userLocals[i].index, userLocals[i].type, slotOf(i)));
+      }
+      body.write([
+        ...Wasm32.i32Const(0),
+        ...Wasm32.i32Const(resumeValue),
+        ...Wasm32.i32Store(2, resumeOff),
+        ...Wasm32.i32Const(0),
+        ...Wasm32.i32Const(1),
+        ...Wasm32.i32Store(2, stateOff),
+        ...defaultConst(returnType),
+      ]);
+      body.writeByte(Wasm.functionReturn);
+    }
+
+    // --- prologue: if rewinding, restore locals, load the resume index, and
+    // clear the state; on a fresh call the resume index is 0. ---
     body.write([
       ...Wasm32.i32Const(0),
       ...Wasm32.i32Load(2, stateOff),
@@ -3305,82 +3367,58 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     }
     body.write([
       ...Wasm32.i32Const(0),
+      ...Wasm32.i32Load(2, resumeOff),
+      ...Wasm.localSet(resumeIdx),
+      ...Wasm32.i32Const(0),
       ...Wasm32.i32Const(0),
       ...Wasm32.i32Store(2, stateOff),
-      ...Wasm32.i32Const(1),
-      ...Wasm.localSet(resumeIdx),
       Wasm.elseInstruction,
       ...Wasm32.i32Const(0),
       ...Wasm.localSet(resumeIdx),
       Wasm.end,
     ]);
 
-    // --- block $L0: on rewind, skip the pre-await segment and the suspend ---
+    // --- resume dispatch: nested blocks ($exit, $L_k .. $L_0) with a
+    // `br_table` over the resume index. Index 0 => segment 0 (fresh); index
+    // i => resume just after await i-1. ---
+    for (var i = 0; i < k + 2; i++) {
+      body.write(Wasm.block(WasmType.voidType));
+    }
     body.write([
-      ...Wasm.block(WasmType.voidType),
       ...Wasm.localGet(resumeIdx),
-      ...Wasm.brIf(0),
+      ...Wasm.brTable([for (var j = 0; j <= k; j++) j], k + 1),
     ]);
+    body.writeByte(Wasm.end); // end $L_0 => segment 0 follows
 
-    // Pre-await segment.
-    for (var i = 0; i < match.awaitStmtIndex; i++) {
-      generateASTStatement(f.statements[i], out: body, context: context);
+    // Segment 0 (before the first await) + first await.
+    for (var i = 0; i < points[0].stmtIndex; i++) {
+      generateASTStatement(stmts[i], out: body, context: context);
+    }
+    emitAwait(points[0], 1);
+    body.writeByte(Wasm.end); // end $L_1 => resume target after await 0
+
+    // Middle segments: each loads the previous await's result, runs its
+    // statements, then awaits.
+    for (var j = 1; j < k; j++) {
+      body.write(loadResultInto(points[j - 1]));
+      for (var i = points[j - 1].stmtIndex + 1; i < points[j].stmtIndex; i++) {
+        generateASTStatement(stmts[i], out: body, context: context);
+      }
+      emitAwait(points[j], j + 1);
+      body.writeByte(Wasm.end); // end $L_{j+1}
     }
 
-    // The await: evaluate args, register & call the suspending host import.
-    final argTypes = <WasmType>[];
-    for (var arg in match.args) {
-      generateASTExpression(arg, out: body, context: context);
-      argTypes.add(context.stackGet(0)!.type.wasmType);
+    // Final segment (after the last await), including the `return`.
+    body.write(loadResultInto(points[k - 1]));
+    for (var i = points[k - 1].stmtIndex + 1; i < stmts.length; i++) {
+      generateASTStatement(stmts[i], out: body, context: context);
     }
-    final importIndex = module.registerImportedFunction(
-      'env',
-      match.calleeName,
-      argTypes,
-      const [],
-    );
-    body.write(Wasm.call(importIndex));
-    for (var _ in match.args) {
-      context.stackDrop();
-    }
+    body.writeByte(Wasm.end); // end $exit
 
-    // Suspend: spill live locals, mark unwound, return a default value.
-    for (var i = 0; i < userLocals.length; i++) {
-      body.write(spill(userLocals[i].index, userLocals[i].type, slotOf(i)));
-    }
-    body.write([
-      ...Wasm32.i32Const(0),
-      ...Wasm32.i32Const(1),
-      ...Wasm32.i32Store(2, stateOff),
-      ...defaultConst(returnType),
-    ]);
-    body.writeByte(Wasm.functionReturn);
-    body.writeByte(Wasm.end); // end $L0 (rewind target)
-
-    // Resume: deliver the host-provided result into the result variable.
-    if (match.resultVarName != null) {
-      final rv = context.getLocalVariable(match.resultVarName!)!;
-      final k = match.resultType!.wasmType;
-      body.write([
-        ...Wasm32.i32Const(0),
-        if (k == WasmType.f64Type)
-          ...Wasm64.f64Load(FloatAlign.align3, resultOff)
-        else if (k == WasmType.i32Type)
-          ...Wasm32.i32Load(2, resultOff)
-        else
-          ...Wasm64.i64Load(3, resultOff),
-        ...Wasm.localSet(rv.index),
-      ]);
-    }
-
-    // Post-await segment (includes the `return`).
-    for (var i = match.awaitStmtIndex + 1; i < f.statements.length; i++) {
-      generateASTStatement(f.statements[i], out: body, context: context);
-    }
-
-    // Safety net (mirrors the synchronous path): a non-void function that can
-    // fall through gets an unreachable default.
-    if (!returnType.isVoid && context.stackLength == 0) {
+    // The `br_table` default lands here (past `end $exit`) with an empty stack,
+    // so a non-void function needs an unreachable default to type-check — the
+    // real resume paths always `return` before reaching it.
+    if (!returnType.isVoid) {
       body.writeByte(Wasm.unreachable);
       body.write(defaultConst(returnType));
     }
@@ -4861,12 +4899,14 @@ class WasmModuleContext {
   // host driver and the generated code agree on these absolute offsets. Offset
   // `0` stays reserved as the null pointer.
   //
-  //   ASY_STATE  (i32 @ 8): 0=normal, 1=unwound(suspended), 2=rewinding
-  //   ASY_RESULT (i64 @16): the awaited value, written back by the host
+  //   ASY_STATE  (i32 @ 8):  0=normal, 1=unwound(suspended), 2=rewinding
+  //   ASY_RESUME (i32 @12):  which await to resume after (0 = fresh)
+  //   ASY_RESULT (i64 @16):  the awaited value, written back by the host
   //   ASY_LOCALS (i64[] @24): spilled live locals across the suspension
 
   static const int asyncifyBase = 8;
   static const int asyncifyStateOffset = 8;
+  static const int asyncifyResumeOffset = 12;
   static const int asyncifyResultOffset = 16;
   static const int asyncifyLocalsOffset = 24;
 
@@ -5263,11 +5303,10 @@ extension on Iterable<ASTFunctionParameterDeclaration> {
   Iterable<int> toWasmCodes() => map((p) => p.type.wasmCode);
 }
 
-/// A matched v1 Asyncify shape (see `_matchAsyncify`): the single statement-
-/// level `await` of an external call that drives the suspension.
-class _AsyncifyMatch {
+/// A single statement-level `await` of an external call (see `_matchAsyncify`).
+class _AwaitPoint {
   /// Index of the await statement within the function's statements.
-  final int awaitStmtIndex;
+  final int stmtIndex;
 
   /// Name of the awaited external (host) function.
   final String calleeName;
@@ -5281,13 +5320,21 @@ class _AsyncifyMatch {
   /// Declared type of [resultVarName] (`null` when there is no result var).
   final ASTType? resultType;
 
-  _AsyncifyMatch(
-    this.awaitStmtIndex,
+  _AwaitPoint(
+    this.stmtIndex,
     this.calleeName,
     this.args,
     this.resultVarName,
     this.resultType,
   );
+}
+
+/// A matched Asyncify shape: the ordered list of statement-level [awaits] that
+/// drive the unwind/rewind state machine.
+class _AsyncifyMatch {
+  final List<_AwaitPoint> awaits;
+
+  _AsyncifyMatch(this.awaits);
 }
 
 extension _ASTFunctionDeclarationExtension on ASTFunctionDeclaration {

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -3169,17 +3169,20 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     return out;
   }
 
-  /// Detects the Asyncify shape: an `async` function whose every `await` is a
+  /// The await points of [f] if its shape is Asyncify-able, assuming the module
+  /// functions in [eligible] are themselves transformed. Each await must be a
   /// top-level statement (`T v = await call(...)` or `await call(...)`) of an
-  /// external (host) call. Returns the ordered list of await points, or `null`
-  /// (=> synchronous-collapse fallback) for anything more complex (an await
-  /// nested in control flow or another expression, multiple awaits in one
-  /// statement, awaiting a module function => multi-frame, or a `var`-typed
-  /// result the Wasm backend can't infer).
-  _AsyncifyMatch? _matchAsyncify(
+  /// external (host) call (a *leaf* suspension) or a call to a function in
+  /// [eligible] (an *internal* frame). Returns `null` for anything more complex
+  /// (an await nested in control flow or another expression, multiple awaits in
+  /// one statement, awaiting a not-yet-eligible module function, or a `var`-
+  /// typed result the Wasm backend can't infer).
+  List<_AwaitPoint>? _asyncifyAwaitPoints(
     ASTFunctionDeclaration f,
     WasmModuleContext module,
+    Set<String> eligible,
   ) {
+    if (!f.modifiers.isAsync) return null;
     final stmts = f.statements;
     final points = <_AwaitPoint>[];
 
@@ -3198,20 +3201,61 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       final name = inner.name;
       final args = inner.arguments;
       if (name == 'print') return null;
-      // A module function would require multi-frame unwind.
-      if (module.functionIndex(name, args.length) != null) return null;
 
+      // Internal frame (awaiting a module function) vs leaf (host import).
+      final isInternal = module.functionIndex(name, args.length) != null;
+      if (isInternal && !eligible.contains(name)) return null;
+
+      String? resultVar;
+      ASTType? resultType;
       if (s is ASTStatementVariableDeclaration && identical(s.value, aw)) {
         if (s.type is ASTTypeVar) return null; // explicit type required
-        points.add(_AwaitPoint(i, name, args, s.name, s.type));
+        resultVar = s.name;
+        resultType = s.type;
       } else if (s is ASTStatementExpression && identical(s.expression, aw)) {
-        points.add(_AwaitPoint(i, name, args, null, null));
+        // discarded result
       } else {
         return null; // await not a clean top-level statement
       }
+
+      points.add(_AwaitPoint(i, name, args, resultVar, resultType, isInternal));
     }
 
     if (points.isEmpty) return null;
+    return points;
+  }
+
+  /// Fixed-point set of Asyncify-eligible function names: async functions whose
+  /// awaits all conform and whose awaited module functions are themselves
+  /// eligible. Computed once per module.
+  Set<String> _asyncifyEligible(WasmModuleContext module) {
+    var cached = module.asyncifyEligible;
+    if (cached != null) return cached;
+
+    final eligible = <String>{};
+    var changed = true;
+    while (changed) {
+      changed = false;
+      for (var f in module.functions) {
+        if (eligible.contains(f.name)) continue;
+        if (_asyncifyAwaitPoints(f, module, eligible) != null) {
+          eligible.add(f.name);
+          changed = true;
+        }
+      }
+    }
+
+    return module.asyncifyEligible = eligible;
+  }
+
+  _AsyncifyMatch? _matchAsyncify(
+    ASTFunctionDeclaration f,
+    WasmModuleContext module,
+  ) {
+    final eligible = _asyncifyEligible(module);
+    if (!eligible.contains(f.name)) return null;
+    final points = _asyncifyAwaitPoints(f, module, eligible);
+    if (points == null) return null;
     return _AsyncifyMatch(points);
   }
 
@@ -3233,7 +3277,6 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     const stateOff = WasmModuleContext.asyncifyStateOffset;
     const resultOff = WasmModuleContext.asyncifyResultOffset;
-    int slotOf(int i) => WasmModuleContext.asyncifyLocalsOffset + i * 8;
 
     final returnType = f.effectiveReturnType;
     final return0 = context.returnsLength;
@@ -3260,33 +3303,8 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       _astTypeInt32,
     );
 
-    List<int> spill(int idx, ASTType t, int slot) {
-      final k = t.wasmType;
-      return [
-        ...Wasm32.i32Const(0),
-        ...Wasm.localGet(idx),
-        if (k == WasmType.f64Type)
-          ...Wasm64.f64Store(FloatAlign.align3, slot)
-        else if (k == WasmType.i32Type)
-          ...Wasm32.i32Store(2, slot)
-        else
-          ...Wasm64.i64Store(3, slot),
-      ];
-    }
-
-    List<int> restore(int idx, ASTType t, int slot) {
-      final k = t.wasmType;
-      return [
-        ...Wasm32.i32Const(0),
-        if (k == WasmType.f64Type)
-          ...Wasm64.f64Load(FloatAlign.align3, slot)
-        else if (k == WasmType.i32Type)
-          ...Wasm32.i32Load(2, slot)
-        else
-          ...Wasm64.i64Load(3, slot),
-        ...Wasm.localSet(idx),
-      ];
-    }
+    const spOff = WasmModuleContext.asyncifyStackPointerOffset;
+    final frameSize = 8 + userLocals.length * 8; // resume(8) + N i64 slots
 
     List<int> defaultConst(ASTType t) {
       final k = t.wasmType;
@@ -3296,12 +3314,57 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       return Wasm64.i64Const(0);
     }
 
-    const resumeOff = WasmModuleContext.asyncifyResumeOffset;
+    // The frame-stack pointer (SP) value on the stack.
+    List<int> loadSP() => [...Wasm32.i32Const(0), ...Wasm32.i32Load(2, spOff)];
+
+    // SP += frameSize (or -= when [sub]).
+    List<int> moveSP({required bool sub}) => [
+      ...Wasm32.i32Const(0),
+      ...loadSP(),
+      ...Wasm32.i32Const(frameSize),
+      if (sub) Wasm32.i32Subtract else Wasm32.i32Add,
+      ...Wasm32.i32Store(2, spOff),
+    ];
+
+    // Spill / restore local [idx] at byte [frameOff] within the current frame
+    // (base = SP).
+    List<int> spillFrame(int idx, ASTType t, int frameOff) {
+      final k = t.wasmType;
+      return [
+        ...loadSP(),
+        ...Wasm32.i32Const(frameOff),
+        Wasm32.i32Add,
+        ...Wasm.localGet(idx),
+        if (k == WasmType.f64Type)
+          ...Wasm64.f64Store(FloatAlign.align3, 0)
+        else if (k == WasmType.i32Type)
+          ...Wasm32.i32Store(2, 0)
+        else
+          ...Wasm64.i64Store(3, 0),
+      ];
+    }
+
+    List<int> restoreFrame(int idx, ASTType t, int frameOff) {
+      final k = t.wasmType;
+      return [
+        ...loadSP(),
+        ...Wasm32.i32Const(frameOff),
+        Wasm32.i32Add,
+        if (k == WasmType.f64Type)
+          ...Wasm64.f64Load(FloatAlign.align3, 0)
+        else if (k == WasmType.i32Type)
+          ...Wasm32.i32Load(2, 0)
+        else
+          ...Wasm64.i64Load(3, 0),
+        ...Wasm.localSet(idx),
+      ];
+    }
+
     final points = match.awaits;
     final k = points.length;
     final stmts = f.statements;
 
-    // Loads the host-provided result of [p] into its result variable.
+    // Loads the host-provided leaf result into a resume's result variable.
     List<int> loadResultInto(_AwaitPoint p) {
       if (p.resultVarName == null) return const [];
       final rv = context.getLocalVariable(p.resultVarName!)!;
@@ -3320,9 +3383,32 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     final body = newOutput();
 
-    // Emits an await: evaluate args, call the suspending host import, then
-    // suspend — spill locals, record the resume index, flag unwound, return.
-    void emitAwait(_AwaitPoint p, int resumeValue) {
+    // Suspend: push this frame (resume index + spilled locals), advance SP,
+    // flag unwound, and return a default value.
+    void emitSuspend(int resumeValue) {
+      body.write([
+        ...loadSP(),
+        ...Wasm32.i32Const(resumeValue),
+        ...Wasm32.i32Store(2, 0), // frame[0] = resume
+      ]);
+      for (var i = 0; i < userLocals.length; i++) {
+        body.write(
+          spillFrame(userLocals[i].index, userLocals[i].type, 8 + i * 8),
+        );
+      }
+      body.write([
+        ...moveSP(sub: false),
+        ...Wasm32.i32Const(0),
+        ...Wasm32.i32Const(1),
+        ...Wasm32.i32Store(2, stateOff), // STATE = unwinding
+        ...defaultConst(returnType),
+      ]);
+      body.writeByte(Wasm.functionReturn);
+    }
+
+    // Leaf await (host import): evaluate args, call the suspending import, and
+    // unconditionally suspend.
+    void emitLeafSuspend(_AwaitPoint p, int resumeValue) {
       final argTypes = <WasmType>[];
       for (var arg in p.args) {
         generateASTExpression(arg, out: body, context: context);
@@ -3338,40 +3424,79 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       for (var _ in p.args) {
         context.stackDrop();
       }
-      for (var i = 0; i < userLocals.length; i++) {
-        body.write(spill(userLocals[i].index, userLocals[i].type, slotOf(i)));
-      }
-      body.write([
-        ...Wasm32.i32Const(0),
-        ...Wasm32.i32Const(resumeValue),
-        ...Wasm32.i32Store(2, resumeOff),
-        ...Wasm32.i32Const(0),
-        ...Wasm32.i32Const(1),
-        ...Wasm32.i32Store(2, stateOff),
-        ...defaultConst(returnType),
-      ]);
-      body.writeByte(Wasm.functionReturn);
+      emitSuspend(resumeValue);
     }
 
-    // --- prologue: if rewinding, restore locals, load the resume index, and
-    // clear the state; on a fresh call the resume index is 0. ---
+    // Leaf resume: deliver the host result and complete the rewind.
+    void emitLeafResume(_AwaitPoint p) {
+      body.write(loadResultInto(p));
+      body.write([
+        ...Wasm32.i32Const(0),
+        ...Wasm32.i32Const(0),
+        ...Wasm32.i32Store(2, stateOff), // STATE = normal (rewind done)
+      ]);
+    }
+
+    // Internal await (module async fn): call it and propagate any unwind. On a
+    // fresh pass the callee may suspend (=> we propagate); on rewind the call is
+    // re-executed (the callee rewinds and returns its real value).
+    void emitInternalAwait(_AwaitPoint p, int resumeValue) {
+      final calleeIndex = module.functionIndex(p.calleeName, p.args.length)!;
+      final callee = module.functionByIndex(calleeIndex)!;
+      for (var i = 0; i < p.args.length; i++) {
+        generateASTExpression(p.args[i], out: body, context: context);
+        final paramType = callee.parameters.getParameterByIndex(i)?.type;
+        if (paramType != null) {
+          _autoConvertStackTypes(
+            context.stackGet(0)!.type,
+            paramType,
+            out: body,
+            context: context,
+          );
+        }
+      }
+      body.write(Wasm.call(calleeIndex));
+      for (var _ in p.args) {
+        context.stackDrop();
+      }
+      if (p.resultVarName != null) {
+        final rv = context.getLocalVariable(p.resultVarName!)!;
+        body.write(Wasm.localSet(rv.index));
+      } else if (!callee.effectiveReturnType.isVoid) {
+        body.writeByte(Wasm.drop);
+      }
+      // Unwind propagation: if the callee suspended, suspend this frame too.
+      body.write([
+        ...Wasm32.i32Const(0),
+        ...Wasm32.i32Load(2, stateOff),
+        ...Wasm32.i32Const(1),
+        Wasm32.i32Equals,
+        ...Wasm.ifInstruction(WasmType.voidType),
+      ]);
+      emitSuspend(resumeValue);
+      body.writeByte(Wasm.end);
+    }
+
+    // --- prologue: on rewind, pop this frame (restore the resume index and
+    // locals) WITHOUT clearing the global state — the state stays "rewinding"
+    // until the leaf that suspended completes. On a fresh call resume = 0. ---
     body.write([
       ...Wasm32.i32Const(0),
       ...Wasm32.i32Load(2, stateOff),
       ...Wasm32.i32Const(2),
       Wasm32.i32Equals,
       ...Wasm.ifInstruction(WasmType.voidType),
+      ...moveSP(sub: true),
+      ...loadSP(),
+      ...Wasm32.i32Load(2, 0),
+      ...Wasm.localSet(resumeIdx), // resume = frame[0]
     ]);
     for (var i = 0; i < userLocals.length; i++) {
-      body.write(restore(userLocals[i].index, userLocals[i].type, slotOf(i)));
+      body.write(
+        restoreFrame(userLocals[i].index, userLocals[i].type, 8 + i * 8),
+      );
     }
     body.write([
-      ...Wasm32.i32Const(0),
-      ...Wasm32.i32Load(2, resumeOff),
-      ...Wasm.localSet(resumeIdx),
-      ...Wasm32.i32Const(0),
-      ...Wasm32.i32Const(0),
-      ...Wasm32.i32Store(2, stateOff),
       Wasm.elseInstruction,
       ...Wasm32.i32Const(0),
       ...Wasm.localSet(resumeIdx),
@@ -3390,30 +3515,32 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     ]);
     body.writeByte(Wasm.end); // end $L_0 => segment 0 follows
 
-    // Segment 0 (before the first await) + first await.
+    // Segment 0 (before the first await).
     for (var i = 0; i < points[0].stmtIndex; i++) {
       generateASTStatement(stmts[i], out: body, context: context);
     }
-    emitAwait(points[0], 1);
-    body.writeByte(Wasm.end); // end $L_1 => resume target after await 0
+    // A leaf await suspends here (before its block boundary); an internal await
+    // emits all its code after the boundary (so it re-executes on rewind).
+    if (!points[0].isInternal) emitLeafSuspend(points[0], 1);
+    body.writeByte(Wasm.end); // end $L_1
 
-    // Middle segments: each loads the previous await's result, runs its
-    // statements, then awaits.
-    for (var j = 1; j < k; j++) {
-      body.write(loadResultInto(points[j - 1]));
-      for (var i = points[j - 1].stmtIndex + 1; i < points[j].stmtIndex; i++) {
+    for (var j = 1; j <= k; j++) {
+      final prev = points[j - 1];
+      if (prev.isInternal) {
+        emitInternalAwait(prev, j);
+      } else {
+        emitLeafResume(prev);
+      }
+
+      final startIdx = prev.stmtIndex + 1;
+      final endIdx = (j < k) ? points[j].stmtIndex : stmts.length;
+      for (var i = startIdx; i < endIdx; i++) {
         generateASTStatement(stmts[i], out: body, context: context);
       }
-      emitAwait(points[j], j + 1);
-      body.writeByte(Wasm.end); // end $L_{j+1}
-    }
 
-    // Final segment (after the last await), including the `return`.
-    body.write(loadResultInto(points[k - 1]));
-    for (var i = points[k - 1].stmtIndex + 1; i < stmts.length; i++) {
-      generateASTStatement(stmts[i], out: body, context: context);
+      if (j < k && !points[j].isInternal) emitLeafSuspend(points[j], j + 1);
+      body.writeByte(Wasm.end); // end $L_{j+1} (=> $exit when j == k)
     }
-    body.writeByte(Wasm.end); // end $exit
 
     // The `br_table` default lands here (past `end $exit`) with an empty stack,
     // so a non-void function needs an unreachable default to type-check — the
@@ -4900,19 +5027,24 @@ class WasmModuleContext {
   // `0` stays reserved as the null pointer.
   //
   //   ASY_STATE  (i32 @ 8):  0=normal, 1=unwound(suspended), 2=rewinding
-  //   ASY_RESUME (i32 @12):  which await to resume after (0 = fresh)
-  //   ASY_RESULT (i64 @16):  the awaited value, written back by the host
-  //   ASY_LOCALS (i64[] @24): spilled live locals across the suspension
+  //   ASY_SP     (i32 @12):  Asyncify frame-stack pointer (byte offset of the
+  //                          next free slot); the host driver initializes it to
+  //                          [asyncifyStackBase] before the first call.
+  //   ASY_RESULT (i64 @16):  the leaf await value, written back by the host
+  //   stack      (@24..):    a LIFO of frames; each suspendable function pushes
+  //                          `[resume:i32 @+0 (8B)] [local0:i64 @+8] ...` on
+  //                          unwind and pops it on rewind. Frames let nested
+  //                          async calls (multi-frame) suspend and resume.
 
   static const int asyncifyBase = 8;
   static const int asyncifyStateOffset = 8;
-  static const int asyncifyResumeOffset = 12;
+  static const int asyncifyStackPointerOffset = 12;
   static const int asyncifyResultOffset = 16;
-  static const int asyncifyLocalsOffset = 24;
+  static const int asyncifyStackBase = 24;
 
-  /// Bytes reserved for the Asyncify control region (state + result + spilled
-  /// locals). 256 bytes => up to 29 spilled i64 locals.
-  static const int asyncifyRegionSize = 256;
+  /// Bytes reserved for the Asyncify control region (state, SP, result, and the
+  /// frame stack). 4 KiB allows a deep enough chain of suspended frames.
+  static const int asyncifyRegionSize = 4096;
 
   /// Whether the module compiled at least one real-suspension `async` function
   /// and therefore reserves the Asyncify control region.
@@ -4921,6 +5053,10 @@ class WasmModuleContext {
   /// Names of functions compiled with the Asyncify transform (real suspension).
   /// Surfaced in the `apollovm_sig` section so the runner drives them.
   final Set<String> asyncifyFunctionNames = {};
+
+  /// Cached fixed-point set of Asyncify-eligible function names (see
+  /// `_asyncifyEligible`); `null` until first computed.
+  Set<String>? asyncifyEligible;
 
   // --- Static data region (interned string literals) ---
 
@@ -5320,12 +5456,17 @@ class _AwaitPoint {
   /// Declared type of [resultVarName] (`null` when there is no result var).
   final ASTType? resultType;
 
+  /// `true` when [calleeName] is another module (async) function — an *internal*
+  /// frame whose suspension must be propagated; `false` for a host import leaf.
+  final bool isInternal;
+
   _AwaitPoint(
     this.stmtIndex,
     this.calleeName,
     this.args,
     this.resultVarName,
     this.resultType,
+    this.isInternal,
   );
 }
 

--- a/lib/src/languages/wasm/wasm_runner.dart
+++ b/lib/src/languages/wasm/wasm_runner.dart
@@ -30,6 +30,30 @@ class ApolloRunnerWasm extends ApolloRunner {
     return ApolloRunnerWasm(apolloVM);
   }
 
+  /// Async host functions for real-suspension (Asyncify) `async` Wasm
+  /// functions, keyed by import name. When a compiled `async` function awaits
+  /// `name(args)`, the runner calls [fn] to produce a `Future`, suspends the
+  /// Wasm call, awaits it, then resumes (rewinds) the module. [params] must
+  /// match the awaited call's Wasm parameter types (e.g. `i64` for `int`).
+  final Map<
+    String,
+    ({
+      List<WasmValueType> params,
+      Future<Object?> Function(List<Object?> args) fn,
+    })
+  >
+  _wasmAsyncExternals = {};
+
+  /// Registers an async host function [name] used by real-suspension `async`
+  /// Wasm code (see [_wasmAsyncExternals]).
+  void mapWasmAsyncFunction(
+    String name,
+    List<WasmValueType> params,
+    Future<Object?> Function(List<Object?> args) fn,
+  ) {
+    _wasmAsyncExternals[name] = (params: params, fn: fn);
+  }
+
   @override
   Future<ASTValue> executeFunction(
     String namespace,
@@ -240,6 +264,23 @@ class ApolloRunnerWasm extends ApolloRunner {
       },
     };
 
+    // Real-suspension `async` support: a registered async host function is
+    // wired as a *suspending* import — its callback produces a `Future` (held
+    // in `pendingAwait`) and returns; the generated Asyncify code then unwinds.
+    // The drive loop below awaits the `Future` and rewinds the module.
+    Future<Object?>? pendingAwait;
+    for (var e in _wasmAsyncExternals.entries) {
+      var spec = e.value;
+      hostImports['env']![e.key] = WasmHostFunction(
+        params: spec.params,
+        results: const [],
+        callback: (args) {
+          pendingAwait = spec.fn(args);
+          return null;
+        },
+      );
+    }
+
     var module = await _wasmRuntime.loadModule(
       codeUnit.id,
       codeUnit.code,
@@ -258,7 +299,7 @@ class ApolloRunnerWasm extends ApolloRunner {
     // BEFORE numeric parameter resolution, which would otherwise mangle them.
     // The function receives the i32 pointer; param types come from the
     // `apollovm_sig` descriptors.
-    var paramTypes = _signatures(codeUnit.code)[functionName]?.params;
+    var paramTypes = _signatures(codeUnit.code).sigs[functionName]?.params;
     if (paramTypes != null) {
       for (var i = 0; i < allParams.length && i < paramTypes.length; ++i) {
         var pt = paramTypes[i];
@@ -291,35 +332,83 @@ class ApolloRunnerWasm extends ApolloRunner {
 
     final (function: function, varArgs: varArgs) = f;
 
-    dynamic res;
-    try {
-      if (!varArgs) {
-        if (function is Function(List)) {
-          res = Function.apply(function, [allParams]);
-        } else if (function is Function()) {
-          if (allParams.isNotEmpty) {
-            throw WasmModuleExecutionError(
-              functionName,
-              parameters: allParams,
-              function: function,
-              cause:
-                  "Function expects no arguments, but ${allParams.length} were provided: $allParams",
-            );
+    dynamic invokeOnce() {
+      try {
+        if (!varArgs) {
+          if (function is Function(List)) {
+            return Function.apply(function, [allParams]);
+          } else if (function is Function()) {
+            if (allParams.isNotEmpty) {
+              throw WasmModuleExecutionError(
+                functionName,
+                parameters: allParams,
+                function: function,
+                cause:
+                    "Function expects no arguments, but ${allParams.length} were provided: $allParams",
+              );
+            }
+            return Function.apply(function, []);
+          } else {
+            return Function.apply(function, allParams);
           }
-          res = Function.apply(function, []);
         } else {
-          res = Function.apply(function, allParams);
+          return Function.apply(function, allParams);
         }
-      } else {
-        res = Function.apply(function, allParams);
+      } catch (e) {
+        throw WasmModuleExecutionError(
+          functionName,
+          parameters: allParams,
+          function: function,
+          cause: e,
+        );
       }
-    } catch (e) {
-      throw WasmModuleExecutionError(
-        functionName,
-        parameters: allParams,
-        function: function,
-        cause: e,
-      );
+    }
+
+    final isAsyncFn = _signatures(
+      codeUnit.code,
+    ).asyncFns.contains(functionName);
+
+    dynamic res;
+    if (!isAsyncFn) {
+      res = invokeOnce();
+    } else {
+      // Asyncify drive loop: invoke; if the call unwound (suspended), await the
+      // host `Future` it produced, write the result back, flag a rewind, and
+      // re-invoke until it completes normally. Offsets match the Asyncify
+      // control region in `WasmModuleContext` (state @8 i32, result @16 i64).
+      const asyStateOff = 8;
+      const asyResultOff = 16;
+      while (true) {
+        res = invokeOnce();
+
+        var mem = module.readMemory();
+        if (mem == null) break;
+        var bd = ByteData.sublistView(mem);
+
+        if (bd.getInt32(asyStateOff, Endian.little) != 1) {
+          break; // normal completion (state 0)
+        }
+
+        var pending = pendingAwait;
+        if (pending == null) {
+          throw WasmModuleExecutionError(
+            functionName,
+            parameters: allParams,
+            cause:
+                "Async Wasm function suspended but no host `Future` was "
+                "produced. Register the awaited host function via "
+                "`mapWasmAsyncFunction`.",
+          );
+        }
+        pendingAwait = null;
+
+        var resolved = await pending;
+        var resolvedInt = resolved is BigInt
+            ? resolved.toInt()
+            : (resolved is num ? resolved.toInt() : 0);
+        _writeI64(bd, asyResultOff, resolvedInt);
+        bd.setInt32(asyStateOff, 2, Endian.little); // rewinding
+      }
     }
 
     res = module.resolveReturnedValue(res, astFunction);
@@ -327,7 +416,7 @@ class ApolloRunnerWasm extends ApolloRunner {
     // Decode the raw Wasm return into a Dart value. The return type comes from
     // the AST when available, else from the module's `apollovm_sig` custom
     // section (for modules loaded from raw bytes).
-    var sigReturn = _signatures(codeUnit.code)[functionName]?.ret;
+    var sigReturn = _signatures(codeUnit.code).sigs[functionName]?.ret;
 
     if (res != null) {
       // `String` return: an i32 pointer to a `[len][utf8]` block.
@@ -458,17 +547,22 @@ class ApolloRunnerWasm extends ApolloRunner {
   static const int _tagMap = 7;
 
   /// Per-module signature cache, keyed by the wasm binary's identity.
-  final Map<Uint8List, Map<String, _WasmSig>> _signaturesCache = {};
+  final Map<Uint8List, ({Map<String, _WasmSig> sigs, Set<String> asyncFns})>
+  _signaturesCache = {};
 
-  Map<String, _WasmSig> _signatures(Uint8List wasmBytes) =>
-      _signaturesCache[wasmBytes] ??= _parseSignatures(wasmBytes);
+  ({Map<String, _WasmSig> sigs, Set<String> asyncFns}) _signatures(
+    Uint8List wasmBytes,
+  ) => _signaturesCache[wasmBytes] ??= _parseSignatures(wasmBytes);
 
   /// Parses the `apollovm_sig` custom section (function name -> return/param
   /// type descriptors). Returns an empty map if absent. Each type is a one-byte
   /// tag, except a list (`6`) which is followed by its element tag byte.
-  static Map<String, _WasmSig> _parseSignatures(Uint8List b) {
+  static ({Map<String, _WasmSig> sigs, Set<String> asyncFns}) _parseSignatures(
+    Uint8List b,
+  ) {
     var sigs = <String, _WasmSig>{};
-    if (b.length < 8) return sigs;
+    var asyncFns = <String>{};
+    if (b.length < 8) return (sigs: sigs, asyncFns: asyncFns);
 
     var pos = 8; // skip magic (4) + version (4)
 
@@ -518,12 +612,20 @@ class ApolloRunnerWasm extends ApolloRunner {
             var params = [for (var p = 0; p < paramCount; ++p) readType()];
             sigs[fname] = _WasmSig(ret, params);
           }
+          // Optional trailing block: names of Asyncify (real-suspension)
+          // functions the runner must drive. Absent in older/non-async modules.
+          if (pos < sectionEnd) {
+            var asyncCount = readLeb();
+            for (var i = 0; i < asyncCount; ++i) {
+              asyncFns.add(readName());
+            }
+          }
         }
       }
       pos = sectionEnd;
     }
 
-    return sigs;
+    return (sigs: sigs, asyncFns: asyncFns);
   }
 
   void _resolveWasmCallParameters(

--- a/lib/src/languages/wasm/wasm_runner.dart
+++ b/lib/src/languages/wasm/wasm_runner.dart
@@ -375,9 +375,24 @@ class ApolloRunnerWasm extends ApolloRunner {
       // Asyncify drive loop: invoke; if the call unwound (suspended), await the
       // host `Future` it produced, write the result back, flag a rewind, and
       // re-invoke until it completes normally. Offsets match the Asyncify
-      // control region in `WasmModuleContext` (state @8 i32, result @16 i64).
+      // control region in `WasmModuleContext` (state @8 i32, SP @12 i32,
+      // result @16 i64, frame stack @24+).
       const asyStateOff = 8;
+      const asyStackPointerOff = 12;
       const asyResultOff = 16;
+      const asyStackBase = 24;
+
+      // Initialize the frame-stack pointer once (memory starts zeroed); it then
+      // persists across the unwind/rewind re-invocations.
+      {
+        var mem0 = module.readMemory();
+        if (mem0 != null) {
+          ByteData.sublistView(
+            mem0,
+          ).setInt32(asyStackPointerOff, asyStackBase, Endian.little);
+        }
+      }
+
       while (true) {
         res = invokeOnce();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, JavaScript, Lua with on-the-fly Wasm compilation.
-version: 0.1.29
+version: 0.1.30
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/apollovm_async_extra_test.dart
+++ b/test/apollovm_async_extra_test.dart
@@ -1,0 +1,264 @@
+@TestOn('vm')
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Loads Dart [source], registers an async `delayMs(ms, v)` external returning a
+/// real `Future<int>` (completes with `v` after `ms` ms), runs
+/// [className].[method] and returns the resolved value and `print` output.
+Future<({Object? value, List output})> _runDart(
+  String source,
+  String className,
+  String method, {
+  List args = const [],
+}) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', source, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source!");
+
+  var runner = vm.createRunner('dart')!;
+  var output = [];
+  runner.externalPrintFunction = (o) => output.add(o);
+
+  runner.externalFunctionMapper!
+      .mapExternalFunction2<dynamic, dynamic, Future<int>>(
+        ASTTypeFuture(ASTTypeInt.instance),
+        'delayMs',
+        ASTTypeDynamic.instance,
+        'ms',
+        ASTTypeDynamic.instance,
+        'v',
+        (ms, v) =>
+            Future.delayed(Duration(milliseconds: ms as int), () => v as int),
+      );
+
+  var astValue = await runner.executeClassMethod(
+    '',
+    className,
+    method,
+    positionalParameters: [args],
+  );
+  return (value: await astValue.getValueNoContext(), output: output);
+}
+
+/// Translates Dart [source] into [language], returning all generated source.
+Future<String> _translate(String source, String language) async {
+  var vm = ApolloVM();
+  await vm.loadCodeUnit(SourceCodeUnit('dart', source, id: 'test'));
+  var cs = vm.generateAllCodeIn(language);
+  var b = StringBuffer();
+  for (var ns in await cs.getNamespaces()) {
+    for (var id in await cs.getNamespaceCodeUnitsIDs(ns)) {
+      b.write(await cs.getNamespaceCodeUnit(ns, id));
+    }
+  }
+  return b.toString();
+}
+
+void main() {
+  group('Dart async runtime (extra)', () {
+    test('await inside a for loop accumulates', () async {
+      var r = await _runDart(
+        r'''
+        class C {
+          Future<int> run(List args) async {
+            var total = 0;
+            for (var i = 1; i <= 3; i = i + 1) {
+              var x = await delayMs(1, i);
+              total = total + x;
+            }
+            return total;
+          }
+        }
+      ''',
+        'C',
+        'run',
+      );
+      expect(r.value, equals(6)); // 1+2+3
+    });
+
+    test('await inside an if branch', () async {
+      var r = await _runDart(
+        r'''
+        class C {
+          Future<int> run(List args) async {
+            var n = 5;
+            if (n > 3) {
+              var x = await delayMs(1, 10);
+              return x;
+            }
+            return 0;
+          }
+        }
+      ''',
+        'C',
+        'run',
+      );
+      expect(r.value, equals(10));
+    });
+
+    test('await in an arithmetic expression', () async {
+      var r = await _runDart(
+        r'''
+        class C {
+          Future<int> run(List args) async {
+            return await delayMs(1, 5) * 2 + 1;
+          }
+        }
+      ''',
+        'C',
+        'run',
+      );
+      expect(r.value, equals(11)); // (5*2)+1
+    });
+
+    test('three-level nested async calls', () async {
+      var r = await _runDart(
+        r'''
+        class C {
+          Future<int> c(int x) async { var v = await delayMs(1, x); return v; }
+          Future<int> b(int x) async { return await c(x) + 1; }
+          Future<int> a(int x) async { return await b(x) + 1; }
+          Future<int> run(List args) async { return await a(10); }
+        }
+      ''',
+        'C',
+        'run',
+      );
+      expect(r.value, equals(12)); // 10 -> 11 -> 12
+    });
+
+    test('futures stored then awaited out of order', () async {
+      var r = await _runDart(
+        r'''
+        class C {
+          Future<int> run(List args) async {
+            var f = delayMs(20, 7);
+            var g = delayMs(2, 3);
+            var b = await g;
+            var a = await f;
+            return a + b;
+          }
+        }
+      ''',
+        'C',
+        'run',
+      );
+      expect(r.value, equals(10)); // 7+3
+    });
+
+    test('await a void-returning async (no result used)', () async {
+      var r = await _runDart(
+        r'''
+        class C {
+          Future<void> step() async {
+            await delayMs(1, 1);
+          }
+          Future<int> run(List args) async {
+            await step();
+            return 42;
+          }
+        }
+      ''',
+        'C',
+        'run',
+      );
+      expect(r.value, equals(42));
+    });
+
+    test('print ordering across awaits is deterministic', () async {
+      var r = await _runDart(
+        r'''
+        class C {
+          Future<int> run(List args) async {
+            print(1);
+            await delayMs(1, 0);
+            print(2);
+            await delayMs(1, 0);
+            print(3);
+            return 0;
+          }
+        }
+      ''',
+        'C',
+        'run',
+      );
+      expect(r.output, equals([1, 2, 3]));
+    });
+  });
+
+  group('Dart -> JavaScript async translation (extra)', () {
+    test('multiple awaits with a loop', () async {
+      var js = await _translate(r'''
+        class C {
+          Future<int> step(int i) async { return i; }
+          Future<int> run(List args) async {
+            var total = 0;
+            for (var i = 0; i < 3; i = i + 1) {
+              total = total + await step(i);
+            }
+            return total;
+          }
+        }
+      ''', 'javascript');
+      expect(js, contains('async step('));
+      expect(js, contains('async run('));
+      expect(js, contains('await '));
+      expect(js, contains('for ('));
+    });
+
+    test('top-level async functions', () async {
+      var js = await _translate(r'''
+        Future<int> compute() async { return 5; }
+        Future<int> main(List args) async {
+          var v = await compute();
+          return v;
+        }
+      ''', 'javascript');
+      expect(js, contains('async function compute('));
+      expect(js, contains('async function main('));
+      expect(js, contains('await '));
+    });
+
+    test('await in a return expression', () async {
+      var js = await _translate(r'''
+        class C {
+          Future<int> run(List args) async {
+            return await compute(args) + 1;
+          }
+        }
+      ''', 'javascript');
+      expect(js, contains('async run('));
+      expect(js, contains('await '));
+    });
+
+    test('static async method keeps both modifiers', () async {
+      var js = await _translate(r'''
+        class C {
+          static Future<int> run(List args) async {
+            return await compute(args);
+          }
+        }
+      ''', 'javascript');
+      expect(js, contains('static async run('));
+    });
+  });
+
+  group('Dart -> Dart async round-trip (extra)', () {
+    test('multiple awaits round-trip', () async {
+      var dart = await _translate(r'''
+        class C {
+          Future<int> run(List args) async {
+            var a = await one(args);
+            var b = await two(args);
+            return a + b;
+          }
+        }
+      ''', 'dart');
+      expect(dart, contains(') async {'));
+      // two await statements preserved.
+      expect('await '.allMatches(dart).length, greaterThanOrEqualTo(2));
+    });
+  });
+}

--- a/test/apollovm_async_test.dart
+++ b/test/apollovm_async_test.dart
@@ -1,0 +1,240 @@
+@TestOn('vm')
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Loads a single Dart [source], registers an async `delayMs(ms, v)` external
+/// (returns a real `Future<int>` completing with `v` after `ms` milliseconds),
+/// runs [className].[method] and returns the resolved (awaited) value plus the
+/// collected `print` output (in completion order).
+Future<({Object? value, List output})> runDartAsync(
+  String source,
+  String className,
+  String method, {
+  List args = const [],
+}) async {
+  var vm = ApolloVM();
+  var loadOK = await vm.loadCodeUnit(
+    SourceCodeUnit('dart', source, id: 'test'),
+  );
+  expect(loadOK, isTrue, reason: "Can't load Dart source!");
+
+  var runner = vm.createRunner('dart')!;
+
+  var output = [];
+  runner.externalPrintFunction = (o) => output.add(o);
+
+  // Param types are `dynamic` so calls with variable (dynamic-typed) arguments
+  // resolve the external by signature.
+  runner.externalFunctionMapper!
+      .mapExternalFunction2<dynamic, dynamic, Future<int>>(
+        ASTTypeFuture(ASTTypeInt.instance),
+        'delayMs',
+        ASTTypeDynamic.instance,
+        'ms',
+        ASTTypeDynamic.instance,
+        'v',
+        (ms, v) =>
+            Future.delayed(Duration(milliseconds: ms as int), () => v as int),
+      );
+
+  var astValue = await runner.executeClassMethod(
+    '',
+    className,
+    method,
+    positionalParameters: [args],
+  );
+
+  return (value: await astValue.getValueNoContext(), output: output);
+}
+
+void main() {
+  group('async/await runtime', () {
+    test('await a delayed Future returns its value', () async {
+      var r = await runDartAsync(
+        r'''
+        class Async {
+          Future<int> run(List args) async {
+            var x = await delayMs(5, 42);
+            return x;
+          }
+        }
+      ''',
+        'Async',
+        'run',
+      );
+
+      expect(r.value, equals(42));
+    });
+
+    test('real suspension: non-awaited calls complete by delay order', () async {
+      // `slow(30,1)` and `slow(5,2)` are started but not awaited. With real
+      // asynchrony the 5ms call completes (and prints) before the 30ms one,
+      // so the print order is [2, 1]. Eager evaluation would print [1, 2].
+      var r = await runDartAsync(
+        r'''
+        class Async {
+          Future<int> slow(int ms, int v) async {
+            await delayMs(ms, v);
+            print(v);
+            return v;
+          }
+
+          Future<int> run(List args) async {
+            var a = slow(30, 1);
+            var b = slow(5, 2);
+            await a;
+            await b;
+            return 0;
+          }
+        }
+      ''',
+        'Async',
+        'run',
+      );
+
+      expect(r.output, equals([2, 1]));
+    });
+
+    test('await chains across async functions', () async {
+      var r = await runDartAsync(
+        r'''
+        class Async {
+          Future<int> twice(int v) async {
+            var d = await delayMs(2, v);
+            return d + d;
+          }
+
+          Future<int> run(List args) async {
+            var a = await twice(10);
+            var b = await twice(a);
+            return b;
+          }
+        }
+      ''',
+        'Async',
+        'run',
+      );
+
+      expect(r.value, equals(40));
+    });
+
+    test('top-level async function', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(
+        SourceCodeUnit(
+          'dart',
+          r'''
+          Future<int> compute() async {
+            return 10;
+          }
+
+          Future<int> main(List args) async {
+            var v = await compute();
+            return v + 1;
+          }
+        ''',
+          id: 'test',
+        ),
+      );
+
+      var runner = vm.createRunner('dart')!;
+      var astValue = await runner.executeFunction(
+        '',
+        'main',
+        positionalParameters: [[]],
+      );
+
+      expect(await astValue.getValueNoContext(), equals(11));
+    });
+  });
+
+  group('async/await parsing', () {
+    test('`await` does not swallow identifiers like `awaiter`', () async {
+      var r = await runDartAsync(
+        r'''
+        class Async {
+          int run(List args) {
+            var awaiter = 5;
+            return awaiter + 1;
+          }
+        }
+      ''',
+        'Async',
+        'run',
+      );
+
+      expect(r.value, equals(6));
+    });
+  });
+
+  group('async/await translation', () {
+    test('Dart -> Dart round-trip preserves async/await', () async {
+      var generated = await _translateDart(
+        r'''
+        class Async {
+          Future<int> run(List args) async {
+            var x = await compute(args);
+            return x;
+          }
+        }
+      ''',
+        'dart',
+      );
+
+      expect(generated, contains(') async {'));
+      expect(generated, contains('await '));
+    });
+
+    test('Dart -> JavaScript emits async function / await', () async {
+      var generated = await _translateDart(
+        r'''
+        class Async {
+          Future<int> run(List args) async {
+            var x = await compute(args);
+            return x;
+          }
+        }
+      ''',
+        'javascript',
+      );
+
+      expect(generated, contains('async run('));
+      expect(generated, contains('await '));
+    });
+
+    test('Dart -> Kotlin async fails loudly (deferred)', () async {
+      expect(
+        () => _translateDart(
+          r'''
+          class Async {
+            Future<int> run(List args) async {
+              return await compute(args);
+            }
+          }
+        ''',
+          'kotlin',
+        ),
+        throwsA(isA<UnsupportedSyntaxError>()),
+      );
+    });
+  });
+}
+
+/// Translates a loaded Dart [source] into [language] and returns all generated
+/// source text.
+Future<String> _translateDart(String source, String language) async {
+  var vm = ApolloVM();
+  await vm.loadCodeUnit(SourceCodeUnit('dart', source, id: 'test'));
+
+  var codeStorage = vm.generateAllCodeIn(language);
+
+  var buffer = StringBuffer();
+  for (var ns in await codeStorage.getNamespaces()) {
+    for (var id in await codeStorage.getNamespaceCodeUnitsIDs(ns)) {
+      buffer.write(await codeStorage.getNamespaceCodeUnit(ns, id));
+    }
+  }
+  return buffer.toString();
+}

--- a/test/apollovm_async_test.dart
+++ b/test/apollovm_async_test.dart
@@ -68,12 +68,14 @@ void main() {
       expect(r.value, equals(42));
     });
 
-    test('real suspension: non-awaited calls complete by delay order', () async {
-      // `slow(30,1)` and `slow(5,2)` are started but not awaited. With real
-      // asynchrony the 5ms call completes (and prints) before the 30ms one,
-      // so the print order is [2, 1]. Eager evaluation would print [1, 2].
-      var r = await runDartAsync(
-        r'''
+    test(
+      'real suspension: non-awaited calls complete by delay order',
+      () async {
+        // `slow(30,1)` and `slow(5,2)` are started but not awaited. With real
+        // asynchrony the 5ms call completes (and prints) before the 30ms one,
+        // so the print order is [2, 1]. Eager evaluation would print [1, 2].
+        var r = await runDartAsync(
+          r'''
         class Async {
           Future<int> slow(int ms, int v) async {
             await delayMs(ms, v);
@@ -90,12 +92,13 @@ void main() {
           }
         }
       ''',
-        'Async',
-        'run',
-      );
+          'Async',
+          'run',
+        );
 
-      expect(r.output, equals([2, 1]));
-    });
+        expect(r.output, equals([2, 1]));
+      },
+    );
 
     test('await chains across async functions', () async {
       var r = await runDartAsync(
@@ -123,9 +126,7 @@ void main() {
     test('top-level async function', () async {
       var vm = ApolloVM();
       await vm.loadCodeUnit(
-        SourceCodeUnit(
-          'dart',
-          r'''
+        SourceCodeUnit('dart', r'''
           Future<int> compute() async {
             return 10;
           }
@@ -134,9 +135,7 @@ void main() {
             var v = await compute();
             return v + 1;
           }
-        ''',
-          id: 'test',
-        ),
+        ''', id: 'test'),
       );
 
       var runner = vm.createRunner('dart')!;
@@ -171,34 +170,28 @@ void main() {
 
   group('async/await translation', () {
     test('Dart -> Dart round-trip preserves async/await', () async {
-      var generated = await _translateDart(
-        r'''
+      var generated = await _translateDart(r'''
         class Async {
           Future<int> run(List args) async {
             var x = await compute(args);
             return x;
           }
         }
-      ''',
-        'dart',
-      );
+      ''', 'dart');
 
       expect(generated, contains(') async {'));
       expect(generated, contains('await '));
     });
 
     test('Dart -> JavaScript emits async function / await', () async {
-      var generated = await _translateDart(
-        r'''
+      var generated = await _translateDart(r'''
         class Async {
           Future<int> run(List args) async {
             var x = await compute(args);
             return x;
           }
         }
-      ''',
-        'javascript',
-      );
+      ''', 'javascript');
 
       expect(generated, contains('async run('));
       expect(generated, contains('await '));
@@ -206,16 +199,13 @@ void main() {
 
     test('Dart -> Kotlin async fails loudly (deferred)', () async {
       expect(
-        () => _translateDart(
-          r'''
+        () => _translateDart(r'''
           class Async {
             Future<int> run(List args) async {
               return await compute(args);
             }
           }
-        ''',
-          'kotlin',
-        ),
+        ''', 'kotlin'),
         throwsA(isA<UnsupportedSyntaxError>()),
       );
     });

--- a/test/apollovm_wasm_async_test.dart
+++ b/test/apollovm_wasm_async_test.dart
@@ -1,0 +1,160 @@
+@TestOn('vm')
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Compiles [code] to Wasm, executes [functionName] both via the AST
+/// interpreter and the compiled+executed Wasm module, and asserts every
+/// execution matches the expected result in [executions].
+///
+/// The Wasm backend executes synchronously, so `async` functions collapse
+/// `Future<T>` to `T` and `await` is a value pass-through (see
+/// `effectiveReturnType` / `generateASTExpressionAwait` in the Wasm generator).
+/// This validates that compute-style async Dart code compiles to Wasm and
+/// produces the same result as the AST interpreter.
+Future<void> _testWasm(
+  String code,
+  String functionName,
+  Map<List, Object?> executions,
+) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', code, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source");
+
+  // 1) AST interpreter (async entry is awaited to a resolved value by execute).
+  var astRunner = vm.createRunner('dart')!;
+  for (var e in executions.entries) {
+    var r = await astRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      await r.getValueNoContext(),
+      e.value,
+      reason: 'AST $functionName(${e.key})',
+    );
+  }
+
+  // 2) Compile to Wasm.
+  var storageWasm = vm.generateAllIn<BytesOutput>('wasm');
+  var wasmModules = await storageWasm.allEntries();
+
+  BytesOutput? compiled;
+  for (var ns in wasmModules.entries) {
+    for (var m in ns.value.entries) {
+      compiled ??= m.value;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var rt = WasmRuntime()..ensureBooted();
+  if (!rt.isSupported) {
+    fail(
+      'Wasm runtime not supported — cannot validate compiled bytes '
+      '(run `dart run wasm_run:setup`).',
+    );
+  }
+
+  // 3) Load + execute the compiled Wasm.
+  var vmWasm = ApolloVM();
+  var loadOK = await vmWasm.loadCodeUnit(
+    BinaryCodeUnit('wasm', compiled!.output(), id: 'test.wasm', namespace: ''),
+  );
+  expect(loadOK, isTrue, reason: 'Compiled Wasm failed to load');
+
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  for (var e in executions.entries) {
+    var r = await wasmRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'WASM $functionName(${e.key})',
+    );
+  }
+}
+
+void main() {
+  group('Wasm async/await (synchronous collapse)', () {
+    test('async function returning a computed value', () async {
+      await _testWasm(
+        r'''
+        Future<int> calc(int n) async {
+          return n * 2;
+        }
+      ''',
+        'calc',
+        {
+          [21]: 42,
+          [0]: 0,
+          [5]: 10,
+        },
+      );
+    });
+
+    test('await another async function', () async {
+      await _testWasm(
+        r'''
+        Future<int> dbl(int n) async {
+          return n * 2;
+        }
+
+        Future<int> calc(int n) async {
+          // Explicit type: the Wasm backend can't statically infer `var x` from
+          // a function-call result (pre-existing limitation, not async-related).
+          int v = await dbl(n);
+          return v + 1;
+        }
+      ''',
+        'calc',
+        {
+          [10]: 21,
+          [0]: 1,
+        },
+      );
+    });
+
+    test('await inside an expression', () async {
+      await _testWasm(
+        r'''
+        Future<int> dbl(int n) async {
+          return n * 2;
+        }
+
+        Future<int> calc(int n) async {
+          return await dbl(n) + n;
+        }
+      ''',
+        'calc',
+        {
+          [10]: 30,
+          [3]: 9,
+        },
+      );
+    });
+
+    test('async with a loop body', () async {
+      await _testWasm(
+        r'''
+        Future<int> sumTo(int n) async {
+          var total = 0;
+          for (var i = 1; i <= n; i = i + 1) {
+            total = total + i;
+          }
+          return total;
+        }
+      ''',
+        'sumTo',
+        {
+          [5]: 15,
+          [10]: 55,
+        },
+      );
+    });
+  });
+}

--- a/test/apollovm_wasm_async_test.dart
+++ b/test/apollovm_wasm_async_test.dart
@@ -138,6 +138,56 @@ void main() {
       );
     });
 
+    test('async with if/else awaiting module functions', () async {
+      await _testWasm(
+        r'''
+        Future<int> big(int n) async {
+          return n * 2;
+        }
+
+        Future<int> small(int n) async {
+          return n + 1;
+        }
+
+        Future<int> classify(int n) async {
+          if (n > 10) {
+            return await big(n);
+          }
+          return await small(n);
+        }
+      ''',
+        'classify',
+        {
+          [15]: 30,
+          [5]: 6,
+          [10]: 11,
+        },
+      );
+    });
+
+    test('nested async (a awaits b awaits c) collapses', () async {
+      await _testWasm(
+        r'''
+        Future<int> c(int n) async {
+          return n + 1;
+        }
+
+        Future<int> b(int n) async {
+          return await c(n) + 1;
+        }
+
+        Future<int> a(int n) async {
+          return await b(n) + 1;
+        }
+      ''',
+        'a',
+        {
+          [10]: 13,
+          [0]: 3,
+        },
+      );
+    });
+
     test('async with a loop body', () async {
       await _testWasm(
         r'''

--- a/test/apollovm_wasm_asyncify_codegen_test.dart
+++ b/test/apollovm_wasm_asyncify_codegen_test.dart
@@ -1,0 +1,176 @@
+@TestOn('vm')
+library;
+
+import 'dart:typed_data';
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Validates the **generator-emitted** Asyncify transform (real suspension):
+/// the Wasm generator compiles an `async` function with a single statement-level
+/// `await` of an external host call into an unwind/rewind state machine. Here a
+/// host-side driver runs that machine against the live `WasmRuntime`, awaiting a
+/// real Dart `Future` between unwind and rewind.
+///
+/// Asyncify control region (must match `WasmModuleContext`):
+const _asyState = 8; //  i32: 0=normal, 1=unwound, 2=rewinding
+const _asyResult = 16; // i64: host writes the awaited value here
+
+/// Compiles [dartSource] to Wasm bytes.
+Future<Uint8List> _compile(String dartSource) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(
+    SourceCodeUnit('dart', dartSource, id: 'test'),
+  );
+  expect(ok, isTrue, reason: "Can't load Dart source");
+
+  var storage = vm.generateAllIn<BytesOutput>('wasm');
+  var modules = await storage.allEntries();
+  for (var ns in modules.entries) {
+    for (var m in ns.value.entries) {
+      return m.value.output();
+    }
+  }
+  fail('No compiled Wasm module');
+}
+
+/// Drives an Asyncify export to completion. [hostCompute] turns the suspending
+/// import's captured args into a real `Future` (the actual async work).
+Future<int> _drive(
+  WasmRuntime rt,
+  Uint8List wasm,
+  String importName,
+  String functionName,
+  List<Object?> args,
+  Future<int> Function(List<Object?> importArgs) hostCompute, {
+  void Function()? onSuspend,
+}) async {
+  List<Object?>? pendingArgs;
+
+  var module = await rt.loadModule(
+    'asyncify-codegen-$functionName',
+    wasm,
+    hostImports: {
+      'env': {
+        // Suspending import: records the args and returns; the generated code
+        // then unwinds. The real value is delivered on rewind via memory.
+        importName: WasmHostFunction(
+          params: const [WasmValueType.i64],
+          results: const [],
+          callback: (a) {
+            pendingArgs = a;
+            return null;
+          },
+        ),
+      },
+    },
+  );
+
+  while (true) {
+    final ret = module.invokeExport(functionName, args) as int;
+
+    final mem = module.readMemory()!;
+    final bd = mem.buffer.asByteData(mem.offsetInBytes, mem.lengthInBytes);
+
+    if (bd.getInt32(_asyState, Endian.little) == 1) {
+      onSuspend?.call();
+      final resolved = await hostCompute(pendingArgs!); // real async gap
+      bd.setInt64(_asyResult, resolved, Endian.little);
+      bd.setInt32(_asyState, 2, Endian.little); // rewinding
+      continue;
+    }
+
+    return ret; // completed
+  }
+}
+
+void main() {
+  late WasmRuntime rt;
+  setUpAll(() => rt = WasmRuntime()..ensureBooted());
+
+  group('Wasm Asyncify codegen (generated, real suspension)', () {
+    test('async fn awaiting an external host call really suspends', () async {
+      if (!rt.isSupported) {
+        fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+      }
+
+      // `hostDouble` is NOT a module function => compiled as a suspending host
+      // import; the single statement-level await triggers the Asyncify path.
+      final wasm = await _compile(r'''
+        Future<int> compute(int n) async {
+          int v = await hostDouble(n);
+          return v + 1;
+        }
+      ''');
+
+      var suspends = 0;
+      var awaited = false;
+
+      final result = await _drive(rt, wasm, 'hostDouble', 'compute', [10], (
+        importArgs,
+      ) async {
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        awaited = true;
+        return (importArgs[0] as int) * 2; // double the awaited arg
+      }, onSuspend: () => suspends++);
+
+      // v = host(10) = 20 ; return v + 1 = 21.
+      expect(result, equals(21));
+      expect(suspends, equals(1), reason: 'one real suspension');
+      expect(awaited, isTrue, reason: 'host awaited a real Future');
+    });
+
+    test('pre/post-await locals survive the suspension', () async {
+      if (!rt.isSupported) {
+        fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+      }
+
+      // `base` is set before the await and must survive the unwind/rewind.
+      final wasm = await _compile(r'''
+        Future<int> compute(int n) async {
+          int base = n * 100;
+          int v = await hostDouble(n);
+          return base + v;
+        }
+      ''');
+
+      final result = await _drive(rt, wasm, 'hostDouble', 'compute', [3], (
+        importArgs,
+      ) async {
+        await Future<void>.delayed(const Duration(milliseconds: 3));
+        return (importArgs[0] as int) * 2;
+      });
+
+      // base = 300 ; v = 6 ; return 306.
+      expect(result, equals(306));
+    });
+
+    test('two generated computations interleave by host delay', () async {
+      if (!rt.isSupported) {
+        fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+      }
+
+      final wasm = await _compile(r'''
+        Future<int> compute(int n) async {
+          int v = await hostDouble(n);
+          return v + 1;
+        }
+      ''');
+
+      final order = <int>[];
+
+      Future<int> run(int n, int delayMs, int id) =>
+          _drive(rt, wasm, 'hostDouble', 'compute', [n], (importArgs) async {
+            await Future<void>.delayed(Duration(milliseconds: delayMs));
+            order.add(id);
+            return (importArgs[0] as int) * 2;
+          });
+
+      final results = await Future.wait([run(10, 30, 1), run(20, 5, 2)]);
+
+      expect(results[0], equals(21));
+      expect(results[1], equals(41));
+      expect(order, equals([2, 1]), reason: 'real concurrent suspension');
+    });
+  });
+}

--- a/test/apollovm_wasm_asyncify_codegen_test.dart
+++ b/test/apollovm_wasm_asyncify_codegen_test.dart
@@ -145,6 +145,64 @@ void main() {
       expect(result, equals(306));
     });
 
+    test(
+      'multiple awaits in one function (br_table resume dispatch)',
+      () async {
+        if (!rt.isSupported) {
+          fail('Wasm runtime not supported.');
+        }
+
+        // Two sequential awaits => two real suspensions, resumed via br_table.
+        final wasm = await _compile(r'''
+        Future<int> compute(int n) async {
+          int a = await hostDouble(n);
+          int b = await hostDouble(a);
+          return a + b;
+        }
+      ''');
+
+        var suspends = 0;
+        final result = await _drive(rt, wasm, 'hostDouble', 'compute', [5], (
+          importArgs,
+        ) async {
+          await Future<void>.delayed(const Duration(milliseconds: 2));
+          return (importArgs[0] as int) * 2;
+        }, onSuspend: () => suspends++);
+
+        // a = 2*5 = 10 ; b = 2*10 = 20 ; return 30.
+        expect(result, equals(30));
+        expect(suspends, equals(2), reason: 'two real suspensions');
+      },
+    );
+
+    test('awaits with statements interleaved + locals across each', () async {
+      if (!rt.isSupported) {
+        fail('Wasm runtime not supported.');
+      }
+
+      final wasm = await _compile(r'''
+        Future<int> compute(int n) async {
+          int base = n * 100;
+          int a = await hostDouble(n);
+          int mid = base + a;
+          int b = await hostDouble(mid);
+          return mid + b;
+        }
+      ''');
+
+      var suspends = 0;
+      final result = await _drive(rt, wasm, 'hostDouble', 'compute', [2], (
+        importArgs,
+      ) async {
+        await Future<void>.delayed(const Duration(milliseconds: 2));
+        return (importArgs[0] as int) * 2;
+      }, onSuspend: () => suspends++);
+
+      // base=200; a=4; mid=204; b=408; return mid+b = 612.
+      expect(result, equals(612));
+      expect(suspends, equals(2));
+    });
+
     test('two generated computations interleave by host delay', () async {
       if (!rt.isSupported) {
         fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');

--- a/test/apollovm_wasm_asyncify_codegen_test.dart
+++ b/test/apollovm_wasm_asyncify_codegen_test.dart
@@ -14,7 +14,9 @@ import 'package:test/test.dart';
 ///
 /// Asyncify control region (must match `WasmModuleContext`):
 const _asyState = 8; //  i32: 0=normal, 1=unwound, 2=rewinding
+const _asySp = 12; //    i32: frame-stack pointer
 const _asyResult = 16; // i64: host writes the awaited value here
+const _asyStackBase = 24; // frame stack grows from here
 
 /// Compiles [dartSource] to Wasm bytes.
 Future<Uint8List> _compile(String dartSource) async {
@@ -65,6 +67,14 @@ Future<int> _drive(
       },
     },
   );
+
+  // Initialize the frame-stack pointer once.
+  {
+    final mem0 = module.readMemory()!;
+    mem0.buffer
+        .asByteData(mem0.offsetInBytes, mem0.lengthInBytes)
+        .setInt32(_asySp, _asyStackBase, Endian.little);
+  }
 
   while (true) {
     final ret = module.invokeExport(functionName, args) as int;

--- a/test/apollovm_wasm_asyncify_prototype_test.dart
+++ b/test/apollovm_wasm_asyncify_prototype_test.dart
@@ -1,0 +1,343 @@
+@TestOn('vm')
+library;
+
+import 'dart:typed_data';
+
+import 'package:apollovm/apollovm.dart';
+// Internal opcode/byte helpers (same-package import, allowed in this package's
+// own tests).
+import 'package:apollovm/src/languages/wasm/wasm.dart';
+import 'package:test/test.dart';
+
+/// Asyncify real-suspension PROTOTYPE for the ApolloVM Wasm backend.
+///
+/// WebAssembly has no native async/await, and ApolloVM's Wasm runtime is
+/// synchronous. This prototype proves that **real suspension** is achievable
+/// with the existing runtime using the Asyncify technique: a running Wasm call
+/// unwinds the stack back to the host (saving each frame's live locals to
+/// linear memory), the host awaits a real Dart `Future`, then re-invokes the
+/// export which rewinds — restoring locals and resuming exactly where it
+/// stopped.
+///
+/// The module below is hand-assembled (two frames, `runner` -> `step`, one
+/// suspension point) to demonstrate the mechanism end-to-end against the real
+/// `WasmRuntime`. It deliberately simplifies full Binaryen Asyncify:
+///   * a single suspension point, so the resume "program counter" is implicit
+///     (before/after the one `await`) rather than a per-frame call index;
+///   * the unwind/rewind bookkeeping is emitted inline after the suspend call
+///     rather than inside imported `asyncify_*` helpers;
+///   * a flat, fixed memory layout instead of a growable Asyncify stack.
+/// Integrating this into the code generator (general bodies, many awaits,
+/// `br_table` resume dispatch, a real frame stack) is the follow-up.
+
+// --- Fixed linear-memory layout (byte offsets in page 0) ---
+const _state = 0; //   i32: 0=normal, 1=unwound(suspended), 2=rewinding
+const _arg = 8; //     i64: argument handed to the host at the suspend point
+const _result = 16; // i64: resolved value written back by the host
+const _savedA = 24; // i64: `runner`'s live local across the suspension
+const _savedB = 32; // i64: `step`'s live local across the suspension
+const _counter = 40; // i32: counts prologue executions (side-effect probe)
+
+/// Builds the prototype module. Function indices: import `env.suspend` = 0,
+/// `runner` = 1, `step` = 2. Exports: `runner` and `memory`.
+Uint8List _buildModule() {
+  // step(i64 x) -> i64 : computes b = x + 7, suspends, resumes to b + result.
+  final step = <int>[
+    // if (load i32 STATE == 2) { rewind }
+    ...Wasm32.i32Const(0), ...Wasm32.i32Load(2, _state),
+    ...Wasm32.i32Const(2), Wasm32.i32Equals,
+    ...Wasm.ifInstruction(WasmType.voidType),
+    // b = SAVED_B
+    ...Wasm32.i32Const(0), ...Wasm64.i64Load(3, _savedB), ...Wasm.localSet(1),
+    // return b + RESULT  (resume point — after the await)
+    ...Wasm.localGet(1),
+    ...Wasm32.i32Const(0), ...Wasm64.i64Load(3, _result), Wasm64.i64Add,
+    Wasm.functionReturn,
+    Wasm.end,
+    // --- normal path ---
+    // COUNTER += 1  (side effect that must run exactly once)
+    ...Wasm32.i32Const(0),
+    ...Wasm32.i32Const(0), ...Wasm32.i32Load(2, _counter),
+    ...Wasm32.i32Const(1), Wasm32.i32Add,
+    ...Wasm32.i32Store(2, _counter),
+    // b = x + 7
+    ...Wasm.localGet(0), ...Wasm64.i64Const(7), Wasm64.i64Add,
+    ...Wasm.localSet(1),
+    // ARG = x  (tell the host what to await on)
+    ...Wasm32.i32Const(0), ...Wasm.localGet(0), ...Wasm64.i64Store(3, _arg),
+    // await: call the host suspend marker
+    ...Wasm.localGet(0), ...Wasm.call(0),
+    // unwind: SAVED_B = b; STATE = 1; return dummy
+    ...Wasm32.i32Const(0), ...Wasm.localGet(1), ...Wasm64.i64Store(3, _savedB),
+    ...Wasm32.i32Const(0), ...Wasm32.i32Const(1), ...Wasm32.i32Store(2, _state),
+    ...Wasm64.i64Const(0),
+    Wasm.end,
+  ];
+
+  // runner(i64 x) -> i64 : a = x + 100, calls step, returns a + step-result.
+  final runner = <int>[
+    // if (load i32 STATE == 2) { rewind }
+    ...Wasm32.i32Const(0), ...Wasm32.i32Load(2, _state),
+    ...Wasm32.i32Const(2), Wasm32.i32Equals,
+    ...Wasm.ifInstruction(WasmType.voidType),
+    // a = SAVED_A
+    ...Wasm32.i32Const(0), ...Wasm64.i64Load(3, _savedA), ...Wasm.localSet(1),
+    // r = step(x)  (step rewinds and returns its resolved result)
+    ...Wasm.localGet(0), ...Wasm.call(2), ...Wasm.localSet(2),
+    // STATE = 0  (suspension complete)
+    ...Wasm32.i32Const(0), ...Wasm32.i32Const(0), ...Wasm32.i32Store(2, _state),
+    // return a + r
+    ...Wasm.localGet(1), ...Wasm.localGet(2), Wasm64.i64Add,
+    Wasm.functionReturn,
+    Wasm.end,
+    // --- normal path ---
+    // a = x + 100
+    ...Wasm.localGet(0), ...Wasm64.i64Const(100), Wasm64.i64Add,
+    ...Wasm.localSet(1),
+    // SAVED_A = a
+    ...Wasm32.i32Const(0), ...Wasm.localGet(1), ...Wasm64.i64Store(3, _savedA),
+    // r = step(x)
+    ...Wasm.localGet(0), ...Wasm.call(2), ...Wasm.localSet(2),
+    // if (STATE == 1) { propagate unwind: return dummy }
+    ...Wasm32.i32Const(0), ...Wasm32.i32Load(2, _state),
+    ...Wasm32.i32Const(1), Wasm32.i32Equals,
+    ...Wasm.ifInstruction(WasmType.voidType),
+    ...Wasm64.i64Const(0), Wasm.functionReturn,
+    Wasm.end,
+    // return a + r  (step completed without suspending)
+    ...Wasm.localGet(1), ...Wasm.localGet(2), Wasm64.i64Add,
+    Wasm.end,
+  ];
+
+  // Code-section bodies: local declarations (vec of (count, valtype) groups)
+  // followed by the instructions.
+  final stepBody = <int>[
+    ..._lebU(1), ..._lebU(1), WasmType.i64Type.value, // 1 group: 1 i64 (b)
+    ...step,
+  ];
+  final runnerBody = <int>[
+    ..._lebU(1), ..._lebU(2), WasmType.i64Type.value, // 1 group: 2 i64 (a, r)
+    ...runner,
+  ];
+
+  return _assembleModule(
+    types: [
+      // type 0: (i64) -> ()   [suspend]
+      [Wasm.functionType, ..._lebU(1), WasmType.i64Type.value, 0],
+      // type 1: (i64) -> (i64)  [runner, step]
+      [
+        Wasm.functionType,
+        ..._lebU(1),
+        WasmType.i64Type.value,
+        ..._lebU(1),
+        WasmType.i64Type.value,
+      ],
+    ],
+    importSuspendTypeIdx: 0,
+    funcTypeIdxs: const [1, 1], // runner, step
+    exports: [
+      ('runner', Wasm.externalKindFunction, 1),
+      ('memory', Wasm.externalKindMemory, 0),
+    ],
+    bodies: [runnerBody, stepBody],
+  );
+}
+
+/// Assembles a minimal module: type, import (`env.suspend`), function, memory
+/// (1 page, exported), export, and code sections.
+Uint8List _assembleModule({
+  required List<List<int>> types,
+  required int importSuspendTypeIdx,
+  required List<int> funcTypeIdxs,
+  required List<(String, int, int)> exports,
+  required List<List<int>> bodies,
+}) {
+  final out = <int>[...Wasm.magicModuleHeader, ...Wasm.moduleVersion];
+
+  // Type section.
+  out.addAll(_section(Wasm.sectionType, _vec(types)));
+
+  // Import section: env.suspend (function, type index).
+  final import = <int>[
+    ...Wasm.encodeString('env'),
+    ...Wasm.encodeString('suspend'),
+    Wasm.externalKindFunction,
+    ..._lebU(importSuspendTypeIdx),
+  ];
+  out.addAll(_section(Wasm.sectionImport, _vec([import])));
+
+  // Function section: type index per defined function.
+  out.addAll(
+    _section(Wasm.sectionFunction, _vec(funcTypeIdxs.map(_lebU).toList())),
+  );
+
+  // Memory section: 1 memory, limits {min: 1} (flags 0x00).
+  out.addAll(
+    _section(
+      Wasm.sectionMemory,
+      _vec([
+        <int>[0x00, 0x01],
+      ]),
+    ),
+  );
+
+  // Export section.
+  final exportEntries = exports
+      .map((e) => <int>[...Wasm.encodeString(e.$1), e.$2, ..._lebU(e.$3)])
+      .toList();
+  out.addAll(_section(Wasm.sectionExport, _vec(exportEntries)));
+
+  // Code section: each body (locals + instructions + trailing `end`) is
+  // length-prefixed.
+  final codeEntries = bodies
+      .map((b) => <int>[..._lebU(b.length), ...b])
+      .toList();
+  out.addAll(_section(Wasm.sectionCode, _vec(codeEntries)));
+
+  return Uint8List.fromList(out);
+}
+
+List<int> _section(int id, List<int> payload) => [
+  id,
+  ..._lebU(payload.length),
+  ...payload,
+];
+
+List<int> _vec(List<List<int>> items) => [
+  ..._lebU(items.length),
+  for (final it in items) ...it,
+];
+
+List<int> _lebU(int v) {
+  final out = <int>[];
+  var x = v;
+  do {
+    var b = x & 0x7f;
+    x >>= 7;
+    if (x != 0) b |= 0x80;
+    out.add(b);
+  } while (x != 0);
+  return out;
+}
+
+/// Drives an Asyncify-style export to completion, awaiting [hostCompute] (a real
+/// `Future`) at each suspension point. Returns the export's final result.
+/// [onSuspend] fires once per suspension (for observing real interleaving).
+Future<int> _runAsyncify(
+  WasmModule module,
+  int x,
+  Future<int> Function(int arg) hostCompute, {
+  void Function()? onSuspend,
+}) async {
+  while (true) {
+    final ret = module.invokeExport('runner', [x]) as int;
+
+    final mem = module.readMemory()!;
+    final bd = mem.buffer.asByteData(mem.offsetInBytes, mem.lengthInBytes);
+
+    final state = bd.getInt32(_state, Endian.little);
+    if (state == 1) {
+      // Unwound: the Wasm call returned to the host mid-execution.
+      onSuspend?.call();
+      final arg = bd.getInt64(_arg, Endian.little);
+      final resolved = await hostCompute(arg); // <-- REAL async suspension
+      bd.setInt64(_result, resolved, Endian.little);
+      bd.setInt32(_state, 2, Endian.little); // rewinding
+      continue;
+    }
+
+    return ret; // state == 0: completed normally
+  }
+}
+
+Future<WasmModule> _loadModule(WasmRuntime rt, String name) {
+  return rt.loadModule(
+    name,
+    _buildModule(),
+    hostImports: {
+      'env': {
+        // The suspend marker: the unwind bookkeeping is done inline in Wasm, so
+        // the host callback is a no-op (it just has to satisfy the import).
+        'suspend': WasmHostFunction(
+          params: const [WasmValueType.i64],
+          results: const [],
+          callback: (args) => null,
+        ),
+      },
+    },
+  );
+}
+
+int _counterOf(WasmModule m) {
+  final mem = m.readMemory()!;
+  final bd = mem.buffer.asByteData(mem.offsetInBytes, mem.lengthInBytes);
+  return bd.getInt32(_counter, Endian.little);
+}
+
+void main() {
+  late WasmRuntime rt;
+
+  setUpAll(() {
+    rt = WasmRuntime()..ensureBooted();
+  });
+
+  group('Wasm Asyncify prototype (real suspension)', () {
+    test('suspends to the host, awaits a real Future, and rewinds', () async {
+      if (!rt.isSupported) {
+        fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+      }
+
+      final module = await _loadModule(rt, 'asyncify-1');
+
+      var suspends = 0;
+      var hostResumedAsync = false;
+
+      final result = await _runAsyncify(module, 10, (arg) async {
+        // A genuine async gap: the Wasm stack is unwound while we await.
+        await Future<void>.delayed(const Duration(milliseconds: 5));
+        hostResumedAsync = true;
+        return arg * 2; // host injects 2*arg back into the computation
+      }, onSuspend: () => suspends++);
+
+      // a = x+100 = 110 ; b = x+7 = 17 ; host result = 2x = 20.
+      // final = a + (b + result) = 110 + 17 + 20 = 147.
+      expect(result, equals(147));
+      expect(suspends, equals(1), reason: 'exactly one suspension point');
+      expect(hostResumedAsync, isTrue, reason: 'host actually awaited');
+      // Side-effecting prologue ran exactly once — proving rewind skipped the
+      // already-executed code instead of re-running it.
+      expect(_counterOf(module), equals(1));
+    });
+
+    test('two suspended computations interleave by host delay', () async {
+      if (!rt.isSupported) {
+        fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+      }
+
+      // Independent instances => independent linear memory / Asyncify state.
+      final m1 = await _loadModule(rt, 'asyncify-slow');
+      final m2 = await _loadModule(rt, 'asyncify-fast');
+
+      final completionOrder = <int>[];
+
+      Future<int> drive(WasmModule m, int x, int delayMs, int id) {
+        return _runAsyncify(m, x, (arg) async {
+          await Future<void>.delayed(Duration(milliseconds: delayMs));
+          completionOrder.add(id);
+          return arg * 2;
+        });
+      }
+
+      // Both start (and suspend) before either host Future resolves; the 5ms
+      // one resolves first, proving real concurrent suspension.
+      final results = await Future.wait([
+        drive(m1, 10, 30, 1), // slow
+        drive(m2, 20, 5, 2), // fast
+      ]);
+
+      expect(results[0], equals(147)); // 4*10 + 107
+      expect(results[1], equals(187)); // 4*20 + 107
+      expect(completionOrder, equals([2, 1]));
+    });
+  });
+}

--- a/test/apollovm_wasm_asyncify_runner_test.dart
+++ b/test/apollovm_wasm_asyncify_runner_test.dart
@@ -1,0 +1,125 @@
+@TestOn('vm')
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// End-to-end real-suspension `async`/`await` in Wasm THROUGH the normal VM
+/// runner: `ApolloRunnerWasm.executeFunction` compiles the async function with
+/// the Asyncify transform, then drives its unwind/rewind loop — awaiting a real
+/// Dart `Future` produced by a host function registered via
+/// `mapWasmAsyncFunction`.
+
+int _asInt(Object? v) => v is BigInt ? v.toInt() : (v as num).toInt();
+
+Future<ApolloRunnerWasm?> _wasmRunner(String dartSource) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(
+    SourceCodeUnit('dart', dartSource, id: 'test'),
+  );
+  expect(ok, isTrue, reason: "Can't load Dart source");
+
+  // Compile to Wasm and reload the bytes as a runnable code unit.
+  var storage = vm.generateAllIn<BytesOutput>('wasm');
+  var modules = await storage.allEntries();
+  BytesOutput? compiled;
+  for (var ns in modules.entries) {
+    for (var m in ns.value.entries) {
+      compiled ??= m.value;
+    }
+  }
+  if (compiled == null) return null;
+
+  var rt = WasmRuntime()..ensureBooted();
+  if (!rt.isSupported) return null;
+
+  var vmWasm = ApolloVM();
+  await vmWasm.loadCodeUnit(
+    BinaryCodeUnit('wasm', compiled.output(), id: 'test.wasm', namespace: ''),
+  );
+  return vmWasm.createRunner('wasm') as ApolloRunnerWasm;
+}
+
+void main() {
+  group('Wasm Asyncify via ApolloRunnerWasm (real suspension)', () {
+    test(
+      'executeFunction drives an async fn that awaits a host Future',
+      () async {
+        var runner = await _wasmRunner(r'''
+        Future<int> compute(int n) async {
+          int v = await hostDouble(n);
+          return v + 1;
+        }
+      ''');
+        if (runner == null) {
+          fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+        }
+
+        var awaited = false;
+        runner.mapWasmAsyncFunction('hostDouble', const [WasmValueType.i64], (
+          args,
+        ) async {
+          await Future<void>.delayed(const Duration(milliseconds: 5));
+          awaited = true;
+          return _asInt(args[0]) * 2;
+        });
+
+        var r = await runner.executeFunction(
+          '',
+          'compute',
+          positionalParameters: [10],
+        );
+
+        expect(r.getValueNoContext(), equals(21)); // host(10)=20; +1 => 21
+        expect(awaited, isTrue, reason: 'a real Future was awaited');
+      },
+    );
+
+    test('locals set before the await survive the suspension', () async {
+      var runner = await _wasmRunner(r'''
+        Future<int> compute(int n) async {
+          int base = n * 100;
+          int v = await hostDouble(n);
+          return base + v;
+        }
+      ''');
+      if (runner == null) {
+        fail('Wasm runtime not supported.');
+      }
+
+      runner.mapWasmAsyncFunction('hostDouble', const [WasmValueType.i64], (
+        args,
+      ) async {
+        await Future<void>.delayed(const Duration(milliseconds: 3));
+        return _asInt(args[0]) * 2;
+      });
+
+      var r = await runner.executeFunction(
+        '',
+        'compute',
+        positionalParameters: [3],
+      );
+
+      expect(r.getValueNoContext(), equals(306)); // 300 + 6
+    });
+
+    test('a non-async Wasm function still runs synchronously', () async {
+      var runner = await _wasmRunner(r'''
+        int addOne(int n) {
+          return n + 1;
+        }
+      ''');
+      if (runner == null) {
+        fail('Wasm runtime not supported.');
+      }
+
+      var r = await runner.executeFunction(
+        '',
+        'addOne',
+        positionalParameters: [41],
+      );
+
+      expect(r.getValueNoContext(), equals(42));
+    });
+  });
+}

--- a/test/apollovm_wasm_asyncify_runner_test.dart
+++ b/test/apollovm_wasm_asyncify_runner_test.dart
@@ -103,6 +103,41 @@ void main() {
       expect(r.getValueNoContext(), equals(306)); // 300 + 6
     });
 
+    test('multiple awaits of different host functions', () async {
+      var runner = await _wasmRunner(r'''
+        Future<int> pipeline(int n) async {
+          int a = await hostInc(n);
+          int b = await hostTriple(a);
+          return a + b;
+        }
+      ''');
+      if (runner == null) {
+        fail('Wasm runtime not supported.');
+      }
+
+      runner.mapWasmAsyncFunction('hostInc', const [WasmValueType.i64], (
+        args,
+      ) async {
+        await Future<void>.delayed(const Duration(milliseconds: 2));
+        return _asInt(args[0]) + 1;
+      });
+      runner.mapWasmAsyncFunction('hostTriple', const [WasmValueType.i64], (
+        args,
+      ) async {
+        await Future<void>.delayed(const Duration(milliseconds: 2));
+        return _asInt(args[0]) * 3;
+      });
+
+      var r = await runner.executeFunction(
+        '',
+        'pipeline',
+        positionalParameters: [4],
+      );
+
+      // a = 4+1 = 5 ; b = 5*3 = 15 ; return 20.
+      expect(r.getValueNoContext(), equals(20));
+    });
+
     test('a non-async Wasm function still runs synchronously', () async {
       var runner = await _wasmRunner(r'''
         int addOne(int n) {

--- a/test/apollovm_wasm_asyncify_runner_test.dart
+++ b/test/apollovm_wasm_asyncify_runner_test.dart
@@ -168,6 +168,115 @@ void main() {
       expect(awaited, isTrue);
     });
 
+    test('multi-frame: async fn awaits another async module fn', () async {
+      // `outer` awaits `inner` (a module async fn) which awaits a host import.
+      // The unwind must propagate through both frames and rewind back down.
+      var runner = await _wasmRunner(r'''
+        Future<int> inner(int n) async {
+          int v = await hostDouble(n);
+          return v + 1;
+        }
+
+        Future<int> outer(int n) async {
+          int a = await inner(n);
+          return a + 100;
+        }
+      ''');
+      if (runner == null) {
+        fail('Wasm runtime not supported.');
+      }
+
+      runner.mapWasmAsyncFunction('hostDouble', const [WasmValueType.i64], (
+        args,
+      ) async {
+        await Future<void>.delayed(const Duration(milliseconds: 4));
+        return _asInt(args[0]) * 2;
+      });
+
+      var r = await runner.executeFunction(
+        '',
+        'outer',
+        positionalParameters: [5],
+      );
+
+      // inner(5): host(5)=10, v=10, return 11. outer: a=11, return 111.
+      expect(r.getValueNoContext(), equals(111));
+    });
+
+    test('multi-frame: three nested async frames (a->b->c->host)', () async {
+      var runner = await _wasmRunner(r'''
+        Future<int> c(int n) async {
+          int v = await hostInc(n);
+          return v;
+        }
+
+        Future<int> b(int n) async {
+          int v = await c(n);
+          return v + 10;
+        }
+
+        Future<int> a(int n) async {
+          int v = await b(n);
+          return v + 100;
+        }
+      ''');
+      if (runner == null) {
+        fail('Wasm runtime not supported.');
+      }
+
+      runner.mapWasmAsyncFunction('hostInc', const [WasmValueType.i64], (
+        args,
+      ) async {
+        await Future<void>.delayed(const Duration(milliseconds: 3));
+        return _asInt(args[0]) + 1;
+      });
+
+      var r = await runner.executeFunction('', 'a', positionalParameters: [5]);
+
+      // c(5): host(5)=6. b: 6+10=16. a: 16+100=116.
+      expect(r.getValueNoContext(), equals(116));
+    });
+
+    test('multi-frame: a frame mixing a leaf and an internal await', () async {
+      var runner = await _wasmRunner(r'''
+        Future<int> inner(int n) async {
+          int v = await hostInc(n);
+          return v;
+        }
+
+        Future<int> outer(int n) async {
+          int x = await hostDouble(n);
+          int y = await inner(x);
+          return x + y;
+        }
+      ''');
+      if (runner == null) {
+        fail('Wasm runtime not supported.');
+      }
+
+      runner.mapWasmAsyncFunction('hostDouble', const [WasmValueType.i64], (
+        args,
+      ) async {
+        await Future<void>.delayed(const Duration(milliseconds: 2));
+        return _asInt(args[0]) * 2;
+      });
+      runner.mapWasmAsyncFunction('hostInc', const [WasmValueType.i64], (
+        args,
+      ) async {
+        await Future<void>.delayed(const Duration(milliseconds: 2));
+        return _asInt(args[0]) + 1;
+      });
+
+      var r = await runner.executeFunction(
+        '',
+        'outer',
+        positionalParameters: [5],
+      );
+
+      // x = 2*5 = 10 ; inner(10): 10+1 = 11 ; return 10 + 11 = 21.
+      expect(r.getValueNoContext(), equals(21));
+    });
+
     test('a non-async Wasm function still runs synchronously', () async {
       var runner = await _wasmRunner(r'''
         int addOne(int n) {

--- a/test/apollovm_wasm_asyncify_runner_test.dart
+++ b/test/apollovm_wasm_asyncify_runner_test.dart
@@ -138,6 +138,36 @@ void main() {
       expect(r.getValueNoContext(), equals(20));
     });
 
+    test('await with a discarded result (statement await)', () async {
+      var runner = await _wasmRunner(r'''
+        Future<int> compute(int n) async {
+          await hostWait(n);
+          return n + 1;
+        }
+      ''');
+      if (runner == null) {
+        fail('Wasm runtime not supported.');
+      }
+
+      var awaited = false;
+      runner.mapWasmAsyncFunction('hostWait', const [WasmValueType.i64], (
+        args,
+      ) async {
+        await Future<void>.delayed(const Duration(milliseconds: 3));
+        awaited = true;
+        return 0; // result is discarded by the function
+      });
+
+      var r = await runner.executeFunction(
+        '',
+        'compute',
+        positionalParameters: [7],
+      );
+
+      expect(r.getValueNoContext(), equals(8)); // suspends, then n + 1
+      expect(awaited, isTrue);
+    });
+
     test('a non-async Wasm function still runs synchronously', () async {
       var runner = await _wasmRunner(r'''
         int addOne(int n) {


### PR DESCRIPTION
## Summary

Adds `async`/`await` support to ApolloVM with **real asynchrony** at runtime. Because execution runs on the shared AST, the runtime semantics apply to any source language; this PR wires up Dart (parse/run/translate), JavaScript (translate), and Wasm (compile/run via synchronous collapse). Kotlin async translation is intentionally deferred and fails loudly (no silent miscompilation).

Bumps version `0.1.29` → `0.1.30`. Full suite: **661 tests passing**, analyzer clean.

## Runtime (shared AST)
- `ASTModifiers.isAsync`; new `ASTExpressionAwait` expression node; new `generateASTExpressionAwait` generator hook.
- An `async` function returns a **first-class future immediately** — a non-awaited call yields an `ASTValueFuture` that can be stored in a `Future<T>` variable and awaited later (`_callAsync`/`_runAsyncBody`).
- `await` suspends on real Dart `Future`s, including those returned by external functions declared with a `Future<...>` return type (kept first-class instead of eager-awaited).
- `ASTEntryPointBlock.execute` awaits the entry future before tearing down the entry-point context (external function mapper, current context), so deferred bodies still see their environment.
- Reuses the pre-existing `ASTTypeFuture`/`ASTValueFuture` (added `ASTTypeFuture.futureValueType`).

## Dart parse / translate
- Grammar parses the trailing `async` body keyword (after the parameter list) and the `await` prefix expression; `Future<T>` → `ASTTypeFuture`.
- Contextual-keyword guards: `awaiter` is not read as `await` + `er`, and `await x;` is not read as a `await`-typed variable declaration.
- Dart generator emits `) async {` and `await `.

## JavaScript translate
- Emits `async function` / `async name(` and `await ` (Promise is inferred; `Future<T>` is omitted as JS is untyped).

## Wasm compile / run (synchronous collapse)
- The Wasm backend executes synchronously (sync runtime, no JSPI/tables), so a `Future<T>` value is always already available. `async` functions compile as normal functions returning the unwrapped `T` (new `effectiveReturnType`), and `await expr` compiles to just `expr`.
- Compute-style async Dart now **compiles to Wasm and produces the same result as the AST interpreter** (`test/apollovm_wasm_async_test.dart` asserts AST-vs-compiled-Wasm parity).
- A real-suspension **Asyncify prototype** (`test/apollovm_wasm_asyncify_prototype_test.dart`) first proves real suspension is achievable on the synchronous `WasmRuntime` (hand-assembled two-frame module).
- **Asyncify code generation (v1)**: the generator now *emits* the unwind/rewind state machine for an async function with a single statement-level `await` of an external host call (Asyncify control region in `WasmModuleContext`, `br_if` rewind dispatch, live-local spill/restore, suspend epilogue). Validated end-to-end against the live runtime in `test/apollovm_wasm_asyncify_codegen_test.dart`: real suspension on a host Future, pre/post-await local preservation, and concurrent interleaving. More complex shapes fall back to synchronous-collapse.
- **Asyncify runner integration**: `ApolloRunnerWasm.executeFunction` detects real-suspension async functions (flagged in `apollovm_sig`) and drives their unwind/rewind loop, awaiting a real Dart `Future` from a host function registered via the new `mapWasmAsyncFunction` API — so real-suspension async/await works end-to-end through the VM (`test/apollovm_wasm_asyncify_runner_test.dart`). Supports **multiple await points** (`br_table` resume dispatch) and **multi-frame unwinding** — an async function may await another module async function (internal frame) as well as a host import (leaf); the unwind propagates up a LIFO frame stack to the host and rewinds back down. Validated with 2-/3-frame chains and mixed leaf+internal awaits end-to-end. Remaining fallbacks (synchronous-collapse): awaits nested in control flow, multiple awaits per statement, async recursion.

## Deferred (fail loudly)
- Kotlin async/await (`suspend fun` + coroutines mapping) throws `UnsupportedSyntaxError`.

## Tests
- `test/apollovm_async_test.dart` — parse, **real-suspension ordering** (two non-awaited calls with 30 ms / 5 ms delays complete in delay order: `print` output `[2, 1]`; eager would give `[1, 2]`), await chains, top-level async, identifier guard, Dart/JS/Kotlin translation.
- `test/apollovm_wasm_async_test.dart` — async return, await-of-async, await-in-expression, async-with-loop, each run through both the AST interpreter and compiled Wasm.

## Notes / pre-existing limitations worked around (not async bugs)
- No-return-type functions parse as constructors, so async functions require an explicit `Future<T>` return type.
- Instance-field mutation does not persist across method calls (so the ordering test observes via `print`), and the Wasm backend can't statically infer `var x = call()` (so the Wasm await-into-var test uses an explicit type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)