### PR TITLE
Wasm Asyncify: awaits inside for-each over a list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.1.32
+
+- Wasm Asyncify: **awaits inside `for-each`** over a list. `for (T e in it)` is
+  desugared in the CFG into an indexed loop (`__i = 0; while (__i < it.length) {
+  T e = it[__i]; body; __i++ }`), so awaits in the body really suspend. `it[__i]`
+  uses the normal list index-access; the index/length are temp locals
+  spilled/restored on the Asyncify frame stack, and the only non-AST bit (the
+  length read + index reset) is emitted via a small per-block raw hook. The
+  iterable must be a list variable; other iterables fall back to
+  synchronous-collapse. Tested end-to-end through `ApolloRunnerWasm`.
+
 ## 0.1.31
 
 - TypeScript language support (parse, run, translate):

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -47,7 +47,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.31';
+  static final String VERSION = '0.1.32';
 
   static int _idCount = 0;
 

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -3507,6 +3507,81 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
             cur = exitPc;
             continue;
           }
+          // `for (T e in it)` over a list variable, desugared to an index loop:
+          //   __i = 0; while (__i < it.length) { T e = it[__i]; body; __i++ }
+          // Only `it.length` is raw (no AST getter); the rest is synthetic AST.
+          if (s is ASTStatementForEach) {
+            final iter = s.iterableExpression;
+            if (iter is! ASTExpressionVariableAccess) {
+              ok = false;
+              return cur;
+            }
+            final itVar = iter.variable;
+            final iName = '\$async_fe_i${temps.length}';
+            final lenName = '\$async_fe_n${temps.length}';
+            temps.add((name: iName, type: _astTypeInt));
+            temps.add((name: lenName, type: _astTypeInt));
+
+            ASTExpression iAccess() =>
+                ASTExpressionVariableAccess(ASTScopeVariable(iName));
+
+            final condPc = newBb();
+            blocks[cur].rawInit = (body, ctx) {
+              final i = ctx.getLocalVariable(iName)!;
+              final n = ctx.getLocalVariable(lenName)!;
+              final it = ctx.getLocalVariable(itVar.name)!;
+              body.write([
+                ...Wasm64.i64Const(0),
+                ...Wasm.localSet(i.index), // __i = 0
+                ...Wasm.localGet(it.index), // list header ptr
+                ...Wasm32.i32Load(2, 0), // length (i32)
+                Wasm32.i32ExtendToI64Unsigned,
+                ...Wasm.localSet(n.index), // __len
+              ]);
+            };
+            blocks[cur].term = _TGoto(condPc);
+
+            final bodyPc = newBb();
+            final exitPc = newBb();
+            blocks[condPc].term = _TBranch(
+              ASTExpressionOperation(
+                iAccess(),
+                ASTExpressionOperator.lower,
+                ASTExpressionVariableAccess(ASTScopeVariable(lenName)),
+              ),
+              bodyPc,
+              exitPc,
+            );
+
+            // Body entry: bind `T e = it[__i]`, then the original body.
+            blocks[bodyPc].stmts.add(
+              ASTStatementVariableDeclaration(
+                s.variableType,
+                s.variableName,
+                ASTExpressionVariableEntryAccess(itVar, iAccess()),
+              ),
+            );
+            final bodyExit = lower(s.loopBlock.statements, bodyPc, true);
+            if (bodyExit >= 0) {
+              // __i = __i + 1
+              blocks[bodyExit].stmts.add(
+                ASTStatementExpression(
+                  ASTExpressionVariableAssignment(
+                    ASTScopeVariable(iName),
+                    ASTAssignmentOperator.set,
+                    ASTExpressionOperation(
+                      iAccess(),
+                      ASTExpressionOperator.add,
+                      ASTExpressionLiteral(ASTValueInt(1)),
+                    ),
+                  ),
+                ),
+              );
+              blocks[bodyExit].term = _TGoto(condPc);
+            }
+            cur = exitPc;
+            continue;
+          }
           if (s is ASTBranchIfBlock) {
             final thenPc = newBb();
             final joinPc = newBb();
@@ -4152,6 +4227,8 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
           ...Wasm32.i32Store(2, stateOff), // STATE = normal (rewind done)
         ]);
       }
+
+      bb.rawInit?.call(body, context);
 
       for (final s in bb.stmts) {
         generateASTStatement(s, out: body, context: context);
@@ -6212,6 +6289,10 @@ class _Bb {
   /// When set, on entering this block the leaf await's host result is loaded
   /// into its variable (the block is a leaf-await resume target).
   _AwaitPoint? leafResume;
+
+  /// Raw Wasm emitted at block entry (before [stmts]); used for `for-each` loop
+  /// setup that has no AST form (reading the list length, resetting the index).
+  void Function(BytesOutput body, WasmContext ctx)? rawInit;
 
   _Term? term;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, JavaScript, TypeScript, Lua with on-the-fly Wasm compilation.
-version: 0.1.31
+version: 0.1.32
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/apollovm_wasm_asyncify_runner_test.dart
+++ b/test/apollovm_wasm_asyncify_runner_test.dart
@@ -595,6 +595,40 @@ void main() {
       );
     });
 
+    test('await inside a for-each over a list', () async {
+      var runner = await _wasmRunner(r'''
+        Future<int> sumList(List<int> items) async {
+          int total = 0;
+          for (var x in items) {
+            int v = await hostId(x);
+            total = total + v;
+          }
+          return total;
+        }
+      ''');
+      if (runner == null) {
+        fail('Wasm runtime not supported.');
+      }
+      var suspends = 0;
+      runner.mapWasmAsyncFunction('hostId', const [WasmValueType.i64], (
+        args,
+      ) async {
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+        suspends++;
+        return _asInt(args[0]);
+      });
+
+      var r = await runner.executeFunction(
+        '',
+        'sumList',
+        positionalParameters: [
+          [1, 2, 3, 4],
+        ],
+      );
+      expect(r.getValueNoContext(), equals(10)); // 1+2+3+4
+      expect(suspends, equals(4), reason: 'one suspension per element');
+    });
+
     test('a non-async Wasm function still runs synchronously', () async {
       var runner = await _wasmRunner(r'''
         int addOne(int n) {


### PR DESCRIPTION
## Summary

Closes the last Wasm async/await coverage gap: `await` inside a **`for-each`** loop now really suspends instead of falling back to synchronous-collapse. Bumps version `0.1.31` → **0.1.32** (0.1.31 is published). Full suite: **717 tests passing**, `dart format` + `dart analyze` clean.

## How it works
`for (T e in it) { body }` over a list variable is desugared in the CFG into an indexed loop:
```
__i = 0
while (__i < it.length) {
  T e = it[__i]
  body
  __i = __i + 1
}
```
- `it[__i]` is emitted as a normal `ASTExpressionVariableEntryAccess` (the existing list index-access codegen).
- The index `__i` and length `__len` are synthetic temp locals, spilled/restored on the Asyncify frame stack like any loop-carried state — so they survive a suspension mid-iteration.
- The only part with no AST form — reading the list length (`i32.load(header, 0)`) and resetting the index — is emitted via a small new per-block `rawInit` hook.

## Constraints
The iterable must be a list **variable** (`for (x in items)`); other iterables (call results, maps) fall back to synchronous-collapse.

## Tests
`test/apollovm_wasm_asyncify_runner_test.dart` — `await` per element of a `List<int>` for-each, end-to-end through `ApolloRunnerWasm` (one suspension per element, correct sum).

## Note on rebase
This branch was rebased onto current `master` (which gained TypeScript support / 0.1.31), so it cleanly applies on top and bumps to 0.1.32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)