### PR TITLE
Kotlin: translate async/await to suspend fun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,8 +63,9 @@
     API. So real-suspension async/await works end-to-end through the VM
     (`test/apollovm_wasm_asyncify_runner_test.dart`). A `br_table`
     multi-await/multi-frame transform is the remaining follow-up.
-  - Kotlin async/await translation is deferred and fails loudly via
-    `UnsupportedSyntaxError` (the eventual mapping is `suspend fun` + coroutines).
+  - Kotlin async/await translation: an `async` function maps to a `suspend fun`
+    (the declared `Future<T>` collapses to `T`), and `await e` becomes just `e`
+    (suspension is implicit when calling a `suspend` function in coroutines).
   - Tests: `test/apollovm_async_test.dart` (parse, real-suspension ordering,
     await chains, top-level async, identifier guard, Dart/JS/Kotlin translation)
     and `test/apollovm_wasm_async_test.dart` (AST-vs-compiled-Wasm parity).

--- a/lib/src/languages/kotlin/kotlin_generator.dart
+++ b/lib/src/languages/kotlin/kotlin_generator.dart
@@ -4,7 +4,6 @@
 
 import '../../apollovm_code_generator.dart';
 import '../../apollovm_code_storage.dart';
-import '../../apollovm_parser.dart';
 import '../../ast/apollovm_ast_expression.dart';
 import '../../ast/apollovm_ast_statement.dart';
 import '../../ast/apollovm_ast_toplevel.dart';
@@ -173,20 +172,23 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
   ) {
     out ??= newOutput();
 
-    if (f.modifiers.isAsync) {
-      // Kotlin async maps to `suspend fun` + coroutines, not yet implemented.
-      throw UnsupportedSyntaxError(
-        "Kotlin async/await translation not yet supported (function: '${f.name}')",
-      );
-    }
-
     var blockCode = generateASTBlock(f, indent: indent, withBrackets: false);
 
     out.write(indent);
 
+    // Dart `async` maps to a Kotlin `suspend fun`; `Future<T>` collapses to `T`
+    // (suspension is implicit in coroutines — see [generateASTExpressionAwait]).
+    var returnType = f.returnType;
+    if (f.modifiers.isAsync) {
+      out.write('suspend ');
+      if (returnType is ASTTypeFuture) {
+        returnType = returnType.futureValueType;
+      }
+    }
+
     out.write('fun ');
     out.write(f.name);
-    _generateFunctionParamsAndBlock(f, blockCode, out, indent, f.returnType);
+    _generateFunctionParamsAndBlock(f, blockCode, out, indent, returnType);
 
     return out;
   }
@@ -198,8 +200,13 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
     String indent = '',
     bool headIndented = true,
   }) {
-    throw UnsupportedSyntaxError(
-      'Kotlin async/await translation not yet supported',
+    // Kotlin suspends implicitly when calling a `suspend` function, so `await e`
+    // becomes just `e`.
+    return generateASTExpression(
+      expression.expression,
+      out: out,
+      indent: indent,
+      headIndented: headIndented,
     );
   }
 

--- a/test/apollovm_async_extra_test.dart
+++ b/test/apollovm_async_extra_test.dart
@@ -245,6 +245,73 @@ void main() {
     });
   });
 
+  group('Dart -> Kotlin async translation', () {
+    test(
+      'async method -> suspend fun, Future<T> -> T, await dropped',
+      () async {
+        var kt = await _translate(r'''
+        class C {
+          Future<int> compute(List args) async { return 5; }
+          Future<int> run(List args) async {
+            var x = await compute(args);
+            return x + 1;
+          }
+        }
+      ''', 'kotlin');
+        expect(kt, contains('suspend fun compute('));
+        expect(kt, contains('suspend fun run('));
+        expect(kt, contains('): Int'));
+        expect(kt, contains('var x = compute(args)')); // await dropped
+        expect(kt, isNot(contains('await')));
+        expect(kt, isNot(contains('Future')));
+      },
+    );
+
+    test('top-level async functions -> suspend fun', () async {
+      var kt = await _translate(r'''
+        Future<int> compute() async { return 5; }
+        Future<int> main(List args) async {
+          var v = await compute();
+          return v;
+        }
+      ''', 'kotlin');
+      expect(kt, contains('suspend fun compute('));
+      expect(kt, contains('suspend fun main('));
+    });
+
+    test('async with a loop + await -> suspend fun, await dropped', () async {
+      var kt = await _translate(r'''
+        class C {
+          Future<int> step(int i) async { return i; }
+          Future<int> run(List args) async {
+            var total = 0;
+            for (var i = 0; i < 3; i = i + 1) {
+              total = total + await step(i);
+            }
+            return total;
+          }
+        }
+      ''', 'kotlin');
+      expect(kt, contains('suspend fun run('));
+      expect(kt, contains('suspend fun step('));
+      expect(kt, contains('for ('));
+      expect(kt, isNot(contains('await')));
+    });
+
+    test('Future<void> async -> suspend fun with no return type', () async {
+      var kt = await _translate(r'''
+        class C {
+          Future<void> ping() async {
+            await beat();
+          }
+        }
+      ''', 'kotlin');
+      expect(kt, contains('suspend fun ping()'));
+      expect(kt, isNot(contains(': Unit'))); // void/Unit return omitted
+      expect(kt, isNot(contains('await')));
+    });
+  });
+
   group('Dart -> Dart async round-trip (extra)', () {
     test('multiple awaits round-trip', () async {
       var dart = await _translate(r'''

--- a/test/apollovm_async_test.dart
+++ b/test/apollovm_async_test.dart
@@ -197,17 +197,19 @@ void main() {
       expect(generated, contains('await '));
     });
 
-    test('Dart -> Kotlin async fails loudly (deferred)', () async {
-      expect(
-        () => _translateDart(r'''
+    test('Dart -> Kotlin emits suspend fun and drops await', () async {
+      var kt = await _translateDart(r'''
           class Async {
             Future<int> run(List args) async {
               return await compute(args);
             }
           }
-        ''', 'kotlin'),
-        throwsA(isA<UnsupportedSyntaxError>()),
-      );
+        ''', 'kotlin');
+      // `async` -> `suspend fun`; `Future<int>` -> `Int`; `await x` -> `x`.
+      expect(kt, contains('suspend fun run('));
+      expect(kt, contains('): Int'));
+      expect(kt, contains('return compute(args)'));
+      expect(kt, isNot(contains('await')));
     });
   });
 }


### PR DESCRIPTION
## Summary

Implements the previously-deferred **Kotlin async/await translation** (it used to fail loudly with `UnsupportedSyntaxError`). Full suite: **703 tests passing**, `dart format` + `dart analyze` clean. Stays on the unreleased **0.1.30**.

## Mapping
- A Dart `async` function becomes a Kotlin **`suspend fun`**, and its declared `Future<T>` return type collapses to **`T`** (`Future<void>` → no return type / `Unit`).
- `await e` becomes just **`e`** — in Kotlin coroutines, suspension is implicit when calling a `suspend` function, so the keyword is dropped.

Example:
```dart
class C {
  Future<int> compute(List args) async { return 5; }
  Future<int> run(List args) async {
    var x = await compute(args);
    return x + 1;
  }
}
```
↓
```kotlin
class C {
  suspend fun compute(args: List<Any>): Int {
    return 5
  }
  suspend fun run(args: List<Any>): Int {
    var x = compute(args)
    return x + 1
  }
}
```

## Tests
Updated the former "fails loudly" assertion to check the new output, and added a **Dart → Kotlin async** group: suspend fun + `Future<T>`→`T` + dropped await, top-level async functions, async with a loop + await, and `Future<void>` → `suspend fun` with no return type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)