### PR TITLE
Classes, object fields, constructors, Wasm toString(); bump to 0.1.35

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,86 @@
+## 0.1.35
+
+### Wasm: `print` accepts any value (not only `String`)
+
+- `int` / `double` reuse the host number-to-string imports (`env.int_to_str` /
+  `env.double_to_str`); `bool` lowers in-module to the interned `"true"` /
+  `"false"` literals (via `select`); `print(null)` prints `"null"`. String
+  interpolation gained the same parity.
+- The interpreter's mapped `print` now accepts `null` (nullable `Object?`), and a
+  `bool` argument passed to a public Wasm function is marshalled to its i32 ABI
+  value.
+
+### Classes and instantiation (Dart, Java, and Wasm)
+
+- The `new` keyword is now parsed in Dart and Java (`new User()`); `new User()`
+  and `User()` resolve to the same constructor (boundary-safe, so identifiers
+  like `newValue` are unaffected). Java also gained a generic
+  `new ClassName(args)` rule (previously only `new ArrayList<…>()` /
+  `new HashMap<…>()` were recognized).
+- Classes that declare no constructor get an implicit default (zero-arg)
+  constructor — on the interpreter and the Wasm backend; field initializers still
+  apply.
+- Constructors that set fields: `this.field` parameters, and constructor
+  **bodies** that assign fields (`this.field = value` and bare `field = value`,
+  with parameters shadowing same-named fields, e.g. `User(int id) { this.id = id; }`).
+  Fixed empty-parameter constructors with a body (`User() { … }`), which threw a
+  parser cast error.
+- A class method can instantiate sibling classes and call top-level functions
+  (`ASTClass.getFunction` falls back to the enclosing `ASTRoot`) — essential for
+  Java, where all code lives in a class.
+- Dart arrow (expression-bodied) functions and methods: `T name(params) => expr;`
+  (e.g. `String toString() => '…';`), for top-level functions and instance
+  methods, including `void` bodies. Desugars to `{ return expr; }`.
+- WebAssembly compilation of classes (first slice): single classes (no
+  inheritance) with `int` / `double` / `bool` / `String` / object-reference
+  fields, constructors (`this.field` params, field initializers, default and
+  body constructors), instance methods, in-code instantiation, and method calls
+  (`p.sum()` and implicit-`this` `foo()`). An object is an i32 pointer to a
+  bump-allocated struct; methods take `this` as the first parameter; a discovery
+  pass registers host imports before the code section so cross-function call
+  indices stay correct.
+
+### Object field access on instances (read and write)
+
+- Field assignment `obj.field = value` (and `this.field = value`), including
+  compound operators (`+=`, `-=`, `*=`, `/=`, `~/=`), via a new
+  `ASTExpressionObjectSetterAssignment` node — added to the Dart, Java, Kotlin,
+  JavaScript and TypeScript grammars, the shared source generator (round-trips
+  back to `obj.field = value`), and the Wasm backend (stores at `recv + offset`).
+- Field read `obj.field` is now supported in Java (which had no object
+  getter-access rule); `this.field` reads resolve to the current instance's field
+  across all languages (previously routed to a local-getter lookup and failed
+  with "Can't find getter").
+
+### `print(obj)` calls the user-defined `toString()`
+
+- Interpreter: `print(instance)` invokes a user-declared `toString()` (a class
+  without one still prints the default `Class{…}` representation), and
+  `ASTExternalFunction.call` now awaits resolved argument values so an async
+  resolver result isn't passed through as a `Future`.
+- Wasm: `print(instance)` (and string coercion / interpolation) calls the
+  instance's compiled `toString()` and prints the resulting string handle.
+
+This makes programs like the following compile and run on Wasm with
+interpreter-parity:
+
+```dart
+class User {
+  int id;
+  String name;
+  User(this.id, this.name);
+  String toString() => 'User#$id<$name>';
+}
+void main() {
+  var user = new User(123, 'Joe');
+  print(user);
+  print(user.id * 1000);
+}
+```
+
+Not included: inheritance / interfaces / abstract / `static` members /
+polymorphism.
+
 ## 0.1.34
 
 - Wasm `throw` / `try` / `catch` / `finally`: exception handling now compiles to

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -47,7 +47,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.34';
+  static final String VERSION = '0.1.35';
 
   static int _idCount = 0;
 
@@ -857,20 +857,30 @@ class ApolloExternalFunctionMapper {
   }
 
   /// Maps an external function with 1 parameter.
+  ///
+  /// - [parameterResolver] optionally transforms the argument [ASTValue] before
+  ///   it reaches [f] (e.g. invoking a class instance's `toString()`).
   void mapExternalFunction1<T, R>(
     ASTType<R> fReturn,
     String fName,
     ASTType<T> pType1,
     String pName1,
-    Function(T p1) f,
-  ) {
+    Function(T p1) f, {
+    ParameterValueResolver? parameterResolver,
+  }) {
     var fParameters = ASTFunctionParametersDeclaration(
       [ASTFunctionParameterDeclaration(pType1, pName1, 0, false)],
       null,
       null,
     );
 
-    var fExternal = ASTExternalFunction(fName, fParameters, fReturn, f);
+    var fExternal = ASTExternalFunction(
+      fName,
+      fParameters,
+      fReturn,
+      f,
+      parameterResolver,
+    );
 
     addExternalFunction(fExternal);
   }

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -1229,6 +1229,13 @@ abstract class ApolloCodeGenerator
         indent: indent,
         headIndented: headIndented,
       );
+    } else if (expression is ASTExpressionObjectSetterAssignment) {
+      return generateASTExpressionObjectSetterAssignment(
+        expression,
+        out: out,
+        indent: indent,
+        headIndented: headIndented,
+      );
     } else if (expression is ASTExpressionOperation) {
       return generateASTExpressionOperation(
         expression,
@@ -1675,6 +1682,39 @@ abstract class ApolloCodeGenerator
     out.write(getterName);
 
     _generateChainFunctionInvocation(expression, out, indent);
+
+    return out;
+  }
+
+  StringBuffer generateASTExpressionObjectSetterAssignment(
+    ASTExpressionObjectSetterAssignment expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    generateASTVariable(
+      expression.variable,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+    out.write('.');
+    out.write(expression.name);
+
+    var op = getASTAssignmentOperatorText(expression.operator);
+    out.write(' ');
+    out.write(op);
+    out.write(' ');
+    generateASTExpression(
+      expression.expression,
+      out: out,
+      indent: '$indent  ',
+      headIndented: false,
+    );
 
     return out;
   }

--- a/lib/src/apollovm_runner.dart
+++ b/lib/src/apollovm_runner.dart
@@ -60,15 +60,43 @@ abstract class ApolloRunner implements VMTypeResolver {
   ApolloExternalFunctionMapper? createDefaultApolloExternalFunctionMapper() {
     var externalFunctionMapper = ApolloExternalFunctionMapper();
 
-    externalFunctionMapper.mapExternalFunction1(
+    // `print` accepts any value, including `null`: force the parameter generic
+    // to be nullable (`Object?`) so the external call doesn't reject `null`.
+    // A `parameterResolver` invokes a class instance's user-defined `toString()`
+    // (if any) so `print(obj)` prints `obj.toString()` rather than the default
+    // `Class{…}` representation.
+    externalFunctionMapper.mapExternalFunction1<Object?, void>(
       ASTTypeVoid.instance,
       'print',
       ASTTypeObject.instance,
       'o',
       (o) => externalPrintFunction(o),
+      parameterResolver: _resolvePrintArgument,
     );
 
     return externalFunctionMapper;
+  }
+
+  /// Resolves a `print` argument: if it is a class instance with a user-defined
+  /// `toString()`, invokes it and returns the resulting String; otherwise
+  /// returns the argument's plain value (the default behavior).
+  static FutureOr<Object?> _resolvePrintArgument(
+    ASTValue? paramVal,
+    VMContext context,
+  ) {
+    if (paramVal is ASTClassInstance) {
+      var f = paramVal.clazz.getFunction(
+        'toString',
+        ASTFunctionSignature.from(null, null),
+        context,
+      );
+      if (f is ASTClassFunctionDeclaration) {
+        return f
+            .objectCall(context, paramVal, positionalParameters: const [])
+            .resolveMapped((ret) => ret.getValue(context));
+      }
+    }
+    return paramVal?.getValue(context);
   }
 
   /// The external [print] function to map.

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -2574,3 +2574,90 @@ class ASTExpressionObjectGetterAccess extends ASTExpressionGetterAccess
     return '$variable.$f';
   }
 }
+
+/// [ASTExpression] that assigns to a class instance field: `obj.field = value`
+/// (and `this.field = value`), including compound operators (`+=`, `-=`, …).
+class ASTExpressionObjectSetterAssignment extends ASTExpression {
+  ASTVariable variable;
+
+  String name;
+
+  ASTAssignmentOperator operator;
+
+  ASTExpression expression;
+
+  ASTExpressionObjectSetterAssignment(
+    this.variable,
+    this.name,
+    this.operator,
+    this.expression,
+  );
+
+  @override
+  bool get isComplex => true;
+
+  @override
+  Iterable<ASTNode> get children => [variable, expression];
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+    variable.resolveNode(this);
+    expression.resolveNode(this);
+  }
+
+  @override
+  FutureOr<ASTType> resolveType(VMContext? context) =>
+      expression.resolveType(context);
+
+  @override
+  FutureOr<ASTValue> run(
+    VMContext parentContext,
+    ASTRunStatus runStatus,
+  ) async {
+    var context = defineRunContext(parentContext);
+
+    var obj = await variable.getValue(context);
+    if (obj is! ASTClassInstance) {
+      throw ApolloVMRuntimeError(
+        "Can't set field `$name`: target is not a class instance: $obj",
+      );
+    }
+
+    var classContext = obj.createContext(context);
+    var value = await expression.run(context, runStatus);
+
+    FutureOr<ASTValue> result;
+    switch (operator) {
+      case ASTAssignmentOperator.set:
+        result = value;
+      case ASTAssignmentOperator.sum:
+        result = (await _currentField(classContext, obj)) + value;
+      case ASTAssignmentOperator.subtract:
+        result = (await _currentField(classContext, obj)) - value;
+      case ASTAssignmentOperator.multiply:
+        result = (await _currentField(classContext, obj)) * value;
+      case ASTAssignmentOperator.divide:
+        result = (await _currentField(classContext, obj)) / value;
+      case ASTAssignmentOperator.divideAsInt:
+        result = (await _currentField(classContext, obj)) ~/ value;
+    }
+
+    var resultValue = await result;
+    await obj.setField(classContext, name, resultValue);
+    return resultValue;
+  }
+
+  FutureOr<ASTValue> _currentField(
+    VMClassContext classContext,
+    ASTClassInstance obj,
+  ) {
+    return obj
+        .getField(classContext, name)
+        .resolveMapped((v) => v ?? ASTValueNull.instance);
+  }
+
+  @override
+  String toString({bool asGroup = false}) =>
+      '$variable.$name $operator $expression';
+}

--- a/lib/src/ast/apollovm_ast_toplevel.dart
+++ b/lib/src/ast/apollovm_ast_toplevel.dart
@@ -263,6 +263,39 @@ abstract class ASTClass<T> extends ASTEntryPointBlock {
     VMContext? parentContext,
   ]) => VMClassContext(this, parent: parentContext, typeResolver: typeResolver);
 
+  /// Resolves a function/constructor visible from inside this class. Falls back
+  /// to the enclosing [ASTRoot] (reached via the `parentNode` chain set by
+  /// `ASTRoot.resolveNode`) so a method can instantiate sibling classes (their
+  /// constructors) and call top-level functions — the class-method execution
+  /// context is rooted at the class, not the program root.
+  @override
+  ASTInvocableDeclaration? getFunction(
+    String fName,
+    ASTFunctionSignature parametersSignature,
+    VMContext context, {
+    bool caseInsensitive = false,
+  }) {
+    var f = super.getFunction(
+      fName,
+      parametersSignature,
+      context,
+      caseInsensitive: caseInsensitive,
+    );
+    if (f != null) return f;
+
+    for (ASTNode? node = parentNode; node != null; node = node.parentNode) {
+      if (node is ASTRoot) {
+        return node.getFunction(
+          fName,
+          parametersSignature,
+          context,
+          caseInsensitive: caseInsensitive,
+        );
+      }
+    }
+    return null;
+  }
+
   List<ASTConstructorSet> get constructors;
 
   void resolveNodeConstructors(ASTNode? parentNode);
@@ -618,6 +651,29 @@ class ASTClassNormal extends ASTClass<VMObject> {
     return set != null;
   }
 
+  /// Lazily-synthesized implicit default (zero-arg) constructor, for a class
+  /// that declares no constructor at all (see [getConstructor]).
+  ASTClassConstructorDeclaration? _defaultConstructor;
+
+  /// Returns the implicit default (unnamed, zero-arg) constructor, synthesized
+  /// the first time it's needed. Field initializers are still applied at
+  /// instantiation by [initializeInstance] (independent of the constructor
+  /// body), so the empty body is correct.
+  ASTClassConstructorDeclaration _ensureDefaultConstructor() {
+    var ctor = _defaultConstructor;
+    if (ctor != null) return ctor;
+
+    ctor = ASTClassConstructorDeclaration(
+      type,
+      '',
+      ASTConstructorParametersDeclaration(null, null, null),
+    );
+    ctor.parentBlock = this;
+    ctor.resolveNode(this); // resolves `parentClass`.
+
+    return _defaultConstructor = ctor;
+  }
+
   @override
   ASTClassConstructorDeclaration? getConstructor(
     String fName,
@@ -626,7 +682,15 @@ class ASTClassNormal extends ASTClass<VMObject> {
     bool caseInsensitive = false,
   }) {
     var set = getConstructorWithName(fName, caseInsensitive: caseInsensitive);
-    if (set == null) return null;
+    if (set == null) {
+      // A class with no declared constructor gets an implicit default
+      // (zero-arg) constructor for the unnamed (`''`) constructor — matching
+      // Dart/Java semantics (declaring any constructor suppresses it).
+      if (fName.isEmpty && _constructors.isEmpty) {
+        return _ensureDefaultConstructor();
+      }
+      return null;
+    }
 
     if (parametersSignature == null) {
       return set.firstFunction;
@@ -2342,7 +2406,15 @@ class ASTClassConstructorDeclaration<T>
     List? positionalParameters,
     Map? namedParameters,
   }) async {
-    var context = VMScopeContext(this, parent: parent);
+    // Run in a class context so that, after the instance is created, `this` and
+    // bare field reads/writes in the constructor body resolve to the instance
+    // being constructed (and persist to the returned `obj`). Parameters are
+    // declared as locals here, so a parameter shadows a same-named field (the
+    // idiomatic `User(int id) { this.id = id; }`).
+    final parentClass = this.parentClass;
+    var context = parentClass != null
+        ? parentClass.createContext(parent.typeResolver, parent)
+        : VMScopeContext(this, parent: parent);
 
     var prevContext = VMContext.setCurrent(context);
     try {
@@ -2351,6 +2423,10 @@ class ASTClassConstructorDeclaration<T>
         positionalParameters,
         namedParameters,
       );
+
+      if (context is VMClassContext) {
+        context.setClassInstance(obj);
+      }
 
       final parameters = _parameters;
 
@@ -2681,31 +2757,31 @@ class ASTExternalFunction<T> extends ASTFunctionDeclaration<T> {
         result = externalFunction();
       } else if (externalFunction.isParametersSize1 || parametersSize == 1) {
         var paramVal = await getParameterValueByIndex(context, 0);
-        var a0 = resolveParameterValue(paramVal, context);
+        var a0 = await resolveParameterValue(paramVal, context);
         result = externalFunction(a0);
       } else if (this.parametersSize == 2) {
         var paramVal0 = await getParameterValueByIndex(context, 0);
         var paramVal1 = await getParameterValueByIndex(context, 1);
-        var a0 = resolveParameterValue(paramVal0, context);
-        var a1 = resolveParameterValue(paramVal1, context);
+        var a0 = await resolveParameterValue(paramVal0, context);
+        var a1 = await resolveParameterValue(paramVal1, context);
         result = externalFunction(a0, a1);
       } else if (this.parametersSize == 3) {
         var paramVal0 = await getParameterValueByIndex(context, 0);
         var paramVal1 = await getParameterValueByIndex(context, 1);
         var paramVal2 = await getParameterValueByIndex(context, 2);
-        var a0 = resolveParameterValue(paramVal0, context);
-        var a1 = resolveParameterValue(paramVal1, context);
-        var a2 = resolveParameterValue(paramVal2, context);
+        var a0 = await resolveParameterValue(paramVal0, context);
+        var a1 = await resolveParameterValue(paramVal1, context);
+        var a2 = await resolveParameterValue(paramVal2, context);
         result = externalFunction(a0, a1, a2);
       } else if (this.parametersSize == 4) {
         var paramVal0 = await getParameterValueByIndex(context, 0);
         var paramVal1 = await getParameterValueByIndex(context, 1);
         var paramVal2 = await getParameterValueByIndex(context, 2);
         var paramVal3 = await getParameterValueByIndex(context, 4);
-        var a0 = resolveParameterValue(paramVal0, context);
-        var a1 = resolveParameterValue(paramVal1, context);
-        var a2 = resolveParameterValue(paramVal2, context);
-        var a3 = resolveParameterValue(paramVal3, context);
+        var a0 = await resolveParameterValue(paramVal0, context);
+        var a1 = await resolveParameterValue(paramVal1, context);
+        var a2 = await resolveParameterValue(paramVal2, context);
+        var a3 = await resolveParameterValue(paramVal3, context);
         result = externalFunction(a0, a1, a2, a3);
       } else if (this.parametersSize == 5) {
         var paramVal0 = await getParameterValueByIndex(context, 0);
@@ -2713,11 +2789,11 @@ class ASTExternalFunction<T> extends ASTFunctionDeclaration<T> {
         var paramVal2 = await getParameterValueByIndex(context, 2);
         var paramVal3 = await getParameterValueByIndex(context, 4);
         var paramVal4 = await getParameterValueByIndex(context, 5);
-        var a0 = resolveParameterValue(paramVal0, context);
-        var a1 = resolveParameterValue(paramVal1, context);
-        var a2 = resolveParameterValue(paramVal2, context);
-        var a3 = resolveParameterValue(paramVal3, context);
-        var a4 = resolveParameterValue(paramVal4, context);
+        var a0 = await resolveParameterValue(paramVal0, context);
+        var a1 = await resolveParameterValue(paramVal1, context);
+        var a2 = await resolveParameterValue(paramVal2, context);
+        var a3 = await resolveParameterValue(paramVal3, context);
+        var a4 = await resolveParameterValue(paramVal4, context);
         result = externalFunction(a0, a1, a2, a3, a4);
       } else {
         result = externalFunction.call();
@@ -2791,21 +2867,21 @@ class ASTExternalClassFunction<T> extends ASTClassFunctionDeclaration<T> {
         result = externalFunction(obj);
       } else if (externalFunction.isParametersSize1 || parametersSize == 1) {
         var paramVal = await getParameterValueByIndex(context, 0);
-        var a0 = resolveParameterValue(paramVal, context);
+        var a0 = await resolveParameterValue(paramVal, context);
         result = externalFunction(obj, a0);
       } else if (this.parametersSize == 2) {
         var paramVal0 = await getParameterValueByIndex(context, 0);
         var paramVal1 = await getParameterValueByIndex(context, 1);
-        var a0 = resolveParameterValue(paramVal0, context);
-        var a1 = resolveParameterValue(paramVal1, context);
+        var a0 = await resolveParameterValue(paramVal0, context);
+        var a1 = await resolveParameterValue(paramVal1, context);
         result = externalFunction(obj, a0, a1);
       } else if (this.parametersSize == 3) {
         var paramVal0 = await getParameterValueByIndex(context, 0);
         var paramVal1 = await getParameterValueByIndex(context, 1);
         var paramVal2 = await getParameterValueByIndex(context, 2);
-        var a0 = resolveParameterValue(paramVal0, context);
-        var a1 = resolveParameterValue(paramVal1, context);
-        var a2 = resolveParameterValue(paramVal2, context);
+        var a0 = await resolveParameterValue(paramVal0, context);
+        var a1 = await resolveParameterValue(paramVal1, context);
+        var a2 = await resolveParameterValue(paramVal2, context);
         result = externalFunction(a0, a1, a2);
       } else {
         result = externalFunction.call(obj);

--- a/lib/src/ast/apollovm_ast_variable.dart
+++ b/lib/src/ast/apollovm_ast_variable.dart
@@ -265,7 +265,13 @@ class ASTScopeVariable<T> extends ASTVariable {
       var obj = context.getClassInstance();
       if (obj is ASTClassInstance && obj.clazz.getField(name) != null) {
         return obj.clazz
-            .setInstanceFieldValue(context, ASTRunStatus.dummy, obj, name, value)
+            .setInstanceFieldValue(
+              context,
+              ASTRunStatus.dummy,
+              obj,
+              name,
+              value,
+            )
             .resolveMapped((_) {});
       }
 

--- a/lib/src/ast/apollovm_ast_variable.dart
+++ b/lib/src/ast/apollovm_ast_variable.dart
@@ -252,6 +252,28 @@ class ASTScopeVariable<T> extends ASTVariable {
   void associateToType(ASTTypedNode node) => _associatedNode = node;
 
   @override
+  FutureOr<void> setValue(VMContext context, ASTValue value) {
+    // A local variable (in this or an enclosing scope) is set directly.
+    return context.getVariable(name, false).resolveMapped((local) {
+      if (local != null) {
+        return local.setValue(context, value);
+      }
+
+      // Otherwise, an unqualified assignment to a class field must write
+      // through to the instance — `resolveVariable` returns a value copy whose
+      // `setValue` would not persist to the object.
+      var obj = context.getClassInstance();
+      if (obj is ASTClassInstance && obj.clazz.getField(name) != null) {
+        return obj.clazz
+            .setInstanceFieldValue(context, ASTRunStatus.dummy, obj, name, value)
+            .resolveMapped((_) {});
+      }
+
+      return super.setValue(context, value);
+    });
+  }
+
+  @override
   FutureOr<ASTVariable> resolveVariable(VMContext context) {
     if (name == 'null') {
       return ASTRuntimeVariable(

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -1102,7 +1102,8 @@ class DartGrammarDefinition extends DartGrammarLexer {
           });
 
   /// `obj.field = value` (and `this.field = value`), including `+=` etc.
-  Parser<ASTExpressionObjectSetterAssignment> expressionObjectFieldAssignment() =>
+  Parser<ASTExpressionObjectSetterAssignment>
+  expressionObjectFieldAssignment() =>
       (identifier() &
               char('.') &
               identifier().trimHidden() &

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -97,7 +97,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
               identifier() &
               functionParametersDeclaration() &
               asyncToken().optional() &
-              codeBlock())
+              (arrowBody() | codeBlock()))
           .map((v) {
             var returnType = v[0] as ASTType? ?? ASTTypeDynamic.instance;
             var parameters = v[2];
@@ -285,7 +285,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
 
   Parser<ASTConstructorParametersDeclaration>
   constructorParametersDeclaration() =>
-      (functionEmptyParametersDeclaration() |
+      (constructorEmptyParametersDeclaration() |
               constructorPositionalParametersDeclaration())
           .cast<ASTConstructorParametersDeclaration>();
 
@@ -345,7 +345,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
               identifier() &
               functionParametersDeclaration() &
               asyncToken().optional() &
-              (char(';').trimHidden() | codeBlock()))
+              (arrowBody() | char(';').trimHidden() | codeBlock()))
           .map((v) {
             var modifiers =
                 (v[0] as ASTModifiers?) ?? ASTModifiers.modifiersNone;
@@ -530,20 +530,36 @@ class DartGrammarDefinition extends DartGrammarLexer {
             if (value == null) {
               return ASTStatementReturn();
             } else if (value is ASTExpression) {
-              if (value is ASTExpressionVariableAccess) {
-                if (value.variable.name == 'null') {
-                  return ASTStatementReturnNull();
-                } else {
-                  return ASTStatementReturnVariable(value.variable);
-                }
-              } else if (value is ASTExpressionLiteral) {
-                return ASTStatementReturnValue(value.value);
-              } else {
-                return ASTStatementReturnWithExpression(value);
-              }
+              return _returnStatementForExpression(value);
             }
 
             throw UnsupportedError("Can't handle return value: $value");
+          });
+
+  /// Builds the appropriate `return <value>` statement for an expression
+  /// (shared by `return …;` and the arrow body `=> …`).
+  ASTStatementReturn _returnStatementForExpression(ASTExpression value) {
+    if (value is ASTExpressionVariableAccess) {
+      if (value.variable.name == 'null') {
+        return ASTStatementReturnNull();
+      } else {
+        return ASTStatementReturnVariable(value.variable);
+      }
+    } else if (value is ASTExpressionLiteral) {
+      return ASTStatementReturnValue(value.value);
+    } else {
+      return ASTStatementReturnWithExpression(value);
+    }
+  }
+
+  /// Expression-bodied function/method body: `=> expr ;` desugars to a block
+  /// with a single `return expr;`.
+  Parser<ASTBlock> arrowBody() =>
+      (string('=>').trimHidden() & ref0(expression) & char(';').trimHidden())
+          .map((v) {
+            var value = v[1] as ASTExpression;
+            return ASTBlock(null)
+              ..addAllStatements([_returnStatementForExpression(value)]);
           });
 
   Parser<ASTStatementExpression> statementExpression() =>
@@ -759,6 +775,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
               expressionMapLiteral() |
               expressionVariableDirectOperation() |
               expressionVariableEntryAssignment() |
+              expressionObjectFieldAssignment() |
               expressionVariableAssigment() |
               expressionFunctionInvocation() |
               expressionObjectEntryFunctionInvocation() |
@@ -817,19 +834,23 @@ class DartGrammarDefinition extends DartGrammarLexer {
           });
 
   Parser<ASTExpressionFunctionInvocation> expressionFunctionInvocation() =>
-      ((identifier() & char('.')).optional() &
+      // Optional `new` prefix for class instantiation (`new User()`); the
+      // keyword is consumed and discarded — `new User()` and `User()` both
+      // resolve to the class constructor via `ASTRoot.getFunction`.
+      (newToken().optional() &
+              (identifier() & char('.')).optional() &
               identifier() &
               char('(').trimHidden() &
               ref0(expressionSequence).optional() &
               char(')').trimHidden() &
               expressionChainFunctionInvocation().star())
           .map((v) {
-            var objOpt = v[0] as List?;
+            var objOpt = v[1] as List?;
             var obj = objOpt != null ? objOpt[0] as String : null;
-            var name = v[1] as String;
-            var args = v[3] as List<ASTExpression>?;
+            var name = v[2] as String;
+            var args = v[4] as List<ASTExpression>?;
             args ??= <ASTExpression>[];
-            var chainFunctions = (v[5] as List)
+            var chainFunctions = (v[6] as List)
                 .whereType<ASTExpressionChainFunctionInvocation>()
                 .toList();
 
@@ -861,16 +882,16 @@ class DartGrammarDefinition extends DartGrammarLexer {
                 .whereType<ASTExpressionChainFunctionInvocation>()
                 .toList();
 
-            if (obj != null && obj != 'this') {
-              var variable = ASTScopeVariable(obj);
-              return ASTExpressionObjectGetterAccess(
-                variable,
-                name,
-                chainFunctions,
-              );
-            } else {
-              return ASTExpressionLocalGetterAccess(name, chainFunctions);
-            }
+            // `this.field` reads from the current instance; `obj.field` from the
+            // named variable's instance.
+            ASTVariable variable = obj == 'this'
+                ? ASTThisVariable()
+                : ASTScopeVariable(obj!);
+            return ASTExpressionObjectGetterAccess(
+              variable,
+              name,
+              chainFunctions,
+            );
           });
 
   Parser<List<ASTExpression>> expressionSequence() =>
@@ -1078,6 +1099,29 @@ class DartGrammarDefinition extends DartGrammarLexer {
               ref0(expression))
           .map((v) {
             return ASTExpressionVariableEntryAssignment(v[0], v[2], v[4], v[5]);
+          });
+
+  /// `obj.field = value` (and `this.field = value`), including `+=` etc.
+  Parser<ASTExpressionObjectSetterAssignment> expressionObjectFieldAssignment() =>
+      (identifier() &
+              char('.') &
+              identifier().trimHidden() &
+              assigmentOperator() &
+              ref0(expression))
+          .map((v) {
+            var obj = v[0] as String;
+            var name = v[2] as String;
+            var op = v[3] as ASTAssignmentOperator;
+            var valueExpr = v[4] as ASTExpression;
+            ASTVariable variable = obj == 'this'
+                ? ASTThisVariable()
+                : ASTScopeVariable(obj);
+            return ASTExpressionObjectSetterAssignment(
+              variable,
+              name,
+              op,
+              valueExpr,
+            );
           });
 
   Parser<ASTAssignmentOperator> assigmentOperator() =>

--- a/lib/src/languages/dart/dart_grammar_lexer.dart
+++ b/lib/src/languages/dart/dart_grammar_lexer.dart
@@ -45,7 +45,8 @@ abstract class DartGrammarLexer extends BaseGrammarLexer {
 
   Parser inToken() => ref1(token, 'in');
 
-  Parser newToken() => ref1(token, 'new');
+  // Whole-word match so identifiers like `newValue` aren't read as `new` + …
+  Parser newToken() => _keywordToken('new');
 
   Parser nullToken() => ref1(token, 'null');
 

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -847,7 +847,8 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
       });
 
   /// `obj.field = value` (and `this.field = value`), including `+=` etc.
-  Parser<ASTExpressionObjectSetterAssignment> expressionObjectFieldAssignment() =>
+  Parser<ASTExpressionObjectSetterAssignment>
+  expressionObjectFieldAssignment() =>
       (identifier() &
               char('.') &
               identifier().trimHidden() &

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -145,7 +145,7 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
 
   Parser<ASTConstructorParametersDeclaration>
   constructorParametersDeclaration() =>
-      (functionEmptyParametersDeclaration() |
+      (constructorEmptyParametersDeclaration() |
               constructorPositionalParametersDeclaration())
           .cast<ASTConstructorParametersDeclaration>();
 
@@ -520,10 +520,12 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
               expressionMapLiteral() |
               expressionMapEmptyLiteral() |
               expressionVariableDirectOperation() |
+              expressionObjectFieldAssignment() |
               expressionVariableAssigment() |
               expressionFunctionInvocation() |
               expressionObjectEntryFunctionInvocation() |
               expressionVariableEntryAccess() |
+              expressionGetterAccess() |
               expressionNullValue() |
               expressionVariableAccess() |
               expressionNegative())
@@ -577,19 +579,23 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
           });
 
   Parser<ASTExpressionFunctionInvocation> expressionFunctionInvocation() =>
-      ((identifier() & char('.')).optional() &
+      // Optional `new` prefix for class instantiation (`new User()`); the
+      // collection literals (`new ArrayList<…>()`) match earlier in the
+      // alternation, so this generic rule handles user classes.
+      (newToken().optional() &
+              (identifier() & char('.')).optional() &
               identifier() &
               char('(').trimHidden() &
               ref0(expressionSequence).optional() &
               char(')').trimHidden() &
               expressionChainFunctionInvocation().star())
           .map((v) {
-            var objOpt = v[0] as List?;
+            var objOpt = v[1] as List?;
             var obj = objOpt != null ? objOpt[0] as String : null;
-            var name = v[1] as String;
-            var args = v[3] as List<ASTExpression>?;
+            var name = v[2] as String;
+            var args = v[4] as List<ASTExpression>?;
             args ??= <ASTExpression>[];
-            var chainFunctions = (v[5] as List)
+            var chainFunctions = (v[6] as List)
                 .whereType<ASTExpressionChainFunctionInvocation>()
                 .toList();
 
@@ -608,6 +614,28 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
                 chainFunctions,
               );
             }
+          });
+
+  /// `obj.field` (and `this.field`) read access.
+  Parser<ASTExpressionGetterAccess> expressionGetterAccess() =>
+      ((identifier() & char('.')) &
+              identifier().trimHidden() &
+              expressionChainFunctionInvocation().star())
+          .map((v) {
+            var obj = v[0] as String?;
+            var name = v[2] as String;
+            var chainFunctions = (v[3] as List)
+                .whereType<ASTExpressionChainFunctionInvocation>()
+                .toList();
+
+            ASTVariable variable = obj == 'this'
+                ? ASTThisVariable()
+                : ASTScopeVariable(obj!);
+            return ASTExpressionObjectGetterAccess(
+              variable,
+              name,
+              chainFunctions,
+            );
           });
 
   Parser<ASTExpressionChainFunctionInvocation>
@@ -817,6 +845,29 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
       (variable() & assigmentOperator() & ref0(expression)).map((v) {
         return ASTExpressionVariableAssignment(v[0], v[1], v[2]);
       });
+
+  /// `obj.field = value` (and `this.field = value`), including `+=` etc.
+  Parser<ASTExpressionObjectSetterAssignment> expressionObjectFieldAssignment() =>
+      (identifier() &
+              char('.') &
+              identifier().trimHidden() &
+              assigmentOperator() &
+              ref0(expression))
+          .map((v) {
+            var obj = v[0] as String;
+            var name = v[2] as String;
+            var op = v[3] as ASTAssignmentOperator;
+            var valueExpr = v[4] as ASTExpression;
+            ASTVariable variable = obj == 'this'
+                ? ASTThisVariable()
+                : ASTScopeVariable(obj);
+            return ASTExpressionObjectSetterAssignment(
+              variable,
+              name,
+              op,
+              valueExpr,
+            );
+          });
 
   Parser<ASTAssignmentOperator> assigmentOperator() =>
       (char('=') | string('+=') | string('-=') | string('*=') | string('/='))

--- a/lib/src/languages/java/java11/java11_grammar_lexer.dart
+++ b/lib/src/languages/java/java11/java11_grammar_lexer.dart
@@ -42,10 +42,9 @@ abstract class Java11GrammarLexer extends BaseGrammarLexer {
   Parser inToken() => ref1(token, 'in');
 
   // Whole-word match so identifiers like `newValue` aren't read as `new` + …
-  Parser newToken() =>
-      (string('new') & ref0(identifierPartLexicalToken).not())
-          .map((v) => v[0])
-          .trim(ref0(hiddenStuffWhitespace));
+  Parser newToken() => (string('new') & ref0(identifierPartLexicalToken).not())
+      .map((v) => v[0])
+      .trim(ref0(hiddenStuffWhitespace));
 
   Parser nullToken() => ref1(token, 'null');
 

--- a/lib/src/languages/java/java11/java11_grammar_lexer.dart
+++ b/lib/src/languages/java/java11/java11_grammar_lexer.dart
@@ -41,7 +41,11 @@ abstract class Java11GrammarLexer extends BaseGrammarLexer {
 
   Parser inToken() => ref1(token, 'in');
 
-  Parser newToken() => ref1(token, 'new');
+  // Whole-word match so identifiers like `newValue` aren't read as `new` + …
+  Parser newToken() =>
+      (string('new') & ref0(identifierPartLexicalToken).not())
+          .map((v) => v[0])
+          .trim(ref0(hiddenStuffWhitespace));
 
   Parser nullToken() => ref1(token, 'null');
 

--- a/lib/src/languages/javascript/es/javascript_grammar.dart
+++ b/lib/src/languages/javascript/es/javascript_grammar.dart
@@ -803,7 +803,8 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
       });
 
   /// `obj.field = value` (and `this.field = value`), including `+=` etc.
-  Parser<ASTExpressionObjectSetterAssignment> expressionObjectFieldAssignment() =>
+  Parser<ASTExpressionObjectSetterAssignment>
+  expressionObjectFieldAssignment() =>
       (identifier() &
               char('.') &
               identifier().trimHidden() &

--- a/lib/src/languages/javascript/es/javascript_grammar.dart
+++ b/lib/src/languages/javascript/es/javascript_grammar.dart
@@ -570,6 +570,7 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
               expressionGroup() |
               expressionListLiteral() |
               expressionVariableDirectOperation() |
+              expressionObjectFieldAssignment() |
               expressionVariableAssigment() |
               expressionFunctionInvocation() |
               expressionObjectEntryFunctionInvocation() |
@@ -664,16 +665,16 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
                 .whereType<ASTExpressionChainFunctionInvocation>()
                 .toList();
 
-            if (obj != null && obj != 'this') {
-              var variable = ASTScopeVariable(obj);
-              return ASTExpressionObjectGetterAccess(
-                variable,
-                name,
-                chainFunctions,
-              );
-            } else {
-              return ASTExpressionLocalGetterAccess(name, chainFunctions);
-            }
+            // `this.field` reads from the current instance; `obj.field` from
+            // the named variable's instance.
+            ASTVariable variable = obj == 'this'
+                ? ASTThisVariable()
+                : ASTScopeVariable(obj!);
+            return ASTExpressionObjectGetterAccess(
+              variable,
+              name,
+              chainFunctions,
+            );
           });
 
   Parser<List<ASTExpression>> expressionSequence() =>
@@ -800,6 +801,29 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
       (variable() & assigmentOperator() & ref0(expression)).map((v) {
         return ASTExpressionVariableAssignment(v[0], v[1], v[2]);
       });
+
+  /// `obj.field = value` (and `this.field = value`), including `+=` etc.
+  Parser<ASTExpressionObjectSetterAssignment> expressionObjectFieldAssignment() =>
+      (identifier() &
+              char('.') &
+              identifier().trimHidden() &
+              assigmentOperator() &
+              ref0(expression))
+          .map((v) {
+            var obj = v[0] as String;
+            var name = v[2] as String;
+            var op = v[3] as ASTAssignmentOperator;
+            var valueExpr = v[4] as ASTExpression;
+            ASTVariable variable = obj == 'this'
+                ? ASTThisVariable()
+                : ASTScopeVariable(obj);
+            return ASTExpressionObjectSetterAssignment(
+              variable,
+              name,
+              op,
+              valueExpr,
+            );
+          });
 
   Parser<ASTAssignmentOperator> assigmentOperator() =>
       (string('+=') |

--- a/lib/src/languages/kotlin/kotlin_grammar.dart
+++ b/lib/src/languages/kotlin/kotlin_grammar.dart
@@ -541,6 +541,7 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
               expressionListLiteral() |
               expressionMapLiteral() |
               expressionVariableDirectOperation() |
+              expressionObjectFieldAssignment() |
               expressionVariableAssigment() |
               expressionFunctionInvocation() |
               expressionObjectEntryFunctionInvocation() |
@@ -643,16 +644,16 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
                 .whereType<ASTExpressionChainFunctionInvocation>()
                 .toList();
 
-            if (obj != null && obj != 'this') {
-              var variable = ASTScopeVariable(obj);
-              return ASTExpressionObjectGetterAccess(
-                variable,
-                name,
-                chainFunctions,
-              );
-            } else {
-              return ASTExpressionLocalGetterAccess(name, chainFunctions);
-            }
+            // `this.field` reads from the current instance; `obj.field` from
+            // the named variable's instance.
+            ASTVariable variable = obj == 'this'
+                ? ASTThisVariable()
+                : ASTScopeVariable(obj!);
+            return ASTExpressionObjectGetterAccess(
+              variable,
+              name,
+              chainFunctions,
+            );
           });
 
   Parser<ASTExpressionChainFunctionInvocation>
@@ -810,6 +811,29 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
       (variable() & assigmentOperator() & ref0(expression)).map((v) {
         return ASTExpressionVariableAssignment(v[0], v[1], v[2]);
       });
+
+  /// `obj.field = value` (and `this.field = value`), including `+=` etc.
+  Parser<ASTExpressionObjectSetterAssignment> expressionObjectFieldAssignment() =>
+      (identifier() &
+              char('.') &
+              identifier().trimHidden() &
+              assigmentOperator() &
+              ref0(expression))
+          .map((v) {
+            var obj = v[0] as String;
+            var name = v[2] as String;
+            var op = v[3] as ASTAssignmentOperator;
+            var valueExpr = v[4] as ASTExpression;
+            ASTVariable variable = obj == 'this'
+                ? ASTThisVariable()
+                : ASTScopeVariable(obj);
+            return ASTExpressionObjectSetterAssignment(
+              variable,
+              name,
+              op,
+              valueExpr,
+            );
+          });
 
   Parser<ASTAssignmentOperator> assigmentOperator() =>
       (char('=') | string('+=') | string('-=') | string('*=') | string('/='))

--- a/lib/src/languages/kotlin/kotlin_grammar.dart
+++ b/lib/src/languages/kotlin/kotlin_grammar.dart
@@ -813,7 +813,8 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
       });
 
   /// `obj.field = value` (and `this.field = value`), including `+=` etc.
-  Parser<ASTExpressionObjectSetterAssignment> expressionObjectFieldAssignment() =>
+  Parser<ASTExpressionObjectSetterAssignment>
+  expressionObjectFieldAssignment() =>
       (identifier() &
               char('.') &
               identifier().trimHidden() &

--- a/lib/src/languages/typescript/ts/typescript_grammar.dart
+++ b/lib/src/languages/typescript/ts/typescript_grammar.dart
@@ -809,6 +809,7 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
               expressionGroup() |
               expressionListLiteral() |
               expressionVariableDirectOperation() |
+              expressionObjectFieldAssignment() |
               expressionVariableAssigment() |
               expressionFunctionInvocation() |
               expressionObjectEntryFunctionInvocation() |
@@ -903,16 +904,16 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
                 .whereType<ASTExpressionChainFunctionInvocation>()
                 .toList();
 
-            if (obj != null && obj != 'this') {
-              var variable = ASTScopeVariable(obj);
-              return ASTExpressionObjectGetterAccess(
-                variable,
-                name,
-                chainFunctions,
-              );
-            } else {
-              return ASTExpressionLocalGetterAccess(name, chainFunctions);
-            }
+            // `this.field` reads from the current instance; `obj.field` from
+            // the named variable's instance.
+            ASTVariable variable = obj == 'this'
+                ? ASTThisVariable()
+                : ASTScopeVariable(obj!);
+            return ASTExpressionObjectGetterAccess(
+              variable,
+              name,
+              chainFunctions,
+            );
           });
 
   Parser<List<ASTExpression>> expressionSequence() =>
@@ -1039,6 +1040,29 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
       (variable() & assigmentOperator() & ref0(expression)).map((v) {
         return ASTExpressionVariableAssignment(v[0], v[1], v[2]);
       });
+
+  /// `obj.field = value` (and `this.field = value`), including `+=` etc.
+  Parser<ASTExpressionObjectSetterAssignment> expressionObjectFieldAssignment() =>
+      (identifier() &
+              char('.') &
+              identifier().trimHidden() &
+              assigmentOperator() &
+              ref0(expression))
+          .map((v) {
+            var obj = v[0] as String;
+            var name = v[2] as String;
+            var op = v[3] as ASTAssignmentOperator;
+            var valueExpr = v[4] as ASTExpression;
+            ASTVariable variable = obj == 'this'
+                ? ASTThisVariable()
+                : ASTScopeVariable(obj);
+            return ASTExpressionObjectSetterAssignment(
+              variable,
+              name,
+              op,
+              valueExpr,
+            );
+          });
 
   Parser<ASTAssignmentOperator> assigmentOperator() =>
       (string('+=') |

--- a/lib/src/languages/typescript/ts/typescript_grammar.dart
+++ b/lib/src/languages/typescript/ts/typescript_grammar.dart
@@ -1042,7 +1042,8 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
       });
 
   /// `obj.field = value` (and `this.field = value`), including `+=` etc.
-  Parser<ASTExpressionObjectSetterAssignment> expressionObjectFieldAssignment() =>
+  Parser<ASTExpressionObjectSetterAssignment>
+  expressionObjectFieldAssignment() =>
       (identifier() &
               char('.') &
               identifier().trimHidden() &

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -3649,7 +3649,11 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         Wasm.localGet(thisIndex),
         description: "[OP] this (init field `${field.name}`)",
       );
-      generateASTExpression(field.initialValue, out: bodyCode, context: context);
+      generateASTExpression(
+        field.initialValue,
+        out: bodyCode,
+        context: context,
+      );
       context.stackDrop(); // value consumed by the field store
       _emitElemStore(bodyCode, fieldType, offset);
     }
@@ -3695,7 +3699,10 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     outBody.writeByte(classType.wasmCode, description: "this local (i32)");
     for (var v in bodyLocals) {
       var astType = context.getLocalVariable(v.key)?.type ?? v.value;
-      outBody.write(Leb128.encodeUnsigned(1), description: "Declared var count");
+      outBody.write(
+        Leb128.encodeUnsigned(1),
+        description: "Declared var count",
+      );
       outBody.writeByte(
         astType.wasmCode,
         description: "Local `${v.key}` (${astType.wasmType.name})",
@@ -6188,7 +6195,9 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     } else {
       var localVar = _getLocalVariable(context, name);
       _localVariableGet(out, context, localVar.index, name, '(return)');
-      var pushType = localVar.type is ASTTypeBool ? _astTypeInt32 : localVar.type;
+      var pushType = localVar.type is ASTTypeBool
+          ? _astTypeInt32
+          : localVar.type;
       context.stackPush(
         pushType,
         'Local get: ${localVar.index} \$$name (return)',

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -9,9 +9,11 @@ import 'dart:typed_data';
 import 'package:collection/collection.dart';
 import 'package:data_serializer/data_serializer.dart';
 
+import '../../apollovm_base.dart';
 import '../../apollovm_code_storage.dart';
 import '../../apollovm_generated_output.dart';
 import '../../apollovm_generator.dart';
+import '../../ast/apollovm_ast_base.dart';
 import '../../ast/apollovm_ast_expression.dart';
 import '../../ast/apollovm_ast_statement.dart';
 import '../../ast/apollovm_ast_toplevel.dart';
@@ -63,8 +65,19 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     out.write(Wasm.magicModuleHeader, description: "Wasm Magic");
     out.write(Wasm.moduleVersion, description: "Version 1");
 
-    var functions = root.functions.expand((fs) => fs.functions).toList();
-    var module = WasmModuleContext(functions);
+    var topFunctions = root.functions.expand((fs) => fs.functions).toList();
+
+    // Synthesize the field layouts and the constructor/method functions for
+    // each class, appending them to the module function-index space.
+    var classLayouts = <String, WasmClassLayout>{};
+    var classFunctions = <ASTFunctionDeclaration>[];
+    for (var clazz in root.classes) {
+      classLayouts[clazz.name] = _buildClassLayout(clazz);
+      classFunctions.addAll(_buildClassFunctions(clazz));
+    }
+
+    var functions = [...topFunctions, ...classFunctions];
+    var module = WasmModuleContext(functions, classLayouts: classLayouts);
 
     // A public function with a String or List parameter requires the host to
     // allocate the argument in module memory, so ensure `__alloc` is exported.
@@ -121,6 +134,95 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     return out;
   }
 
+  /// Computes the heap layout of a class instance: instance fields in
+  /// declaration order, each at a byte offset (int/double 8B, else 4B i32).
+  WasmClassLayout _buildClassLayout(ASTClassNormal clazz) {
+    var offsets = <String, int>{};
+    var types = <String, ASTType>{};
+    var offset = 0;
+    for (var field in clazz.fields) {
+      if (field.modifiers.isStatic) continue; // statics aren't instance fields
+      offsets[field.name] = offset;
+      types[field.name] = field.type;
+      offset += _elemSize(field.type);
+    }
+    return WasmClassLayout(clazz.name, offsets, types, offset);
+  }
+
+  /// Synthesizes the module functions for a class: one per constructor (Wasm
+  /// signature = the constructor's value params, returns an i32 object pointer)
+  /// and one per non-static instance method (`this` prepended as param 0).
+  List<ASTFunctionDeclaration> _buildClassFunctions(ASTClassNormal clazz) {
+    var result = <ASTFunctionDeclaration>[];
+
+    var constructors = clazz.constructors;
+    if (constructors.isEmpty) {
+      // Implicit default (zero-arg) constructor: allocate + apply field
+      // initializers + return `this`.
+      var defaultCtor = ASTClassConstructorDeclaration(
+        clazz.type,
+        '',
+        ASTConstructorParametersDeclaration(null, null, null),
+      );
+      defaultCtor.parentBlock = clazz;
+      defaultCtor.resolveNode(clazz);
+      result.add(
+        _WasmConstructorFunction(
+          clazz,
+          defaultCtor,
+          ASTFunctionParametersDeclaration([]),
+        ),
+      );
+    }
+
+    for (var ctorSet in constructors) {
+      for (var ctor in ctorSet.functions) {
+        var params = ctor.parameters.allParameters
+            .map(
+              (p) => ASTFunctionParameterDeclaration(
+                p.type,
+                p.name,
+                p.index,
+                p.optional,
+              ),
+            )
+            .toList();
+        result.add(
+          _WasmConstructorFunction(
+            clazz,
+            ctor,
+            ASTFunctionParametersDeclaration(params),
+          ),
+        );
+      }
+    }
+
+    for (var fnSet in clazz.functions) {
+      for (var fn in fnSet.functions) {
+        if (fn is! ASTClassFunctionDeclaration) continue;
+        if (fn.modifiers.isStatic) continue; // statics not supported this slice
+
+        var params = <ASTFunctionParameterDeclaration>[
+          ASTFunctionParameterDeclaration(clazz.type, 'this', 0, false),
+          ...fn.parameters.allParameters,
+        ];
+
+        result.add(
+          _WasmMethodFunction(
+            clazz,
+            fn,
+            '${clazz.name}.${fn.name}',
+            ASTFunctionParametersDeclaration(params),
+            fn.returnType,
+            block: fn,
+          ),
+        );
+      }
+    }
+
+    return result;
+  }
+
   /// Type tag used by the `apollovm_sig` custom section.
   /// 0=void, 1=int, 2=double, 3=bool, 4=String, 5=other, 6=list, 7=map.
   static int _typeTag(ASTType t) {
@@ -165,6 +267,7 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       if (needs(f.effectiveReturnType)) return true;
       for (var p in f.parameters.allParameters) {
         if (p.type is ASTTypeString ||
+            p.type is ASTTypeBool ||
             p.type is ASTTypeArray ||
             p.type is ASTTypeMap) {
           return true;
@@ -550,8 +653,20 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   }) {
     out ??= newOutput();
 
+    // A function's call indices are `importCount + position`, but host imports
+    // (`env.print`, `env.int_to_str`, …) are registered lazily as bodies are
+    // generated. With classes a function may call another that is generated
+    // later (and registers imports), so emit a discovery pass first to register
+    // all imports — making `importCount` final — before the real pass. Scoped
+    // to class modules so import-free / single-function modules stay byte-stable.
+    if (module.classLayouts.isNotEmpty) {
+      for (var f in module.functions) {
+        _generateModuleFunctionBody(f, module);
+      }
+    }
+
     var entries = module.functions
-        .map((f) => generateASTFunctionDeclaration(f, module: module))
+        .map((f) => _generateModuleFunctionBody(f, module))
         .toList();
 
     // Synth functions (e.g. `__alloc`) registered during user-body codegen.
@@ -576,6 +691,20 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     out.writeBytesLeb128Block(entries, description: "Functions bodies");
 
     return out;
+  }
+
+  /// Generates the code-section body of a single module function, dispatching
+  /// to the constructor/method generators for synthesized class functions.
+  BytesOutput _generateModuleFunctionBody(
+    ASTFunctionDeclaration f,
+    WasmModuleContext module,
+  ) {
+    if (f is _WasmConstructorFunction) {
+      return _generateClassConstructorFunction(f, module: module);
+    } else if (f is _WasmMethodFunction) {
+      return _generateClassMethodFunction(f, module: module);
+    }
+    return generateASTFunctionDeclaration(f, module: module);
   }
 
   /// Builds a Wasm function-type entry `0x60 vec(params) vec(results)`.
@@ -896,10 +1025,112 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       );
     }
 
+    // Instance method call on a class: `recv.method(args)`.
+    if (context.module?.layoutForType(localVar.type) != null) {
+      return _generateMethodInvocation(
+        expression,
+        localVar,
+        out: out,
+        context: context,
+      );
+    }
+
     throw UnimplementedError(
       "Wasm method `.${expression.name}` on ${localVar.type} "
       "is not supported yet.",
     );
+  }
+
+  /// Lowers `recv.method(args)` to a call of the synthesized method function
+  /// (`this` passed as the first argument).
+  BytesOutput _generateMethodInvocation(
+    ASTExpressionObjectFunctionInvocation expression,
+    ({ASTType type, int index}) recvVar, {
+    required BytesOutput out,
+    required WasmContext context,
+  }) {
+    return _emitClassMethodCall(
+      recv: recvVar,
+      receiverDesc: expression.variable.name,
+      methodName: expression.name,
+      arguments: expression.arguments,
+      out: out,
+      context: context,
+    );
+  }
+
+  /// Emits a call to class [methodName] on the receiver local [recv] (passed as
+  /// the first argument, `this`), used by both `recv.method(args)` and the
+  /// implicit-`this` `method(args)` inside another method.
+  BytesOutput _emitClassMethodCall({
+    required ({ASTType type, int index}) recv,
+    required String receiverDesc,
+    required String methodName,
+    required List<ASTExpression> arguments,
+    required BytesOutput out,
+    required WasmContext context,
+  }) {
+    var module = context.module!;
+    var className = recv.type.name;
+    var arity = arguments.length;
+
+    var calleeIndex = module.methodIndex(className, methodName, arity);
+    if (calleeIndex == null) {
+      throw StateError(
+        "Can't resolve method `$className.$methodName` with $arity argument(s).",
+      );
+    }
+    var callee = module.functionByIndex(calleeIndex) as _WasmMethodFunction;
+
+    final stackLng0 = context.stackLength;
+
+    // Receiver (`this`) is the first argument.
+    _localVariableGet(out, context, recv.index, receiverDesc);
+    context.stackPush(recv.type, "receiver `$receiverDesc`");
+
+    for (var i = 0; i < arity; ++i) {
+      var stackBefore = context.stackLength;
+      generateASTExpression(arguments[i], out: out, context: context);
+      context.assertStackLength(stackBefore + 1, "After method arg[$i]");
+
+      var paramType = callee.method.parameters.getParameterByIndex(i)?.type;
+      if (paramType != null) {
+        _autoConvertStackTypes(
+          context.stackGet(0)!.type,
+          paramType,
+          out: out,
+          context: context,
+        );
+      }
+    }
+
+    out.write(
+      Wasm.call(calleeIndex),
+      description: "[OP] call `$className.$methodName` (index $calleeIndex)",
+    );
+
+    for (var i = 0; i < arity + 1; ++i) {
+      context.stackDrop();
+    }
+
+    var returnType = callee.method.returnType;
+    if (!returnType.isVoid) {
+      ASTType resultType;
+      if (returnType is ASTTypeInt) {
+        resultType = _astTypeInt64;
+      } else if (returnType is ASTTypeDouble) {
+        resultType = _astTypeDouble64;
+      } else {
+        resultType = returnType;
+      }
+      context.stackPush(resultType, "method `$methodName` result");
+    }
+
+    context.assertStackLength(
+      stackLng0 + (returnType.isVoid ? 0 : 1),
+      "After method `$methodName`",
+    );
+    return out;
   }
 
   /// `m.containsKey(k)`: linear scan, pushes an i32 bool (1 found / 0 absent).
@@ -1071,15 +1302,22 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   int _elemSize(ASTType elemType) =>
       (elemType is ASTTypeInt || elemType is ASTTypeDouble) ? 8 : 4;
 
+  /// A class-instance reference: an i32 pointer to a heap struct.
+  bool _isWasmObjectRef(ASTType t) => t is ASTType<VMObject>;
+
   void _emitElemStore(BytesOutput out, ASTType elemType, int offset) {
     if (elemType is ASTTypeInt) {
       out.write(Wasm64.i64Store(3, offset));
     } else if (elemType is ASTTypeDouble) {
       out.write(Wasm64.f64Store(FloatAlign.align3, offset));
-    } else if (elemType is ASTTypeString || elemType is ASTTypeBool) {
+    } else if (elemType is ASTTypeString ||
+        elemType is ASTTypeBool ||
+        elemType is ASTTypeArray ||
+        elemType is ASTTypeMap ||
+        _isWasmObjectRef(elemType)) {
       out.write(Wasm32.i32Store(2, offset));
     } else {
-      throw UnimplementedError("Wasm list element store for $elemType");
+      throw UnimplementedError("Wasm element/field store for $elemType");
     }
   }
 
@@ -1088,10 +1326,14 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       out.write(Wasm64.i64Load(3, offset));
     } else if (elemType is ASTTypeDouble) {
       out.write(Wasm64.f64Load(FloatAlign.align3, offset));
-    } else if (elemType is ASTTypeString || elemType is ASTTypeBool) {
+    } else if (elemType is ASTTypeString ||
+        elemType is ASTTypeBool ||
+        elemType is ASTTypeArray ||
+        elemType is ASTTypeMap ||
+        _isWasmObjectRef(elemType)) {
       out.write(Wasm32.i32Load(2, offset));
     } else {
-      throw UnimplementedError("Wasm list element load for $elemType");
+      throw UnimplementedError("Wasm element/field load for $elemType");
     }
   }
 
@@ -1228,6 +1470,24 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     var calleeIndex = context.functionIndex(name, argsCount);
     if (calleeIndex == null) {
+      // Inside a method, an unqualified call is an implicit-`this` method call
+      // (`foo()` == `this.foo()`).
+      var layout = context.classLayout;
+      var thisVar = context.getLocalVariable('this');
+      if (layout != null &&
+          thisVar != null &&
+          context.module?.methodIndex(layout.className, name, argsCount) !=
+              null) {
+        return _emitClassMethodCall(
+          recv: thisVar,
+          receiverDesc: 'this',
+          methodName: name,
+          arguments: arguments,
+          out: out,
+          context: context,
+        );
+      }
+
       throw StateError(
         "Can't resolve local function `$name` with $argsCount argument(s) "
         "in the Wasm function index table.",
@@ -1317,16 +1577,23 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     final stackLng0 = context.stackLength;
 
-    // Evaluate the argument; it must resolve to a string handle (i32).
-    generateASTExpression(expression.arguments[0], out: out, context: context);
-    context.assertStackLength(stackLng0 + 1, "After print argument");
+    var arg = expression.arguments[0];
 
-    var argType = context.stackGet(0)!.type;
-    if (argType != _astTypeInt32 && argType is! ASTTypeString) {
-      throw UnimplementedError(
-        "Wasm `print` currently supports String arguments only "
-        "(got $argType); number/other interpolation lands in a later slice.",
+    // `print(null)` prints the literal `null`. The generic null-value path can't
+    // be lowered (Wasm has no null), so intern the text directly.
+    if (arg is ASTExpressionNullValue) {
+      var ptr = module.internStringLiteral('null');
+      out.write(
+        Wasm32.i32Const(ptr),
+        description: "[OP] push 'null' literal ptr($ptr)",
       );
+      context.stackPush(_astTypeString, "print null literal");
+    } else {
+      // Evaluate the argument, then coerce whatever it is (int/double/bool/
+      // String) to an i32 string handle for `env.print`.
+      generateASTExpression(arg, out: out, context: context);
+      context.assertStackLength(stackLng0 + 1, "After print argument");
+      _emitToStringHandle(out, context, context.stackGet(0)!.type);
     }
 
     var importIndex = module.registerImportedFunction('env', 'print', [
@@ -2291,6 +2558,11 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     var name = expression.variable.name;
 
+    // A bare name that is a class field (and not a local) reads `this + offset`.
+    if (context.isFieldAccess(name)) {
+      return _generateFieldGet(out, context, name);
+    }
+
     var localVar = _getLocalVariable(context, name);
 
     final stackLng0 = context.stackLength;
@@ -2323,6 +2595,12 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     var variable = expression.variable;
     var name = variable.name;
+
+    // A bare name that is a class field (and not a local) stores to
+    // `this + offset`.
+    if (context.isFieldAccess(name)) {
+      return _generateFieldSet(expression, out: out, context: context);
+    }
 
     var localVar = _getLocalVariable(context, name);
 
@@ -2369,6 +2647,73 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       "After variable declaration:  ${localVar.index} \$$name",
     );
 
+    return out;
+  }
+
+  /// Loads a class field of the current method's `this`: `this + offset`.
+  BytesOutput _generateFieldGet(
+    BytesOutput out,
+    WasmContext context,
+    String name,
+  ) {
+    final s0 = context.stackLength;
+    var layout = context.classLayout!;
+    var offset = layout.offsets[name]!;
+    var fieldType = layout.types[name]!;
+
+    out.write(
+      Wasm.localGet(context.thisLocalIndex),
+      description: "[OP] this (read field `$name`)",
+    );
+    _emitElemLoad(out, fieldType, offset);
+    context.stackPush(_elemStackType(fieldType), "field `$name`");
+
+    context.assertStackLength(s0 + 1, "After field get `$name`");
+    return out;
+  }
+
+  /// Stores to a class field of the current method's `this`. Mirrors the local
+  /// assignment-expression contract: the address is pushed to the real stack
+  /// only and the value's virtual entry is left on the stack.
+  BytesOutput _generateFieldSet(
+    ASTExpressionVariableAssignment expression, {
+    required BytesOutput out,
+    required WasmContext context,
+  }) {
+    var name = expression.variable.name;
+    var layout = context.classLayout!;
+    var offset = layout.offsets[name]!;
+    var fieldType = layout.types[name]!;
+
+    final s0 = context.stackLength;
+    var op = expression.operator;
+
+    // Address (`this`) on the real stack; not tracked on the virtual stack so
+    // the value sub-expression's relative assertions hold.
+    out.write(
+      Wasm.localGet(context.thisLocalIndex),
+      description: "[OP] this (store field `$name`)",
+    );
+
+    if (op == ASTAssignmentOperator.set) {
+      generateASTExpression(expression.expression, out: out, context: context);
+    } else {
+      var expOp = op.asASTExpressionOperator!;
+      generateASTExpressionOperation(
+        ASTExpressionOperation(
+          ASTExpressionVariableAccess(expression.variable),
+          expOp,
+          expression.expression,
+        ),
+        out: out,
+        context: context,
+      );
+    }
+
+    // `store` consumes the address and value from the real stack; the value's
+    // virtual entry stays (matching local assignment).
+    _emitElemStore(out, fieldType, offset);
+    context.assertStackLength(s0 + 1, "After field set `$name`");
     return out;
   }
 
@@ -2969,6 +3314,19 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     var listType = localVar.type;
 
+    // `obj.field` on a class instance: load `recv + offset`.
+    var classLayout = context.module?.layoutForType(listType);
+    if (classLayout != null && classLayout.offsets.containsKey(name)) {
+      final s0 = context.stackLength;
+      var offset = classLayout.offsets[name]!;
+      var fieldType = classLayout.types[name]!;
+      _localVariableGet(out, context, localVar.index, varName);
+      _emitElemLoad(out, fieldType, offset);
+      context.stackPush(_elemStackType(fieldType), "$varName.$name");
+      context.assertStackLength(s0 + 1, "After getter $varName.$name");
+      return out;
+    }
+
     // `.length`/`.isEmpty`/`.isNotEmpty` read header[0] (length), which is the
     // same offset for both the list and map layouts.
     if (listType is ASTTypeArray || listType is ASTTypeMap) {
@@ -3169,7 +3527,9 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     );
 
     for (var v in localVariables) {
-      var astType = v.value;
+      // Use the context's (possibly refined) type — a `var` initialized from a
+      // constructor is re-typed from `dynamic` to the class type during body gen.
+      var astType = context.getLocalVariable(v.key)?.type ?? v.value;
       outBody.write(
         Leb128.encodeUnsigned(1),
         description: "Declared variable count",
@@ -3202,6 +3562,160 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     out.writeBytesLeb128Block([outBody], description: "Function body");
 
+    return out;
+  }
+
+  /// Generates a class instance method. Reuses [generateASTFunctionDeclaration]
+  /// with a context that knows the class field layout and that `this` is the
+  /// first parameter (local 0), so bare field accesses in the body lower to
+  /// loads/stores against `this`.
+  BytesOutput _generateClassMethodFunction(
+    _WasmMethodFunction f, {
+    required WasmModuleContext module,
+  }) {
+    var context = WasmContext(module: module);
+    context.classLayout = module.classLayouts[f.clazz.name];
+    context.thisLocalIndex = 0; // `this` is parameter 0.
+    return generateASTFunctionDeclaration(f, context: context, module: module);
+  }
+
+  /// Generates a class constructor as a function returning an i32 object
+  /// pointer: allocates the instance struct, applies field initializers and
+  /// `this.field` parameter stores, runs the constructor body, and returns
+  /// `this`.
+  BytesOutput _generateClassConstructorFunction(
+    _WasmConstructorFunction f, {
+    required WasmModuleContext module,
+  }) {
+    var out = newOutput();
+    var context = WasmContext(module: module);
+
+    var clazz = f.clazz;
+    var layout = module.classLayouts[clazz.name]!;
+    context.classLayout = layout;
+
+    module.requiresMemory = true;
+    module.requiresHeapGlobal = true;
+    module.ensureAllocFunction();
+
+    var classType = clazz.type;
+    var return0 = context.returnsLength;
+    context.returnsPush(classType, "Constructor `${clazz.name}` return");
+
+    // Value parameters become locals 0..n-1.
+    var paramVars = f.parameters.declaredVariables();
+    for (var v in paramVars) {
+      context.addLocalVariable(v.key, v.value);
+    }
+
+    // The `this` pointer is a local just past the parameters.
+    var thisIndex = context.addLocalVariable('this', classType);
+    context.thisLocalIndex = thisIndex;
+
+    // Locals declared in the constructor body.
+    var bodyLocals = f.ctor.statements.declaredVariables();
+    for (var v in bodyLocals) {
+      context.addLocalVariable(v.key, v.value);
+    }
+
+    var bodyCode = newOutput();
+
+    // this = __alloc(sizeof(class))
+    bodyCode.write(
+      Wasm32.i32Const(layout.size),
+      description: "[OP] sizeof ${clazz.name} = ${layout.size}",
+    );
+    _emitInlineAlloc(bodyCode, context);
+    bodyCode.write(
+      Wasm.localSet(thisIndex),
+      description: "[OP] this = alloc(${clazz.name})",
+    );
+
+    var thisParamNames = f.ctor.parameters.allParameters
+        .where((p) => p.thisParameter)
+        .map((p) => p.name)
+        .toSet();
+
+    // Field initializers (e.g. `int y = 5`) for fields not set by a `this.`
+    // parameter.
+    for (var field in clazz.fields) {
+      if (field.modifiers.isStatic) continue;
+      if (thisParamNames.contains(field.name)) continue;
+      if (field is! ASTClassFieldWithInitialValue) continue;
+
+      var offset = layout.offsets[field.name]!;
+      var fieldType = layout.types[field.name]!;
+      bodyCode.write(
+        Wasm.localGet(thisIndex),
+        description: "[OP] this (init field `${field.name}`)",
+      );
+      generateASTExpression(field.initialValue, out: bodyCode, context: context);
+      context.stackDrop(); // value consumed by the field store
+      _emitElemStore(bodyCode, fieldType, offset);
+    }
+
+    // `this.field` parameter stores.
+    for (var p in f.ctor.parameters.allParameters) {
+      if (!p.thisParameter) continue;
+      var offset = layout.offsets[p.name];
+      if (offset == null) continue;
+      var fieldType = layout.types[p.name]!;
+      var paramLocal = context.getLocalVariable(p.name)!;
+      bodyCode.write(
+        Wasm.localGet(thisIndex),
+        description: "[OP] this (store param `${p.name}`)",
+      );
+      bodyCode.write(
+        Wasm.localGet(paramLocal.index),
+        description: "[OP] param `${p.name}`",
+      );
+      _emitElemStore(bodyCode, fieldType, offset);
+    }
+
+    // Explicit constructor body statements.
+    for (var stm in f.ctor.statements) {
+      generateASTStatement(stm, out: bodyCode, context: context);
+    }
+
+    // return this
+    bodyCode.write(
+      Wasm.localGet(thisIndex),
+      description: "[OP] return this (${clazz.name})",
+    );
+
+    // Preamble: the `this` local, then body locals, then scratch locals.
+    var outBody = newOutput();
+    var scratchTypes = context.scratchLocalTypes;
+
+    outBody.write(
+      Leb128.encodeUnsigned(1 + bodyLocals.length + scratchTypes.length),
+      description: "Local variables count",
+    );
+    outBody.write(Leb128.encodeUnsigned(1), description: "this local count");
+    outBody.writeByte(classType.wasmCode, description: "this local (i32)");
+    for (var v in bodyLocals) {
+      var astType = context.getLocalVariable(v.key)?.type ?? v.value;
+      outBody.write(Leb128.encodeUnsigned(1), description: "Declared var count");
+      outBody.writeByte(
+        astType.wasmCode,
+        description: "Local `${v.key}` (${astType.wasmType.name})",
+      );
+    }
+    for (var astType in scratchTypes) {
+      outBody.write(Leb128.encodeUnsigned(1), description: "Scratch var count");
+      outBody.writeByte(
+        astType.wasmCode,
+        description: "Scratch (${astType.wasmType.name})",
+      );
+    }
+
+    outBody.writeBytes(bodyCode);
+    outBody.writeByte(Wasm.end, description: "Code body end");
+
+    context.returnsDrop(classType);
+    context.assertReturnsLength(return0);
+
+    out.writeBytesLeb128Block([outBody], description: "Constructor body");
     return out;
   }
 
@@ -5667,16 +6181,19 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     var variable = statement.variable;
     var name = variable.name;
 
-    var localVar = _getLocalVariable(context, name);
-
     var stackLength0 = context.stackLength;
 
-    _localVariableGet(out, context, localVar.index, name, '(return)');
-
-    context.stackPush(
-      localVar.type,
-      'Local get: ${localVar.index} \$$name (return)',
-    );
+    if (context.isFieldAccess(name)) {
+      _generateFieldGet(out, context, name);
+    } else {
+      var localVar = _getLocalVariable(context, name);
+      _localVariableGet(out, context, localVar.index, name, '(return)');
+      var pushType = localVar.type is ASTTypeBool ? _astTypeInt32 : localVar.type;
+      context.stackPush(
+        pushType,
+        'Local get: ${localVar.index} \$$name (return)',
+      );
+    }
 
     context.assertStackLength(stackLength0 + 1, "Return variable: $name");
 
@@ -5687,7 +6204,7 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     out.writeByte(
       Wasm.functionReturn,
-      description: "[OP] return variable: ${localVar.index} \$$name",
+      description: "[OP] return variable: \$$name",
     );
     context.stackDrop();
 
@@ -5835,6 +6352,13 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       "After variable declaration expression",
     );
 
+    // A `var` that the AST couldn't statically resolve (e.g. `var p = Point()`)
+    // is registered as `dynamic`; refine it to the initializer's real type so
+    // method/field access and the local's Wasm type are correct.
+    if (localVar.type is ASTTypeDynamic) {
+      context.updateLocalVariableType(name, context.stackGet(0)!.type);
+    }
+
     _localVariableSet(out, context, localVar.index, name);
 
     context.assertStackLength(
@@ -5948,6 +6472,12 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       );
     } else if (expression is ASTExpressionGroupFunctionInvocation) {
       return generateASTExpressionGroupFunctionInvocation(expression, out: out);
+    } else if (expression is ASTExpressionObjectSetterAssignment) {
+      return _generateObjectSetterAssignment(
+        expression,
+        out: out,
+        context: context,
+      );
     } else if (expression is ASTExpressionOperation) {
       return generateASTExpressionOperation(
         expression,
@@ -5957,6 +6487,61 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     }
 
     throw UnsupportedError("Can't generate expression: $expression");
+  }
+
+  /// Lowers `obj.field = value` (and `this.field = value`), including compound
+  /// operators, to a store at `recv + offset`.
+  BytesOutput _generateObjectSetterAssignment(
+    ASTExpressionObjectSetterAssignment expression, {
+    BytesOutput? out,
+    WasmContext? context,
+  }) {
+    out ??= newOutput();
+    context ??= WasmContext();
+
+    var recvName = expression.variable.name;
+    var recvVar = _getLocalVariable(context, recvName);
+    var layout = context.module?.layoutForType(recvVar.type);
+    if (layout == null || !layout.offsets.containsKey(expression.name)) {
+      throw UnimplementedError(
+        "Wasm field assignment `${recvVar.type}.${expression.name}` "
+        "is not supported.",
+      );
+    }
+    var offset = layout.offsets[expression.name]!;
+    var fieldType = layout.types[expression.name]!;
+
+    final s0 = context.stackLength;
+
+    // Receiver pointer (the store address) on the real stack only — the value
+    // sub-expression's relative assertions hold, and the value's virtual entry
+    // remains (matching the local assignment-expression contract).
+    _localVariableGet(out, context, recvVar.index, recvName);
+
+    if (expression.operator == ASTAssignmentOperator.set) {
+      generateASTExpression(expression.expression, out: out, context: context);
+    } else {
+      var expOp = expression.operator.asASTExpressionOperator!;
+      generateASTExpressionOperation(
+        ASTExpressionOperation(
+          ASTExpressionObjectGetterAccess(expression.variable, expression.name),
+          expOp,
+          expression.expression,
+        ),
+        out: out,
+        context: context,
+      );
+    }
+
+    _autoConvertStackTypes(
+      context.stackGet(0)!.type,
+      fieldType,
+      out: out,
+      context: context,
+    );
+    _emitElemStore(out, fieldType, offset);
+    context.assertStackLength(s0 + 1, "After object field set");
+    return out;
   }
 
   @override
@@ -6203,16 +6788,7 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     generateASTExpression(value.expression, out: out, context: context);
 
-    var t = context.stackGet(0)!.type;
-    if (t is ASTTypeString) {
-      // Already a string handle.
-    } else if (t is ASTTypeInt || t is ASTTypeDouble) {
-      _emitNumberToString(out, context, t);
-    } else {
-      throw UnimplementedError(
-        "Wasm string interpolation of expression type $t is not supported yet.",
-      );
-    }
+    _emitToStringHandle(out, context, context.stackGet(0)!.type);
 
     return out;
   }
@@ -6228,21 +6804,23 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     context ??= WasmContext();
 
     var name = value.variable.name;
+
+    // A field interpolated inside a method (`'$x'`) loads `this + offset`.
+    if (context.isFieldAccess(name)) {
+      _generateFieldGet(out, context, name);
+      _emitToStringHandle(out, context, context.stackGet(0)!.type);
+      return out;
+    }
+
     var localVar = _getLocalVariable(context, name);
     var t = localVar.type;
 
     _localVariableGet(out, context, localVar.index, name);
 
-    if (t is ASTTypeString) {
-      context.stackPush(_astTypeString, "string var: \$$name");
-    } else if (t is ASTTypeInt || t is ASTTypeDouble) {
-      context.stackPush(t, "number var: \$$name");
-      _emitNumberToString(out, context, t);
-    } else {
-      throw UnimplementedError(
-        "Wasm interpolation of variable `$name` ($t) is not supported yet.",
-      );
-    }
+    // Booleans live as i32 on the stack; push the storage type, then coerce.
+    var pushType = t is ASTTypeBool ? _astTypeInt32 : t;
+    context.stackPush(pushType, "interp var: \$$name");
+    _emitToStringHandle(out, context, pushType);
 
     return out;
   }
@@ -6288,6 +6866,89 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     );
     context.stackDrop();
     context.stackPush(_astTypeString, "number to string");
+  }
+
+  /// Coerces the value currently on top of the stack to an i32 string handle,
+  /// ready for `env.print` or string concatenation. Strings already are handles;
+  /// `int`/`double` route through [_emitNumberToString] and `bool` through
+  /// [_emitBoolToString]. A bare i32 stack value is a `bool` (booleans, logic and
+  /// comparison results are all represented as i32 in this generator).
+  void _emitToStringHandle(BytesOutput out, WasmContext context, ASTType type) {
+    if (type is ASTTypeString) {
+      // Already a string handle.
+    } else if (type is ASTTypeBool || identical(type, _astTypeInt32)) {
+      // Booleans (and comparison/logic results) are the only values pushed as
+      // the i32 singleton; checked before `ASTTypeInt` since `instance32` *is*
+      // an `ASTTypeInt`. Real `int`s are pushed as i64 (`instance64`).
+      _emitBoolToString(out, context);
+    } else if (type is ASTTypeInt || type is ASTTypeDouble) {
+      _emitNumberToString(out, context, type);
+    } else if (_isWasmObjectRef(type)) {
+      _emitInstanceToString(out, context, type);
+    } else {
+      throw UnimplementedError(
+        "Wasm string coercion of type $type is not supported yet.",
+      );
+    }
+  }
+
+  /// Converts the class instance pointer on top of the stack to an i32 string
+  /// handle by calling its `toString()` method (which returns a string handle).
+  void _emitInstanceToString(
+    BytesOutput out,
+    WasmContext context,
+    ASTType type,
+  ) {
+    var module = context.module;
+    var className = type.name;
+    var calleeIndex = module?.methodIndex(className, 'toString', 0);
+    if (calleeIndex == null) {
+      throw UnimplementedError(
+        "Wasm `print`/interpolation of a `$className` needs a `toString()` "
+        "method.",
+      );
+    }
+    // The receiver is already on the stack; `toString()` consumes it and
+    // returns the string handle.
+    out.write(
+      Wasm.call(calleeIndex),
+      description: "[OP] call `$className.toString` (index $calleeIndex)",
+    );
+    context.stackDrop();
+    context.stackPush(_astTypeString, "$className.toString() result");
+  }
+
+  /// Converts the i32 boolean on top of the stack to an i32 string handle:
+  /// `select`s between the interned `"true"` / `"false"` literals. `select`
+  /// pops `[a, b, cond]` and keeps `a` when `cond != 0`, so the condition is
+  /// stashed in a scratch local and re-pushed above the two pointers.
+  void _emitBoolToString(BytesOutput out, WasmContext context) {
+    var module = context.module;
+    if (module == null) {
+      throw StateError("Can't convert a bool to String without a module.");
+    }
+    var truePtr = module.internStringLiteral('true');
+    var falsePtr = module.internStringLiteral('false');
+
+    // i32 scratch local (an `ASTTypeInt` would map to i64; `_astTypeString` is
+    // the i32-typed slot used throughout this generator).
+    var condLocal = context.scratchLocal(_astTypeString, 30);
+
+    // cond := top ; [truePtr, falsePtr, cond] ; select -> chosen pointer.
+    out.write(Wasm.localSet(condLocal), description: "[OP] stash bool cond");
+    out.write(
+      Wasm32.i32Const(truePtr),
+      description: "[OP] push 'true' literal ptr($truePtr)",
+    );
+    out.write(
+      Wasm32.i32Const(falsePtr),
+      description: "[OP] push 'false' literal ptr($falsePtr)",
+    );
+    out.write(Wasm.localGet(condLocal), description: "[OP] reload bool cond");
+    out.writeByte(Wasm.select, description: "[OP] select true/false string");
+
+    context.stackDrop(); // bool consumed
+    context.stackPush(_astTypeString, "bool to string");
   }
 
   /// Concatenates the top two string handles on the stack (`[a, b]`) into a
@@ -6498,14 +7159,93 @@ class WasmSynthFunction {
   });
 }
 
+/// Memory layout of a class instance: field byte [offsets] (declaration order),
+/// field [types], and total [size]. An instance is an i32 pointer to a heap
+/// struct holding the fields at these offsets (int/double -> 8B, everything
+/// else -> 4B i32).
+class WasmClassLayout {
+  final String className;
+  final Map<String, int> offsets;
+  final Map<String, ASTType> types;
+  final int size;
+
+  WasmClassLayout(this.className, this.offsets, this.types, this.size);
+}
+
+/// A synthesized module function wrapping a class constructor. Its Wasm
+/// signature takes the constructor's value parameters and returns an i32 object
+/// pointer; codegen allocates the struct, stores fields, runs the body and
+/// returns `this` (see `generateClassConstructorFunction`).
+class _WasmConstructorFunction extends ASTFunctionDeclaration {
+  final ASTClassNormal clazz;
+  final ASTClassConstructorDeclaration ctor;
+
+  _WasmConstructorFunction(
+    this.clazz,
+    this.ctor,
+    ASTFunctionParametersDeclaration parameters,
+  ) : super(
+        clazz.name,
+        parameters,
+        clazz.type,
+        modifiers: ASTModifiers(isPrivate: true),
+      );
+}
+
+/// A synthesized module function wrapping a class instance method. Its Wasm
+/// signature takes `this` (i32) as the first parameter followed by the method's
+/// declared parameters (see `generateClassMethodFunction`).
+class _WasmMethodFunction extends ASTFunctionDeclaration {
+  final ASTClassNormal clazz;
+  final ASTClassFunctionDeclaration method;
+
+  _WasmMethodFunction(
+    this.clazz,
+    this.method,
+    String name,
+    ASTFunctionParametersDeclaration parameters,
+    ASTType returnType, {
+    ASTBlock? block,
+  }) : super(
+         name,
+         parameters,
+         returnType,
+         block: block,
+         modifiers: ASTModifiers(isPrivate: true),
+       );
+}
+
 /// Module-level Wasm codegen state shared across all functions: the function
 /// index space (imports + defined functions) and the static data region
 /// (interned string literals).
 class WasmModuleContext {
   /// Module-defined functions, in index order (placed after any imports).
+  /// Includes top-level functions plus synthesized class constructors
+  /// ([_WasmConstructorFunction]) and methods ([_WasmMethodFunction]).
   final List<ASTFunctionDeclaration> functions;
 
-  WasmModuleContext(this.functions);
+  /// Field memory layout for each class, keyed by class name.
+  final Map<String, WasmClassLayout> classLayouts;
+
+  WasmModuleContext(this.functions, {this.classLayouts = const {}});
+
+  /// The field layout of the class whose instances have type [t], or `null`.
+  WasmClassLayout? layoutForType(ASTType t) => classLayouts[t.name];
+
+  /// Resolves the Wasm function index of class [className]'s method
+  /// [methodName] taking [arity] declared arguments (excluding `this`).
+  int? methodIndex(String className, String methodName, int arity) {
+    for (var i = 0; i < functions.length; ++i) {
+      var f = functions[i];
+      if (f is _WasmMethodFunction &&
+          f.clazz.name == className &&
+          f.method.name == methodName &&
+          f.method.parameters.size == arity) {
+        return importCount + i;
+      }
+    }
+    return null;
+  }
 
   // --- Imported functions (function indices 0..importCount-1) ---
 
@@ -6877,6 +7617,20 @@ class WasmContext {
   ASTFunctionDeclaration? functionByIndex(int index) =>
       module?.functionByIndex(index);
 
+  /// When generating a class constructor/method body, the field layout of the
+  /// owning class and the local index holding the `this` pointer. A bare name
+  /// that isn't a local but is a field resolves to a load/store at
+  /// `this + offset`.
+  WasmClassLayout? classLayout;
+  int thisLocalIndex = -1;
+
+  /// Whether [name] resolves to a field of the current method's class (and is
+  /// not shadowed by a local variable).
+  bool isFieldAccess(String name) =>
+      classLayout != null &&
+      !_localVariables.containsKey(name) &&
+      classLayout!.offsets.containsKey(name);
+
   final Map<String, ({ASTType type, int index})> _localVariables = {};
 
   ({ASTType type, int index})? getLocalVariable(String name) {
@@ -6922,6 +7676,16 @@ class WasmContext {
     var entry = (type: type, index: _localVariables.length);
     _localVariables[name] = entry;
     return entry.index;
+  }
+
+  /// Re-types an existing local (keeping its index). Used to refine a `var`
+  /// declared as `dynamic` once its initializer's real type is known.
+  void updateLocalVariableType(String name, ASTType type) {
+    var prev = _localVariables[name];
+    if (prev == null) {
+      throw StateError("Variable `$name` not defined!");
+    }
+    _localVariables[name] = (type: type, index: prev.index);
   }
 
   /// Scratch (temporary) local types, in the order they were allocated. These
@@ -7156,6 +7920,9 @@ extension _ASTTypeExtension on ASTType {
       return WasmType.voidType;
     } else if (name == 'void') {
       return WasmType.voidType;
+    } else if (this is ASTType<VMObject>) {
+      // A class instance is an i32 pointer into linear memory.
+      return WasmType.i32Type;
     }
 
     throw StateError("Can't handle type: $this");

--- a/lib/src/languages/wasm/wasm_runner.dart
+++ b/lib/src/languages/wasm/wasm_runner.dart
@@ -306,6 +306,9 @@ class ApolloRunnerWasm extends ApolloRunner {
         var arg = allParams[i];
         if (pt.tag == _tagString && arg is String) {
           allParams[i] = allocAndWriteString(arg);
+        } else if (pt.tag == _tagBool && arg is bool) {
+          // `bool` is an i32 (0/1) in the Wasm ABI.
+          allParams[i] = arg ? 1 : 0;
         } else if (pt.isList && arg is List) {
           allParams[i] = encodeList(arg, pt.elemTag);
         } else if (pt.isMap && arg is Map) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, JavaScript, TypeScript, Lua with on-the-fly Wasm compilation.
-version: 0.1.34
+version: 0.1.35
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/apollovm_instantiation_test.dart
+++ b/test/apollovm_instantiation_test.dart
@@ -25,7 +25,9 @@ Future<List<String>> _runPrints(
 void main() {
   group('Dart: instantiation + toString()', () {
     test('new User() — default constructor + user toString()', () async {
-      var out = await _runPrints('dart', r'''
+      var out = await _runPrints(
+        'dart',
+        r'''
         class User {
           int id;
           String name;
@@ -37,12 +39,17 @@ void main() {
             print(user);
           }
         }
-      ''', 'Main', 'run');
+      ''',
+        'Main',
+        'run',
+      );
       expect(out, equals(['#null<null>']));
     });
 
     test('User() without `new`', () async {
-      var out = await _runPrints('dart', r'''
+      var out = await _runPrints(
+        'dart',
+        r'''
         class User {
           int id = 7;
           String name = "bob";
@@ -51,32 +58,50 @@ void main() {
         class Main {
           void run() { print(User()); }
         }
-      ''', 'Main', 'run');
+      ''',
+        'Main',
+        'run',
+      );
       expect(out, equals(['#7<bob>']));
     });
 
-    test('class without toString() prints the default representation', () async {
-      var out = await _runPrints('dart', r'''
+    test(
+      'class without toString() prints the default representation',
+      () async {
+        var out = await _runPrints(
+          'dart',
+          r'''
         class User { int id = 7; }
         class Main { void run() { print(new User()); } }
-      ''', 'Main', 'run');
-      expect(out.single, contains('User{'));
-    });
+      ''',
+          'Main',
+          'run',
+        );
+        expect(out.single, contains('User{'));
+      },
+    );
 
     test('`new`-prefixed identifiers stay identifiers', () async {
-      var out = await _runPrints('dart', r'''
+      var out = await _runPrints(
+        'dart',
+        r'''
         class Main {
           void run() {
             var newValue = 5;
             print(newValue);
           }
         }
-      ''', 'Main', 'run');
+      ''',
+        'Main',
+        'run',
+      );
       expect(out, equals(['5']));
     });
 
     test('declared constructor still works with `new`', () async {
-      var out = await _runPrints('dart', r'''
+      var out = await _runPrints(
+        'dart',
+        r'''
         class Point {
           int x;
           int y;
@@ -86,16 +111,21 @@ void main() {
         class Main {
           void run() { print(new Point(3, 4)); }
         }
-      ''', 'Main', 'run');
+      ''',
+        'Main',
+        'run',
+      );
       expect(out, equals(['(3,4)']));
     });
 
     test('instantiate from a top-level function', () async {
       var vm = ApolloVM();
-      await vm.loadCodeUnit(SourceCodeUnit('dart', r'''
+      await vm.loadCodeUnit(
+        SourceCodeUnit('dart', r'''
         class User { int id = 9; String toString() { return 'U$id'; } }
         void run() { print(new User()); }
-      ''', id: 'test'));
+      ''', id: 'test'),
+      );
       var runner = vm.createRunner('dart')!;
       var out = <String>[];
       runner.externalPrintFunction = (o) => out.add('$o');
@@ -106,7 +136,9 @@ void main() {
 
   group('Java: instantiation + toString()', () {
     test('new User() — default constructor + user toString()', () async {
-      var out = await _runPrints('java11', r'''
+      var out = await _runPrints(
+        'java11',
+        r'''
         class User {
           int id = 7;
           String name = "bob";
@@ -118,19 +150,27 @@ void main() {
             print(user);
           }
         }
-      ''', 'Main', 'run');
+      ''',
+        'Main',
+        'run',
+      );
       expect(out, equals(['#7<bob>']));
     });
 
     test('`new`-prefixed identifiers stay identifiers', () async {
-      var out = await _runPrints('java11', r'''
+      var out = await _runPrints(
+        'java11',
+        r'''
         class Main {
           void run() {
             int newValue = 5;
             print(newValue);
           }
         }
-      ''', 'Main', 'run');
+      ''',
+        'Main',
+        'run',
+      );
       expect(out, equals(['5']));
     });
   });

--- a/test/apollovm_instantiation_test.dart
+++ b/test/apollovm_instantiation_test.dart
@@ -1,0 +1,137 @@
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Loads [code], runs [className].[methodName] and returns the captured `print`
+/// output (as text).
+Future<List<String>> _runPrints(
+  String language,
+  String code,
+  String className,
+  String methodName,
+) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit(language, code, id: 'test'));
+  expect(ok, isTrue, reason: 'Failed to load $language source');
+
+  var runner = vm.createRunner(language)!;
+  var out = <String>[];
+  runner.externalPrintFunction = (o) => out.add('$o');
+  await runner.executeClassMethod('', className, methodName);
+  return out;
+}
+
+void main() {
+  group('Dart: instantiation + toString()', () {
+    test('new User() — default constructor + user toString()', () async {
+      var out = await _runPrints('dart', r'''
+        class User {
+          int id;
+          String name;
+          String toString() { return '#$id<$name>'; }
+        }
+        class Main {
+          void run() {
+            var user = new User();
+            print(user);
+          }
+        }
+      ''', 'Main', 'run');
+      expect(out, equals(['#null<null>']));
+    });
+
+    test('User() without `new`', () async {
+      var out = await _runPrints('dart', r'''
+        class User {
+          int id = 7;
+          String name = "bob";
+          String toString() { return '#$id<$name>'; }
+        }
+        class Main {
+          void run() { print(User()); }
+        }
+      ''', 'Main', 'run');
+      expect(out, equals(['#7<bob>']));
+    });
+
+    test('class without toString() prints the default representation', () async {
+      var out = await _runPrints('dart', r'''
+        class User { int id = 7; }
+        class Main { void run() { print(new User()); } }
+      ''', 'Main', 'run');
+      expect(out.single, contains('User{'));
+    });
+
+    test('`new`-prefixed identifiers stay identifiers', () async {
+      var out = await _runPrints('dart', r'''
+        class Main {
+          void run() {
+            var newValue = 5;
+            print(newValue);
+          }
+        }
+      ''', 'Main', 'run');
+      expect(out, equals(['5']));
+    });
+
+    test('declared constructor still works with `new`', () async {
+      var out = await _runPrints('dart', r'''
+        class Point {
+          int x;
+          int y;
+          Point(this.x, this.y);
+          String toString() { return '($x,$y)'; }
+        }
+        class Main {
+          void run() { print(new Point(3, 4)); }
+        }
+      ''', 'Main', 'run');
+      expect(out, equals(['(3,4)']));
+    });
+
+    test('instantiate from a top-level function', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(SourceCodeUnit('dart', r'''
+        class User { int id = 9; String toString() { return 'U$id'; } }
+        void run() { print(new User()); }
+      ''', id: 'test'));
+      var runner = vm.createRunner('dart')!;
+      var out = <String>[];
+      runner.externalPrintFunction = (o) => out.add('$o');
+      await runner.executeFunction('', 'run');
+      expect(out, equals(['U9']));
+    });
+  });
+
+  group('Java: instantiation + toString()', () {
+    test('new User() — default constructor + user toString()', () async {
+      var out = await _runPrints('java11', r'''
+        class User {
+          int id = 7;
+          String name = "bob";
+          String toString() { return "#" + id + "<" + name + ">"; }
+        }
+        class Main {
+          void run() {
+            User user = new User();
+            print(user);
+          }
+        }
+      ''', 'Main', 'run');
+      expect(out, equals(['#7<bob>']));
+    });
+
+    test('`new`-prefixed identifiers stay identifiers', () async {
+      var out = await _runPrints('java11', r'''
+        class Main {
+          void run() {
+            int newValue = 5;
+            print(newValue);
+          }
+        }
+      ''', 'Main', 'run');
+      expect(out, equals(['5']));
+    });
+  });
+}

--- a/test/apollovm_object_field_test.dart
+++ b/test/apollovm_object_field_test.dart
@@ -1,0 +1,284 @@
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Loads [code], runs [className].[methodName], returns captured `print` output.
+Future<List<String>> _runPrints(
+  String language,
+  String code,
+  String className,
+  String methodName,
+) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit(language, code, id: 'test'));
+  expect(ok, isTrue, reason: 'Failed to load $language source');
+
+  var runner = vm.createRunner(language)!;
+  var out = <String>[];
+  runner.externalPrintFunction = (o) => out.add('$o');
+  await runner.executeClassMethod('', className, methodName);
+  return out;
+}
+
+/// Re-generates [language] source from parsed [code] and returns it as text.
+Future<String> _regenerate(String language, String code) async {
+  var vm = ApolloVM();
+  await vm.loadCodeUnit(SourceCodeUnit(language, code, id: 'test'));
+  var codeStorage = vm.generateAllCodeIn(language);
+  return (await codeStorage.writeAllSources()).toString();
+}
+
+void main() {
+  group('Object field assignment (write)', () {
+    test('Dart — the motivating example runs', () async {
+      // `print(user)` with no `toString()` prints the default representation;
+      // the point is the code runs (fields assigned through `user.field = …`).
+      var out = await _runPrints('dart', r'''
+        class User {
+          int id;
+          String name;
+        }
+        class App {
+          void main() {
+            var user = new User();
+            user.id = 123;
+            user.name = "Joe";
+            print(user);
+          }
+        }
+      ''', 'App', 'main');
+      expect(out.single, contains('User{'));
+    });
+
+    test('Dart — field assignment persists and supports `+=`', () async {
+      var out = await _runPrints('dart', r'''
+        class User {
+          int id;
+          String name;
+          String toString() { return 'User(#$id, $name)'; }
+        }
+        class App {
+          void main() {
+            var user = new User();
+            user.id = 123;
+            user.name = "Joe";
+            print(user);
+            user.id += 7;
+            print(user.id);
+          }
+        }
+      ''', 'App', 'main');
+      expect(out, equals(['User(#123, Joe)', '130']));
+    });
+
+    test('Java — field assignment + read-back + `+=`', () async {
+      var out = await _runPrints('java11', r'''
+        class User {
+          int id;
+          String name;
+          String toString() { return "User(#" + id + ", " + name + ")"; }
+        }
+        class App {
+          void main() {
+            User user = new User();
+            user.id = 123;
+            user.name = "Joe";
+            print(user);
+            user.id += 7;
+            print(user.id);
+          }
+        }
+      ''', 'App', 'main');
+      expect(out, equals(['User(#123, Joe)', '130']));
+    });
+
+    test('Kotlin — field assignment + read', () async {
+      var out = await _runPrints('kotlin', r'''
+        class User { var id: Int = 0 }
+        class App { fun main() { var u = User(); u.id = 5; u.id += 6; print(u.id); } }
+      ''', 'App', 'main');
+      expect(out, equals(['11']));
+    });
+  });
+
+  group('Object field access (read)', () {
+    test('Dart — read obj.field and this.field', () async {
+      var out = await _runPrints('dart', r'''
+        class User {
+          int id = 9;
+          String name = "bob";
+          int self() { return this.id; }
+        }
+        class App {
+          void main() {
+            var u = new User();
+            print(u.id);
+            print(u.name);
+            print(u.self());
+          }
+        }
+      ''', 'App', 'main');
+      expect(out, equals(['9', 'bob', '9']));
+    });
+
+    test('Java — read obj.field and this.field', () async {
+      var out = await _runPrints('java11', r'''
+        class User {
+          int id = 9;
+          String name = "bob";
+          int self() { return this.id; }
+        }
+        class App {
+          void main() {
+            User u = new User();
+            print(u.id);
+            print(u.name);
+            print(u.self());
+          }
+        }
+      ''', 'App', 'main');
+      expect(out, equals(['9', 'bob', '9']));
+    });
+
+    test('Kotlin — read obj.field', () async {
+      var out = await _runPrints('kotlin', r'''
+        class User { var id: Int = 9 }
+        class App { fun main() { var u = User(); print(u.id); } }
+      ''', 'App', 'main');
+      expect(out, equals(['9']));
+    });
+  });
+
+  group('Source generation round-trip', () {
+    test('Dart emits obj.field assignment', () async {
+      var src = await _regenerate('dart', r'''
+        class User { int id; }
+        class App { void main() { var u = new User(); u.id = 1; u.id += 2; print(u.id); } }
+      ''');
+      expect(src, contains('u.id = 1;'));
+      expect(src, contains('u.id += 2;'));
+    });
+
+    test('Java emits obj.field assignment', () async {
+      var src = await _regenerate('java11', r'''
+        class User { int id; }
+        class App { void main() { User u = new User(); u.id = 1; u.id += 2; print(u.id); } }
+      ''');
+      expect(src, contains('u.id = 1;'));
+      expect(src, contains('u.id += 2;'));
+    });
+  });
+
+  group('Constructors that set fields', () {
+    test('Dart — `this.` parameters', () async {
+      var out = await _runPrints('dart', r'''
+        class User {
+          int id;
+          String name;
+          User(this.id, this.name);
+          String toString() { return 'U#$id<$name>'; }
+        }
+        class App { void main() { print(new User(123, "Joe")); } }
+      ''', 'App', 'main');
+      expect(out, equals(['U#123<Joe>']));
+    });
+
+    test('Dart — `this.` parameters from a top-level main', () async {
+      var vm = ApolloVM();
+      var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', r'''
+        class User {
+          int id;
+          String name;
+
+          User(this.id, this.name);
+
+          String toString() {
+            return 'User#$id<$name>';
+          }
+        }
+
+        void main() {
+          var user = new User(123, 'Joe');
+          print(user);
+        }
+      ''', id: 'test'));
+      expect(ok, isTrue);
+      var runner = vm.createRunner('dart')!;
+      var out = <String>[];
+      runner.externalPrintFunction = (o) => out.add('$o');
+      await runner.executeFunction('', 'main');
+      expect(out, equals(['User#123<Joe>']));
+    });
+
+    test('Dart — arrow (expression-bodied) methods', () async {
+      var vm = ApolloVM();
+      var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', r'''
+        class User {
+          int id;
+          String name;
+
+          User(this.id, this.name);
+
+          String toString() => 'User#$id<$name>';
+        }
+
+        int triple(int a) => a * 3;
+
+        void main() {
+          var user = new User(123, 'Joe');
+          print(user);
+          print(triple(4));
+        }
+      ''', id: 'test'));
+      expect(ok, isTrue);
+      var runner = vm.createRunner('dart')!;
+      var out = <String>[];
+      runner.externalPrintFunction = (o) => out.add('$o');
+      await runner.executeFunction('', 'main');
+      expect(out, equals(['User#123<Joe>', '12']));
+    });
+
+    test('Dart — constructor body assigns fields', () async {
+      var out = await _runPrints('dart', r'''
+        class User {
+          int id;
+          String name;
+          User(int i, String n) { this.id = i; this.name = n; }
+          String toString() { return 'U#$id<$name>'; }
+        }
+        class App { void main() { print(new User(123, "Joe")); } }
+      ''', 'App', 'main');
+      expect(out, equals(['U#123<Joe>']));
+    });
+
+    test('Dart — empty-param constructor with body', () async {
+      var out = await _runPrints('dart', r'''
+        class User { int id; String toString() { return 'id=$id'; } User() { this.id = 99; } }
+        class App { void main() { print(new User()); } }
+      ''', 'App', 'main');
+      expect(out, equals(['id=99']));
+    });
+
+    test('Java — constructor body with param/field shadowing', () async {
+      var out = await _runPrints('java11', r'''
+        class User {
+          int id;
+          String name;
+          User(int id, String name) { this.id = id; this.name = name; }
+          String toString() { return "U#" + id + "<" + name + ">"; }
+        }
+        class App { void main() { print(new User(123, "Joe")); } }
+      ''', 'App', 'main');
+      expect(out, equals(['U#123<Joe>']));
+    });
+
+    test('Java — empty-param constructor with body', () async {
+      var out = await _runPrints('java11', r'''
+        class User { int id; String toString() { return "id=" + id; } User() { this.id = 99; } }
+        class App { void main() { print(new User()); } }
+      ''', 'App', 'main');
+      expect(out, equals(['id=99']));
+    });
+  });
+}

--- a/test/apollovm_object_field_test.dart
+++ b/test/apollovm_object_field_test.dart
@@ -34,7 +34,9 @@ void main() {
     test('Dart — the motivating example runs', () async {
       // `print(user)` with no `toString()` prints the default representation;
       // the point is the code runs (fields assigned through `user.field = …`).
-      var out = await _runPrints('dart', r'''
+      var out = await _runPrints(
+        'dart',
+        r'''
         class User {
           int id;
           String name;
@@ -47,12 +49,17 @@ void main() {
             print(user);
           }
         }
-      ''', 'App', 'main');
+      ''',
+        'App',
+        'main',
+      );
       expect(out.single, contains('User{'));
     });
 
     test('Dart — field assignment persists and supports `+=`', () async {
-      var out = await _runPrints('dart', r'''
+      var out = await _runPrints(
+        'dart',
+        r'''
         class User {
           int id;
           String name;
@@ -68,12 +75,17 @@ void main() {
             print(user.id);
           }
         }
-      ''', 'App', 'main');
+      ''',
+        'App',
+        'main',
+      );
       expect(out, equals(['User(#123, Joe)', '130']));
     });
 
     test('Java — field assignment + read-back + `+=`', () async {
-      var out = await _runPrints('java11', r'''
+      var out = await _runPrints(
+        'java11',
+        r'''
         class User {
           int id;
           String name;
@@ -89,22 +101,32 @@ void main() {
             print(user.id);
           }
         }
-      ''', 'App', 'main');
+      ''',
+        'App',
+        'main',
+      );
       expect(out, equals(['User(#123, Joe)', '130']));
     });
 
     test('Kotlin — field assignment + read', () async {
-      var out = await _runPrints('kotlin', r'''
+      var out = await _runPrints(
+        'kotlin',
+        r'''
         class User { var id: Int = 0 }
         class App { fun main() { var u = User(); u.id = 5; u.id += 6; print(u.id); } }
-      ''', 'App', 'main');
+      ''',
+        'App',
+        'main',
+      );
       expect(out, equals(['11']));
     });
   });
 
   group('Object field access (read)', () {
     test('Dart — read obj.field and this.field', () async {
-      var out = await _runPrints('dart', r'''
+      var out = await _runPrints(
+        'dart',
+        r'''
         class User {
           int id = 9;
           String name = "bob";
@@ -118,12 +140,17 @@ void main() {
             print(u.self());
           }
         }
-      ''', 'App', 'main');
+      ''',
+        'App',
+        'main',
+      );
       expect(out, equals(['9', 'bob', '9']));
     });
 
     test('Java — read obj.field and this.field', () async {
-      var out = await _runPrints('java11', r'''
+      var out = await _runPrints(
+        'java11',
+        r'''
         class User {
           int id = 9;
           String name = "bob";
@@ -137,15 +164,23 @@ void main() {
             print(u.self());
           }
         }
-      ''', 'App', 'main');
+      ''',
+        'App',
+        'main',
+      );
       expect(out, equals(['9', 'bob', '9']));
     });
 
     test('Kotlin — read obj.field', () async {
-      var out = await _runPrints('kotlin', r'''
+      var out = await _runPrints(
+        'kotlin',
+        r'''
         class User { var id: Int = 9 }
         class App { fun main() { var u = User(); print(u.id); } }
-      ''', 'App', 'main');
+      ''',
+        'App',
+        'main',
+      );
       expect(out, equals(['9']));
     });
   });
@@ -172,7 +207,9 @@ void main() {
 
   group('Constructors that set fields', () {
     test('Dart — `this.` parameters', () async {
-      var out = await _runPrints('dart', r'''
+      var out = await _runPrints(
+        'dart',
+        r'''
         class User {
           int id;
           String name;
@@ -180,13 +217,17 @@ void main() {
           String toString() { return 'U#$id<$name>'; }
         }
         class App { void main() { print(new User(123, "Joe")); } }
-      ''', 'App', 'main');
+      ''',
+        'App',
+        'main',
+      );
       expect(out, equals(['U#123<Joe>']));
     });
 
     test('Dart — `this.` parameters from a top-level main', () async {
       var vm = ApolloVM();
-      var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', r'''
+      var ok = await vm.loadCodeUnit(
+        SourceCodeUnit('dart', r'''
         class User {
           int id;
           String name;
@@ -202,7 +243,8 @@ void main() {
           var user = new User(123, 'Joe');
           print(user);
         }
-      ''', id: 'test'));
+      ''', id: 'test'),
+      );
       expect(ok, isTrue);
       var runner = vm.createRunner('dart')!;
       var out = <String>[];
@@ -213,7 +255,8 @@ void main() {
 
     test('Dart — arrow (expression-bodied) methods', () async {
       var vm = ApolloVM();
-      var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', r'''
+      var ok = await vm.loadCodeUnit(
+        SourceCodeUnit('dart', r'''
         class User {
           int id;
           String name;
@@ -230,7 +273,8 @@ void main() {
           print(user);
           print(triple(4));
         }
-      ''', id: 'test'));
+      ''', id: 'test'),
+      );
       expect(ok, isTrue);
       var runner = vm.createRunner('dart')!;
       var out = <String>[];
@@ -240,7 +284,9 @@ void main() {
     });
 
     test('Dart — constructor body assigns fields', () async {
-      var out = await _runPrints('dart', r'''
+      var out = await _runPrints(
+        'dart',
+        r'''
         class User {
           int id;
           String name;
@@ -248,20 +294,30 @@ void main() {
           String toString() { return 'U#$id<$name>'; }
         }
         class App { void main() { print(new User(123, "Joe")); } }
-      ''', 'App', 'main');
+      ''',
+        'App',
+        'main',
+      );
       expect(out, equals(['U#123<Joe>']));
     });
 
     test('Dart — empty-param constructor with body', () async {
-      var out = await _runPrints('dart', r'''
+      var out = await _runPrints(
+        'dart',
+        r'''
         class User { int id; String toString() { return 'id=$id'; } User() { this.id = 99; } }
         class App { void main() { print(new User()); } }
-      ''', 'App', 'main');
+      ''',
+        'App',
+        'main',
+      );
       expect(out, equals(['id=99']));
     });
 
     test('Java — constructor body with param/field shadowing', () async {
-      var out = await _runPrints('java11', r'''
+      var out = await _runPrints(
+        'java11',
+        r'''
         class User {
           int id;
           String name;
@@ -269,15 +325,23 @@ void main() {
           String toString() { return "U#" + id + "<" + name + ">"; }
         }
         class App { void main() { print(new User(123, "Joe")); } }
-      ''', 'App', 'main');
+      ''',
+        'App',
+        'main',
+      );
       expect(out, equals(['U#123<Joe>']));
     });
 
     test('Java — empty-param constructor with body', () async {
-      var out = await _runPrints('java11', r'''
+      var out = await _runPrints(
+        'java11',
+        r'''
         class User { int id; String toString() { return "id=" + id; } User() { this.id = 99; } }
         class App { void main() { print(new User()); } }
-      ''', 'App', 'main');
+      ''',
+        'App',
+        'main',
+      );
       expect(out, equals(['id=99']));
     });
   });

--- a/test/apollovm_wasm_class_test.dart
+++ b/test/apollovm_wasm_class_test.dart
@@ -1,0 +1,294 @@
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Runs [functionName] via the AST interpreter AND the compiled+executed Wasm
+/// module and asserts both return [expectedReturn]. Exercises in-code class
+/// instantiation, field access and instance methods on both paths.
+Future<void> _testClassReturn(
+  String code,
+  String functionName,
+  List args,
+  Object? expectedReturn,
+) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', code, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source");
+
+  // 1) AST interpreter.
+  var astRunner = vm.createRunner('dart')!;
+  var astRet = await astRunner.executeFunction(
+    '',
+    functionName,
+    positionalParameters: args,
+  );
+  expect(
+    astRet.getValueNoContext(),
+    expectedReturn,
+    reason: 'interpreter return',
+  );
+
+  // 2) Compile to Wasm.
+  var storageWasm = vm.generateAllIn<BytesOutput>('wasm');
+  var wasmModules = await storageWasm.allEntries();
+  BytesOutput? compiled;
+  for (var ns in wasmModules.entries) {
+    for (var m in ns.value.entries) {
+      compiled ??= m.value;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var rt = WasmRuntime()..ensureBooted();
+  if (!rt.isSupported) {
+    fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+  }
+
+  // 3) Load + run the compiled Wasm.
+  var vmWasm = ApolloVM();
+  await vmWasm.loadCodeUnit(
+    BinaryCodeUnit('wasm', compiled!.output(), id: 'test.wasm', namespace: ''),
+  );
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  var wasmRet = await wasmRunner.executeFunction(
+    '',
+    functionName,
+    positionalParameters: args,
+  );
+  expect(wasmRet.getValueNoContext(), expectedReturn, reason: 'Wasm return');
+}
+
+/// Runs [functionName] via the AST interpreter AND the compiled+executed Wasm
+/// module and asserts both produce [expectedText] as `print` output (compared
+/// as text, since Wasm always stringifies).
+Future<void> _testClassPrint(
+  String code,
+  String functionName,
+  List args,
+  List<String> expectedText,
+) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', code, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source");
+
+  var astRunner = vm.createRunner('dart')!;
+  var astOut = [];
+  astRunner.externalPrintFunction = (o) => astOut.add('$o');
+  await astRunner.executeFunction('', functionName, positionalParameters: args);
+  expect(astOut, equals(expectedText), reason: 'interpreter print output');
+
+  var storageWasm = vm.generateAllIn<BytesOutput>('wasm');
+  var wasmModules = await storageWasm.allEntries();
+  BytesOutput? compiled;
+  for (var ns in wasmModules.entries) {
+    for (var m in ns.value.entries) {
+      compiled ??= m.value;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var rt = WasmRuntime()..ensureBooted();
+  if (!rt.isSupported) {
+    fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+  }
+
+  var vmWasm = ApolloVM();
+  await vmWasm.loadCodeUnit(
+    BinaryCodeUnit('wasm', compiled!.output(), id: 'test.wasm', namespace: ''),
+  );
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  var wasmOut = [];
+  wasmRunner.externalPrintFunction = (o) => wasmOut.add('$o');
+  await wasmRunner.executeFunction('', functionName, positionalParameters: args);
+  expect(wasmOut, equals(expectedText), reason: 'Wasm print output');
+}
+
+void main() {
+  group('Wasm classes: instantiation + methods', () {
+    test('constructor + instance method', () async {
+      await _testClassReturn(
+        '''
+        class Point {
+          int x;
+          int y;
+          Point(this.x, this.y);
+          int sum() { return x + y; }
+        }
+        int run() {
+          var p = Point(3, 4);
+          return p.sum();
+        }
+        ''',
+        'run',
+        [],
+        7,
+      );
+    });
+
+    test('field initializer (int y = 10)', () async {
+      await _testClassReturn(
+        '''
+        class C {
+          int x;
+          int y = 10;
+          C(this.x);
+          int sum() { return x + y; }
+        }
+        int run() { var c = C(5); return c.sum(); }
+        ''',
+        'run',
+        [],
+        15,
+      );
+    });
+
+    test('external field read (p.x)', () async {
+      await _testClassReturn(
+        '''
+        class C { int x; int y; C(this.x, this.y); }
+        int run() { var c = C(3, 4); return c.x + c.y; }
+        ''',
+        'run',
+        [],
+        7,
+      );
+    });
+
+    test('bare field assignment inside a method', () async {
+      await _testClassReturn(
+        '''
+        class Counter {
+          int n;
+          Counter(this.n);
+          int bump() { n = n + 1; return n; }
+        }
+        int run() { var c = Counter(41); return c.bump(); }
+        ''',
+        'run',
+        [],
+        42,
+      );
+    });
+
+    test('method with multiple arguments', () async {
+      await _testClassReturn(
+        '''
+        class C {
+          int y;
+          C(this.y);
+          int calc(int a, int b) { return y * a + b; }
+        }
+        int run() { var c = C(2); return c.calc(10, 3); }
+        ''',
+        'run',
+        [],
+        23,
+      );
+    });
+
+    test('double field + method', () async {
+      await _testClassReturn(
+        '''
+        class C { double d; C(this.d); double half() { return d / 2.0; } }
+        double run() { var c = C(7.0); return c.half(); }
+        ''',
+        'run',
+        [],
+        3.5,
+      );
+    });
+
+    test('multiple instances are independent', () async {
+      await _testClassReturn(
+        '''
+        class Box { int v; Box(this.v); int get() { return v; } }
+        int run() {
+          var a = Box(10);
+          var b = Box(20);
+          return a.get() + b.get();
+        }
+        ''',
+        'run',
+        [],
+        30,
+      );
+    });
+
+    test('method calling another method', () async {
+      await _testClassReturn(
+        '''
+        class C {
+          int x;
+          C(this.x);
+          int doubled() { return x * 2; }
+          int quadrupled() { return doubled() + doubled(); }
+        }
+        int run() { var c = C(5); return c.quadrupled(); }
+        ''',
+        'run',
+        [],
+        20,
+      );
+    });
+  });
+
+  group('Wasm classes: print + fields', () {
+    test('print a bool field', () async {
+      await _testClassPrint(
+        '''
+        class C { bool flag; C(this.flag); void show() { print(flag); } }
+        void run() { var c = C(true); c.show(); }
+        ''',
+        'run',
+        [],
+        ['true'],
+      );
+    });
+
+    test('print an int field', () async {
+      await _testClassPrint(
+        '''
+        class C { int x; C(this.x); void show() { print(x); } }
+        void run() { var c = C(42); c.show(); }
+        ''',
+        'run',
+        [],
+        ['42'],
+      );
+    });
+
+    test('interpolate fields', () async {
+      await _testClassPrint(
+        '''
+        class Point {
+          int x;
+          int y;
+          Point(this.x, this.y);
+          void describe() { print("(\$x, \$y)"); }
+        }
+        void run() { var p = Point(3, 4); p.describe(); }
+        ''',
+        'run',
+        [],
+        ['(3, 4)'],
+      );
+    });
+
+    test('String field concatenation', () async {
+      await _testClassPrint(
+        '''
+        class Greeter {
+          String name;
+          Greeter(this.name);
+          void hi() { print("Hi " + name); }
+        }
+        void run() { var g = Greeter("Bob"); g.hi(); }
+        ''',
+        'run',
+        [],
+        ['Hi Bob'],
+      );
+    });
+  });
+}

--- a/test/apollovm_wasm_class_test.dart
+++ b/test/apollovm_wasm_class_test.dart
@@ -100,7 +100,11 @@ Future<void> _testClassPrint(
   var wasmRunner = vmWasm.createRunner('wasm')!;
   var wasmOut = [];
   wasmRunner.externalPrintFunction = (o) => wasmOut.add('$o');
-  await wasmRunner.executeFunction('', functionName, positionalParameters: args);
+  await wasmRunner.executeFunction(
+    '',
+    functionName,
+    positionalParameters: args,
+  );
   expect(wasmOut, equals(expectedText), reason: 'Wasm print output');
 }
 

--- a/test/apollovm_wasm_object_field_test.dart
+++ b/test/apollovm_wasm_object_field_test.dart
@@ -53,7 +53,8 @@ Future<void> _testWasmPrints(
 void main() {
   group('Wasm: object fields + default constructor + toString', () {
     test('the motivating program', () async {
-      await _testWasmPrints(r'''
+      await _testWasmPrints(
+        r'''
         class User {
           int id;
           String name;
@@ -67,11 +68,15 @@ void main() {
           var id2 = user.id * 1000;
           print(id2);
         }
-      ''', 'main', ['User#123<Joe>', '123000']);
+      ''',
+        'main',
+        ['User#123<Joe>', '123000'],
+      );
     });
 
     test('default constructor + external field read/write', () async {
-      await _testWasmPrints(r'''
+      await _testWasmPrints(
+        r'''
         class Point { int x; int y; }
         void main() {
           var p = new Point();
@@ -79,11 +84,15 @@ void main() {
           p.y = 4;
           print(p.x + p.y);
         }
-      ''', 'main', ['7']);
+      ''',
+        'main',
+        ['7'],
+      );
     });
 
     test('compound assignment on a field', () async {
-      await _testWasmPrints(r'''
+      await _testWasmPrints(
+        r'''
         class Counter { int n; }
         void main() {
           var c = new Counter();
@@ -91,11 +100,15 @@ void main() {
           c.n += 5;
           print(c.n);
         }
-      ''', 'main', ['15']);
+      ''',
+        'main',
+        ['15'],
+      );
     });
 
     test('constructor with `this.` parameters', () async {
-      await _testWasmPrints(r'''
+      await _testWasmPrints(
+        r'''
         class Point {
           int x;
           int y;
@@ -107,11 +120,15 @@ void main() {
           print(p);
           print(p.x * p.y);
         }
-      ''', 'main', ['(3,4)', '12']);
+      ''',
+        'main',
+        ['(3,4)', '12'],
+      );
     });
 
     test('constructor body assigns fields', () async {
-      await _testWasmPrints(r'''
+      await _testWasmPrints(
+        r'''
         class Box {
           int v;
           Box(int initial) { this.v = initial * 2; }
@@ -121,11 +138,15 @@ void main() {
           var b = new Box(21);
           print(b);
         }
-      ''', 'main', ['Box(42)']);
+      ''',
+        'main',
+        ['Box(42)'],
+      );
     });
 
     test('arrow (expression-bodied) toString + method', () async {
-      await _testWasmPrints(r'''
+      await _testWasmPrints(
+        r'''
         class User {
           int id;
           String name;
@@ -136,11 +157,15 @@ void main() {
           var user = new User(123, 'Joe');
           print(user);
         }
-      ''', 'main', ['User#123<Joe>']);
+      ''',
+        'main',
+        ['User#123<Joe>'],
+      );
     });
 
     test('String field through toString', () async {
-      await _testWasmPrints(r'''
+      await _testWasmPrints(
+        r'''
         class Greeter {
           String name;
           String toString() { return 'Hi ' + name; }
@@ -150,7 +175,10 @@ void main() {
           g.name = 'Bob';
           print(g);
         }
-      ''', 'main', ['Hi Bob']);
+      ''',
+        'main',
+        ['Hi Bob'],
+      );
     });
   });
 }

--- a/test/apollovm_wasm_object_field_test.dart
+++ b/test/apollovm_wasm_object_field_test.dart
@@ -1,0 +1,156 @@
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Compiles [code] to Wasm, runs top-level [functionName] on BOTH the AST
+/// interpreter and the compiled Wasm module, and asserts both produce
+/// [expectedPrints] (compared as text).
+Future<void> _testWasmPrints(
+  String code,
+  String functionName,
+  List<String> expectedPrints,
+) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', code, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source");
+
+  // 1) AST interpreter.
+  var astRunner = vm.createRunner('dart')!;
+  var astOut = <String>[];
+  astRunner.externalPrintFunction = (o) => astOut.add('$o');
+  await astRunner.executeFunction('', functionName);
+  expect(astOut, equals(expectedPrints), reason: 'interpreter print output');
+
+  // 2) Compile to Wasm.
+  var storageWasm = vm.generateAllIn<BytesOutput>('wasm');
+  var wasmModules = await storageWasm.allEntries();
+  BytesOutput? compiled;
+  for (var ns in wasmModules.entries) {
+    for (var m in ns.value.entries) {
+      compiled ??= m.value;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var rt = WasmRuntime()..ensureBooted();
+  if (!rt.isSupported) {
+    fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+  }
+
+  // 3) Run the compiled Wasm.
+  var vmWasm = ApolloVM();
+  await vmWasm.loadCodeUnit(
+    BinaryCodeUnit('wasm', compiled!.output(), id: 'test.wasm', namespace: ''),
+  );
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  var wasmOut = <String>[];
+  wasmRunner.externalPrintFunction = (o) => wasmOut.add('$o');
+  await wasmRunner.executeFunction('', functionName);
+  expect(wasmOut, equals(expectedPrints), reason: 'Wasm print output');
+}
+
+void main() {
+  group('Wasm: object fields + default constructor + toString', () {
+    test('the motivating program', () async {
+      await _testWasmPrints(r'''
+        class User {
+          int id;
+          String name;
+          String toString() { return 'User#$id<$name>'; }
+        }
+        void main() {
+          var user = new User();
+          user.id = 123;
+          user.name = 'Joe';
+          print(user);
+          var id2 = user.id * 1000;
+          print(id2);
+        }
+      ''', 'main', ['User#123<Joe>', '123000']);
+    });
+
+    test('default constructor + external field read/write', () async {
+      await _testWasmPrints(r'''
+        class Point { int x; int y; }
+        void main() {
+          var p = new Point();
+          p.x = 3;
+          p.y = 4;
+          print(p.x + p.y);
+        }
+      ''', 'main', ['7']);
+    });
+
+    test('compound assignment on a field', () async {
+      await _testWasmPrints(r'''
+        class Counter { int n; }
+        void main() {
+          var c = new Counter();
+          c.n = 10;
+          c.n += 5;
+          print(c.n);
+        }
+      ''', 'main', ['15']);
+    });
+
+    test('constructor with `this.` parameters', () async {
+      await _testWasmPrints(r'''
+        class Point {
+          int x;
+          int y;
+          Point(this.x, this.y);
+          String toString() { return '($x,$y)'; }
+        }
+        void main() {
+          var p = new Point(3, 4);
+          print(p);
+          print(p.x * p.y);
+        }
+      ''', 'main', ['(3,4)', '12']);
+    });
+
+    test('constructor body assigns fields', () async {
+      await _testWasmPrints(r'''
+        class Box {
+          int v;
+          Box(int initial) { this.v = initial * 2; }
+          String toString() { return 'Box($v)'; }
+        }
+        void main() {
+          var b = new Box(21);
+          print(b);
+        }
+      ''', 'main', ['Box(42)']);
+    });
+
+    test('arrow (expression-bodied) toString + method', () async {
+      await _testWasmPrints(r'''
+        class User {
+          int id;
+          String name;
+          User(this.id, this.name);
+          String toString() => 'User#$id<$name>';
+        }
+        void main() {
+          var user = new User(123, 'Joe');
+          print(user);
+        }
+      ''', 'main', ['User#123<Joe>']);
+    });
+
+    test('String field through toString', () async {
+      await _testWasmPrints(r'''
+        class Greeter {
+          String name;
+          String toString() { return 'Hi ' + name; }
+        }
+        void main() {
+          var g = new Greeter();
+          g.name = 'Bob';
+          print(g);
+        }
+      ''', 'main', ['Hi Bob']);
+    });
+  });
+}

--- a/test/apollovm_wasm_p2_test.dart
+++ b/test/apollovm_wasm_p2_test.dart
@@ -104,7 +104,11 @@ Future<void> _testWasmPrintText(
   var wasmRunner = vmWasm.createRunner('wasm')!;
   var wasmOut = [];
   wasmRunner.externalPrintFunction = (o) => wasmOut.add('$o');
-  await wasmRunner.executeFunction('', functionName, positionalParameters: args);
+  await wasmRunner.executeFunction(
+    '',
+    functionName,
+    positionalParameters: args,
+  );
   expect(wasmOut, equals(expectedText), reason: 'Wasm print output');
 }
 
@@ -571,12 +575,7 @@ void main() {
 
   group('Wasm P2: print(any type)', () {
     test('print int literal', () async {
-      await _testWasmPrintText(
-        'void run() { print(42); }',
-        'run',
-        [],
-        ['42'],
-      );
+      await _testWasmPrintText('void run() { print(42); }', 'run', [], ['42']);
     });
 
     test('print int parameter', () async {
@@ -589,12 +588,9 @@ void main() {
     });
 
     test('print double literal', () async {
-      await _testWasmPrintText(
-        'void run() { print(3.14); }',
-        'run',
-        [],
-        ['3.14'],
-      );
+      await _testWasmPrintText('void run() { print(3.14); }', 'run', [], [
+        '3.14',
+      ]);
     });
 
     test('print bool literals', () async {
@@ -616,12 +612,9 @@ void main() {
     });
 
     test('print null', () async {
-      await _testWasmPrintText(
-        'void run() { print(null); }',
-        'run',
-        [],
-        ['null'],
-      );
+      await _testWasmPrintText('void run() { print(null); }', 'run', [], [
+        'null',
+      ]);
     });
 
     test('print expression result (int)', () async {

--- a/test/apollovm_wasm_p2_test.dart
+++ b/test/apollovm_wasm_p2_test.dart
@@ -57,6 +57,57 @@ Future<void> _testWasmPrint(
   expect(wasmOut, equals(expectedOutput), reason: 'Wasm print output');
 }
 
+/// Like [_testWasmPrint], but for non-String values: the AST interpreter
+/// receives the raw object (e.g. the `int` 42) while the Wasm host always
+/// receives the stringified form, so both are compared as text against
+/// [expectedText].
+Future<void> _testWasmPrintText(
+  String code,
+  String functionName,
+  List args,
+  List<String> expectedText,
+) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', code, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source");
+
+  // 1) AST interpreter (raw objects -> text).
+  var astRunner = vm.createRunner('dart')!;
+  var astOut = [];
+  astRunner.externalPrintFunction = (o) => astOut.add('$o');
+  await astRunner.executeFunction('', functionName, positionalParameters: args);
+  expect(astOut, equals(expectedText), reason: 'interpreter print output');
+
+  // 2) Compile to Wasm.
+  var storageWasm = vm.generateAllIn<BytesOutput>('wasm');
+  var wasmModules = await storageWasm.allEntries();
+  BytesOutput? compiled;
+  for (var ns in wasmModules.entries) {
+    for (var m in ns.value.entries) {
+      compiled ??= m.value;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var rt = WasmRuntime()..ensureBooted();
+  if (!rt.isSupported) {
+    fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+  }
+
+  // 3) Load + run the compiled Wasm, capturing its `print` host import.
+  var vmWasm = ApolloVM();
+  var loadOK = await vmWasm.loadCodeUnit(
+    BinaryCodeUnit('wasm', compiled!.output(), id: 'test.wasm', namespace: ''),
+  );
+  expect(loadOK, isTrue, reason: 'Compiled Wasm failed to load');
+
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  var wasmOut = [];
+  wasmRunner.externalPrintFunction = (o) => wasmOut.add('$o');
+  await wasmRunner.executeFunction('', functionName, positionalParameters: args);
+  expect(wasmOut, equals(expectedText), reason: 'Wasm print output');
+}
+
 /// Runs [functionName] via the AST interpreter AND the compiled+executed Wasm
 /// module and asserts both return [expectedReturn].
 Future<void> _testWasmReturn(
@@ -514,6 +565,80 @@ void main() {
         'repeat',
         [200],
         '0123456789' * 200,
+      );
+    });
+  });
+
+  group('Wasm P2: print(any type)', () {
+    test('print int literal', () async {
+      await _testWasmPrintText(
+        'void run() { print(42); }',
+        'run',
+        [],
+        ['42'],
+      );
+    });
+
+    test('print int parameter', () async {
+      await _testWasmPrintText(
+        'void show(int n) { print(n); }',
+        'show',
+        [7],
+        ['7'],
+      );
+    });
+
+    test('print double literal', () async {
+      await _testWasmPrintText(
+        'void run() { print(3.14); }',
+        'run',
+        [],
+        ['3.14'],
+      );
+    });
+
+    test('print bool literals', () async {
+      await _testWasmPrintText(
+        'void run() { print(true); print(false); }',
+        'run',
+        [],
+        ['true', 'false'],
+      );
+    });
+
+    test('print bool parameter', () async {
+      await _testWasmPrintText(
+        'void show(bool b) { print(b); }',
+        'show',
+        [true],
+        ['true'],
+      );
+    });
+
+    test('print null', () async {
+      await _testWasmPrintText(
+        'void run() { print(null); }',
+        'run',
+        [],
+        ['null'],
+      );
+    });
+
+    test('print expression result (int)', () async {
+      await _testWasmPrintText(
+        'void run() { int a = 20; int b = 22; print(a + b); }',
+        'run',
+        [],
+        ['42'],
+      );
+    });
+
+    test('interpolate bool', () async {
+      await _testWasmPrintText(
+        r'void run() { bool b = true; print("flag: $b"); }',
+        'run',
+        [],
+        ['flag: true'],
       );
     });
   });


### PR DESCRIPTION
Release **0.1.35** — classes, object fields, constructors, and broader Wasm support, on top of the published 0.1.34.

## Wasm: `print` accepts any value
- `int` / `double` / `bool` / `String` / `null` (and string interpolation gains the same parity). The interpreter's mapped `print` accepts `null`, and `bool` arguments to public Wasm functions are marshalled to their i32 ABI value.

## Classes and instantiation (Dart, Java, Wasm)
- `new` keyword in Dart and Java (boundary-safe; Java also gets a generic `new ClassName(args)` rule).
- Implicit default (zero-arg) constructors for classes that declare none.
- Constructors that set fields: `this.field` params **and** constructor bodies (`this.field = value` / bare `field = value`), with parameter/field shadowing (`User(int id) { this.id = id; }`). Fixed empty-param constructors with a body (`User() { … }`).
- A class method can instantiate sibling classes and call top-level functions (essential for Java).
- Dart arrow (expression-bodied) functions/methods: `String toString() => '…';`.
- WebAssembly compilation of single classes: fields (`int`/`double`/`bool`/`String`/object-ref), constructors (`this.field`, initializers, default & body), instance methods, instantiation, method calls (`p.sum()` and implicit-`this`).

## Object field access on instances (read & write)
- `obj.field = value` / `this.field = value` (and compound `+=` etc.) via a new `ASTExpressionObjectSetterAssignment` node — added to Dart, Java, Kotlin, JS and TS grammars, the shared source generator, and the Wasm backend.
- `obj.field` read now supported in Java; `this.field` reads resolve to the current instance across all languages.

## `print(obj)` → user `toString()`
- Interpreter and Wasm both invoke a user-declared `toString()` (a class without one still prints the default `Class{…}`).

This makes programs like this compile and run on Wasm with interpreter parity:

```dart
class User {
  int id;
  String name;
  User(this.id, this.name);
  String toString() => 'User#$id<$name>';
}
void main() {
  var user = new User(123, 'Joe');
  print(user);
  print(user.id * 1000);
}
```

**Not included:** inheritance / interfaces / abstract / `static` members / polymorphism.

## Tests
All 814 tests pass; `dart analyze` clean. New dual-path (interpreter vs compiled Wasm) tests for classes, object fields, constructors, and arrow methods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)