### PR TITLE
Add TypeScript support; generalize interfaces/enums/modifiers (also for Dart)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,32 @@
+## 0.1.31
+
+- TypeScript language support (parse, run, translate):
+  - New language at `lib/src/languages/typescript/ts/`: `ApolloParserTypeScript`,
+    `TypeScriptGrammarDefinition`, `TypeScriptGrammarLexer`,
+    `ApolloCodeGeneratorTypeScript`, `ApolloRunnerTypeScript`.
+  - Superset of JavaScript: all JS features plus **type annotations** on
+    variables, parameters, return types and class fields
+    (`number`/`string`/`boolean`/`any`/`void`, `T[]`/`Array<T>`), **interfaces**,
+    **enums**, and access modifiers (`public`/`private`/`protected`/`readonly`/
+    `static`/`abstract`).
+  - Code generation emits idiomatic TypeScript (type annotations, `interface`,
+    `enum`, `abstract class`, member modifiers) and erases types cleanly when
+    targeting JavaScript.
+  - Registered `'typescript'`/`'ts'` in the parser/runner/generator factories and
+    the `.ts` file-extension mapping; CLI `apollovm run`/`translate` support `.ts`.
+  - Tests: TypeScript test definitions under `test/tests_definitions/` plus the
+    `test/hello_world.ts` fixture and `example/apollovm_example_typescript.dart`.
+
+- Generalized class/member modeling in the shared AST (used by Dart and TypeScript):
+  - `ASTModifiers`: added `isAbstract` and `isProtected` (and `modifierAbstract`).
+  - `ASTClassNormal`: added `kind` (`ASTClassKind.normalClass` / `abstractClass` /
+    `interface`), plus optional `superClassName` and `implementsTypes`.
+  - New `ASTClassEnum` (extends `ASTClassNormal`) with `ASTEnumEntry` entries.
+  - `ASTClassField`: added a `modifiers` field (e.g. `static`/`private`/`readonly`).
+  - Dart now parses and generates `abstract class`, `enum`, `extends`/`implements`,
+    abstract (body-less) methods, and `static` fields; these cross-translate
+    between Dart, TypeScript and JavaScript.
+
 ## 0.1.30
 
 - `async`/`await` support (real asynchrony) — Dart parse/run/translate and

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Code size](https://img.shields.io/github/languages/code-size/ApolloVM/apollovm_dart?logo=github&logoColor=white)](https://github.com/ApolloVM/apollovm_dart)
 [![License](https://img.shields.io/github/license/ApolloVM/apollovm_dart?logo=open-source-initiative&logoColor=green)](https://github.com/ApolloVM/apollovm_dart/blob/master/LICENSE)
 
-ApolloVM is a portable VM (native, JS/Web, Flutter) that can parse, translate, and execute multiple languages such as Dart, Java, Kotlin, JavaScript, and Lua. It also provides on-the-fly compilation to Wasm.
+ApolloVM is a portable VM (native, JS/Web, Flutter) that can parse, translate, and execute multiple languages such as Dart, Java, Kotlin, JavaScript, TypeScript, and Lua. It also provides on-the-fly compilation to Wasm.
 
 -----------------------------
 
@@ -41,7 +41,7 @@ Now you can use the `apollovm` Dart executable:
 ```shell
 $> apollovm help
 
-ApolloVM - A compact VM for Dart, Java, Kotlin, JavaScript and Lua.
+ApolloVM - A compact VM for Dart, Java, Kotlin, JavaScript, TypeScript and Lua.
 
 Usage: apollovm <command> [arguments]
 
@@ -115,6 +115,25 @@ class Hello {
 <<<< [SOURCES_END] >>>>
 ```
 
+The same commands work for TypeScript (`.ts`) files. To `translate` a TypeScript file to Dart:
+```shell
+$> apollovm translate -v --target dart test/hello_world.ts
+## [TRANSLATE]  File: 'test/hello_world.ts' ; language: typescript > targetLanguage: dart
+<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test/hello_world.ts" >>>>
+class Hello {
+
+  static void main(String name) {
+    print('Hello World!');
+    print('- name: ${name}');
+  }
+
+}
+<<<< CODE_UNIT_END="/test/hello_world.ts" >>>>
+<<<< [SOURCES_END] >>>>
+```
+
 ### Compiling ApolloVM executable.
 
 Dart supports compilation to native self-contained executables.
@@ -146,7 +165,7 @@ even if you don't have Dart installed.
 
 ## Package Usage
 
-The ApolloVM is still in alpha stage. Below, we can see simple usage examples in Dart, Java, Kotlin, JavaScript and Lua.
+The ApolloVM is still in alpha stage. Below, we can see simple usage examples in Dart, Java, Kotlin, JavaScript, TypeScript and Lua.
 
 ### Language: `Dart`
 
@@ -527,6 +546,83 @@ the AST, execute it, and generate idiomatic modern ES (`let`/`const`, template
 literals, `for...of`, top-level functions, `===`/`!==`) from any loaded AST (Dart,
 Java, or JavaScript).
 
+### Language: `TypeScript`
+
+TypeScript is supported as a superset of JavaScript: everything JavaScript supports,
+plus **type annotations** (variables, parameters, return types, fields), **interfaces**,
+**enums**, and **access modifiers** (`public`/`private`/`protected`/`readonly`/`static`/
+`abstract`).
+
+Loading TypeScript source code, executing it, and then converting it to Dart:
+
+```dart
+import 'package:apollovm/apollovm.dart';
+
+void main() async {
+  var vm = ApolloVM();
+
+  var codeUnit = SourceCodeUnit(
+          'typescript',
+          r'''
+            class Foo {
+              greet(name: string, count: number): void {
+                let msg: string = `Hello ${name}, you have ${count} messages.`;
+                print(msg);
+              }
+            }
+          ''',
+          id: 'test');
+
+  var loadOK = await vm.loadCodeUnit(codeUnit);
+
+  if (!loadOK) {
+    throw StateError('Error parsing TypeScript code!');
+  }
+
+  var tsRunner = vm.createRunner('typescript')!;
+
+  // Map the `print` function in the VM:
+  tsRunner.externalPrintFunction = (o) => print("» $o");
+
+  await tsRunner.executeClassMethod('', 'Foo', 'greet',
+      positionalParameters: ['World', 3]);
+
+  print('---------------------------------------');
+
+  // Regenerate code in Dart:
+  var codeStorageDart = vm.generateAllCodeIn('dart');
+  var allSourcesDart = await codeStorageDart.writeAllSources();
+  print(allSourcesDart.toString());
+}
+```
+
+*Note: the parsed function `print` was mapped as an external function.*
+
+Output:
+```text
+» Hello World, you have 3 messages.
+---------------------------------------
+<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  void greet(String name, num count) {
+    String msg = 'Hello ${name}, you have ${count} messages.';
+    print(msg);
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+```
+
+TypeScript is bidirectional: ApolloVM parses `.ts`/`typescript` source (including
+`interface`, `enum`, and member modifiers) into the AST, executes it, and generates
+idiomatic TypeScript with type annotations. The same `interface`/`enum`/modifier
+constructs are also supported in Dart (`abstract class`, `enum`, `static`/`final`),
+so they cross-translate between Dart, TypeScript and JavaScript.
+
 ### Language: `Lua`
 
 Loading Lua source code, executing it, and then converting it to Dart:
@@ -607,7 +703,7 @@ generates idiomatic Lua (keyword-delimited blocks with `end`, `local` variables,
 concatenation, `and`/`or`/`not`/`~=`, and generic `for ... in ipairs(...)`) from any
 loaded AST. Object-oriented code uses the conventional table + metatable form
 (`Name = {}`, `Name.__index = Name`, `function Name:method(...)`), so classes round-trip
-to and from Dart, Java, Kotlin and JavaScript.
+to and from Dart, Java, Kotlin, JavaScript and TypeScript.
 
 ## Wasm Support
 
@@ -825,6 +921,10 @@ Any help from the open-source community is always welcome and needed:
 
 - JavaScript: extended support (anonymous arrow callbacks/closures, destructuring, spread, async/await, `this.x` constructor parameters, full ESM modules). *Named arrow functions (`const f = (a, b) => a + b;`) are already supported.*
   - *See the [JavaScript implementation (at "lib/src/languages/javascript/es")](https://github.com/ApolloVM/apollovm_dart/tree/master/lib/src/languages/javascript/es).*
+
+
+- TypeScript: extended support (generics, union/intersection types, type aliases, parameter properties, enum member access at runtime, decorators). *Type annotations, `interface`, `enum`, and access modifiers (`public`/`private`/`protected`/`readonly`/`static`/`abstract`) are already supported.*
+  - *See the [TypeScript implementation (at "lib/src/languages/typescript/ts")](https://github.com/ApolloVM/apollovm_dart/tree/master/lib/src/languages/typescript/ts).*
 
 
 - Lua: extended support (`repeat ... until`, multiple assignment/returns, varargs, non-`ipairs` numeric-for round-tripping, and hand-written metatable styles beyond the `Name = {}` / `function Name:method` convention).

--- a/example/apollovm_example_typescript.dart
+++ b/example/apollovm_example_typescript.dart
@@ -1,0 +1,71 @@
+import 'package:apollovm/apollovm.dart';
+
+void main() async {
+  var vm = ApolloVM();
+
+  var codeUnit = SourceCodeUnit('typescript', r'''
+      class Foo {
+        main(title: string, a: number, b: number, c: number): void {
+          let sumAB: number = a + b;
+          let sumABC: number = a + b + c;
+          print(title);
+          print(sumAB);
+          print(sumABC);
+        }
+      }
+      ''', id: 'test');
+
+  var loadOK = await vm.loadCodeUnit(codeUnit);
+
+  if (!loadOK) {
+    print("Can't load source!");
+    return;
+  }
+
+  print('---------------------------------------');
+
+  var tsRunner = vm.createRunner('typescript')!;
+
+  // Map the `print` function in the VM:
+  tsRunner.externalPrintFunction = (o) => print("» $o");
+
+  await tsRunner.executeClassMethod(
+    '',
+    'Foo',
+    'main',
+    positionalParameters: ['Sums:', 10, 20, 30],
+  );
+
+  print('---------------------------------------');
+
+  // Regenerate code in Dart:
+  var codeStorageDart = vm.generateAllCodeIn('dart');
+  var allSourcesDart = await codeStorageDart.writeAllSources();
+  print(allSourcesDart);
+}
+
+/////////////
+// OUTPUT: //
+/////////////
+// ---------------------------------------
+// » Sums:
+// » 30
+// » 60
+// ---------------------------------------
+// <<<< [SOURCES_BEGIN] >>>>
+// <<<< NAMESPACE="" >>>>
+// <<<< CODE_UNIT_START="/test" >>>>
+// class Foo {
+//
+//   void main(String title, num a, num b, num c) {
+//     num sumAB = a + b;
+//     num sumABC = (a + b) + c;
+//     print(title);
+//     print(sumAB);
+//     print(sumABC);
+//   }
+//
+// }
+// <<<< CODE_UNIT_END="/test" >>>>
+// <<<< [SOURCES_END] >>>>
+//

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -37,6 +37,9 @@ import 'languages/kotlin/kotlin_runner.dart';
 import 'languages/lua/lua_generator.dart';
 import 'languages/lua/lua_parser.dart';
 import 'languages/lua/lua_runner.dart';
+import 'languages/typescript/ts/typescript_generator.dart';
+import 'languages/typescript/ts/typescript_parser.dart';
+import 'languages/typescript/ts/typescript_runner.dart';
 import 'languages/wasm/wasm_generator.dart';
 import 'languages/wasm/wasm_parser.dart';
 import 'languages/wasm/wasm_runner.dart';
@@ -44,7 +47,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.30';
+  static final String VERSION = '0.1.31';
 
   static int _idCount = 0;
 
@@ -61,6 +64,9 @@ class ApolloVM implements VMTypeResolver {
       case 'js':
       case 'javascript':
         return ApolloParserJavaScript.instance as ApolloCodeParser<T>;
+      case 'ts':
+      case 'typescript':
+        return ApolloParserTypeScript.instance as ApolloCodeParser<T>;
       case 'kotlin':
         return ApolloParserKotlin.instance as ApolloCodeParser<T>;
       case 'lua':
@@ -199,6 +205,12 @@ class ApolloVM implements VMTypeResolver {
           this,
           importCorePackageMath: importCorePackageMath,
         );
+      case 'ts':
+      case 'typescript':
+        return ApolloRunnerTypeScript(
+          this,
+          importCorePackageMath: importCorePackageMath,
+        );
       case 'kotlin':
         return ApolloRunnerKotlin(
           this,
@@ -240,6 +252,9 @@ class ApolloVM implements VMTypeResolver {
       case 'js':
       case 'javascript':
         return ApolloCodeGeneratorJavaScript(codeStorage);
+      case 'ts':
+      case 'typescript':
+        return ApolloCodeGeneratorTypeScript(codeStorage);
       case 'kotlin':
         return ApolloCodeGeneratorKotlin(codeStorage);
       case 'lua':
@@ -351,6 +366,8 @@ class ApolloVM implements VMTypeResolver {
         return 'java11';
       case 'js':
         return 'javascript';
+      case 'ts':
+        return 'typescript';
       case 'py':
         return 'python';
       case 'rb':

--- a/lib/src/ast/apollovm_ast_base.dart
+++ b/lib/src/ast/apollovm_ast_base.dart
@@ -139,6 +139,7 @@ class ASTModifiers {
     isFinal: true,
   );
   static final ASTModifiers modifierAsync = ASTModifiers(isAsync: true);
+  static final ASTModifiers modifierAbstract = ASTModifiers(isAbstract: true);
 
   final bool isStatic;
 
@@ -151,12 +152,21 @@ class ASTModifiers {
   /// If `true` this is an asynchronous element (`async` function).
   final bool isAsync;
 
+  /// If `true` this is an abstract element (e.g. an abstract method or a member
+  /// without a body, as in an interface or abstract class).
+  final bool isAbstract;
+
+  /// If `true` this is a protected element (e.g. TypeScript `protected`).
+  final bool isProtected;
+
   ASTModifiers({
     this.isStatic = false,
     this.isFinal = false,
     this.isPrivate = false,
     this.isPublic = false,
     this.isAsync = false,
+    this.isAbstract = false,
+    this.isProtected = false,
   }) {
     if (isPrivate && isPublic) {
       throw StateError("Can't be private and public at the same time!");
@@ -169,6 +179,8 @@ class ASTModifiers {
     bool? isPrivate,
     bool? isPublic,
     bool? isAsync,
+    bool? isAbstract,
+    bool? isProtected,
   }) {
     return ASTModifiers(
       isStatic: isStatic ?? this.isStatic,
@@ -176,12 +188,16 @@ class ASTModifiers {
       isPrivate: isPrivate ?? this.isPrivate,
       isPublic: isPublic ?? this.isPublic,
       isAsync: isAsync ?? this.isAsync,
+      isAbstract: isAbstract ?? this.isAbstract,
+      isProtected: isProtected ?? this.isProtected,
     );
   }
 
   List<String> get modifiers => [
     if (isPublic) 'public',
     if (isPrivate) 'private',
+    if (isProtected) 'protected',
+    if (isAbstract) 'abstract',
     if (isStatic) 'static',
     if (isFinal) 'final',
     if (isAsync) 'async',

--- a/lib/src/ast/apollovm_ast_toplevel.dart
+++ b/lib/src/ast/apollovm_ast_toplevel.dart
@@ -13,6 +13,7 @@ import '../apollovm_base.dart';
 import '../apollovm_utils.dart';
 import '../core/apollovm_core_base.dart';
 import 'apollovm_ast_base.dart';
+import 'apollovm_ast_expression.dart';
 import 'apollovm_ast_statement.dart';
 import 'apollovm_ast_type.dart';
 import 'apollovm_ast_value.dart';
@@ -530,9 +531,35 @@ class ASTClassPrimitive<T> extends ASTClass<T> {
   }) => null;
 }
 
+/// The kind of an [ASTClassNormal]: a regular class, an abstract class, or an
+/// interface (e.g. a TypeScript `interface`).
+enum ASTClassKind { normalClass, abstractClass, interface }
+
 /// AST of a normal VM Class.
 class ASTClassNormal extends ASTClass<VMObject> {
-  ASTClassNormal(super.name, super.type, super.parentBlock);
+  /// The kind of this class (normal / abstract / interface).
+  final ASTClassKind kind;
+
+  /// The name of the super class this class `extends` (if any).
+  final String? superClassName;
+
+  /// The names of the interfaces this class `implements` (if any).
+  final List<String>? implementsTypes;
+
+  ASTClassNormal(
+    super.name,
+    super.type,
+    super.parentBlock, {
+    this.kind = ASTClassKind.normalClass,
+    this.superClassName,
+    this.implementsTypes,
+  });
+
+  /// Returns `true` if this class is an `interface`.
+  bool get isInterface => kind == ASTClassKind.interface;
+
+  /// Returns `true` if this class is `abstract`.
+  bool get isAbstract => kind == ASTClassKind.abstractClass;
 
   @override
   void set(ASTBlock? other) {
@@ -873,6 +900,41 @@ class ASTClassNormal extends ASTClass<VMObject> {
   String toString() {
     return 'class $name';
   }
+}
+
+/// An entry of an [ASTClassEnum] (e.g. `Red` or `Red = 1`).
+class ASTEnumEntry {
+  /// The entry name.
+  final String name;
+
+  /// The optional explicit value expression (e.g. `1` in `Red = 1`).
+  final ASTExpression? value;
+
+  ASTEnumEntry(this.name, [this.value]);
+
+  @override
+  String toString() => value != null ? '$name = $value' : name;
+}
+
+/// AST of an enum class (e.g. Dart/TypeScript `enum`).
+///
+/// Extends [ASTClassNormal] so it flows through the existing class generation
+/// and resolution; the [entries] hold the enum constants.
+class ASTClassEnum extends ASTClassNormal {
+  /// The enum entries (constants), in declaration order.
+  final List<ASTEnumEntry> entries;
+
+  ASTClassEnum(
+    super.name,
+    super.type,
+    super.parentBlock, {
+    List<ASTEnumEntry>? entries,
+    super.superClassName,
+    super.implementsTypes,
+  }) : entries = entries ?? <ASTEnumEntry>[];
+
+  @override
+  String toString() => 'enum $name';
 }
 
 /// An AST Root.

--- a/lib/src/ast/apollovm_ast_variable.dart
+++ b/lib/src/ast/apollovm_ast_variable.dart
@@ -105,7 +105,16 @@ abstract class ASTTypedVariable<T> extends ASTVariable {
 
 /// [ASTVariable] for class fields.
 class ASTClassField<T> extends ASTTypedVariable<T> {
-  ASTClassField(super.type, super.name, super.finalValue);
+  /// The modifiers of this field (e.g. `static`, `private`, `protected`,
+  /// `final`/`readonly`). Defaults to none.
+  final ASTModifiers modifiers;
+
+  ASTClassField(
+    super.type,
+    super.name,
+    super.finalValue, {
+    ASTModifiers? modifiers,
+  }) : modifiers = modifiers ?? ASTModifiers.modifiersNone;
 
   @override
   Iterable<ASTNode> get children => [];
@@ -128,8 +137,9 @@ class ASTClassFieldWithInitialValue<T> extends ASTClassField<T> {
     ASTType<T> type,
     String name,
     this._initialValueExpression,
-    bool finalValue,
-  ) : super(type, name, finalValue);
+    bool finalValue, {
+    ASTModifiers? modifiers,
+  }) : super(type, name, finalValue, modifiers: modifiers);
 
   ASTExpression get initialValue => _initialValueExpression;
 

--- a/lib/src/languages/dart/dart_generator.dart
+++ b/lib/src/languages/dart/dart_generator.dart
@@ -263,7 +263,8 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
     var isAbstractMethod =
         f is ASTFunctionDeclaration && f.modifiers.isAbstract;
 
-    if (isAbstractMethod || (emptyBlock && f is ASTClassConstructorDeclaration)) {
+    if (isAbstractMethod ||
+        (emptyBlock && f is ASTClassConstructorDeclaration)) {
       out.write(';\n\n');
     } else {
       out.write(' {\n');

--- a/lib/src/languages/dart/dart_generator.dart
+++ b/lib/src/languages/dart/dart_generator.dart
@@ -77,16 +77,63 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
   }) {
     out ??= newOutput();
 
+    if (clazz is ASTClassEnum) {
+      return generateASTClassEnum(clazz, out: out, indent: indent);
+    }
+
     var code = generateASTBlock(
       clazz,
       withBrackets: true,
       withBlankHeadLine: true,
     );
 
+    // Dart has no `interface` keyword; an interface is an `abstract class`.
+    if (clazz.isAbstract || clazz.isInterface) {
+      out.write('abstract ');
+    }
+
     out.write('class ');
     out.write(clazz.name);
+
+    if (clazz.superClassName != null) {
+      out.write(' extends ');
+      out.write(clazz.superClassName!);
+    }
+
+    var implementsTypes = clazz.implementsTypes;
+    if (implementsTypes != null && implementsTypes.isNotEmpty) {
+      out.write(' implements ');
+      out.write(implementsTypes.join(', '));
+    }
+
     out.write(' ');
     out.write(code);
+
+    return out;
+  }
+
+  /// Generates a Dart `enum` declaration.
+  StringBuffer generateASTClassEnum(
+    ASTClassEnum clazz, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    out.write(indent);
+    out.write('enum ');
+    out.write(clazz.name);
+    out.write(' {\n');
+
+    var entries = clazz.entries;
+    for (var i = 0; i < entries.length; ++i) {
+      out.write('$indent  ');
+      out.write(entries[i].name);
+      if (i < entries.length - 1) out.write(',');
+      out.write('\n');
+    }
+
+    out.write('$indent}\n');
 
     return out;
   }
@@ -102,6 +149,10 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
     var typeCode = generateASTType(field.type);
 
     out.write(indent);
+
+    if (field.modifiers.isStatic) {
+      out.write('static ');
+    }
 
     if (field.finalValue) {
       out.write('final ');
@@ -208,7 +259,11 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
     var blockStr = blockCode.toString();
     var emptyBlock = blockStr.trim().isEmpty;
 
-    if (emptyBlock && f is ASTClassConstructorDeclaration) {
+    // Abstract/interface methods have no body.
+    var isAbstractMethod =
+        f is ASTFunctionDeclaration && f.modifiers.isAbstract;
+
+    if (isAbstractMethod || (emptyBlock && f is ASTClassConstructorDeclaration)) {
       out.write(';\n\n');
     } else {
       out.write(' {\n');

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -86,8 +86,9 @@ class DartGrammarDefinition extends DartGrammarLexer {
           });
 
   Parser topLevelDefinition() =>
-      (functionDeclaration() |
+      (enumDeclaration() |
               classDeclaration() |
+              functionDeclaration() |
               statementVariableDeclaration())
           .plus();
 
@@ -125,13 +126,77 @@ class DartGrammarDefinition extends DartGrammarLexer {
           });
 
   Parser<ASTClassNormal> classDeclaration() =>
-      (string('class').trimHidden() & identifier() & classCodeBlock()).map((v) {
-        var name = v[1] as String;
-        var block = v[2];
-        var clazz = ASTClassNormal(name, ASTType<VMObject>(name), null);
-        clazz.set(block);
-        return clazz;
-      });
+      (abstractToken().trimHidden().optional() &
+              string('class').trimHidden() &
+              identifier() &
+              (extendsToken().trimHidden() & identifier()).optional() &
+              (implementsToken().trimHidden() &
+                      identifier() &
+                      (char(',').trimHidden() & identifier()).star())
+                  .optional() &
+              classCodeBlock())
+          .map((v) {
+            var isAbstract = v[0] != null;
+            var name = v[2] as String;
+
+            var extendsOpt = v[3] as List?;
+            var superName = extendsOpt != null ? extendsOpt[1] as String : null;
+
+            var implementsOpt = v[4] as List?;
+            var interfaces = <String>[];
+            if (implementsOpt != null) {
+              interfaces.add(implementsOpt[1] as String);
+              for (var e in (implementsOpt[2] as List)) {
+                interfaces.add(e[1] as String);
+              }
+            }
+
+            var block = v[5];
+            var clazz = ASTClassNormal(
+              name,
+              ASTType<VMObject>(name),
+              null,
+              kind: isAbstract
+                  ? ASTClassKind.abstractClass
+                  : ASTClassKind.normalClass,
+              superClassName: superName,
+              implementsTypes: interfaces.isEmpty ? null : interfaces,
+            );
+            clazz.set(block);
+            return clazz;
+          });
+
+  Parser<ASTClassEnum> enumDeclaration() =>
+      (string('enum').trimHidden() &
+              identifier() &
+              char('{').trimHidden() &
+              enumEntry() &
+              (char(',').trimHidden() & enumEntry()).star() &
+              char(',').trimHidden().optional() &
+              char('}').trimHidden())
+          .map((v) {
+            var name = v[1] as String;
+            var entries = <ASTEnumEntry>[v[3] as ASTEnumEntry];
+            for (var e in (v[4] as List)) {
+              entries.add(e[1] as ASTEnumEntry);
+            }
+            return ASTClassEnum(
+              name,
+              ASTType<VMObject>(name),
+              null,
+              entries: entries,
+            );
+          });
+
+  Parser<ASTEnumEntry> enumEntry() =>
+      (identifier().trimHidden() &
+              (char('=').trimHidden() & ref0(expression)).optional())
+          .map((v) {
+            var name = v[0] as String;
+            var valueOpt = v[1] as List?;
+            var value = valueOpt != null ? valueOpt[1] as ASTExpression : null;
+            return ASTEnumEntry(name, value);
+          });
 
   Parser<ASTBlock> classCodeBlock() =>
       (char('{').trimHidden() &
@@ -159,29 +224,46 @@ class DartGrammarDefinition extends DartGrammarLexer {
           });
 
   Parser<ASTClassField> classFieldDeclaration() =>
-      ((finalToken() | constToken()).optional() &
+      (staticToken().trimHidden().optional() &
+              (finalToken() | constToken()).optional() &
               type().trimHidden() &
               identifier().trimHidden() &
               char(';').trimHidden())
           .map((v) {
-            var finalValue = v[0] != null;
-            var type = v[1] as ASTType;
-            var name = v[2] as String;
-            return ASTClassField(type, name, finalValue);
+            var isStatic = v[0] != null;
+            var finalValue = v[1] != null;
+            var type = v[2] as ASTType;
+            var name = v[3] as String;
+            return ASTClassField(
+              type,
+              name,
+              finalValue,
+              modifiers: ASTModifiers(isStatic: isStatic, isFinal: finalValue),
+            );
           });
 
   Parser<ASTClassField> classFieldDeclarationWithValue() =>
-      (type() &
+      (staticToken().trimHidden().optional() &
+              (finalToken() | constToken()).optional() &
+              type() &
               identifier() &
               char('=').trimHidden() &
               ref0(expression) &
               char(';').trimHidden())
           .map((v) {
-            var type = v[0] as ASTType;
-            var name = v[1] as String;
-            var expression = v[3] as ASTExpression;
+            var isStatic = v[0] != null;
+            var finalValue = v[1] != null;
+            var type = v[2] as ASTType;
+            var name = v[3] as String;
+            var expression = v[5] as ASTExpression;
             type.associateToType(expression);
-            return ASTClassFieldWithInitialValue(type, name, expression, false);
+            return ASTClassFieldWithInitialValue(
+              type,
+              name,
+              expression,
+              finalValue,
+              modifiers: ASTModifiers(isStatic: isStatic, isFinal: finalValue),
+            );
           });
 
   Parser<ASTClassConstructorDeclaration> classConstructorDefaultDeclaration() =>
@@ -263,7 +345,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
               identifier() &
               functionParametersDeclaration() &
               asyncToken().optional() &
-              codeBlock())
+              (char(';').trimHidden() | codeBlock()))
           .map((v) {
             var modifiers =
                 (v[0] as ASTModifiers?) ?? ASTModifiers.modifiersNone;
@@ -273,7 +355,11 @@ class DartGrammarDefinition extends DartGrammarLexer {
             var returnType = v[1] as ASTType? ?? ASTTypeDynamic.instance;
             var name = v[2] as String;
             var parameters = v[3] as ASTFunctionParametersDeclaration;
-            var block = v[5] as ASTBlock;
+            // An abstract/interface method has no body (`;` instead of a block).
+            var block = v[5] is ASTBlock ? v[5] as ASTBlock : null;
+            if (block == null) {
+              modifiers = modifiers.copyWith(isAbstract: true);
+            }
             return ASTClassFunctionDeclaration(
               null,
               name,

--- a/lib/src/languages/typescript/ts/typescript_generator.dart
+++ b/lib/src/languages/typescript/ts/typescript_generator.dart
@@ -556,7 +556,11 @@ class ApolloCodeGeneratorTypeScript extends ApolloCodeGenerator {
   }
 
   /// TypeScript arrays are rendered as `T[]` (1D), `T[][]` (2D), `T[][][]` (3D).
-  StringBuffer _writeArrayType(ASTType elementType, int dims, StringBuffer out) {
+  StringBuffer _writeArrayType(
+    ASTType elementType,
+    int dims,
+    StringBuffer out,
+  ) {
     out.write(generateASTType(elementType));
     out.write('[]' * dims);
     return out;

--- a/lib/src/languages/typescript/ts/typescript_generator.dart
+++ b/lib/src/languages/typescript/ts/typescript_generator.dart
@@ -1,0 +1,724 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import '../../../apollovm_code_generator.dart';
+import '../../../apollovm_code_storage.dart';
+import '../../../ast/apollovm_ast_expression.dart';
+import '../../../ast/apollovm_ast_statement.dart';
+import '../../../ast/apollovm_ast_toplevel.dart';
+import '../../../ast/apollovm_ast_type.dart';
+import '../../../ast/apollovm_ast_value.dart';
+import '../../../ast/apollovm_ast_variable.dart';
+
+/// TypeScript implementation of an [ApolloCodeGenerator].
+///
+/// Emits idiomatic ECMAScript: `let`/`const`, template literals for string
+/// interpolation, `for...of` loops, top-level `function` declarations,
+/// untyped parameters/fields and `===`/`!==` equality.
+class ApolloCodeGeneratorTypeScript extends ApolloCodeGenerator {
+  ApolloCodeGeneratorTypeScript(ApolloSourceCodeStorage codeStorage)
+    : super('typescript', codeStorage);
+
+  @override
+  String normalizeTypeName(String typeName, [String? callingFunction]) {
+    // Static-call targets (e.g. `Number.parseInt`) use the JS global object,
+    // not the TypeScript primitive type name.
+    if (callingFunction != null) {
+      switch (typeName) {
+        case 'int':
+        case 'Integer':
+        case 'double':
+        case 'Double':
+        case 'num':
+        case 'number':
+          return 'Number';
+        default:
+          return typeName;
+      }
+    }
+
+    // Type annotations use TypeScript primitive names.
+    switch (typeName) {
+      case 'int':
+      case 'Integer':
+      case 'double':
+      case 'Double':
+      case 'num':
+        return 'number';
+      case 'bool':
+      case 'Boolean':
+        return 'boolean';
+      case 'String':
+        return 'string';
+      case 'void':
+        return 'void';
+      case 'dynamic':
+      case 'Object':
+        return 'any';
+      default:
+        return typeName;
+    }
+  }
+
+  /// Emits a `: type` annotation when [type] is an explicit type (i.e. not an
+  /// inferred `var` and not `dynamic`).
+  void _writeTypeAnnotation(ASTType type, StringBuffer out) {
+    if (type is ASTTypeVar || type == ASTTypeDynamic.instance) return;
+    out.write(': ');
+    out.write(generateASTType(type));
+  }
+
+  @override
+  String normalizeTypeFunction(String typeName, String functionName) {
+    switch (typeName) {
+      case 'int':
+      case 'Integer':
+        {
+          switch (functionName) {
+            case 'parse':
+            case 'parseInt':
+              return 'parseInt';
+            default:
+              return functionName;
+          }
+        }
+      case 'double':
+      case 'Double':
+        {
+          switch (functionName) {
+            case 'parse':
+            case 'parseDouble':
+            case 'parseFloat':
+              return 'parseFloat';
+            default:
+              return functionName;
+          }
+        }
+      default:
+        return functionName;
+    }
+  }
+
+  @override
+  StringBuffer generateASTStatementImport(
+    ASTStatementImport import, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    final path = import.path;
+    final prefix = import.prefix;
+
+    out ??= newOutput();
+
+    if (prefix != null) {
+      out.write("import * as $prefix from '$path';\n");
+    } else {
+      out.write("import '$path';\n");
+    }
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTClass(
+    ASTClassNormal clazz, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    if (clazz is ASTClassEnum) {
+      return generateASTClassEnum(clazz, out: out, indent: indent);
+    }
+
+    var code = generateASTBlock(
+      clazz,
+      withBrackets: true,
+      withBlankHeadLine: true,
+    );
+
+    if (clazz.isAbstract) out.write('abstract ');
+    out.write(clazz.isInterface ? 'interface ' : 'class ');
+    out.write(clazz.name);
+
+    if (clazz.superClassName != null) {
+      out.write(' extends ');
+      out.write(clazz.superClassName!);
+    }
+
+    var implementsTypes = clazz.implementsTypes;
+    if (implementsTypes != null && implementsTypes.isNotEmpty) {
+      // An interface `extends` other interfaces; a class `implements` them.
+      out.write(clazz.isInterface ? ' extends ' : ' implements ');
+      out.write(implementsTypes.join(', '));
+    }
+
+    out.write(' ');
+    out.write(code);
+
+    return out;
+  }
+
+  /// Generates a TypeScript `enum` declaration.
+  StringBuffer generateASTClassEnum(
+    ASTClassEnum clazz, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    out.write(indent);
+    out.write('enum ');
+    out.write(clazz.name);
+    out.write(' {\n');
+
+    var entries = clazz.entries;
+    for (var i = 0; i < entries.length; ++i) {
+      var e = entries[i];
+      out.write('$indent  ');
+      out.write(e.name);
+      if (e.value != null) {
+        out.write(' = ');
+        generateASTExpression(e.value!, out: out, headIndented: false);
+      }
+      if (i < entries.length - 1) out.write(',');
+      out.write('\n');
+    }
+
+    out.write('$indent}\n');
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTClassField(
+    ASTClassField field, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    out.write(indent);
+
+    var m = field.modifiers;
+    if (m.isPrivate) {
+      out.write('private ');
+    } else if (m.isProtected) {
+      out.write('protected ');
+    }
+    if (m.isStatic) out.write('static ');
+    if (m.isFinal) out.write('readonly ');
+
+    out.write(field.name);
+    _writeTypeAnnotation(field.type, out);
+
+    if (field is ASTClassFieldWithInitialValue) {
+      out.write(' = ');
+      generateASTExpression(field.initialValue, out: out, headIndented: false);
+    }
+
+    out.write(';\n');
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTClassConstructorDeclaration(
+    ASTClassConstructorDeclaration c, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    var blockCode = generateASTBlock(c, indent: indent, withBrackets: false);
+
+    out.write(indent);
+    out.write('constructor');
+    _generateFunctionParamsAndBlock(c, blockCode, out, indent);
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTFunctionDeclaration(
+    ASTFunctionDeclaration f, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    // TypeScript allows top-level `function` declarations.
+    out ??= newOutput();
+
+    var blockCode = generateASTBlock(f, indent: indent, withBrackets: false);
+
+    out.write(indent);
+    if (f.modifiers.isAsync) {
+      out.write('async ');
+    }
+    out.write('function ');
+    out.write(f.name);
+    _generateFunctionParamsAndBlock(f, blockCode, out, indent);
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTClassFunctionDeclaration(
+    ASTClassFunctionDeclaration f, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    var blockCode = generateASTBlock(f, indent: indent, withBrackets: false);
+
+    out.write(indent);
+
+    var m = f.modifiers;
+    if (m.isPrivate) {
+      out.write('private ');
+    } else if (m.isProtected) {
+      out.write('protected ');
+    }
+
+    // Interface members are implicitly abstract; don't emit the keyword there.
+    var clazz = f.clazz;
+    var inInterface = clazz is ASTClassNormal && clazz.isInterface;
+    if (m.isAbstract && !inInterface) out.write('abstract ');
+    if (m.isStatic) out.write('static ');
+    if (m.isAsync) out.write('async ');
+
+    out.write(f.name);
+    _generateFunctionParamsAndBlock(f, blockCode, out, indent);
+
+    return out;
+  }
+
+  void _generateFunctionParamsAndBlock(
+    ASTInvocableDeclaration f,
+    StringBuffer blockCode,
+    StringBuffer out,
+    String indent,
+  ) {
+    out.write('(');
+
+    if (f.parametersSize > 0) {
+      generateASTParametersDeclaration(f.parameters, out: out);
+    }
+
+    out.write(')');
+
+    // Return type annotation (functions/methods only, not constructors).
+    if (f is ASTFunctionDeclaration) {
+      _writeTypeAnnotation(f.returnType, out);
+    }
+
+    // Abstract/interface methods have no body.
+    if (f is ASTFunctionDeclaration && f.modifiers.isAbstract) {
+      out.write(';\n\n');
+      return;
+    }
+
+    out.write(' {\n');
+    out.write(blockCode);
+    out.write(indent);
+    out.write('}\n\n');
+  }
+
+  @override
+  StringBuffer generateASTParametersDeclaration(
+    ASTParametersDeclaration parameters, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    var all = <ASTParameterDeclaration>[
+      ...?parameters.positionalParameters,
+      ...?parameters.optionalParameters,
+      ...?parameters.namedParameters,
+    ];
+
+    for (var i = 0; i < all.length; ++i) {
+      if (i > 0) out.write(', ');
+      generateASTParameterDeclaration(all[i], out: out);
+    }
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTParameterDeclaration(
+    ASTParameterDeclaration parameter, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    // TypeScript parameters carry an optional `: type` annotation.
+    out ??= newOutput();
+    out.write(parameter.name);
+    _writeTypeAnnotation(parameter.type, out);
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTFunctionParameterDeclaration(
+    ASTFunctionParameterDeclaration parameter, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    return generateASTParameterDeclaration(parameter, out: out, indent: indent);
+  }
+
+  @override
+  StringBuffer generateASTStatementVariableDeclaration(
+    ASTStatementVariableDeclaration statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    // `const` only when unmodifiable AND initialized (JS forbids uninitialized
+    // `const`); otherwise `let`.
+    var keyword = (statement.unmodifiable && statement.value != null)
+        ? 'const'
+        : 'let';
+
+    out.write(keyword);
+    out.write(' ');
+    out.write(statement.name);
+    _writeTypeAnnotation(statement.type, out);
+
+    if (statement.value != null) {
+      out.write(' = ');
+      generateASTExpression(
+        statement.value!,
+        out: out,
+        indent: indent,
+        headIndented: false,
+      );
+    }
+
+    out.write(';');
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTStatementForEach(
+    ASTStatementForEach forEach, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write('for (const ');
+    out.write(forEach.variableName);
+    out.write(' of ');
+
+    generateASTExpression(
+      forEach.iterableExpression,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+
+    out.write(') {\n');
+
+    var blockCode = generateASTBlock(
+      forEach.loopBlock,
+      indent: indent,
+      withBrackets: false,
+    );
+
+    out.write(blockCode);
+    out.write(indent);
+    out.write('}');
+
+    return out;
+  }
+
+  @override
+  String resolveASTExpressionOperatorText(
+    ASTExpressionOperator operator,
+    ASTNumType aNumType,
+    ASTNumType bNumType,
+  ) {
+    switch (operator) {
+      // Strict equality in TypeScript.
+      case ASTExpressionOperator.equals:
+        return '===';
+      case ASTExpressionOperator.notEquals:
+        return '!==';
+      default:
+        return getASTExpressionOperatorText(operator);
+    }
+  }
+
+  @override
+  StringBuffer generateASTExpressionOperation(
+    ASTExpressionOperation expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    // TypeScript has no integer-division operator; `a ~/ b` becomes
+    // `Math.trunc(a / b)`.
+    if (expression.operator == ASTExpressionOperator.divideAsInt) {
+      out ??= newOutput();
+      if (headIndented) out.write(indent);
+
+      out.write('Math.trunc(');
+      generateASTExpression(
+        expression.expression1,
+        out: out,
+        indent: indent,
+        headIndented: false,
+      );
+      out.write(' / ');
+      generateASTExpression(
+        expression.expression2,
+        out: out,
+        indent: indent,
+        headIndented: false,
+      );
+      out.write(')');
+
+      return out;
+    }
+
+    return super.generateASTExpressionOperation(
+      expression,
+      out: out,
+      indent: indent,
+      headIndented: headIndented,
+    );
+  }
+
+  @override
+  StringBuffer generateASTExpressionListLiteral(
+    ASTExpressionListLiteral expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write('[');
+
+    var valuesExpressions = expression.valuesExpressions;
+    for (var i = 0; i < valuesExpressions.length; ++i) {
+      if (i > 0) out.write(', ');
+      generateASTExpression(
+        valuesExpressions[i],
+        out: out,
+        headIndented: false,
+      );
+    }
+
+    out.write(']');
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTExpressionMapLiteral(
+    ASTExpressionMapLiteral expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write('{');
+
+    var entriesExpressions = expression.entriesExpressions;
+    for (var i = 0; i < entriesExpressions.length; ++i) {
+      var e = entriesExpressions[i];
+      if (i > 0) out.write(', ');
+      generateASTExpression(e.key, out: out, headIndented: false);
+      out.write(': ');
+      generateASTExpression(e.value, out: out, headIndented: false);
+    }
+
+    out.write('}');
+
+    return out;
+  }
+
+  /// TypeScript arrays are rendered as `T[]` (1D), `T[][]` (2D), `T[][][]` (3D).
+  StringBuffer _writeArrayType(ASTType elementType, int dims, StringBuffer out) {
+    out.write(generateASTType(elementType));
+    out.write('[]' * dims);
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTTypeArray(
+    ASTTypeArray type, {
+    StringBuffer? out,
+    String indent = '',
+  }) => _writeArrayType(type.elementType, 1, out ??= newOutput());
+
+  @override
+  StringBuffer generateASTTypeArray2D(
+    ASTTypeArray2D type, {
+    StringBuffer? out,
+    String indent = '',
+  }) => _writeArrayType(type.elementType, 2, out ??= newOutput());
+
+  @override
+  StringBuffer generateASTTypeArray3D(
+    ASTTypeArray3D type, {
+    StringBuffer? out,
+    String indent = '',
+  }) => _writeArrayType(type.elementType, 3, out ??= newOutput());
+
+  @override
+  StringBuffer generateASTValueString(
+    ASTValueString value, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write("'");
+    out.write(_escapeSingleQuoted(value.value));
+    out.write("'");
+
+    return out;
+  }
+
+  static String _escapeSingleQuoted(String str) {
+    return str
+        .replaceAll('\\', r'\\')
+        .replaceAll('\t', r'\t')
+        .replaceAll('\r', r'\r')
+        .replaceAll('\n', r'\n')
+        .replaceAll('\b', r'\b')
+        .replaceAll("'", r"\'");
+  }
+
+  static String _escapeTemplateLiteral(String str) {
+    return str
+        .replaceAll('\\', r'\\')
+        .replaceAll('`', r'\`')
+        .replaceAll(r'$', r'\$')
+        .replaceAll('\t', r'\t')
+        .replaceAll('\r', r'\r')
+        .replaceAll('\n', r'\n')
+        .replaceAll('\b', r'\b');
+  }
+
+  /// Renders a string-component value as the inner content of a template
+  /// literal (without the surrounding back-ticks).
+  String _templateInner(ASTValue value) {
+    if (value is ASTValueString) {
+      return _escapeTemplateLiteral(value.value);
+    } else if (value is ASTValueStringVariable) {
+      return '\${${value.variable.name}}';
+    } else if (value is ASTValueStringExpression) {
+      var exp = generateASTExpression(value.expression).toString();
+      return '\${$exp}';
+    } else if (value is ASTValueStringConcatenation) {
+      return value.values.map(_templateInner).join();
+    } else {
+      return generateASTValue(value).toString();
+    }
+  }
+
+  @override
+  StringBuffer generateASTValueStringConcatenation(
+    ASTValueStringConcatenation value, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    out.write('`');
+    out.write(value.values.map(_templateInner).join());
+    out.write('`');
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTValueStringVariable(
+    ASTValueStringVariable value, {
+    StringBuffer? out,
+    String indent = '',
+    bool precededByString = false,
+  }) {
+    out ??= newOutput();
+
+    out.write('`\${');
+    out.write(value.variable.name);
+    out.write('}`');
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTValueStringExpression(
+    ASTValueStringExpression value, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    var exp = generateASTExpression(value.expression).toString();
+    out.write('`\${');
+    out.write(exp);
+    out.write('}`');
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTValueArray(
+    ASTValueArray value, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    out.write(value.value);
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTValueArray2D(
+    ASTValueArray2D value, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    out.write(value.value);
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTValueArray3D(
+    ASTValueArray3D value, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    out.write(value.value);
+    return out;
+  }
+}

--- a/lib/src/languages/typescript/ts/typescript_grammar.dart
+++ b/lib/src/languages/typescript/ts/typescript_grammar.dart
@@ -1,0 +1,1116 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'package:petitparser/petitparser.dart';
+
+import '../../../apollovm_base.dart';
+import '../../../ast/apollovm_ast_base.dart';
+import '../../../ast/apollovm_ast_expression.dart';
+import '../../../ast/apollovm_ast_statement.dart';
+import '../../../ast/apollovm_ast_toplevel.dart';
+import '../../../ast/apollovm_ast_type.dart';
+import '../../../ast/apollovm_ast_value.dart';
+import '../../../ast/apollovm_ast_variable.dart';
+import 'typescript_grammar_lexer.dart';
+
+/// TypeScript grammar definition.
+///
+/// Parses untyped TypeScript into the shared ApolloVM AST. Inferred types
+/// (variables, parameters, fields, return types) are mapped to `dynamic`.
+class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
+  @override
+  Parser start() => ref0(compilationUnit).trim().end();
+
+  Parser<ASTRoot> compilationUnit() =>
+      (ref0(statementImport).star() & ref0(topLevelDefinition).star()).map((v) {
+        var imports = v[0] as List;
+        var topDef = v[1] as List;
+
+        var root = ASTRoot();
+
+        for (var import in imports) {
+          if (import is ASTStatementImport) {
+            root.addImport(import);
+          }
+        }
+
+        for (var defList in topDef) {
+          for (var def in defList) {
+            if (def is ASTFunctionDeclaration) {
+              root.addFunction(def);
+            } else if (def is ASTClassNormal) {
+              root.addClass(def);
+            } else if (def is ASTStatementVariableDeclaration) {
+              root.addStatement(def);
+            }
+          }
+        }
+
+        root.resolveNode(null);
+
+        return root;
+      });
+
+  Parser topLevelDefinition() =>
+      (arrowNamedFunction() |
+              functionDeclaration() |
+              enumDeclaration() |
+              interfaceDeclaration() |
+              classDeclaration() |
+              statementVariableDeclaration())
+          .plus();
+
+  // ---------------------------------------------------------------------------
+  // TypeScript type annotations.
+  // ---------------------------------------------------------------------------
+
+  /// Maps a TypeScript type name to the shared AST type.
+  static ASTType getTypeByName(String name) {
+    switch (name) {
+      case 'number':
+        return ASTTypeNum.instance;
+      case 'string':
+        return ASTTypeString.instance;
+      case 'boolean':
+        return ASTTypeBool.instance;
+      case 'void':
+        return ASTTypeVoid.instance;
+      case 'any':
+      case 'unknown':
+      case 'object':
+        return ASTTypeDynamic.instance;
+      case 'Object':
+        return ASTTypeObject.instance;
+      default:
+        return ASTType(name);
+    }
+  }
+
+  /// A type reference: `T`, `T[]`, `Array<T>`, `Map<K,V>`.
+  Parser<ASTType> type() =>
+      (ref0(arrayType) | ref0(genericOrSimpleType)).cast<ASTType>();
+
+  Parser<ASTType> genericOrSimpleType() =>
+      (identifier() & ref0(typeGenerics).optional()).map((v) {
+        var name = v[0] as String;
+        var generics = (v[1] as List<ASTType>?) ?? const <ASTType>[];
+        if ((name == 'Array' || name == 'List') && generics.isNotEmpty) {
+          return ASTTypeArray(generics.first);
+        }
+        return getTypeByName(name);
+      });
+
+  Parser<List<ASTType>> typeGenerics() =>
+      (char('<').trimHidden() &
+              ref0(type) &
+              (char(',').trimHidden() & ref0(type)).star() &
+              char('>').trimHidden())
+          .map((v) {
+            var list = <ASTType>[v[1] as ASTType];
+            for (var e in (v[2] as List)) {
+              list.add(e[1] as ASTType);
+            }
+            return list;
+          });
+
+  Parser<ASTType> arrayType() =>
+      (identifier() &
+              (char('[').trimHidden() & char(']').trimHidden()).plus())
+          .map((v) {
+            var elem = getTypeByName(v[0] as String);
+            var dims = (v[1] as List).length;
+            switch (dims) {
+              case 1:
+                return ASTTypeArray(elem);
+              case 2:
+                return ASTTypeArray2D.fromElementType(elem);
+              case 3:
+                return ASTTypeArray3D.fromElementType(elem);
+              default:
+                throw UnsupportedError("Can't parse array with $dims dims");
+            }
+          });
+
+  /// `: type` annotation (used after variables, parameters, fields, returns).
+  Parser<ASTType> typeAnnotation() =>
+      (char(':').trimHidden() & ref0(type)).map((v) => v[1] as ASTType);
+
+  /// Parses zero or more member access/declaration modifiers.
+  Parser<ASTModifiers> memberModifiers() => memberModifier().star().map((list) {
+    var names = list.cast<String>();
+    return ASTModifiers(
+      isStatic: names.contains('static'),
+      isPrivate: names.contains('private'),
+      isProtected: names.contains('protected'),
+      isAbstract: names.contains('abstract'),
+      isFinal: names.contains('readonly'),
+    );
+  });
+
+  Parser<String> memberModifier() =>
+      (publicToken() |
+              privateToken() |
+              protectedToken() |
+              readonlyToken() |
+              staticToken() |
+              abstractToken())
+          .trimHidden()
+          .map((t) => (t as Token).value as String);
+
+  Parser<ASTStatementImport> statementImport() =>
+      (importToken().trimHidden() &
+              (importClause() & fromToken().trimHidden()).optional() &
+              stringPathLexicalToken() &
+              char(';').trimHidden())
+          .map((v) {
+            var clause = v[1] as List?;
+            var prefix = clause != null ? clause[0] as String? : null;
+            var path = v[2] as String;
+            return ASTStatementImport(path, prefix: prefix);
+          });
+
+  /// Matches `* as name` or `name` in an import; returns the binding name.
+  Parser<String?> importClause() =>
+      ((char('*').trimHidden() & string('as').trimHidden() & identifier()) |
+              identifier())
+          .map((v) {
+            if (v is List) return v[2] as String;
+            return v as String;
+          });
+
+  Parser<ASTFunctionDeclaration> functionDeclaration() =>
+      (functionToken().trimHidden() &
+              identifier() &
+              functionParametersDeclaration() &
+              typeAnnotation().optional() &
+              codeBlock())
+          .map((v) {
+            var name = v[1] as String;
+            var parameters = v[2] as ASTFunctionParametersDeclaration;
+            var declaredReturn = v[3] as ASTType?;
+            var block = v[4] as ASTBlock;
+            return ASTFunctionDeclaration(
+              name,
+              parameters,
+              declaredReturn ?? inferReturnType(block),
+              block: block,
+              modifiers: ASTModifiers.modifierStatic,
+            );
+          });
+
+  Parser<ASTClassNormal> classDeclaration() =>
+      (abstractToken().trimHidden().optional() &
+              classToken().trimHidden() &
+              identifier() &
+              (extendsToken().trimHidden() & identifier()).optional() &
+              implementsClause().optional() &
+              classCodeBlock())
+          .map((v) {
+            var isAbstract = v[0] != null;
+            var name = v[2] as String;
+            var extendsOpt = v[3] as List?;
+            var superName = extendsOpt != null ? extendsOpt[1] as String : null;
+            var interfaces = (v[4] as List<String>?) ?? const <String>[];
+            var block = v[5] as ASTBlock;
+            var clazz = ASTClassNormal(
+              name,
+              ASTType<VMObject>(name),
+              null,
+              kind: isAbstract
+                  ? ASTClassKind.abstractClass
+                  : ASTClassKind.normalClass,
+              superClassName: superName,
+              implementsTypes: interfaces.isEmpty ? null : interfaces,
+            );
+            clazz.set(block);
+            return clazz;
+          });
+
+  /// `implements A, B, C`.
+  Parser<List<String>> implementsClause() =>
+      (implementsToken().trimHidden() &
+              identifier() &
+              (char(',').trimHidden() & identifier()).star())
+          .map((v) {
+            var list = <String>[v[1] as String];
+            for (var e in (v[2] as List)) {
+              list.add(e[1] as String);
+            }
+            return list;
+          });
+
+  /// `interface Name [extends A, B] { members }`.
+  ///
+  /// Represented as an [ASTClassNormal] with [ASTClassKind.interface]; methods
+  /// are body-less (abstract) and fields are typed.
+  Parser<ASTClassNormal> interfaceDeclaration() =>
+      (interfaceToken().trimHidden() &
+              identifier() &
+              (extendsToken().trimHidden() &
+                      identifier() &
+                      (char(',').trimHidden() & identifier()).star())
+                  .optional() &
+              classCodeBlock())
+          .map((v) {
+            var name = v[1] as String;
+            var extendsOpt = v[2] as List?;
+            var interfaces = <String>[];
+            if (extendsOpt != null) {
+              interfaces.add(extendsOpt[1] as String);
+              for (var e in (extendsOpt[2] as List)) {
+                interfaces.add(e[1] as String);
+              }
+            }
+            var block = v[3] as ASTBlock;
+            var clazz = ASTClassNormal(
+              name,
+              ASTType<VMObject>(name),
+              null,
+              kind: ASTClassKind.interface,
+              implementsTypes: interfaces.isEmpty ? null : interfaces,
+            );
+            clazz.set(block);
+            return clazz;
+          });
+
+  /// `enum Name { A, B, C = expr }`.
+  Parser<ASTClassEnum> enumDeclaration() =>
+      (enumToken().trimHidden() &
+              identifier() &
+              char('{').trimHidden() &
+              enumEntry() &
+              (char(',').trimHidden() & enumEntry()).star() &
+              char(',').trimHidden().optional() &
+              char('}').trimHidden())
+          .map((v) {
+            var name = v[1] as String;
+            var entries = <ASTEnumEntry>[v[3] as ASTEnumEntry];
+            for (var e in (v[4] as List)) {
+              entries.add(e[1] as ASTEnumEntry);
+            }
+            return ASTClassEnum(
+              name,
+              ASTType<VMObject>(name),
+              null,
+              entries: entries,
+            );
+          });
+
+  Parser<ASTEnumEntry> enumEntry() =>
+      (identifier().trimHidden() &
+              (char('=').trimHidden() & ref0(expression)).optional())
+          .map((v) {
+            var name = v[0] as String;
+            var valueOpt = v[1] as List?;
+            var value = valueOpt != null ? valueOpt[1] as ASTExpression : null;
+            return ASTEnumEntry(name, value);
+          });
+
+  Parser<ASTBlock> classCodeBlock() =>
+      (char('{').trimHidden() &
+              (ref0(classFunctionDeclaration) |
+                      ref0(classFieldDeclarationWithValue) |
+                      ref0(classFieldDeclaration))
+                  .star() &
+              char('}').trimHidden())
+          .map((v) {
+            var list = v[1] as List;
+            var fields = list.whereType<ASTClassField>().toList();
+            var functions = list.whereType<ASTFunctionDeclaration>().toList();
+
+            var block = ASTClassNormal('?', ASTType<VMObject>('?'), null);
+
+            block.addAllFields(fields);
+            block.addAllFunctions(functions);
+
+            return block;
+          });
+
+  /// `[modifiers] name[: type];` — a class/interface field.
+  Parser<ASTClassField> classFieldDeclaration() =>
+      (memberModifiers() &
+              identifier().trimHidden() &
+              typeAnnotation().optional() &
+              char(';').trimHidden())
+          .map((v) {
+            var modifiers = v[0] as ASTModifiers;
+            var name = v[1] as String;
+            var type = (v[2] as ASTType?) ?? ASTTypeDynamic.instance;
+            return ASTClassField(
+              type,
+              name,
+              modifiers.isFinal,
+              modifiers: modifiers,
+            );
+          });
+
+  /// `[modifiers] name[: type] = expr;` — a field with an initial value.
+  Parser<ASTClassField> classFieldDeclarationWithValue() =>
+      (memberModifiers() &
+              identifier().trimHidden() &
+              typeAnnotation().optional() &
+              char('=').trimHidden() &
+              ref0(expression) &
+              char(';').trimHidden())
+          .map((v) {
+            var modifiers = v[0] as ASTModifiers;
+            var name = v[1] as String;
+            var declaredType = v[2] as ASTType?;
+            var expression = v[4] as ASTExpression;
+            var type = declaredType ?? ASTTypeDynamic.instance;
+            return ASTClassFieldWithInitialValue(
+              type,
+              name,
+              expression,
+              modifiers.isFinal,
+              modifiers: modifiers,
+            );
+          });
+
+  /// `[modifiers] name(params)[: returnType] ( { block } | ; )` — a method.
+  ///
+  /// A method named `constructor` is parsed as a regular method; the code
+  /// generator emits it back as the `constructor` keyword. A body-less method
+  /// (`;`) is an abstract/interface method.
+  Parser<ASTFunctionDeclaration> classFunctionDeclaration() =>
+      (memberModifiers() &
+              identifier() &
+              functionParametersDeclaration() &
+              typeAnnotation().optional() &
+              (char(';').trimHidden() | codeBlock()))
+          .map((v) {
+            var modifiers = v[0] as ASTModifiers;
+            var name = v[1] as String;
+            var parameters = v[2] as ASTFunctionParametersDeclaration;
+            var declaredReturn = v[3] as ASTType?;
+            var block = v[4] is ASTBlock ? v[4] as ASTBlock : null;
+            if (block == null) {
+              modifiers = modifiers.copyWith(isAbstract: true);
+            }
+            var returnType =
+                declaredReturn ??
+                (block != null
+                    ? inferReturnType(block)
+                    : ASTTypeDynamic.instance);
+            return ASTClassFunctionDeclaration(
+              null,
+              name,
+              parameters,
+              returnType,
+              block: block,
+              modifiers: modifiers,
+            );
+          });
+
+  Parser<ASTBlock> codeBlock() =>
+      (char('{').trimHidden() & ref0(statement).star() & char('}').trimHidden())
+          .map((v) {
+            var statements = (v[1] as List).cast<ASTStatement>().toList();
+            return ASTBlock(null)..addAllStatements(statements);
+          });
+
+  Parser<ASTBlock> codeBlockOrSingleLineBlock() =>
+      ((codeBlock() | singleLineCodeBlock())).cast<ASTBlock>();
+
+  Parser<ASTSingleLineStatementBlock> singleLineCodeBlock() =>
+      (singleLineStatement().trimHidden()).map((v) {
+        return ASTSingleLineStatementBlock(null)..addStatement(v);
+      });
+
+  Parser<ASTStatement> singleLineStatement() =>
+      (statementReturn() | statementExpression()).cast<ASTStatement>();
+
+  Parser<ASTStatement> statement() =>
+      (branch() |
+              statementForLoop() |
+              statementForEach() |
+              statementWhileLoop() |
+              statementReturn() |
+              statementFunctionDeclaration() |
+              statementArrowFunction() |
+              statementVariableDeclaration() |
+              statementBlock() |
+              statementExpression())
+          .cast<ASTStatement>();
+
+  Parser<ASTStatement> statementSimple() =>
+      (statementVariableDeclaration() | statementExpression())
+          .cast<ASTStatement>();
+
+  Parser<ASTStatementForLoop> statementForLoop() =>
+      (forToken().trimHidden() &
+              char('(').trimHidden() &
+              ref0(statementSimple) &
+              ref0(expression) &
+              char(';').trimHidden() &
+              ref0(expression) &
+              char(')').trimHidden() &
+              codeBlock())
+          .map((v) {
+            return ASTStatementForLoop(v[2], v[3], v[5], v[7]);
+          });
+
+  Parser<ASTStatementForEach> statementForEach() =>
+      (forToken().trimHidden() &
+              char('(').trimHidden() &
+              (constToken() | letToken() | varToken()).trimHidden() &
+              identifier().trimHidden() &
+              ofToken().trimHidden() &
+              ref0(expression) &
+              char(')').trimHidden() &
+              codeBlock())
+          .map((v) {
+            var variableName = v[3] as String;
+            var iterableExp = v[5] as ASTExpression;
+            var block = v[7] as ASTBlock;
+            return ASTStatementForEach(
+              ASTTypeDynamic.instance,
+              variableName,
+              iterableExp,
+              block,
+            );
+          });
+
+  Parser<ASTStatementWhileLoop> statementWhileLoop() =>
+      (whileToken().trimHidden() &
+              char('(').trimHidden() &
+              ref0(expression) &
+              char(')').trimHidden() &
+              codeBlock())
+          .map((v) {
+            return ASTStatementWhileLoop(v[2], v[4]);
+          });
+
+  Parser<ASTStatementReturn> statementReturn() =>
+      (returnToken().trimHidden() &
+              expression().optional() &
+              char(';').trimHidden())
+          .map((v) {
+            var value = v[1];
+
+            if (value == null) {
+              return ASTStatementReturn();
+            } else if (value is ASTExpression) {
+              if (value is ASTExpressionVariableAccess) {
+                if (value.variable.name == 'null') {
+                  return ASTStatementReturnNull();
+                } else {
+                  return ASTStatementReturnVariable(value.variable);
+                }
+              } else if (value is ASTExpressionLiteral) {
+                return ASTStatementReturnValue(value.value);
+              } else {
+                return ASTStatementReturnWithExpression(value);
+              }
+            }
+
+            throw UnsupportedError("Can't handle return value: $value");
+          });
+
+  Parser<ASTStatementExpression> statementExpression() =>
+      (expression() & char(';').trimHidden()).map((v) {
+        return ASTStatementExpression(v[0]);
+      });
+
+  Parser<ASTStatementBlock> statementBlock() =>
+      (codeBlock()).map((v) => ASTStatementBlock(v));
+
+  Parser<ASTStatementFunctionDeclaration> statementFunctionDeclaration() =>
+      (functionToken().trimHidden() &
+              identifier() &
+              functionParametersDeclaration() &
+              typeAnnotation().optional() &
+              codeBlock())
+          .map((v) {
+            var name = v[1] as String;
+            var parameters = v[2] as ASTFunctionParametersDeclaration;
+            var declaredReturn = v[3] as ASTType?;
+            var block = v[4] as ASTBlock;
+            return ASTStatementFunctionDeclaration(
+              ASTFunctionDeclaration(
+                name,
+                parameters,
+                declaredReturn ?? inferReturnType(block),
+                block: block,
+                modifiers: ASTModifiers.modifierStatic,
+              ),
+            );
+          });
+
+  // ---------------------------------------------------------------------------
+  // Arrow functions.
+  //
+  // Supported form: an arrow assigned to a name, desugared to a named function
+  // declaration (so it is callable as `name(...)`), e.g.
+  //   const add = (a, b) => a + b;
+  //   const square = x => x * x;
+  //   const greet = () => { print('hi'); };
+  // Anonymous arrows passed as callbacks (true closures) are not yet supported.
+  // ---------------------------------------------------------------------------
+
+  /// `(const|let|var) name = <arrow> ;` → a named [ASTFunctionDeclaration].
+  Parser<ASTFunctionDeclaration> arrowNamedFunction() =>
+      ((constToken() | letToken() | varToken()).trimHidden() &
+              identifier().trimHidden() &
+              char('=').trimHidden() &
+              arrowParameters() &
+              typeAnnotation().optional() &
+              string('=>').trimHidden() &
+              arrowBody() &
+              char(';').trimHidden())
+          .map((v) {
+            var name = v[1] as String;
+            var parameters = v[3] as ASTFunctionParametersDeclaration;
+            var declaredReturn = v[4] as ASTType?;
+            var block = v[6] as ASTBlock;
+            return ASTFunctionDeclaration(
+              name,
+              parameters,
+              declaredReturn ?? inferReturnType(block),
+              block: block,
+              modifiers: ASTModifiers.modifierStatic,
+            );
+          });
+
+  /// Statement form of [arrowNamedFunction] (registers the function in the
+  /// enclosing block when run, making it callable by name).
+  Parser<ASTStatementFunctionDeclaration> statementArrowFunction() =>
+      arrowNamedFunction().map((f) => ASTStatementFunctionDeclaration(f));
+
+  /// Arrow parameters: `(a, b)`, `()`, or a single bare identifier `a`.
+  Parser<ASTFunctionParametersDeclaration> arrowParameters() =>
+      (functionParametersDeclaration() | arrowSingleParameter())
+          .cast<ASTFunctionParametersDeclaration>();
+
+  Parser<ASTFunctionParametersDeclaration> arrowSingleParameter() =>
+      identifier().trimHidden().map((name) {
+        return ASTFunctionParametersDeclaration(
+          [
+            ASTFunctionParameterDeclaration(
+              ASTTypeDynamic.instance,
+              name,
+              -1,
+              false,
+            ),
+          ],
+          null,
+          null,
+        );
+      });
+
+  /// Arrow body: a `{ … }` block, or an expression (`=> expr`) wrapped as
+  /// `{ return expr; }`.
+  Parser<ASTBlock> arrowBody() =>
+      (codeBlock() | arrowExpressionBody()).cast<ASTBlock>();
+
+  Parser<ASTBlock> arrowExpressionBody() => ref0(expression).map((exp) {
+    return ASTBlock(null)..addStatement(_arrowReturnStatement(exp));
+  });
+
+  static ASTStatement _arrowReturnStatement(ASTExpression value) {
+    if (value is ASTExpressionVariableAccess) {
+      if (value.variable.name == 'null') return ASTStatementReturnNull();
+      return ASTStatementReturnVariable(value.variable);
+    } else if (value is ASTExpressionLiteral) {
+      return ASTStatementReturnValue(value.value);
+    } else {
+      return ASTStatementReturnWithExpression(value);
+    }
+  }
+
+  Parser<ASTStatementVariableDeclaration> statementVariableDeclaration() =>
+      ((constToken() | letToken() | varToken()).trimHidden() &
+              identifier().trimHidden() &
+              typeAnnotation().optional() &
+              (char('=').trimHidden() & ref0(expression)).optional() &
+              char(';').trimHidden())
+          .map((v) {
+            var keyword = (v[0] as Token).value as String;
+            var unmodifiable = keyword == 'const';
+            var name = v[1] as String;
+            var declaredType = v[2] as ASTType?;
+
+            var valueOpt = v[3];
+            var value = valueOpt != null ? valueOpt[1] as ASTExpression : null;
+
+            ASTType type;
+            if (declaredType != null) {
+              type = declaredType;
+            } else {
+              var inferred = ASTTypeVar(unmodifiable: unmodifiable);
+              if (value != null) inferred.associateToType(value);
+              type = inferred;
+            }
+
+            return ASTStatementVariableDeclaration(
+              type,
+              name,
+              value,
+              unmodifiable: unmodifiable,
+            );
+          });
+
+  Parser<ASTBranch> branch() =>
+      (ref0(branchIfElseIfsElseBlock) |
+              ref0(branchIfElseBlock) |
+              ref0(branchIfBlock))
+          .cast<ASTBranch>();
+
+  Parser<ASTBranchIfBlock> branchIfBlock() =>
+      (ifToken().trimHidden() &
+              char('(').trimHidden() &
+              ref0(expression) &
+              char(')').trimHidden() &
+              codeBlockOrSingleLineBlock())
+          .map((v) {
+            return ASTBranchIfBlock(v[2], v[4]);
+          });
+
+  Parser<ASTBranchIfElseBlock> branchIfElseBlock() =>
+      (ifToken().trimHidden() &
+              char('(').trimHidden() &
+              ref0(expression) &
+              char(')').trimHidden() &
+              codeBlock() &
+              elseToken().trimHidden() &
+              codeBlock())
+          .map((v) {
+            return ASTBranchIfElseBlock(v[2], v[4], v[6]);
+          });
+
+  Parser<ASTBranchIfElseIfsElseBlock> branchIfElseIfsElseBlock() =>
+      (ifToken().trimHidden() &
+              char('(').trimHidden() &
+              ref0(expression) &
+              char(')').trimHidden() &
+              codeBlock() &
+              ref0(branchElseIfs).plus() &
+              (elseToken().trimHidden() & codeBlock()).optional())
+          .map((v) {
+            var condition = v[2];
+            var blockIf = v[4];
+            var blockElseIfs = v[5] as List;
+            var blockElse = v[6]?[1];
+
+            return ASTBranchIfElseIfsElseBlock(
+              condition,
+              blockIf,
+              blockElseIfs.cast<ASTBranchIfBlock>().toList(),
+              blockElse,
+            );
+          });
+
+  Parser<ASTBranchIfBlock> branchElseIfs() =>
+      (elseToken().trimHidden() &
+              ifToken().trimHidden() &
+              char('(').trimHidden() &
+              ref0(expression) &
+              char(')').trimHidden() &
+              codeBlock())
+          .map((v) {
+            return ASTBranchIfBlock(v[3], v[5]);
+          });
+
+  @override
+  Parser<ASTExpression> parseExpressionInString() => ref0(expression);
+
+  Parser<ASTExpression> expression() =>
+      (ref0(expressionNoOperation) &
+              (expressionOperator() & ref0(expressionNoOperation)).star())
+          .map((v) {
+            var exp1 = v[0];
+
+            var rest = v[1] as List;
+            if (rest.isEmpty) {
+              return exp1;
+            }
+
+            var extra = _expandListDeeply(rest);
+            var all = <dynamic>[exp1, ...extra];
+
+            return computeFinalExpression(all);
+          });
+
+  Parser<ASTExpressionOperator> expressionOperator() =>
+      (string('===') |
+              string('!==') |
+              string('==') |
+              string('!=') |
+              string('>=') |
+              string('<=') |
+              string('&&') |
+              string('||') |
+              char('+') |
+              char('-') |
+              char('*') |
+              char('/') |
+              char('>') |
+              char('<') |
+              char('%'))
+          .trimHidden()
+          .map((v) {
+            switch (v) {
+              case '===':
+                return ASTExpressionOperator.equals;
+              case '!==':
+                return ASTExpressionOperator.notEquals;
+              case '/':
+                // TypeScript `/` is always floating-point division.
+                return ASTExpressionOperator.divideAsDouble;
+              default:
+                return getASTExpressionOperator(v);
+            }
+          });
+
+  Parser<ASTExpression> expressionNoOperation() =>
+      (expressionNegate() |
+              expressionLiteral() |
+              expressionGroupFunctionInvocation() |
+              expressionGroup() |
+              expressionListLiteral() |
+              expressionVariableDirectOperation() |
+              expressionVariableAssigment() |
+              expressionFunctionInvocation() |
+              expressionObjectEntryFunctionInvocation() |
+              expressionVariableEntryAccess() |
+              expressionGetterAccess() |
+              expressionNullValue() |
+              expressionVariableAccess() |
+              expressionNegative())
+          .cast<ASTExpression>();
+
+  Parser<ASTExpressionNegation> expressionNegate() =>
+      (char('!').trimHidden() &
+              (ref0(expressionNoOperation) | ref0(expressionGroup)))
+          .map((v) => ASTExpressionNegation(v[1] as ASTExpression));
+
+  Parser<ASTExpressionNegative> expressionNegative() =>
+      (char('-').trimHidden() &
+              (ref0(expressionNoOperation) | ref0(expressionGroup)))
+          .map((v) => ASTExpressionNegative(v[1] as ASTExpression));
+
+  Parser<ASTExpression> expressionGroup() =>
+      (char('(').trimHidden() & ref0(expression) & char(')').trimHidden()).map(
+        (v) => v[1] as ASTExpression,
+      );
+
+  Parser<ASTExpressionGroupFunctionInvocation>
+  expressionGroupFunctionInvocation() =>
+      (ref0(expressionGroup) &
+              char('.') &
+              identifier() &
+              char('(').trimHidden() &
+              ref0(expressionSequence).optional() &
+              char(')').trimHidden() &
+              expressionChainFunctionInvocation().star())
+          .map((v) {
+            var expression = v[0] as ASTExpression;
+            var name = v[2] as String;
+            var args = (v[4] as List<ASTExpression>?) ?? <ASTExpression>[];
+            var chainFunctions = (v[6] as List)
+                .whereType<ASTExpressionChainFunctionInvocation>()
+                .toList();
+
+            return ASTExpressionGroupFunctionInvocation(
+              expression,
+              name,
+              args,
+              chainFunctions,
+            );
+          });
+
+  Parser<ASTExpressionFunctionInvocation> expressionFunctionInvocation() =>
+      ((identifier() & char('.')).optional() &
+              identifier() &
+              char('(').trimHidden() &
+              ref0(expressionSequence).optional() &
+              char(')').trimHidden() &
+              expressionChainFunctionInvocation().star())
+          .map((v) {
+            var objOpt = v[0] as List?;
+            var obj = objOpt != null ? objOpt[0] as String : null;
+            var name = v[1] as String;
+            var args = (v[3] as List<ASTExpression>?) ?? <ASTExpression>[];
+            var chainFunctions = (v[5] as List)
+                .whereType<ASTExpressionChainFunctionInvocation>()
+                .toList();
+
+            if (obj != null && obj != 'this') {
+              var variable = ASTScopeVariable(obj);
+              return ASTExpressionObjectFunctionInvocation(
+                variable,
+                name,
+                args,
+                chainFunctions,
+              );
+            } else {
+              return ASTExpressionLocalFunctionInvocation(
+                name,
+                args,
+                chainFunctions,
+              );
+            }
+          });
+
+  Parser<ASTExpressionGetterAccess> expressionGetterAccess() =>
+      ((identifier() & char('.')) &
+              identifier().trimHidden() &
+              expressionChainFunctionInvocation().star())
+          .map((v) {
+            var obj = v[0] as String?;
+            var name = v[2] as String;
+            var chainFunctions = (v[3] as List)
+                .whereType<ASTExpressionChainFunctionInvocation>()
+                .toList();
+
+            if (obj != null && obj != 'this') {
+              var variable = ASTScopeVariable(obj);
+              return ASTExpressionObjectGetterAccess(
+                variable,
+                name,
+                chainFunctions,
+              );
+            } else {
+              return ASTExpressionLocalGetterAccess(name, chainFunctions);
+            }
+          });
+
+  Parser<List<ASTExpression>> expressionSequence() =>
+      (ref0(expression) & (char(',').trimHidden() & ref0(expression)).star())
+          .map((v) {
+            var list = _expandListDeeply(v);
+            return list.whereType<ASTExpression>().toList();
+          });
+
+  Parser<ASTExpressionNullValue> expressionNullValue() =>
+      (nullToken()).map((v) => ASTExpressionNullValue());
+
+  Parser<ASTExpressionVariableAccess> expressionVariableAccess() =>
+      (variable()).map((v) => ASTExpressionVariableAccess(v));
+
+  Parser<ASTExpressionLiteral> expressionLiteral() =>
+      (literal()).map((v) => ASTExpressionLiteral(v));
+
+  Parser<ASTExpressionVariableEntryAccess> expressionVariableEntryAccess() =>
+      (variable() & char('[') & ref0(expression) & char(']')).map((v) {
+        return ASTExpressionVariableEntryAccess(v[0], v[2]);
+      });
+
+  Parser<ASTExpressionObjectEntryFunctionInvocation>
+  expressionObjectEntryFunctionInvocation() =>
+      (variable() &
+              char('[') &
+              ref0(expression) &
+              char(']') &
+              char('.').trimHidden() &
+              identifier() &
+              char('(').trimHidden() &
+              ref0(expressionSequence).optional() &
+              char(')').trimHidden() &
+              expressionChainFunctionInvocation().star())
+          .map((v) {
+            var variable = v[0];
+            var expression = v[2];
+            var fName = v[5];
+            var args = (v[7] as List<ASTExpression>?) ?? <ASTExpression>[];
+            var chainFunctions = (v[9] as List)
+                .whereType<ASTExpressionChainFunctionInvocation>()
+                .toList();
+
+            return ASTExpressionObjectEntryFunctionInvocation(
+              variable,
+              expression,
+              fName,
+              args,
+              chainFunctions,
+            );
+          });
+
+  Parser<ASTExpressionChainFunctionInvocation>
+  expressionChainFunctionInvocation() =>
+      (char('.').trimHidden() &
+              identifier() &
+              char('(').trimHidden() &
+              ref0(expressionSequence).optional() &
+              char(')').trimHidden())
+          .map((v) {
+            var fName = v[1];
+            var args = (v[3] as List<ASTExpression>?) ?? <ASTExpression>[];
+            return ASTExpressionChainFunctionInvocation(fName, args);
+          });
+
+  Parser<ASTExpressionListLiteral> expressionListLiteral() =>
+      (char('[').trimHidden() &
+              (ref0(expression) &
+                      (char(',').trimHidden() & ref0(expression)).star() &
+                      char(',').trimHidden().optional())
+                  .optional() &
+              char(']').trimHidden())
+          .map((v) {
+            var body = v[1] as List?;
+
+            var vs = <ASTExpression>[];
+            if (body != null) {
+              vs.add(body[0] as ASTExpression);
+              var tail = (body[1] as List?) ?? [];
+              vs.addAll(tail.expand((e) => e).whereType<ASTExpression>());
+            }
+
+            ASTType? type;
+            if (vs.isNotEmpty) {
+              var vsTypeResolving = vs.map((e) => e.resolveType(null)).toList();
+              var vsTypes = vsTypeResolving.whereType<ASTType>().toList();
+              if (vsTypes.length == vsTypeResolving.length) {
+                type = vsTypes.isEmpty
+                    ? ASTTypeDynamic.instance
+                    : vsTypes.reduce(
+                        (a, b) => a.commonType(b) ?? ASTTypeDynamic.instance,
+                      );
+              }
+            }
+
+            return ASTExpressionListLiteral(
+              type ?? ASTTypeDynamic.instance,
+              vs,
+            );
+          });
+
+  Parser<ASTExpressionVariableDirectOperation>
+  expressionVariableDirectOperation() =>
+      (expressionVariableDirectPosOperation() |
+              expressionVariableDirectPreOperation())
+          .cast<ASTExpressionVariableDirectOperation>();
+
+  Parser<ASTExpressionVariableDirectOperation>
+  expressionVariableDirectPosOperation() =>
+      (variable() & (string('++') | string('--'))).map((v) {
+        var operator = getASTAssignmentDirectOperator(v[1]);
+        return ASTExpressionVariableDirectOperation(v[0], operator, false);
+      });
+
+  Parser<ASTExpressionVariableDirectOperation>
+  expressionVariableDirectPreOperation() =>
+      ((string('++') | string('--')) & variable()).map((v) {
+        var operator = getASTAssignmentDirectOperator(v[0]);
+        return ASTExpressionVariableDirectOperation(v[1], operator, true);
+      });
+
+  Parser<ASTExpressionVariableAssignment> expressionVariableAssigment() =>
+      (variable() & assigmentOperator() & ref0(expression)).map((v) {
+        return ASTExpressionVariableAssignment(v[0], v[1], v[2]);
+      });
+
+  Parser<ASTAssignmentOperator> assigmentOperator() =>
+      (string('+=') |
+              string('-=') |
+              string('*=') |
+              string('/=') |
+              string('%=') |
+              char('='))
+          .trimHidden()
+          .map((v) => getASTAssignmentOperator(v));
+
+  Parser<ASTVariable> variable() =>
+      (thisVariable() | scopeVariable()).cast<ASTVariable>();
+
+  Parser<ASTThisVariable> thisVariable() =>
+      (token('this')).map((v) => ASTThisVariable());
+
+  Parser<ASTScopeVariable> scopeVariable() =>
+      (identifier()).map((v) => ASTScopeVariable(v));
+
+  Parser<ASTFunctionParametersDeclaration> functionParametersDeclaration() =>
+      (functionEmptyParametersDeclaration() |
+              functionPositionalParametersDeclaration())
+          .cast<ASTFunctionParametersDeclaration>();
+
+  Parser<ASTFunctionParametersDeclaration>
+  functionEmptyParametersDeclaration() =>
+      (char('(').trimHidden() & char(')').trimHidden()).map((v) {
+        return ASTFunctionParametersDeclaration(null, null, null);
+      });
+
+  Parser<ASTFunctionParametersDeclaration>
+  functionPositionalParametersDeclaration() =>
+      (char('(').trimHidden() & parametersList() & char(')').trimHidden()).map((
+        v,
+      ) {
+        return ASTFunctionParametersDeclaration(v[1], null, null);
+      });
+
+  Parser<List<ASTFunctionParameterDeclaration>> parametersList() =>
+      (parameterDeclaration() &
+              (char(',').trimHidden() & parameterDeclaration()).star() &
+              char(',').trimHidden().optional())
+          .map((v) {
+            var params = _expandListDeeply(v);
+            return params.whereType<ASTFunctionParameterDeclaration>().toList();
+          });
+
+  /// A parameter `name` with an optional `: type` annotation (untyped → dynamic).
+  Parser<ASTFunctionParameterDeclaration> parameterDeclaration() =>
+      (identifier().trimHidden() & typeAnnotation().optional()).map((v) {
+        var name = v[0] as String;
+        var type = (v[1] as ASTType?) ?? ASTTypeDynamic.instance;
+        return ASTFunctionParameterDeclaration(type, name, -1, false);
+      });
+
+  Parser<ASTValue> literal() => (literalBool() | literalNum() | literalString())
+      .trimHidden()
+      .cast<ASTValue>();
+
+  Parser<ASTValueBool> literalBool() => (trueToken() | falseToken()).map((v) {
+    var s = v is Token ? v.value : '$v';
+    return ASTValueBool(s == 'true');
+  });
+
+  Parser<ASTValueNum> literalNum() =>
+      (char('-').optional() & numberLexicalToken()).trim().map((v) {
+        var negative = v[0] == '-';
+        var value = v[1];
+        return ASTValueNum.from(value, negative: negative);
+      });
+
+  Parser<ASTValue<String>> literalString() => stringLexicalToken();
+
+  /// Infers a function/method return type from its body: `void` when the body
+  /// has no value-returning `return`, otherwise `dynamic` (TypeScript is
+  /// untyped, but this keeps cross-translation to typed languages correct).
+  static ASTType inferReturnType(ASTBlock block) =>
+      _hasValueReturn(block) ? ASTTypeDynamic.instance : ASTTypeVoid.instance;
+
+  static bool _hasValueReturn(ASTNode node) {
+    if (node is ASTStatementReturnValue ||
+        node is ASTStatementReturnVariable ||
+        node is ASTStatementReturnWithExpression ||
+        node is ASTStatementReturnNull) {
+      return true;
+    }
+    // Do not descend into nested function declarations.
+    if (node is ASTStatementFunctionDeclaration) return false;
+    for (var child in node.children) {
+      if (_hasValueReturn(child)) return true;
+    }
+    return false;
+  }
+
+  static List _expandListDeeply(List l) {
+    if (l.isEmpty) return l;
+    if (l.length == 1 && l[0] is! List) return l;
+
+    final result = [];
+    _expandInto(l, result);
+    return result;
+  }
+
+  static void _expandInto(List source, List target) {
+    for (final e in source) {
+      if (e is List) {
+        _expandInto(e, target);
+      } else {
+        target.add(e);
+      }
+    }
+  }
+}

--- a/lib/src/languages/typescript/ts/typescript_grammar.dart
+++ b/lib/src/languages/typescript/ts/typescript_grammar.dart
@@ -115,8 +115,7 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
           });
 
   Parser<ASTType> arrayType() =>
-      (identifier() &
-              (char('[').trimHidden() & char(']').trimHidden()).plus())
+      (identifier() & (char('[').trimHidden() & char(']').trimHidden()).plus())
           .map((v) {
             var elem = getTypeByName(v[0] as String);
             var dims = (v[1] as List).length;

--- a/lib/src/languages/typescript/ts/typescript_grammar_lexer.dart
+++ b/lib/src/languages/typescript/ts/typescript_grammar_lexer.dart
@@ -1,0 +1,263 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'package:petitparser/petitparser.dart';
+
+import '../../../ast/apollovm_ast_expression.dart';
+import '../../../ast/apollovm_ast_value.dart';
+import '../../grammar.dart';
+
+/// TypeScript grammar lexer: keywords, numbers, string literals
+/// (single/double quoted + back-tick template literals with `${...}`
+/// interpolation), whitespace and comments.
+abstract class TypeScriptGrammarLexer extends BaseGrammarLexer {
+  // -----------------------------------------------------------------
+  // Keyword definitions.
+  // -----------------------------------------------------------------
+  Parser breakToken() => ref1(token, 'break');
+
+  Parser caseToken() => ref1(token, 'case');
+
+  Parser catchToken() => ref1(token, 'catch');
+
+  Parser classToken() => ref1(token, 'class');
+
+  Parser constToken() => ref1(token, 'const');
+
+  Parser continueToken() => ref1(token, 'continue');
+
+  Parser defaultToken() => ref1(token, 'default');
+
+  Parser doToken() => ref1(token, 'do');
+
+  Parser elseToken() => ref1(token, 'else');
+
+  Parser extendsToken() => ref1(token, 'extends');
+
+  Parser falseToken() => ref1(token, 'false');
+
+  Parser forToken() => ref1(token, 'for');
+
+  Parser fromToken() => ref1(token, 'from');
+
+  Parser functionToken() => ref1(token, 'function');
+
+  Parser ifToken() => ref1(token, 'if');
+
+  Parser importToken() => ref1(token, 'import');
+
+  Parser inToken() => ref1(token, 'in');
+
+  Parser letToken() => ref1(token, 'let');
+
+  Parser newToken() => ref1(token, 'new');
+
+  Parser nullToken() => ref1(token, 'null');
+
+  Parser ofToken() => ref1(token, 'of');
+
+  Parser returnToken() => ref1(token, 'return');
+
+  Parser staticToken() => ref1(token, 'static');
+
+  Parser superToken() => ref1(token, 'super');
+
+  Parser switchToken() => ref1(token, 'switch');
+
+  Parser thisToken() => ref1(token, 'this');
+
+  Parser trueToken() => ref1(token, 'true');
+
+  Parser varToken() => ref1(token, 'var');
+
+  Parser whileToken() => ref1(token, 'while');
+
+  // TypeScript-specific keywords.
+  Parser abstractToken() => ref1(token, 'abstract');
+
+  Parser asToken() => ref1(token, 'as');
+
+  Parser enumToken() => ref1(token, 'enum');
+
+  Parser implementsToken() => ref1(token, 'implements');
+
+  Parser interfaceToken() => ref1(token, 'interface');
+
+  Parser privateToken() => ref1(token, 'private');
+
+  Parser protectedToken() => ref1(token, 'protected');
+
+  Parser publicToken() => ref1(token, 'public');
+
+  Parser readonlyToken() => ref1(token, 'readonly');
+
+  Parser typeToken() => ref1(token, 'type');
+
+  // -----------------------------------------------------------------
+  // Numbers.
+  // -----------------------------------------------------------------
+  Parser hexNumberLexicalToken() =>
+      string('0x') & ref0(hexDigitLexicalToken).plus() |
+      string('0X') & ref0(hexDigitLexicalToken).plus();
+
+  Parser numberLexicalToken() =>
+      ((ref0(digitLexicalToken).plus() &
+                  ref0(numberOptFractionalPartLexicalToken) &
+                  ref0(exponentLexicalToken).optional()) |
+              (char('.') &
+                  ref0(digitLexicalToken).plus() &
+                  ref0(exponentLexicalToken).optional()))
+          .flatten();
+
+  Parser numberOptFractionalPartLexicalToken() =>
+      char('.') & ref0(digitLexicalToken).plus() | epsilon();
+
+  Parser hexDigitLexicalToken() => pattern('0-9a-fA-F');
+
+  Parser exponentLexicalToken() =>
+      pattern('eE') & pattern('+-').optional() & ref0(digitLexicalToken).plus();
+
+  // -----------------------------------------------------------------
+  // Strings.
+  // -----------------------------------------------------------------
+
+  /// A string literal that resolves to an [ASTValue] of [String].
+  ///
+  /// Single/double quoted strings have no interpolation; back-tick template
+  /// literals support `${ expression }` interpolation.
+  Parser<ASTValue<String>> stringLexicalToken() =>
+      (ref0(singleQuotedString) |
+              ref0(doubleQuotedString) |
+              ref0(templateString))
+          .trim()
+          .cast<ASTValue<String>>();
+
+  /// Hook into the full expression parser, implemented by the grammar, used
+  /// inside template literal `${...}` blocks.
+  Parser<ASTExpression> parseExpressionInString();
+
+  Parser<ASTValue<String>> singleQuotedString() =>
+      (char("'") &
+              (ref0(escapeSequence) | pattern("^'\\\n\r").plus().flatten())
+                  .star() &
+              char("'"))
+          .map((v) {
+            var content = (v[1] as List).join();
+            return ASTValueString(content);
+          });
+
+  Parser<ASTValue<String>> doubleQuotedString() =>
+      (char('"') &
+              (ref0(escapeSequence) | pattern('^"\\\n\r').plus().flatten())
+                  .star() &
+              char('"'))
+          .map((v) {
+            var content = (v[1] as List).join();
+            return ASTValueString(content);
+          });
+
+  Parser<ASTValue<String>> templateString() =>
+      (char('`') &
+              (ref0(templateExpression) |
+                      ref0(escapeSequence) |
+                      ref0(templateDollar) |
+                      pattern('^`\\\$').plus().flatten())
+                  .star() &
+              char('`'))
+          .map((v) {
+            var rawParts = v[1] as List;
+
+            // Merge adjacent literal strings; keep interpolated expressions.
+            var parts = <ASTValue<String>>[];
+            for (var p in rawParts) {
+              if (p is ASTValue<String>) {
+                parts.add(p);
+              } else {
+                // literal `String` chunk
+                var s = p as String;
+                if (parts.isNotEmpty && parts.last is ASTValueString) {
+                  var prev = parts.removeLast() as ASTValueString;
+                  parts.add(ASTValueString(prev.value + s));
+                } else {
+                  parts.add(ASTValueString(s));
+                }
+              }
+            }
+
+            if (parts.isEmpty) return ASTValueString('');
+            if (parts.length == 1) return parts.first;
+            return ASTValueStringConcatenation(parts);
+          });
+
+  Parser<ASTValueStringExpression> templateExpression() =>
+      (string('\${') & ref0(parseExpressionInString) & char('}')).map((v) {
+        var exp = v[1] as ASTExpression;
+        return ASTValueStringExpression(exp);
+      });
+
+  /// A `$` inside a template literal that does NOT start an interpolation.
+  Parser<String> templateDollar() =>
+      (char('\$') & char('{').not()).map((_) => '\$');
+
+  Parser<String> escapeSequence() => (char('\\') & any()).map((v) {
+    var c = v[1] as String;
+    switch (c) {
+      case 'n':
+        return '\n';
+      case 'r':
+        return '\r';
+      case 't':
+        return '\t';
+      case 'b':
+        return '\b';
+      case 'f':
+        return '\f';
+      case '0':
+        return '\x00';
+      default:
+        // Includes \\ , \' , \" , \` , \$ , \/ etc.
+        return c;
+    }
+  });
+
+  /// A quoted string returning its raw content (used for import paths).
+  Parser<String> stringPathLexicalToken() =>
+      ((char("'") & pattern("^'\n\r").star().flatten() & char("'")) |
+              (char('"') & pattern('^"\n\r').star().flatten() & char('"')))
+          .trim()
+          .map((v) => v[1] as String);
+
+  // -----------------------------------------------------------------
+  // Whitespace and comments.
+  // -----------------------------------------------------------------
+  @override
+  Parser hiddenWhitespace() => ref0(hiddenStuffWhitespace).plus();
+
+  @override
+  Parser hiddenStuffWhitespace() => hiddenStuffWhitespaceStatic();
+
+  static Parser hiddenStuffWhitespaceStatic() =>
+      ref0(visibleWhitespace) |
+      ref0(singleLineComment) |
+      ref0(multiLineComment);
+
+  static Parser visibleWhitespace() => whitespace();
+
+  static Parser<String> newlineLexicalToken() => pattern('\n\r');
+
+  static Parser singleLineComment() =>
+      string('//') &
+      ref0(newlineLexicalToken).neg().star() &
+      ref0(newlineLexicalToken).optional();
+
+  static Parser multiLineComment() =>
+      string('/*') &
+      (ref0(multiLineComment) | string('*/').neg()).star() &
+      string('*/');
+}
+
+extension TrimHiddenStuffWhitespaceParserExtensionTS<R> on Parser<R> {
+  Parser<R> trimHidden() =>
+      trim(TypeScriptGrammarLexer.hiddenStuffWhitespaceStatic());
+}

--- a/lib/src/languages/typescript/ts/typescript_parser.dart
+++ b/lib/src/languages/typescript/ts/typescript_parser.dart
@@ -1,0 +1,27 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import '../../../apollovm_parser.dart';
+import 'typescript_grammar.dart';
+
+/// TypeScript implementation of an [ApolloParser].
+class ApolloParserTypeScript extends ApolloSourceCodeParser {
+  static final ApolloParserTypeScript instance = ApolloParserTypeScript();
+
+  ApolloParserTypeScript() : super(TypeScriptGrammarDefinition());
+
+  @override
+  String get language => 'typescript';
+
+  @override
+  bool acceptsLanguage(String language) {
+    language = language.toLowerCase().trim();
+
+    if (this.language == language || language == 'ts') {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/lib/src/languages/typescript/ts/typescript_runner.dart
+++ b/lib/src/languages/typescript/ts/typescript_runner.dart
@@ -1,0 +1,18 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import '../../../apollovm_runner.dart';
+
+/// TypeScript implementation of an [ApolloRunner].
+class ApolloRunnerTypeScript extends ApolloRunner {
+  ApolloRunnerTypeScript(super.apolloVM, {super.importCorePackageMath});
+
+  @override
+  String get language => 'typescript';
+
+  @override
+  ApolloRunnerTypeScript copy() {
+    return ApolloRunnerTypeScript(apolloVM);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
-description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, JavaScript, Lua with on-the-fly Wasm compilation.
-version: 0.1.30
+description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, JavaScript, TypeScript, Lua with on-the-fly Wasm compilation.
+version: 0.1.31
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/hello_world.ts
+++ b/test/hello_world.ts
@@ -1,0 +1,6 @@
+class Hello {
+  static main(name: string): void {
+    print(`Hello World!`);
+    print(`- name: ${name}`);
+  }
+}

--- a/test/tests_definitions/typescript_arrow_toplevel.test.xml
+++ b/test/tests_definitions/typescript_arrow_toplevel.test.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="TypeScript typed arrow function">
+    <source language="typescript">
+        <![CDATA[
+const mul = (a: number, b: number): number => a * b;
+        ]]>
+    </source>
+    <call function="mul">
+        [4,6]
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  function mul(a: number, b: number): number {
+    return a * b;
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  function mul(a, b) {
+    return a * b;
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  num mul(num a, num b) {
+    return a * b;
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/typescript_basic_arithmetic.test.xml
+++ b/test/tests_definitions/typescript_basic_arithmetic.test.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Basic TypeScript arithmetic">
+    <source language="typescript">
+        <![CDATA[
+class M {
+  run(x: number, y: number): number {
+    return x * x + y;
+  }
+}
+        ]]>
+    </source>
+    <call class="M" function="run">
+        [3,5]
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class M {
+
+  run(x: number, y: number): number {
+    return (x * x) + y;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class M {
+
+  run(x, y) {
+    return (x * x) + y;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class M {
+
+  num run(num x, num y) {
+    return (x * x) + y;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/typescript_basic_class_function.test.xml
+++ b/test/tests_definitions/typescript_basic_class_function.test.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="TypeScript typed class method with template literal">
+    <source language="typescript">
+        <![CDATA[
+class Foo {
+  test(a: number): void {
+    let s: string = `a: ${a}`;
+    print(s);
+  }
+}
+        ]]>
+    </source>
+    <call class="Foo" function="test">
+        [123]
+    </call>
+    <output>
+        ["a: 123"]
+    </output>
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  test(a: number): void {
+    let s: string = `a: ${a}`;
+    print(s);
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  test(a) {
+    let s = `a: ${a}`;
+    print(s);
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  void test(num a) {
+    String s = 'a: ${a}';
+    print(s);
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/typescript_basic_vars.test.xml
+++ b/test/tests_definitions/typescript_basic_vars.test.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Basic TypeScript typed variables">
+    <source language="typescript">
+        <![CDATA[
+class M {
+  run(): void {
+    let a: number = 10;
+    const b: number = 20;
+    var c: number = a + b;
+    print(a);
+    print(b);
+    print(c);
+  }
+}
+        ]]>
+    </source>
+    <call class="M" function="run">
+        []
+    </call>
+    <output>
+        [10,20,30]
+    </output>
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class M {
+
+  run(): void {
+    let a: number = 10;
+    const b: number = 20;
+    let c: number = a + b;
+    print(a);
+    print(b);
+    print(c);
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class M {
+
+  run() {
+    let a = 10;
+    const b = 20;
+    let c = a + b;
+    print(a);
+    print(b);
+    print(c);
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class M {
+
+  void run() {
+    num a = 10;
+    num b = 20;
+    num c = a + b;
+    print(a);
+    print(b);
+    print(c);
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/typescript_branches.test.xml
+++ b/test/tests_definitions/typescript_branches.test.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="TypeScript if/else branches">
+    <source language="typescript">
+        <![CDATA[
+class M {
+  run(x: number): string {
+    if (x > 0) {
+      return `pos`;
+    } else {
+      return `nonpos`;
+    }
+  }
+}
+        ]]>
+    </source>
+    <call class="M" function="run">
+        [3]
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class M {
+
+  run(x: number): string {
+    if (x > 0) {
+        return 'pos';
+    } else {
+        return 'nonpos';
+    }
+
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class M {
+
+  run(x) {
+    if (x > 0) {
+        return 'pos';
+    } else {
+        return 'nonpos';
+    }
+
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class M {
+
+  String run(num x) {
+    if (x > 0) {
+        return 'pos';
+    } else {
+        return 'nonpos';
+    }
+
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/typescript_enum.test.xml
+++ b/test/tests_definitions/typescript_enum.test.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="TypeScript enum declaration">
+    <source language="typescript">
+        <![CDATA[
+enum Color {
+  Red,
+  Green,
+  Blue
+}
+        ]]>
+    </source>
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+enum Color {
+  Red,
+  Green,
+  Blue
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+enum Color {
+  Red,
+  Green,
+  Blue
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/typescript_for_loop.test.xml
+++ b/test/tests_definitions/typescript_for_loop.test.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="TypeScript for loop">
+    <source language="typescript">
+        <![CDATA[
+class M {
+  run(n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n; i++) {
+      total = total + i;
+    }
+    return total;
+  }
+}
+        ]]>
+    </source>
+    <call class="M" function="run">
+        [5]
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class M {
+
+  run(n: number): number {
+    let total: number = 0;
+    for (let i: number = 0; i < n ; i++) {
+      total = total + i;
+    }
+    return total;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class M {
+
+  run(n) {
+    let total = 0;
+    for (let i = 0; i < n ; i++) {
+      total = total + i;
+    }
+    return total;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class M {
+
+  num run(num n) {
+    num total = 0;
+    for (num i = 0; i < n ; i++) {
+      total = total + i;
+    }
+    return total;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/typescript_for_of.test.xml
+++ b/test/tests_definitions/typescript_for_of.test.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="TypeScript for...of over a typed array">
+    <source language="typescript">
+        <![CDATA[
+class M {
+  run(items: string[]): void {
+    for (const it of items) {
+      print(it);
+    }
+  }
+}
+        ]]>
+    </source>
+    <call class="M" function="run">
+        [["a","b","c"]]
+    </call>
+    <output>
+        ["a","b","c"]
+    </output>
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class M {
+
+  run(items: string[]): void {
+    for (const it of items) {
+      print(it);
+    }
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class M {
+
+  run(items) {
+    for (const it of items) {
+      print(it);
+    }
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class M {
+
+  void run(List<String> items) {
+    for (var it in items) {
+      print(it);
+    }
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/typescript_function_toplevel.test.xml
+++ b/test/tests_definitions/typescript_function_toplevel.test.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="TypeScript top-level typed function">
+    <source language="typescript">
+        <![CDATA[
+function sum(a: number, b: number): number {
+  return a + b;
+}
+        ]]>
+    </source>
+    <call function="sum">
+        [4,6]
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  function sum(a: number, b: number): number {
+    return a + b;
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  function sum(a, b) {
+    return a + b;
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  num sum(num a, num b) {
+    return a + b;
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/typescript_interface.test.xml
+++ b/test/tests_definitions/typescript_interface.test.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="TypeScript interface declaration">
+    <source language="typescript">
+        <![CDATA[
+interface Shape {
+  name: string;
+  area(): number;
+}
+        ]]>
+    </source>
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+interface Shape {
+
+  name: string;
+
+  area(): number;
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+abstract class Shape {
+
+  String name;
+
+  num area();
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/typescript_modifiers.test.xml
+++ b/test/tests_definitions/typescript_modifiers.test.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="TypeScript class with access modifiers">
+    <source language="typescript">
+        <![CDATA[
+abstract class Base {
+  abstract describe(): string;
+  static label(): string {
+    return `base`;
+  }
+  private helper(): number {
+    return 1;
+  }
+}
+        ]]>
+    </source>
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+abstract class Base {
+
+  abstract describe(): string;
+
+  static label(): string {
+    return 'base';
+  }
+
+  private helper(): number {
+    return 1;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+abstract class Base {
+
+  String describe();
+
+  static String label() {
+    return 'base';
+  }
+
+  num helper() {
+    return 1;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/typescript_this_method.test.xml
+++ b/test/tests_definitions/typescript_this_method.test.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="TypeScript this method call">
+    <source language="typescript">
+        <![CDATA[
+class Foo {
+  value(): number {
+    return 42;
+  }
+  run(): void {
+    print(this.value());
+  }
+}
+        ]]>
+    </source>
+    <call class="Foo" function="run">
+        []
+    </call>
+    <output>
+        [42]
+    </output>
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  value(): number {
+    return 42;
+  }
+
+  run(): void {
+    print(value());
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  value() {
+    return 42;
+  }
+
+  run() {
+    print(value());
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  num value() {
+    return 42;
+  }
+
+  void run() {
+    print(value());
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/typescript_while_loop.test.xml
+++ b/test/tests_definitions/typescript_while_loop.test.xml
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="TypeScript while loop">
+    <source language="typescript">
+        <![CDATA[
+class M {
+  run(n: number): number {
+    let i: number = 0;
+    let total: number = 0;
+    while (i < n) {
+      total = total + i;
+      i++;
+    }
+    return total;
+  }
+}
+        ]]>
+    </source>
+    <call class="M" function="run">
+        [5]
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class M {
+
+  run(n: number): number {
+    let i: number = 0;
+    let total: number = 0;
+    while( i < n ) {
+      total = total + i;
+      i++;
+    }
+    return total;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class M {
+
+  run(n) {
+    let i = 0;
+    let total = 0;
+    while( i < n ) {
+      total = total + i;
+      i++;
+    }
+    return total;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class M {
+
+  num run(num n) {
+    num i = 0;
+    num total = 0;
+    while( i < n ) {
+      total = total + i;
+      i++;
+    }
+    return total;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>


### PR DESCRIPTION
## Summary

Adds **TypeScript** as a new parse/run/translate language (modeled on the existing JavaScript implementation) and **generalizes interfaces, enums and member modifiers into the shared AST** so they work for both **Dart** and **TypeScript** (and cross-translate between Dart ↔ TypeScript ↔ JavaScript).

## Core AST generalization (additive)
- `ASTModifiers`: add `isAbstract`, `isProtected` (+ `modifierAbstract`).
- `ASTClassNormal`: add `kind` (`normalClass`/`abstractClass`/`interface`), `superClassName`, `implementsTypes`.
- New `ASTClassEnum` + `ASTEnumEntry`.
- `ASTClassField`: add a `modifiers` field.

All additions are optional/defaulted, so existing positional constructor calls across every language keep compiling.

## Dart
Now parses and generates `abstract class`, `enum`, `extends`/`implements`, body-less abstract methods, and `static` fields.

## TypeScript (`lib/src/languages/typescript/ts/`)
Standalone language (5 files) copied from the current async-aware JavaScript implementation and extended with:
- Type annotations on variables, parameters, return types, and class fields (`number`/`string`/`boolean`/`any`/`void`, `T[]`/`Array<T>`).
- `interface`, `enum`, and access modifiers (`public`/`private`/`protected`/`readonly`/`static`/`abstract`).
- Context-aware `normalizeTypeName` (TS primitives for annotations vs JS `Number` for static calls).

Registered `'typescript'`/`'ts'` in the parser/runner/generator factories and the `.ts` extension mapping; CLI `apollovm run`/`translate` works on `.ts`. Version bumped `0.1.30 → 0.1.31` (pubspec + `ApolloVM.VERSION`).

## Tests, example, docs
- 13 golden test definitions in `test/tests_definitions/typescript_*.test.xml` (parse → run → generate TS/JS/Dart → reparse → run), plus `test/hello_world.ts` and `example/apollovm_example_typescript.dart`.
- README "Language: TypeScript" section + CLI note + roadmap; CHANGELOG `0.1.31` entry.

## Verification
- `dart analyze`: no issues.
- All language/version tests pass (98 in the extended+basic+version run); broader suites (ast, features, bugfix, kotlin, lua, async, integration, maps — 256+ tests) pass with **no regressions**.
- The only failing tests are the pre-existing `wasm_*` suites, which fail on the clean merge base too (missing `wasm_run` native lib; needs `dart run wasm_run:setup`) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)