### PR TITLE
Add try/catch/finally and throw (Dart, Java, Kotlin, JS, TS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,23 @@
+## 0.1.33
+
+- Exception handling: **`throw`, `try` / `catch` / `finally`** for Dart, Java,
+  Kotlin, JavaScript and TypeScript (parse, run and translate).
+  - New AST nodes `ASTStatementThrow`, `ASTStatementTryCatch` and `ASTCatchClause`;
+    a thrown value is carried by the new `ApolloVMThrownException`.
+  - Catch semantics (faithful to Dart's `catch (e)`): an **untyped** `catch`
+    catches both user `throw`n values *and* built-in VM runtime errors (e.g.
+    integer division by zero, surfaced as their message `String`); a **typed**
+    clause matches user-thrown values by type. The universal supertypes
+    (`Object`, `dynamic`, `Exception`, `Throwable`, `Error`) act as catch-all so
+    an untyped catch round-trips faithfully across languages.
+  - `finally` always runs (on normal completion, after a caught throw, or on a
+    `return` inside `try`/`catch`), and a `return` inside `finally` overrides.
+  - Per-language catch syntax on both parse and generation: Dart `on T catch (e)`
+    / `catch (e)`, Java `catch (T e)` (untyped → `catch (Exception e)`), Kotlin
+    `catch (e: T)` (untyped → `catch (e: Throwable)`), JS/TS `catch (e)`.
+  - **Wasm** `try`/`catch`/`throw` is deferred: it fails loudly (no silent
+    miscompile).
+
 ## 0.1.32
 
 - Wasm Asyncify: **awaits inside `for-each`** over a list. `for (T e in it)` is

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -47,7 +47,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.32';
+  static final String VERSION = '0.1.33';
 
   static int _idCount = 0;
 
@@ -1283,6 +1283,17 @@ class ApolloVMNullPointerException extends ApolloVMRuntimeError {
 
   @override
   String toString() => 'ApolloVMNullPointerException: $message';
+}
+
+/// A value thrown by a user `throw` statement, carrying the thrown [value].
+/// Caught by an `ASTStatementTryCatch`.
+class ApolloVMThrownException implements Exception {
+  final ASTValue value;
+
+  ApolloVMThrownException(this.value);
+
+  @override
+  String toString() => 'ApolloVMThrownException: $value';
 }
 
 /// An VM Object instance, with respective fields for class [type].

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -428,6 +428,20 @@ abstract class ApolloCodeGenerator
         indent: indent,
         headIndented: headIndented,
       );
+    } else if (statement is ASTStatementThrow) {
+      return generateASTStatementThrow(
+        statement,
+        out: out,
+        indent: indent,
+        headIndented: headIndented,
+      );
+    } else if (statement is ASTStatementTryCatch) {
+      return generateASTStatementTryCatch(
+        statement,
+        out: out,
+        indent: indent,
+        headIndented: headIndented,
+      );
     }
 
     throw UnsupportedError("Can't handle statement: $statement");
@@ -588,6 +602,82 @@ abstract class ApolloCodeGenerator
     out.write('}');
 
     return out;
+  }
+
+  StringBuffer generateASTStatementThrow(
+    ASTStatementThrow statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write('throw ');
+    generateASTExpression(
+      statement.expression,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+    out.write(';');
+
+    return out;
+  }
+
+  StringBuffer generateASTStatementTryCatch(
+    ASTStatementTryCatch tryCatch, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write('try {\n');
+    out.write(
+      generateASTBlock(tryCatch.tryBlock, indent: indent, withBrackets: false),
+    );
+    out.write(indent);
+    out.write('}');
+
+    for (var catchClause in tryCatch.catches) {
+      out.write(' ');
+      out.write(generateASTCatchClauseHeader(catchClause));
+      out.write(' {\n');
+      out.write(
+        generateASTBlock(
+          catchClause.block,
+          indent: indent,
+          withBrackets: false,
+        ),
+      );
+      out.write(indent);
+      out.write('}');
+    }
+
+    var finallyBlock = tryCatch.finallyBlock;
+    if (finallyBlock != null) {
+      out.write(' finally {\n');
+      out.write(
+        generateASTBlock(finallyBlock, indent: indent, withBrackets: false),
+      );
+      out.write(indent);
+      out.write('}');
+    }
+
+    return out;
+  }
+
+  /// Renders the catch-clause header (everything before the `{` block), e.g.
+  /// `catch (e)` or `on T catch (e)`. The base emits an untyped `catch (e)`
+  /// (used by JavaScript/TypeScript); language generators override this to
+  /// emit their idiomatic, typed form.
+  String generateASTCatchClauseHeader(ASTCatchClause catchClause) {
+    var name = catchClause.variableName ?? 'e';
+    return 'catch ($name)';
   }
 
   @override

--- a/lib/src/ast/apollovm_ast_statement.dart
+++ b/lib/src/ast/apollovm_ast_statement.dart
@@ -1287,3 +1287,187 @@ class ASTStatementForEach extends ASTStatement {
   @override
   ASTType resolveType(VMContext? context) => ASTTypeVoid.instance;
 }
+
+/// [ASTStatement] for `throw <expression>;`.
+class ASTStatementThrow extends ASTStatement {
+  ASTExpression expression;
+
+  ASTStatementThrow(this.expression);
+
+  @override
+  Iterable<ASTNode> get children => [expression];
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+    expression.resolveNode(parentNode);
+  }
+
+  @override
+  FutureOr<ASTValue> run(VMContext parentContext, ASTRunStatus runStatus) {
+    return expression.run(parentContext, runStatus).resolveMapped((value) {
+      throw ApolloVMThrownException(value);
+    });
+  }
+
+  @override
+  ASTType resolveType(VMContext? context) => ASTTypeVoid.instance;
+
+  @override
+  String toString() => 'throw $expression ;';
+}
+
+/// A single `catch` clause of an [ASTStatementTryCatch].
+///
+/// [exceptionType] is the matched type (`null` = catch-all); [variableName] is
+/// the bound variable (`null` = no variable); [block] is the handler body.
+class ASTCatchClause {
+  final ASTType? exceptionType;
+  final String? variableName;
+  final ASTBlock block;
+
+  ASTCatchClause(this.exceptionType, this.variableName, this.block);
+
+  void resolveNode(ASTNode? parentNode) {
+    exceptionType?.resolveNode(parentNode);
+    block.resolveNode(parentNode);
+  }
+
+  /// Runs the handler with [caught] bound to [variableName] in a child scope.
+  Future<ASTValue> run(
+    VMContext parentContext,
+    ASTRunStatus runStatus,
+    ASTValue caught,
+  ) async {
+    var context = VMScopeContext(parentContext.block, parent: parentContext);
+    var name = variableName;
+    if (name != null) {
+      context.declareVariableWithValue(
+        exceptionType ?? ASTTypeDynamic.instance,
+        name,
+        caught,
+      );
+    }
+    var prevContext = VMContext.setCurrent(context);
+    try {
+      var result = await block.run(context, runStatus);
+      // Materialize any lazy returned value (e.g. a string interpolation that
+      // references the bound variable) while the catch variable is still in
+      // scope — otherwise it would be resolved later, after this scope is gone.
+      if (runStatus.returned) {
+        var returnedValue = runStatus.returnedValue;
+        if (returnedValue != null) {
+          var resolved = await returnedValue.resolve(context);
+          runStatus.returnedValue = resolved;
+          result = resolved;
+        }
+      }
+      return result;
+    } finally {
+      VMContext.setCurrent(prevContext);
+    }
+  }
+}
+
+/// The universal "catch-all" exception supertypes across the supported
+/// languages. A `catch` clause typed with one of these matches any thrown
+/// value (including built-in VM errors), so that an untyped Dart/JS `catch (e)`
+/// round-trips faithfully to Java `catch (Exception e)`, Kotlin
+/// `catch (e: Throwable)`, etc.
+const _catchAllTypeNames = {
+  'Object',
+  'dynamic',
+  'Exception',
+  'Throwable',
+  'Error',
+};
+
+bool _isCatchAllType(ASTType type) => _catchAllTypeNames.contains(type.name);
+
+/// [ASTStatement] for `try { } catch ... { } finally { }`.
+///
+/// Catches both user `throw`n values ([ApolloVMThrownException]) and built-in VM
+/// runtime errors ([ApolloVMRuntimeError]); the latter are surfaced as a
+/// `String` value (their message). A typed clause matches only when the caught
+/// value is an instance of its type; a clause with a `null` type catches all.
+/// The [finallyBlock] always runs, and a `return` inside it overrides.
+class ASTStatementTryCatch extends ASTStatement {
+  final ASTBlock tryBlock;
+  final List<ASTCatchClause> catches;
+  final ASTBlock? finallyBlock;
+
+  ASTStatementTryCatch(this.tryBlock, this.catches, this.finallyBlock);
+
+  @override
+  Iterable<ASTNode> get children => [tryBlock, ?finallyBlock];
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+    tryBlock.resolveNode(parentNode);
+    for (var c in catches) {
+      c.resolveNode(parentNode);
+    }
+    finallyBlock?.resolveNode(parentNode);
+  }
+
+  @override
+  VMContext defineRunContext(VMContext parentContext) => parentContext;
+
+  @override
+  FutureOr<ASTValue> run(
+    VMContext parentContext,
+    ASTRunStatus runStatus,
+  ) async {
+    try {
+      try {
+        return await tryBlock.run(parentContext, runStatus);
+      } catch (error) {
+        // Like Dart's `catch (e)` (which catches any `Object`): user `throw`s
+        // surface their thrown value; built-in VM/runtime errors surface as a
+        // `String` (their message). Control flow (return/break) uses
+        // `ASTRunStatus` flags, not exceptions, so it is never caught here.
+        var caught = error is ApolloVMThrownException
+            ? error.value
+            : ASTValueString(error.toString());
+
+        for (var c in catches) {
+          var t = c.exceptionType;
+          if (t == null ||
+              _isCatchAllType(t) ||
+              await caught.isInstanceOfAsync(t)) {
+            return await c.run(parentContext, runStatus, caught);
+          }
+        }
+        rethrow; // no clause matched
+      }
+    } finally {
+      var finallyBlock = this.finallyBlock;
+      if (finallyBlock != null) {
+        var finallyStatus = ASTRunStatus();
+        await finallyBlock.run(parentContext, finallyStatus);
+        // A `return` inside `finally` overrides the try/catch outcome.
+        if (finallyStatus.returned) {
+          runStatus.returned = true;
+          runStatus.returnedValue = finallyStatus.returnedValue;
+          runStatus.returnedFutureValue = finallyStatus.returnedFutureValue;
+        }
+      }
+    }
+  }
+
+  @override
+  ASTType resolveType(VMContext? context) => ASTTypeVoid.instance;
+
+  @override
+  String toString() {
+    var str = StringBuffer('try $tryBlock');
+    for (var c in catches) {
+      str.write(' catch ${c.block}');
+    }
+    if (finallyBlock != null) {
+      str.write(' finally $finallyBlock');
+    }
+    return str.toString();
+  }
+}

--- a/lib/src/languages/dart/dart_generator.dart
+++ b/lib/src/languages/dart/dart_generator.dart
@@ -29,6 +29,16 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
   }
 
   @override
+  String generateASTCatchClauseHeader(ASTCatchClause catchClause) {
+    var name = catchClause.variableName ?? 'e';
+    var type = catchClause.exceptionType;
+    if (type != null) {
+      return 'on ${generateASTType(type)} catch ($name)';
+    }
+    return 'catch ($name)';
+  }
+
+  @override
   String normalizeTypeFunction(String typeName, String functionName) {
     switch (typeName) {
       case 'int':

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -395,7 +395,9 @@ class DartGrammarDefinition extends DartGrammarLexer {
       (statementReturn() | statementExpression()).cast<ASTStatement>();
 
   Parser<ASTStatement> statement() =>
-      (branch() |
+      (statementTryCatch() |
+              statementThrow() |
+              branch() |
               statementForLoop() |
               statementForEach() |
               statementWhileLoop() |
@@ -405,6 +407,62 @@ class DartGrammarDefinition extends DartGrammarLexer {
               statementBlock() |
               statementExpression())
           .cast<ASTStatement>();
+
+  Parser<ASTStatementThrow> statementThrow() =>
+      (string('throw').trimHidden() & ref0(expression) & char(';').trimHidden())
+          .map((v) => ASTStatementThrow(v[1] as ASTExpression));
+
+  Parser<ASTStatementTryCatch> statementTryCatch() =>
+      (string('try').trimHidden() &
+              codeBlock() &
+              catchClause().star() &
+              (string('finally').trimHidden() & codeBlock()).optional())
+          .map((v) {
+            var tryBlock = v[1] as ASTBlock;
+            var catches = (v[2] as List).cast<ASTCatchClause>();
+            var finallyOpt = v[3] as List?;
+            var finallyBlock = finallyOpt != null
+                ? finallyOpt[1] as ASTBlock
+                : null;
+            return ASTStatementTryCatch(tryBlock, catches, finallyBlock);
+          });
+
+  Parser<ASTCatchClause> catchClause() =>
+      (onCatchClause() | bareCatchClause()).cast<ASTCatchClause>();
+
+  /// Dart `on Type [catch (e[, st])] { }`.
+  Parser<ASTCatchClause> onCatchClause() =>
+      (string('on').trimHidden() &
+              type() &
+              (string('catch').trimHidden() &
+                      char('(').trimHidden() &
+                      identifier().trimHidden() &
+                      (char(',').trimHidden() & identifier().trimHidden())
+                          .optional() &
+                      char(')').trimHidden())
+                  .optional() &
+              codeBlock())
+          .map((v) {
+            var type = v[1] as ASTType;
+            var catchPart = v[2] as List?;
+            var varName = catchPart != null ? catchPart[2] as String : null;
+            var block = v[3] as ASTBlock;
+            return ASTCatchClause(type, varName, block);
+          });
+
+  /// Dart `catch (e[, st]) { }` (untyped catch-all).
+  Parser<ASTCatchClause> bareCatchClause() =>
+      (string('catch').trimHidden() &
+              char('(').trimHidden() &
+              identifier().trimHidden() &
+              (char(',').trimHidden() & identifier().trimHidden()).optional() &
+              char(')').trimHidden() &
+              codeBlock())
+          .map((v) {
+            var varName = v[2] as String;
+            var block = v[5] as ASTBlock;
+            return ASTCatchClause(null, varName, block);
+          });
 
   Parser<ASTStatement> statementSimple() =>
       (statementVariableDeclaration() | statementExpression())

--- a/lib/src/languages/java/java11/java11_generator.dart
+++ b/lib/src/languages/java/java11/java11_generator.dart
@@ -30,6 +30,14 @@ class ApolloCodeGeneratorJava11 extends ApolloCodeGenerator {
   }
 
   @override
+  String generateASTCatchClauseHeader(ASTCatchClause catchClause) {
+    var name = catchClause.variableName ?? 'e';
+    var type = catchClause.exceptionType;
+    var typeStr = type != null ? '${generateASTType(type)}' : 'Exception';
+    return 'catch ($typeStr $name)';
+  }
+
+  @override
   String normalizeTypeFunction(String typeName, String functionName) {
     switch (typeName) {
       case 'int':

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -265,7 +265,9 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
       (statementReturn() | statementExpression()).cast<ASTStatement>();
 
   Parser<ASTStatement> statement() =>
-      (branch() |
+      (statementTryCatch() |
+              statementThrow() |
+              branch() |
               statementReturn() |
               statementForLoop() |
               statementForEach() |
@@ -273,6 +275,40 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
               statementVariableDeclaration() |
               statementExpression())
           .cast<ASTStatement>();
+
+  Parser<ASTStatementThrow> statementThrow() =>
+      (string('throw').trimHidden() & ref0(expression) & char(';').trimHidden())
+          .map((v) => ASTStatementThrow(v[1] as ASTExpression));
+
+  Parser<ASTStatementTryCatch> statementTryCatch() =>
+      (string('try').trimHidden() &
+              codeBlock() &
+              catchClause().star() &
+              (string('finally').trimHidden() & codeBlock()).optional())
+          .map((v) {
+            var tryBlock = v[1] as ASTBlock;
+            var catches = (v[2] as List).cast<ASTCatchClause>();
+            var finallyOpt = v[3] as List?;
+            var finallyBlock = finallyOpt != null
+                ? finallyOpt[1] as ASTBlock
+                : null;
+            return ASTStatementTryCatch(tryBlock, catches, finallyBlock);
+          });
+
+  /// Java `catch (Type e) { }`.
+  Parser<ASTCatchClause> catchClause() =>
+      (string('catch').trimHidden() &
+              char('(').trimHidden() &
+              type() &
+              identifier().trimHidden() &
+              char(')').trimHidden() &
+              codeBlock())
+          .map((v) {
+            var type = v[2] as ASTType;
+            var varName = v[3] as String;
+            var block = v[5] as ASTBlock;
+            return ASTCatchClause(type, varName, block);
+          });
 
   Parser<ASTStatement> statementSimple() =>
       (statementVariableDeclaration() | statementExpression())

--- a/lib/src/languages/javascript/es/javascript_grammar.dart
+++ b/lib/src/languages/javascript/es/javascript_grammar.dart
@@ -196,7 +196,9 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
       (statementReturn() | statementExpression()).cast<ASTStatement>();
 
   Parser<ASTStatement> statement() =>
-      (branch() |
+      (statementTryCatch() |
+              statementThrow() |
+              branch() |
               statementForLoop() |
               statementForEach() |
               statementWhileLoop() |
@@ -207,6 +209,42 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
               statementBlock() |
               statementExpression())
           .cast<ASTStatement>();
+
+  Parser<ASTStatementThrow> statementThrow() =>
+      (throwToken().trimHidden() &
+              ref0(expression) &
+              char(';').trimHidden().optional())
+          .map((v) => ASTStatementThrow(v[1] as ASTExpression));
+
+  Parser<ASTStatementTryCatch> statementTryCatch() =>
+      (tryToken().trimHidden() &
+              codeBlock() &
+              catchClause().star() &
+              (finallyToken().trimHidden() & codeBlock()).optional())
+          .map((v) {
+            var tryBlock = v[1] as ASTBlock;
+            var catches = (v[2] as List).cast<ASTCatchClause>();
+            var finallyOpt = v[3] as List?;
+            var finallyBlock = finallyOpt != null
+                ? finallyOpt[1] as ASTBlock
+                : null;
+            return ASTStatementTryCatch(tryBlock, catches, finallyBlock);
+          });
+
+  /// JavaScript `catch (e) { }` (untyped; binding optional).
+  Parser<ASTCatchClause> catchClause() =>
+      (catchToken().trimHidden() &
+              (char('(').trimHidden() &
+                      identifier().trimHidden() &
+                      char(')').trimHidden())
+                  .optional() &
+              codeBlock())
+          .map((v) {
+            var bind = v[1] as List?;
+            var varName = bind != null ? bind[1] as String : null;
+            var block = v[2] as ASTBlock;
+            return ASTCatchClause(null, varName, block);
+          });
 
   Parser<ASTStatement> statementSimple() =>
       (statementVariableDeclaration() | statementExpression())

--- a/lib/src/languages/javascript/es/javascript_grammar_lexer.dart
+++ b/lib/src/languages/javascript/es/javascript_grammar_lexer.dart
@@ -73,6 +73,12 @@ abstract class JavaScriptGrammarLexer extends BaseGrammarLexer {
 
   Parser whileToken() => ref1(token, 'while');
 
+  Parser tryToken() => ref1(token, 'try');
+
+  Parser finallyToken() => ref1(token, 'finally');
+
+  Parser throwToken() => ref1(token, 'throw');
+
   // -----------------------------------------------------------------
   // Numbers.
   // -----------------------------------------------------------------

--- a/lib/src/languages/kotlin/kotlin_generator.dart
+++ b/lib/src/languages/kotlin/kotlin_generator.dart
@@ -39,6 +39,14 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
   }
 
   @override
+  String generateASTCatchClauseHeader(ASTCatchClause catchClause) {
+    var name = catchClause.variableName ?? 'e';
+    var type = catchClause.exceptionType;
+    var typeStr = type != null ? '${generateASTType(type)}' : 'Throwable';
+    return 'catch ($name: $typeStr)';
+  }
+
+  @override
   String normalizeTypeFunction(String typeName, String functionName) {
     switch (typeName) {
       case 'int':

--- a/lib/src/languages/kotlin/kotlin_grammar.dart
+++ b/lib/src/languages/kotlin/kotlin_grammar.dart
@@ -284,13 +284,52 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
       (statementReturn() | statementExpression()).cast<ASTStatement>();
 
   Parser<ASTStatement> statement() =>
-      (branch() |
+      (statementTryCatch() |
+              statementThrow() |
+              branch() |
               statementForEach() |
               statementWhileLoop() |
               statementReturn() |
               statementVariableDeclaration() |
               statementExpression())
           .cast<ASTStatement>();
+
+  Parser<ASTStatementThrow> statementThrow() =>
+      (throwToken().trimHidden() &
+              ref0(expression) &
+              char(';').trimHidden().optional())
+          .map((v) => ASTStatementThrow(v[1] as ASTExpression));
+
+  Parser<ASTStatementTryCatch> statementTryCatch() =>
+      (tryToken().trimHidden() &
+              codeBlock() &
+              catchClause().star() &
+              (finallyToken().trimHidden() & codeBlock()).optional())
+          .map((v) {
+            var tryBlock = v[1] as ASTBlock;
+            var catches = (v[2] as List).cast<ASTCatchClause>();
+            var finallyOpt = v[3] as List?;
+            var finallyBlock = finallyOpt != null
+                ? finallyOpt[1] as ASTBlock
+                : null;
+            return ASTStatementTryCatch(tryBlock, catches, finallyBlock);
+          });
+
+  /// Kotlin `catch (e: Type) { }`.
+  Parser<ASTCatchClause> catchClause() =>
+      (catchToken().trimHidden() &
+              char('(').trimHidden() &
+              identifier().trimHidden() &
+              char(':').trimHidden() &
+              type() &
+              char(')').trimHidden() &
+              codeBlock())
+          .map((v) {
+            var varName = v[2] as String;
+            var exceptionType = v[4] as ASTType;
+            var block = v[6] as ASTBlock;
+            return ASTCatchClause(exceptionType, varName, block);
+          });
 
   Parser<ASTStatementForEach> statementForEach() =>
       (forToken().trimHidden() &

--- a/lib/src/languages/kotlin/kotlin_grammar_lexer.dart
+++ b/lib/src/languages/kotlin/kotlin_grammar_lexer.dart
@@ -49,6 +49,14 @@ abstract class KotlinGrammarLexer extends BaseGrammarLexer {
 
   Parser whileToken() => ref1(token, 'while');
 
+  Parser tryToken() => ref1(token, 'try');
+
+  Parser catchToken() => ref1(token, 'catch');
+
+  Parser finallyToken() => ref1(token, 'finally');
+
+  Parser throwToken() => ref1(token, 'throw');
+
   // -----------------------------------------------------------------
   // Number tokens.
   // -----------------------------------------------------------------

--- a/lib/src/languages/typescript/ts/typescript_grammar.dart
+++ b/lib/src/languages/typescript/ts/typescript_grammar.dart
@@ -421,7 +421,9 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
       (statementReturn() | statementExpression()).cast<ASTStatement>();
 
   Parser<ASTStatement> statement() =>
-      (branch() |
+      (statementTryCatch() |
+              statementThrow() |
+              branch() |
               statementForLoop() |
               statementForEach() |
               statementWhileLoop() |
@@ -432,6 +434,44 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
               statementBlock() |
               statementExpression())
           .cast<ASTStatement>();
+
+  Parser<ASTStatementThrow> statementThrow() =>
+      (throwToken().trimHidden() &
+              ref0(expression) &
+              char(';').trimHidden().optional())
+          .map((v) => ASTStatementThrow(v[1] as ASTExpression));
+
+  Parser<ASTStatementTryCatch> statementTryCatch() =>
+      (tryToken().trimHidden() &
+              codeBlock() &
+              catchClause().star() &
+              (finallyToken().trimHidden() & codeBlock()).optional())
+          .map((v) {
+            var tryBlock = v[1] as ASTBlock;
+            var catches = (v[2] as List).cast<ASTCatchClause>();
+            var finallyOpt = v[3] as List?;
+            var finallyBlock = finallyOpt != null
+                ? finallyOpt[1] as ASTBlock
+                : null;
+            return ASTStatementTryCatch(tryBlock, catches, finallyBlock);
+          });
+
+  /// TypeScript `catch (e[: Type]) { }` (binding and type optional;
+  /// TS only allows `any`/`unknown` annotations, so the type is ignored).
+  Parser<ASTCatchClause> catchClause() =>
+      (catchToken().trimHidden() &
+              (char('(').trimHidden() &
+                      identifier().trimHidden() &
+                      (char(':').trimHidden() & type()).optional() &
+                      char(')').trimHidden())
+                  .optional() &
+              codeBlock())
+          .map((v) {
+            var bind = v[1] as List?;
+            var varName = bind != null ? bind[1] as String : null;
+            var block = v[2] as ASTBlock;
+            return ASTCatchClause(null, varName, block);
+          });
 
   Parser<ASTStatement> statementSimple() =>
       (statementVariableDeclaration() | statementExpression())

--- a/lib/src/languages/typescript/ts/typescript_grammar_lexer.dart
+++ b/lib/src/languages/typescript/ts/typescript_grammar_lexer.dart
@@ -73,6 +73,12 @@ abstract class TypeScriptGrammarLexer extends BaseGrammarLexer {
 
   Parser whileToken() => ref1(token, 'while');
 
+  Parser tryToken() => ref1(token, 'try');
+
+  Parser finallyToken() => ref1(token, 'finally');
+
+  Parser throwToken() => ref1(token, 'throw');
+
   // TypeScript-specific keywords.
   Parser abstractToken() => ref1(token, 'abstract');
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, JavaScript, TypeScript, Lua with on-the-fly Wasm compilation.
-version: 0.1.32
+version: 0.1.33
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/apollovm_try_catch_test.dart
+++ b/test/apollovm_try_catch_test.dart
@@ -1,0 +1,369 @@
+@TestOn('vm')
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Loads [source] in [language] and runs the top-level function [function],
+/// returning the resolved native return value and the collected `print` output.
+Future<({Object? value, List output})> _run(
+  String language,
+  String source,
+  String function, {
+  List positionalParameters = const [],
+}) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit(language, source, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load $language source!");
+
+  var runner = vm.createRunner(language)!;
+  var output = [];
+  runner.externalPrintFunction = (o) => output.add(o);
+
+  var astValue = await runner.executeFunction(
+    '',
+    function,
+    positionalParameters: positionalParameters,
+  );
+
+  return (value: astValue.getValueNoContext(), output: output);
+}
+
+/// Translates a loaded Dart [source] into [language], returning the generated
+/// source (single concatenated unit).
+Future<String> _translateDart(String source, String language) async {
+  var vm = ApolloVM();
+  await vm.loadCodeUnit(SourceCodeUnit('dart', source, id: 'test'));
+  var codeStorage = vm.generateAllCodeIn(language);
+  var buffer = StringBuffer();
+  for (var ns in await codeStorage.getNamespaces()) {
+    for (var id in await codeStorage.getNamespaceCodeUnitsIDs(ns)) {
+      buffer.write(await codeStorage.getNamespaceCodeUnit(ns, id));
+    }
+  }
+  return buffer.toString();
+}
+
+void main() {
+  group('Dart try/catch/finally runtime', () {
+    test('catch a user-thrown String', () async {
+      var r = await _run('dart', '''
+String main() {
+  try {
+    throw 'boom';
+  } catch (e) {
+    return 'caught: \$e';
+  }
+}
+''', 'main');
+      expect(r.value, equals('caught: boom'));
+    });
+
+    test('catch a user-thrown int value', () async {
+      var r = await _run('dart', '''
+int main() {
+  try {
+    throw 42;
+  } catch (e) {
+    return e;
+  }
+}
+''', 'main');
+      expect(r.value, equals(42));
+    });
+
+    test('finally runs on normal completion', () async {
+      var r = await _run('dart', '''
+void main() {
+  try {
+    print('try');
+  } finally {
+    print('finally');
+  }
+}
+''', 'main');
+      expect(r.output, equals(['try', 'finally']));
+    });
+
+    test('finally runs after a caught throw', () async {
+      var r = await _run('dart', '''
+void main() {
+  try {
+    print('try');
+    throw 'x';
+  } catch (e) {
+    print('catch');
+  } finally {
+    print('finally');
+  }
+}
+''', 'main');
+      expect(r.output, equals(['try', 'catch', 'finally']));
+    });
+
+    test('typed `on T catch` matches by type', () async {
+      var r = await _run('dart', '''
+String main() {
+  try {
+    throw 'boom';
+  } on String catch (e) {
+    return 'string: \$e';
+  } catch (e) {
+    return 'other: \$e';
+  }
+}
+''', 'main');
+      expect(r.value, equals('string: boom'));
+    });
+
+    test(
+      'typed `on T catch` falls through to catch-all when type mismatches',
+      () async {
+        var r = await _run('dart', '''
+String main() {
+  try {
+    throw 123;
+  } on String catch (e) {
+    return 'string: \$e';
+  } catch (e) {
+    return 'other: \$e';
+  }
+}
+''', 'main');
+        expect(r.value, equals('other: 123'));
+      },
+    );
+
+    test('catches a built-in VM error (integer division by zero)', () async {
+      var r = await _run('dart', '''
+String main() {
+  try {
+    var x = 1 ~/ 0;
+    return 'no error: \$x';
+  } catch (e) {
+    return 'caught vm error';
+  }
+}
+''', 'main');
+      expect(r.value, equals('caught vm error'));
+    });
+
+    test('return inside try still runs finally', () async {
+      var r = await _run('dart', '''
+int main() {
+  try {
+    return 1;
+  } finally {
+    print('finally');
+  }
+}
+''', 'main');
+      expect(r.value, equals(1));
+      expect(r.output, equals(['finally']));
+    });
+
+    test('return inside finally overrides return inside try', () async {
+      var r = await _run('dart', '''
+int main() {
+  try {
+    return 1;
+  } finally {
+    return 2;
+  }
+}
+''', 'main');
+      expect(r.value, equals(2));
+    });
+
+    test('nested try/catch: inner rethrows, outer catches', () async {
+      var r = await _run('dart', '''
+String main() {
+  try {
+    try {
+      throw 'inner';
+    } on String catch (e) {
+      throw 'wrapped: \$e';
+    }
+  } catch (e) {
+    return 'outer: \$e';
+  }
+}
+''', 'main');
+      expect(r.value, equals('outer: wrapped: inner'));
+    });
+
+    test('throw from a called function is caught by the caller', () async {
+      var r = await _run('dart', '''
+void boom() {
+  throw 'from boom';
+}
+String main() {
+  try {
+    boom();
+    return 'unreachable';
+  } catch (e) {
+    return 'caught: \$e';
+  }
+}
+''', 'main');
+      expect(r.value, equals('caught: from boom'));
+    });
+  });
+
+  group('Java try/catch/finally runtime', () {
+    test('catch a typed user throw and run finally', () async {
+      var vm = ApolloVM();
+      var ok = await vm.loadCodeUnit(
+        SourceCodeUnit('java11', '''
+class Foo {
+  static void run() {
+    try {
+      print("try");
+      throw "boom";
+    } catch (String e) {
+      print("caught: " + e);
+    } finally {
+      print("finally");
+    }
+  }
+}
+''', id: 'test'),
+      );
+      expect(ok, isTrue);
+      var runner = vm.createRunner('java11')!;
+      var output = [];
+      runner.externalPrintFunction = (o) => output.add(o);
+      await runner.executeClassMethod('', 'Foo', 'run');
+      expect(output, equals(['try', 'caught: boom', 'finally']));
+    });
+  });
+
+  group('Kotlin try/catch/finally runtime', () {
+    test('catch a typed user throw and run finally', () async {
+      var r = await _run('kotlin', '''
+fun main() {
+  try {
+    print("try")
+    throw "boom"
+  } catch (e: String) {
+    print("caught: \$e")
+  } finally {
+    print("finally")
+  }
+}
+''', 'main');
+      expect(r.output, equals(['try', 'caught: boom', 'finally']));
+    });
+  });
+
+  group('JavaScript / TypeScript try/catch/finally runtime', () {
+    test('JS catches a user throw and runs finally', () async {
+      var r = await _run('javascript', '''
+function main() {
+  try {
+    print("try");
+    throw "boom";
+  } catch (e) {
+    print("caught: " + e);
+  } finally {
+    print("finally");
+  }
+}
+''', 'main');
+      expect(r.output, equals(['try', 'caught: boom', 'finally']));
+    });
+
+    test('TS catches a user throw and runs finally', () async {
+      var r = await _run('typescript', '''
+function main(): void {
+  try {
+    print("try");
+    throw "boom";
+  } catch (e) {
+    print("caught: " + e);
+  } finally {
+    print("finally");
+  }
+}
+''', 'main');
+      expect(r.output, equals(['try', 'caught: boom', 'finally']));
+    });
+  });
+
+  group('Translation Dart -> *', () {
+    var src = '''
+class Foo {
+  void run() {
+    try {
+      throw 'boom';
+    } on String catch (e) {
+      print(e);
+    } finally {
+      print('done');
+    }
+  }
+}
+''';
+
+    test('-> Dart keeps `on T catch (e)` and `finally`', () async {
+      var out = await _translateDart(src, 'dart');
+      expect(out, contains("throw 'boom';"));
+      expect(out, contains('on String catch (e)'));
+      expect(out, contains('finally {'));
+    });
+
+    test('-> Java uses `catch (T e)`', () async {
+      var out = await _translateDart(src, 'java11');
+      expect(out, contains('catch (String e)'));
+      expect(out, contains('finally {'));
+    });
+
+    test('-> Kotlin uses `catch (e: T)`', () async {
+      var out = await _translateDart(src, 'kotlin');
+      expect(out, contains('catch (e: String)'));
+      expect(out, contains('finally {'));
+    });
+
+    test('-> JavaScript uses untyped `catch (e)`', () async {
+      var out = await _translateDart(src, 'javascript');
+      expect(out, contains('catch (e)'));
+      expect(out, contains('finally {'));
+    });
+
+    test('-> TypeScript uses untyped `catch (e)`', () async {
+      var out = await _translateDart(src, 'typescript');
+      expect(out, contains('catch (e)'));
+      expect(out, contains('finally {'));
+    });
+
+    test('untyped Dart catch -> Java `catch (Exception e)`', () async {
+      var out = await _translateDart('''
+class Foo {
+  void run() {
+    try {
+      throw 'x';
+    } catch (e) {
+      print(e);
+    }
+  }
+}
+''', 'java11');
+      expect(out, contains('catch (Exception e)'));
+    });
+
+    test('untyped Dart catch -> Kotlin `catch (e: Throwable)`', () async {
+      var out = await _translateDart('''
+class Foo {
+  void run() {
+    try {
+      throw 'x';
+    } catch (e) {
+      print(e);
+    }
+  }
+}
+''', 'kotlin');
+      expect(out, contains('catch (e: Throwable)'));
+    });
+  });
+}

--- a/test/tests_definitions/dart_try_catch.test.xml
+++ b/test/tests_definitions/dart_try_catch.test.xml
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Try/Catch/Finally and Throw">
+    <source language="dart">
+        <![CDATA[
+
+            class Calc {
+              String check(int x) {
+                try {
+                  if (x < 0) {
+                    throw 'negative';
+                  }
+                  return 'ok';
+                } catch (e) {
+                  return 'caught';
+                } finally {
+                  print('done');
+                }
+              }
+            }
+
+        ]]>
+    </source>
+    <call class="Calc" function="check" return="ok">
+        [ 5 ]
+    </call>
+    <output>
+        ["done"]
+    </output>
+    <call class="Calc" function="check" return="caught">
+        [ -1 ]
+    </call>
+    <output>
+        ["done"]
+    </output>
+
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Calc {
+
+  String check(int x) {
+    try {
+      if (x < 0) {
+          throw 'negative';
+      }
+
+      return 'ok';
+    } catch (e) {
+      return 'caught';
+    } finally {
+      print('done');
+    }
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="java11"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Calc {
+
+  String check(int x) {
+    try {
+      if (x < 0) {
+          throw "negative";
+      }
+
+      return "ok";
+    } catch (Exception e) {
+      return "caught";
+    } finally {
+      print("done");
+    }
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Calc {
+
+  check(x) {
+    try {
+      if (x < 0) {
+          throw 'negative';
+      }
+
+      return 'ok';
+    } catch (e) {
+      return 'caught';
+    } finally {
+      print('done');
+    }
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+</test>


### PR DESCRIPTION
## Summary

Adds exception handling — `throw expr;` and `try { } catch { } finally { }` — to ApolloVM across **Dart, Java, Kotlin, JavaScript and TypeScript**, on **parse, run, and translate**. Bumps to **0.1.33**.

Wasm `try/catch/throw` is intentionally **deferred** and fails loudly (no silent miscompile).

## What's included

**AST (shared interpreter)**
- New nodes `ASTStatementThrow`, `ASTStatementTryCatch`, `ASTCatchClause`; thrown values carried by the new public `ApolloVMThrownException`.
- `finally` always runs (normal completion, after a caught throw, or `return` in `try`/`catch`); a `return` inside `finally` overrides. Control flow keeps using `ASTRunStatus`, so only thrown values are caught.

**Catch semantics** (faithful to Dart's `catch (e)`)
- An **untyped** catch catches both user `throw`n values *and* built-in VM runtime errors (e.g. integer division by zero, surfaced as their message `String`).
- A **typed** clause matches user-thrown values by type. The universal supertypes (`Object`, `dynamic`, `Exception`, `Throwable`, `Error`) act as catch-all, so an untyped catch round-trips faithfully between languages.

**Parsers + lexers**
- Per-language `try`/`catch`/`finally`/`throw` rules and the missing keyword tokens.
- Catch forms: Dart `on T catch (e)` / `catch (e)`, Java `catch (T e)`, Kotlin `catch (e: T)`, JS/TS `catch (e)`.

**Generators**
- Base text generator emits the C-style `try/catch/finally` with an overridable catch-clause header; per-language overrides emit the idiomatic typed form (untyped → `Exception` / `Throwable`).

## Tests
- `test/apollovm_try_catch_test.dart`: runtime + translation coverage for all five languages (22 tests) — user throws, typed/untyped/catch-all matching, VM-error catch, `finally`/return semantics, nested try, throw-across-call.
- `test/tests_definitions/dart_try_catch.test.xml`: cross-language round-trip (Dart → Dart/Java/JS) that re-loads and re-runs the generated code.
- Full suite green: **740 tests pass**; `dart analyze` clean; `dart format` applied.

## Out of scope (deferred)
- Wasm `try/catch` codegen (fails loudly).
- Lua (`pcall`) translation.
- `throw` in expression position; multi-catch `catch (A | B e)`; Dart `rethrow`; `catch (e, stackTrace)` binding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)