### PR TITLE
Closures/lambdas, ternary, function types, Wasm closures; bug fixes & docs (0.1.36)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,61 @@
+## 0.1.36
+
+### Ternary / conditional expressions
+
+- Parse `condition ? a : b` in Dart, Java, JavaScript and TypeScript, plus the
+  native conditional-expression forms `a if condition else b` (Python) and
+  `if (condition) a else b` (Kotlin).
+- New `ASTExpressionConditional` AST node (only the selected branch is
+  evaluated); generated idiomatically per target: `?:` (Dart/Java/JS/TS),
+  `a if c else b` (Python), `if (c) a else b` (Kotlin), `c and a or b` (Lua),
+  and a value-typed `if`/`else` block in Wasm.
+
+### Anonymous functions / lambdas / closures
+
+- New `ASTExpressionLiteralFunction` AST node that captures the defining scope
+  (closure semantics); function values held in variables/parameters are now
+  invocable.
+- Parse anonymous functions: `(x) => …` / `(x) { … }` (Dart), `(x) => …` /
+  `x => …` (JavaScript, TypeScript) and `lambda x: …` (Python).
+- Generate anonymous functions for every target: arrow forms (Dart/JS/TS),
+  Java `(x) -> …`, Kotlin `{ x -> … }`, Lua `function(x) … end`, Python
+  `lambda x: …`.
+
+### Dart function types
+
+- Parse function types `int Function(int n)`, `void Function()` and
+  `Function(int n)` (omitted return type → `dynamic`); `ASTTypeFunction` accepts
+  any other function type, and function types are generated as
+  `int Function(int)` (Dart) / bare `Function` elsewhere.
+
+### Wasm: closures via function table + `call_indirect`
+
+- Added Table and Element sections and the `call_indirect` instruction. A
+  function value is an i32 pointer to a heap environment struct
+  `[tableSlot, captured…]`; each closure function takes a hidden environment
+  pointer and reads its captured variables from it.
+- Concrete signatures are inferred for capture-less closures, untyped lambda
+  parameters, capturing closures, and closures returned through a concrete
+  `Function` return type. Each closure instance gets its own heap environment.
+- *Not yet supported in Wasm:* polymorphic dynamic-return function types (a
+  `Function(int)` parameter called with both an `int`- and a `double`-returning
+  lambda) — these report a clear error and still work on the interpreter.
+
+### Bug fixes
+
+- Python: `self.method()` and `self.field` now round-trip correctly; fixed a
+  `self.field` getter parse crash and a stack overflow on self-referential
+  bindings (`s = s + i`) during code generation.
+- Local function declarations were duplicated in regenerated code after a
+  function was executed (`addFunction` is now idempotent and block generation
+  no longer emits a statement-level function twice).
+- Fixed doubled indentation of nested function declarations.
+
+### Documentation
+
+- Added **Python** to the package description and the README (a `Python`
+  language section and updated the TODO list).
+
 ## 0.1.35
 
 ### Python language support

--- a/README.md
+++ b/README.md
@@ -705,6 +705,80 @@ loaded AST. Object-oriented code uses the conventional table + metatable form
 (`Name = {}`, `Name.__index = Name`, `function Name:method(...)`), so classes round-trip
 to and from Dart, Java, Kotlin, JavaScript and TypeScript.
 
+### Language: `Python`
+
+Loading Python source code, executing it, and then converting it to Dart:
+
+```dart
+import 'package:apollovm/apollovm.dart';
+
+void main() async {
+  var vm = ApolloVM();
+
+  var codeUnit = SourceCodeUnit(
+          'python',
+          r'''
+            class Foo:
+                def greet(self, name, count):
+                    msg = f'Hello {name}, you have {count} messages.'
+                    print(msg)
+          ''',
+          id: 'test');
+
+  var loadOK = await vm.loadCodeUnit(codeUnit);
+
+  if (!loadOK) {
+    throw StateError('Error parsing Python code!');
+  }
+
+  var pyRunner = vm.createRunner('python')!;
+
+  // Map the `print` function in the VM:
+  pyRunner.externalPrintFunction = (o) => print("» $o");
+
+  await pyRunner.executeClassMethod('', 'Foo', 'greet',
+      positionalParameters: ['World', 3]);
+
+  print('---------------------------------------');
+
+  // Regenerate code in Dart:
+  var codeStorageDart = vm.generateAllCodeIn('dart');
+  var allSourcesDart = await codeStorageDart.writeAllSources();
+  print(allSourcesDart.toString());
+}
+```
+
+*Note: the parsed function `print` was mapped as an external function.*
+
+Output:
+```text
+» Hello World, you have 3 messages.
+---------------------------------------
+<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  void greet(dynamic name, dynamic count) {
+    var msg = 'Hello ${name}, you have ${count} messages.';
+    print(msg);
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+```
+
+Python is bidirectional: ApolloVM parses `.py`/`python` source into the AST, executes it,
+and generates strict, idiomatic Python 3. Indentation-significant blocks are handled by an
+INDENT/DEDENT/NEWLINE pre-tokenizer, and generation emits PEP-484 type hints when the AST
+type is statically known (`def f(x: int) -> int:`, `x: str = ...`, `List[T]`/`Dict[K, V]`)
+with a dynamic fallback. Supported constructs include functions, `self`-based methods and
+`class` declarations, `if`/`elif`/`else`, `while`, `for ... in`, `try`/`except`/`finally`
+with `raise`, lists & dicts, f-string interpolation, `//` integer division,
+`and`/`or`/`not`, `True`/`False`/`None`, and `import`/`from ... import` — all
+cross-translatable with Dart, Java, Kotlin, JavaScript, TypeScript and Lua.
+
 ## Wasm Support
 
 ApolloVM can compile its AST tree to WebAssembly (Wasm). This means that parsed code loaded into the VM can be compiled
@@ -919,7 +993,7 @@ Any help from the open-source community is always welcome and needed:
 
 ## TODO
 
-- JavaScript: extended support (anonymous arrow callbacks/closures, destructuring, spread, async/await, `this.x` constructor parameters, full ESM modules). *Named arrow functions (`const f = (a, b) => a + b;`) are already supported.*
+- JavaScript: extended support (destructuring, spread, async/await, `this.x` constructor parameters, full ESM modules). *Named arrow functions (`const f = (a, b) => a + b;`), anonymous arrow callbacks/closures (`(x) => x * 2`), and the ternary operator (`c ? a : b`) are already supported.*
   - *See the [JavaScript implementation (at "lib/src/languages/javascript/es")](https://github.com/ApolloVM/apollovm_dart/tree/master/lib/src/languages/javascript/es).*
 
 
@@ -931,7 +1005,8 @@ Any help from the open-source community is always welcome and needed:
   - *See the [Lua implementation (at "lib/src/languages/lua")](https://github.com/ApolloVM/apollovm_dart/tree/master/lib/src/languages/lua).*
 
 
-- Python support.
+- Python: extended support (comprehensions, decorators, `with` statements, `*args`/`**kwargs`, multiple assignment/returns). *Functions, classes/`self`-methods, `if`/`elif`/`else`, `while`, `for ... in`, `try`/`except`/`finally` + `raise`, lists & dicts, f-strings, keyword arguments, `lambda` expressions, conditional expressions (`a if c else b`), and `import`/`from ... import` are already supported.*
+  - *See the [Python implementation (at "lib/src/languages/python")](https://github.com/ApolloVM/apollovm_dart/tree/master/lib/src/languages/python).*
 
 
 - Package Importer.

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -50,7 +50,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.35';
+  static final String VERSION = '0.1.36';
 
   static int _idCount = 0;
 

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -144,8 +144,18 @@ abstract class ApolloCodeGenerator
       }
     }
 
+    // Local function declarations are kept as statements (and emitted in the
+    // statements loop below). Executing the block also registers them in
+    // `block.functions` for resolution, so skip those here to avoid emitting
+    // them twice.
+    var statementFunctions = block.statements
+        .whereType<ASTStatementFunctionDeclaration>()
+        .map((s) => s.functionDeclaration)
+        .toList();
+
     for (var set in block.functions) {
       for (var f in set.functions) {
+        if (statementFunctions.any((s) => identical(s, f))) continue;
         if (f is ASTClassFunctionDeclaration) {
           generateASTClassFunctionDeclaration(f, out: out, indent: indent2);
         } else {
@@ -269,9 +279,24 @@ abstract class ApolloCodeGenerator
       return generateASTTypeArray2D(type, out: out, indent: indent);
     } else if (type is ASTTypeArray3D) {
       return generateASTTypeArray3D(type, out: out, indent: indent);
+    } else if (type is ASTTypeFunction) {
+      return generateASTTypeFunction(type, out: out, indent: indent);
     }
 
     return generateASTTypeDefault(type, out: out, indent: indent);
+  }
+
+  /// Renders a function type. The default drops the signature generics and
+  /// emits a bare `Function` (valid as a type name in most targets); languages
+  /// with a dedicated function-type syntax (e.g. Dart) override this.
+  StringBuffer generateASTTypeFunction(
+    ASTTypeFunction type, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+    out.write('Function');
+    return out;
   }
 
   @override
@@ -883,12 +908,13 @@ abstract class ApolloCodeGenerator
   }) {
     out ??= newOutput();
 
-    if (headIndented) out.write(indent);
-
+    // `generateASTFunctionDeclaration` writes the leading indent itself, so
+    // don't write it here too (that produced a doubled indent for nested
+    // function declarations).
     return generateASTFunctionDeclaration(
       statement.functionDeclaration,
       out: out,
-      indent: indent,
+      indent: headIndented ? indent : '',
     );
   }
 
@@ -1243,6 +1269,20 @@ abstract class ApolloCodeGenerator
         indent: indent,
         headIndented: headIndented,
       );
+    } else if (expression is ASTExpressionConditional) {
+      return generateASTExpressionConditional(
+        expression,
+        out: out,
+        indent: indent,
+        headIndented: headIndented,
+      );
+    } else if (expression is ASTExpressionLiteralFunction) {
+      return generateASTExpressionLiteralFunction(
+        expression,
+        out: out,
+        indent: indent,
+        headIndented: headIndented,
+      );
     }
 
     throw UnsupportedError("Can't generate expression: $expression");
@@ -1312,6 +1352,102 @@ abstract class ApolloCodeGenerator
     if (group2) out.write('(');
     out.write(exp2);
     if (group2) out.write(')');
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTExpressionConditional(
+    ASTExpressionConditional expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    var cond = generateASTExpression(
+      expression.condition,
+      indent: '$indent  ',
+      headIndented: false,
+    );
+    var valueTrue = generateASTExpression(
+      expression.valueIfTrue,
+      indent: '$indent  ',
+      headIndented: false,
+    );
+    var valueFalse = generateASTExpression(
+      expression.valueIfFalse,
+      indent: '$indent  ',
+      headIndented: false,
+    );
+
+    if (expression.condition.isComplex) {
+      out.write('(');
+      out.write(cond);
+      out.write(')');
+    } else {
+      out.write(cond);
+    }
+
+    out.write(' ? ');
+    out.write(valueTrue);
+    out.write(' : ');
+    out.write(valueFalse);
+
+    return out;
+  }
+
+  /// If [f]'s body is a single `return <expr>;`, returns that expression (used
+  /// to emit concise single-expression lambdas); otherwise returns `null`.
+  ASTExpression? singleReturnExpression(ASTFunctionDeclaration f) {
+    var statements = f.statements;
+    if (statements.length != 1) return null;
+    var stm = statements.first;
+    if (stm is ASTStatementReturnWithExpression) return stm.expression;
+    return null;
+  }
+
+  /// Generates the comma-separated parameter names of [f] wrapped in `( )`.
+  StringBuffer generateFunctionParametersNames(
+    ASTFunctionDeclaration f, {
+    required StringBuffer out,
+  }) {
+    out.write('(');
+    if (f.parametersSize > 0) {
+      generateASTParametersDeclaration(f.parameters, out: out);
+    }
+    out.write(')');
+    return out;
+  }
+
+  /// Default (C-style arrow, e.g. JavaScript/TypeScript) anonymous function:
+  /// `(params) => expr` or `(params) => { body }`.
+  @override
+  StringBuffer generateASTExpressionLiteralFunction(
+    ASTExpressionLiteralFunction expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    var f = expression.function;
+    generateFunctionParametersNames(f, out: out);
+    out.write(' => ');
+
+    var single = singleReturnExpression(f);
+    if (single != null) {
+      generateASTExpression(single, out: out, headIndented: false);
+    } else {
+      var blockCode = generateASTBlock(f, indent: indent, withBrackets: false);
+      out.write('{\n');
+      out.write(blockCode);
+      out.write(indent);
+      out.write('}');
+    }
 
     return out;
   }

--- a/lib/src/apollovm_generator.dart
+++ b/lib/src/apollovm_generator.dart
@@ -274,12 +274,26 @@ abstract class ApolloGenerator<
       return generateASTExpressionGroupFunctionInvocation(expression, out: out);
     } else if (expression is ASTExpressionOperation) {
       return generateASTExpressionOperation(expression, out: out);
+    } else if (expression is ASTExpressionConditional) {
+      return generateASTExpressionConditional(expression, out: out);
+    } else if (expression is ASTExpressionLiteralFunction) {
+      return generateASTExpressionLiteralFunction(expression, out: out);
     }
 
     throw UnsupportedError("Can't generate expression: $expression");
   }
 
   O generateASTExpressionOperation(ASTExpressionOperation expression, {O? out});
+
+  O generateASTExpressionConditional(
+    ASTExpressionConditional expression, {
+    O? out,
+  });
+
+  O generateASTExpressionLiteralFunction(
+    ASTExpressionLiteralFunction expression, {
+    O? out,
+  });
 
   String resolveASTExpressionOperatorText(
     ASTExpressionOperator operator,

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -827,11 +827,7 @@ class ASTExpressionConditional extends ASTExpression {
   ASTExpression valueIfTrue;
   ASTExpression valueIfFalse;
 
-  ASTExpressionConditional(
-    this.condition,
-    this.valueIfTrue,
-    this.valueIfFalse,
-  );
+  ASTExpressionConditional(this.condition, this.valueIfTrue, this.valueIfFalse);
 
   @override
   bool get isComplex => true;

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -817,6 +817,107 @@ class ASTExpressionNegative extends ASTExpression {
   }
 }
 
+/// [ASTExpression] for a conditional (ternary) expression:
+/// `condition ? valueIfTrue : valueIfFalse` in C-style languages, or
+/// `valueIfTrue if condition else valueIfFalse` in Python.
+///
+/// Only the selected branch is evaluated.
+class ASTExpressionConditional extends ASTExpression {
+  ASTExpression condition;
+  ASTExpression valueIfTrue;
+  ASTExpression valueIfFalse;
+
+  ASTExpressionConditional(
+    this.condition,
+    this.valueIfTrue,
+    this.valueIfFalse,
+  );
+
+  @override
+  bool get isComplex => true;
+
+  @override
+  Iterable<ASTNode> get children => [condition, valueIfTrue, valueIfFalse];
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+
+    condition.resolveNode(this);
+    valueIfTrue.resolveNode(this);
+    valueIfFalse.resolveNode(this);
+  }
+
+  @override
+  FutureOr<ASTType> resolveType(VMContext? context) =>
+      ASTExpression.typeFromExpressions([
+        valueIfTrue,
+        valueIfFalse,
+      ], context: context);
+
+  @override
+  FutureOr<ASTValue> run(VMContext parentContext, ASTRunStatus runStatus) {
+    var context = defineRunContext(parentContext);
+
+    return condition.run(context, runStatus).resolveMapped((condVal) {
+      return condVal.getValue(context).resolveMapped((condResolved) {
+        if (condResolved is! bool) {
+          throw ApolloVMRuntimeError(
+            'A conditional (ternary) condition should return a boolean: '
+            '$condResolved',
+          );
+        }
+
+        var branch = condResolved ? valueIfTrue : valueIfFalse;
+        return branch.run(context, runStatus);
+      });
+    });
+  }
+
+  @override
+  String toString({bool asGroup = false}) {
+    var s = '$condition ? $valueIfTrue : $valueIfFalse';
+    return asGroup ? '($s)' : s;
+  }
+}
+
+/// [ASTExpression] for an anonymous function / lambda / closure literal, e.g.
+/// `(x) => x * 2`, `(x) { return x * 2; }` or Python's `lambda x: x * 2`.
+///
+/// Evaluating it yields an [ASTValueFunction] that captures the current scope,
+/// so the function body can read variables from the enclosing function
+/// (closure semantics).
+class ASTExpressionLiteralFunction extends ASTExpression {
+  final ASTFunctionDeclaration function;
+
+  ASTExpressionLiteralFunction(this.function);
+
+  @override
+  bool get isComplex => true;
+
+  @override
+  Iterable<ASTNode> get children => [function];
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+
+    function.resolveNode(parentNode);
+  }
+
+  @override
+  FutureOr<ASTType> resolveType(VMContext? context) => ASTTypeFunction();
+
+  @override
+  FutureOr<ASTValue> run(VMContext parentContext, ASTRunStatus runStatus) {
+    // Capture the defining scope so the body can reference enclosing variables.
+    return ASTValueFunction(ASTTypeFunction(), function, null, parentContext);
+  }
+
+  @override
+  String toString({bool asGroup = false}) => '$function';
+}
+
 /// [ASTExpression] that awaits another [expression] (`await x`).
 ///
 /// At runtime it resolves [expression] and, if the resolved value is a
@@ -1942,6 +2043,76 @@ class ASTExpressionLocalFunctionInvocation
 
   @override
   bool get isComplex => false;
+
+  @override
+  FutureOr<ASTType> resolveType(VMContext? context) {
+    if (context != null) {
+      var declared = context.getFunction(name, _getASTFunctionSignature());
+      if (declared == null) {
+        // The name refers to a variable holding a function value (closure or
+        // function-typed parameter); its return type isn't known statically.
+        var variable = context.getVariable(name, true);
+        return variable.resolveMapped((v) {
+          if (v == null) return super.resolveType(context);
+          // Use the function value's declared return type when available.
+          return v.getValue(context).resolveMapped((value) {
+            if (value is ASTValueFunction) {
+              return value.astFunction.returnType;
+            }
+            return ASTTypeDynamic.instance;
+          });
+        });
+      }
+    }
+    return super.resolveType(context);
+  }
+
+  @override
+  FutureOr<ASTValue> run(VMContext parentContext, ASTRunStatus runStatus) {
+    // A declared function (including named arrow functions) takes precedence.
+    var fSignature = _getASTFunctionSignature();
+    var declared = parentContext.getFunction(name, fSignature);
+    if (declared != null) {
+      return super.run(parentContext, runStatus);
+    }
+
+    // Otherwise the name may refer to a variable holding a function value: an
+    // anonymous closure assigned to a variable, or a function-typed parameter.
+    return parentContext.getVariable(name, true).resolveMapped((variable) {
+      if (variable != null) {
+        return variable.getValue(parentContext).resolveMapped((value) {
+          if (value is ASTValueFunction) {
+            return _invokeFunctionValue(parentContext, runStatus, value);
+          }
+          // Not a function value: let the declared-function path report the
+          // "can't find function" error.
+          return super.run(parentContext, runStatus);
+        });
+      }
+      return super.run(parentContext, runStatus);
+    });
+  }
+
+  FutureOr<ASTValue> _invokeFunctionValue(
+    VMContext parentContext,
+    ASTRunStatus runStatus,
+    ASTValueFunction value,
+  ) {
+    return _resolveArgumentsValues(
+      parentContext,
+      runStatus,
+      arguments,
+    ).resolveMapped((argumentsValues) {
+      var ret = value.call(
+        parentContext,
+        positionalParameters: argumentsValues,
+      );
+      if (!hasChainFunctionInvocation) return ret;
+      return ret.resolveMapped((prevObj) {
+        return _callChainFunction(parentContext, runStatus, prevObj);
+      });
+    });
+  }
 
   @override
   ASTInvocableDeclaration _getFunction(VMContext parentContext) {

--- a/lib/src/ast/apollovm_ast_statement.dart
+++ b/lib/src/ast/apollovm_ast_statement.dart
@@ -183,6 +183,11 @@ class ASTBlock extends ASTStatement {
     if (set == null) {
       _functions[name] = ASTFunctionSetSingle(f);
     } else {
+      // Idempotent: a local function declaration is re-registered on every
+      // execution (see `ASTStatementFunctionDeclaration.run`); without this
+      // guard the same declaration would accumulate in the set, corrupting the
+      // AST and duplicating it in regenerated code.
+      if (set.functions.any((e) => identical(e, f))) return;
       var set2 = set.add(f);
       if (!identical(set, set2)) {
         _functions[name] = set2;

--- a/lib/src/ast/apollovm_ast_type.dart
+++ b/lib/src/ast/apollovm_ast_type.dart
@@ -919,6 +919,10 @@ class ASTTypeVar extends ASTType<dynamic> {
 
   @override
   FutureOr<ASTValue<dynamic>> toValue(VMContext context, Object? v) {
+    // Preserve function values (anonymous functions / closures) assigned to a
+    // `var`/`final` variable so they remain callable.
+    if (v is ASTValueFunction) return v;
+
     if (v is ASTValue<dynamic> && v.type == this) {
       return v;
     }
@@ -960,6 +964,10 @@ class ASTTypeDynamic extends ASTType<dynamic> {
 
   @override
   FutureOr<ASTValue<dynamic>> toValue(VMContext context, Object? v) {
+    // Preserve function values (anonymous functions / closures) so they remain
+    // callable when held in a `dynamic`/untyped variable or parameter.
+    if (v is ASTValueFunction) return v;
+
     if (v is ASTValue && v.type == this) {
       return v;
     }
@@ -1466,22 +1474,41 @@ class ASTTypeFunction<F extends Function> extends ASTType<F> {
   ASTTypeFunction([ASTType? returnType, List<ASTType>? parameters])
     : super('Function', generics: [?returnType, ...?parameters]);
 
+  /// Any function type is accepted as another function type. Function values
+  /// carry their own declaration and are checked at call time, so signature
+  /// generics (return/parameter types) aren't enforced structurally here — this
+  /// lets an untyped `Function` argument bind to a typed `int Function(int)`
+  /// parameter and vice versa.
+  @override
+  bool acceptsType(ASTType type) {
+    if (type is ASTTypeFunction) return true;
+    return super.acceptsType(type);
+  }
+
   @override
   Iterable<ASTNode> get children => [];
 
   @override
-  ASTValueFunction<F>? toValue(VMContext context, Object? v) {
+  FutureOr<ASTValueFunction<F>?> toValue(VMContext context, Object? v) {
     if (v == null) return null;
 
-    throw UnsupportedError(
-      "Can't resolve an `ASTValueFunction` from a: ${v.runtimeType}",
-    );
+    if (v is ASTValueFunction) return v as ASTValueFunction<F>;
+
+    if (v is ASTValue) {
+      return v.getValue(context).resolveMapped((val) => toASTValue(val));
+    }
+
+    return toASTValue(v);
   }
 
   @override
   ASTValueFunction<F>? toASTValue(Object? value) {
     if (value == null) return null;
 
+    if (value is ASTValueFunction) return value as ASTValueFunction<F>;
+
+    // A raw Dart [Function] isn't backed by an AST declaration, so it can't be
+    // turned into an `ASTValueFunction` here.
     throw UnsupportedError(
       "Can't resolve an `ASTValueFunction` from a: ${value.runtimeType}",
     );

--- a/lib/src/ast/apollovm_ast_value.dart
+++ b/lib/src/ast/apollovm_ast_value.dart
@@ -1623,14 +1623,24 @@ class ASTValueFuture<T extends ASTType<V>, V> extends ASTValue<Future<V>> {
 class ASTValueFunction<F extends Function> extends ASTValue<F> {
   final ASTFunctionDeclaration astFunction;
 
+  /// The scope where this function was defined, captured for closure
+  /// semantics. When set, it is used as the parent context for calls, so the
+  /// function body can read variables from its enclosing scope. `null` for
+  /// plain (non-closure) function references.
+  final VMContext? closureContext;
+
   F? function;
 
-  ASTValueFunction(ASTType type, this.astFunction, [this.function])
-    : super(
-        type is ASTTypeFunction
-            ? type as ASTTypeFunction<F>
-            : ASTTypeFunction<F>(),
-      );
+  ASTValueFunction(
+    ASTType type,
+    this.astFunction, [
+    this.function,
+    this.closureContext,
+  ]) : super(
+         type is ASTTypeFunction
+             ? type as ASTTypeFunction<F>
+             : ASTTypeFunction<F>(),
+       );
 
   @override
   Iterable<ASTNode> get children => [];
@@ -1654,7 +1664,9 @@ class ASTValueFunction<F extends Function> extends ASTValue<F> {
     Map? namedParameters,
   }) async {
     return astFunction.call(
-      parent,
+      // For a closure, run the body in the scope where it was defined so it
+      // can capture enclosing variables; otherwise use the caller's context.
+      closureContext ?? parent,
       positionalParameters: positionalParameters,
       namedParameters: namedParameters,
     );

--- a/lib/src/languages/dart/dart_generator.dart
+++ b/lib/src/languages/dart/dart_generator.dart
@@ -223,6 +223,69 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
     return _generateASTFunctionDeclarationImpl(f, out, indent);
   }
 
+  @override
+  StringBuffer generateASTTypeFunction(
+    ASTTypeFunction type, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    var generics = type.generics;
+    if (generics == null || generics.isEmpty) {
+      out.write('Function');
+      return out;
+    }
+
+    // generics[0] is the return type; the rest are parameter types:
+    // `<returnType> Function(<paramType>, ...)`. A `dynamic` return type is
+    // implicit in Dart, so it is omitted: `Function(<paramType>, ...)`.
+    var returnType = generics.first;
+    if (returnType is! ASTTypeDynamic) {
+      out.write(generateASTType(returnType));
+      out.write(' ');
+    }
+    out.write('Function(');
+    var params = generics.skip(1).toList();
+    for (var i = 0; i < params.length; ++i) {
+      if (i > 0) out.write(', ');
+      out.write(generateASTType(params[i]));
+    }
+    out.write(')');
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTExpressionLiteralFunction(
+    ASTExpressionLiteralFunction expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    var f = expression.function;
+    generateFunctionParametersNames(f, out: out);
+
+    // Dart anonymous functions: `(params) => expr` or `(params) { body }`
+    // (no `=>` before a block body, unlike JavaScript).
+    var single = singleReturnExpression(f);
+    if (single != null) {
+      out.write(' => ');
+      generateASTExpression(single, out: out, headIndented: false);
+    } else {
+      out.write(' ');
+      var blockCode = generateASTBlock(f, indent: indent, withBrackets: false);
+      out.write('{\n');
+      out.write(blockCode);
+      out.write(indent);
+      out.write('}');
+    }
+
+    return out;
+  }
+
   StringBuffer _generateASTFunctionDeclarationImpl(
     ASTFunctionDeclaration f,
     StringBuffer? out,

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -567,6 +567,68 @@ class DartGrammarDefinition extends DartGrammarLexer {
         return ASTStatementExpression(v[0]);
       });
 
+  /// Anonymous function / closure used as an expression: `(params) => expr` or
+  /// `(params) { body }`. Parameters may be typed (`(int a)`) or untyped
+  /// (`(a)`). Captures the enclosing scope at runtime.
+  Parser<ASTExpression> expressionAnonymousFunction() =>
+      (anonFunctionParameters() & (anonArrowBody() | codeBlock())).map((v) {
+        var parameters = v[0] as ASTFunctionParametersDeclaration;
+        var block = v[1] as ASTBlock;
+        var f = ASTFunctionDeclaration(
+          '',
+          parameters,
+          ASTTypeDynamic.instance,
+          block: block,
+          modifiers: ASTModifiers.modifierStatic,
+        );
+        return ASTExpressionLiteralFunction(f);
+      });
+
+  /// `=> expr` body for an anonymous function (no trailing `;`, unlike a
+  /// declaration's [arrowBody]).
+  Parser<ASTBlock> anonArrowBody() =>
+      (string('=>').trimHidden() & ref0(expression)).map((v) {
+        return ASTBlock(null)
+          ..addAllStatements([_returnStatementForExpression(v[1])]);
+      });
+
+  Parser<ASTFunctionParametersDeclaration> anonFunctionParameters() =>
+      (functionEmptyParametersDeclaration() | anonPositionalParameters())
+          .cast<ASTFunctionParametersDeclaration>();
+
+  Parser<ASTFunctionParametersDeclaration> anonPositionalParameters() =>
+      (char('(').trimHidden() &
+              anonParameter() &
+              (char(',').trimHidden() & anonParameter()).star() &
+              char(',').optional() &
+              char(')').trimHidden())
+          .map((v) {
+            var params = <ASTFunctionParameterDeclaration>[v[1]];
+            for (var e in (v[2] as List)) {
+              params.add((e as List)[1] as ASTFunctionParameterDeclaration);
+            }
+            return ASTFunctionParametersDeclaration(params, null, null);
+          });
+
+  /// A single anonymous-function parameter: typed (`int a`) or untyped (`a`).
+  Parser<ASTFunctionParameterDeclaration> anonParameter() =>
+      ((type().trim() & identifier()) | identifier().trim()).map((v) {
+        if (v is List) {
+          return ASTFunctionParameterDeclaration(
+            v[0] as ASTType,
+            v[1] as String,
+            -1,
+            false,
+          );
+        }
+        return ASTFunctionParameterDeclaration(
+          ASTTypeDynamic.instance,
+          v as String,
+          -1,
+          false,
+        );
+      });
+
   Parser<ASTStatementBlock> statementBlock() =>
       (codeBlock()).map((v) => ASTStatementBlock(v));
 
@@ -719,6 +781,24 @@ class DartGrammarDefinition extends DartGrammarLexer {
       expression().map((e) => ParsedString.expression(e));
 
   Parser<ASTExpression> expression() =>
+      (ref0(expressionOperationChain) &
+              (char('?').trimHidden() &
+                      ref0(expression) &
+                      char(':').trimHidden() &
+                      ref0(expression))
+                  .optional())
+          .map((v) {
+            var base = v[0] as ASTExpression;
+            var ternary = v[1] as List?;
+            if (ternary == null) return base;
+            return ASTExpressionConditional(
+              base,
+              ternary[1] as ASTExpression,
+              ternary[3] as ASTExpression,
+            );
+          });
+
+  Parser<ASTExpression> expressionOperationChain() =>
       (ref0(expressionNoOperation) &
               (expressionOperator() & ref0(expressionNoOperation)).star())
           .map((v) {
@@ -765,6 +845,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
 
   Parser<ASTExpression> expressionNoOperation() =>
       (expressionAwait() |
+              expressionAnonymousFunction() |
               expressionNegate() |
               expressionLiteral() |
               expressionGroupFunctionInvocation() |
@@ -1188,6 +1269,11 @@ class DartGrammarDefinition extends DartGrammarLexer {
           });
 
   Parser<ASTType> type() =>
+      (functionType() | typeNonFunction()).cast<ASTType>();
+
+  /// Any type except a function type (used as the return type of a function
+  /// type, and as the fallback when there is no trailing `Function(...)`).
+  Parser<ASTType> typeNonFunction() =>
       (futureTyped() |
               arrayTyped() |
               arrayTypeDynamic() |
@@ -1195,6 +1281,51 @@ class DartGrammarDefinition extends DartGrammarLexer {
               mapTypeDynamic() |
               simpleType())
           .cast<ASTType>();
+
+  /// A function type: `[returnType] Function(<paramType> [name], ...)`, e.g.
+  /// `int Function(int n)`, `void Function()`, or `Function(int n)` (return
+  /// type omitted → `dynamic`).
+  Parser<ASTType> functionType() =>
+      (functionTypeWithReturn() | functionTypeNoReturn()).cast<ASTType>();
+
+  Parser<ASTType> functionTypeWithReturn() =>
+      (ref0(typeNonFunction) &
+              string('Function').trim() &
+              char('(').trimHidden() &
+              functionTypeParameters().optional() &
+              char(')').trimHidden())
+          .map((v) {
+            var returnType = v[0] as ASTType;
+            var parameters = v[3] as List<ASTType>?;
+            return ASTTypeFunction(returnType, parameters);
+          });
+
+  Parser<ASTType> functionTypeNoReturn() =>
+      (string('Function').trim() &
+              char('(').trimHidden() &
+              functionTypeParameters().optional() &
+              char(')').trimHidden())
+          .map((v) {
+            var parameters = v[2] as List<ASTType>?;
+            return ASTTypeFunction(ASTTypeDynamic.instance, parameters);
+          });
+
+  Parser<List<ASTType>> functionTypeParameters() =>
+      (functionTypeParameter() &
+              (char(',').trimHidden() & functionTypeParameter()).star() &
+              char(',').optional())
+          .map((v) {
+            var params = <ASTType>[v[0] as ASTType];
+            for (var e in (v[1] as List)) {
+              params.add((e as List)[1] as ASTType);
+            }
+            return params;
+          });
+
+  /// A single function-type parameter: a type with an optional (ignored) name,
+  /// e.g. `int` or `int n`.
+  Parser<ASTType> functionTypeParameter() =>
+      (ref0(type) & identifier().trim().optional()).map((v) => v[0] as ASTType);
 
   Parser<ASTTypeFuture> futureTyped() =>
       (string('Future') &

--- a/lib/src/languages/java/java11/java11_generator.dart
+++ b/lib/src/languages/java/java11/java11_generator.dart
@@ -18,6 +18,35 @@ class ApolloCodeGeneratorJava11 extends ApolloCodeGenerator {
     : super('java11', codeStorage);
 
   @override
+  StringBuffer generateASTExpressionLiteralFunction(
+    ASTExpressionLiteralFunction expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    var f = expression.function;
+    generateFunctionParametersNames(f, out: out);
+
+    // Java lambda: `(params) -> expr` or `(params) -> { body }`.
+    out.write(' -> ');
+    var single = singleReturnExpression(f);
+    if (single != null) {
+      generateASTExpression(single, out: out, headIndented: false);
+    } else {
+      var blockCode = generateASTBlock(f, indent: indent, withBrackets: false);
+      out.write('{\n');
+      out.write(blockCode);
+      out.write(indent);
+      out.write('}');
+    }
+
+    return out;
+  }
+
+  @override
   String normalizeTypeName(String typeName, [String? callingFunction]) {
     switch (typeName) {
       case 'int':

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -478,6 +478,24 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
           });
 
   Parser<ASTExpression> expression() =>
+      (ref0(expressionOperationChain) &
+              (char('?').trimHidden() &
+                      ref0(expression) &
+                      char(':').trimHidden() &
+                      ref0(expression))
+                  .optional())
+          .map((v) {
+            var base = v[0] as ASTExpression;
+            var ternary = v[1] as List?;
+            if (ternary == null) return base;
+            return ASTExpressionConditional(
+              base,
+              ternary[1] as ASTExpression,
+              ternary[3] as ASTExpression,
+            );
+          });
+
+  Parser<ASTExpression> expressionOperationChain() =>
       (ref0(expressionNoOperation) &
               (expressionOperator() & ref0(expressionNoOperation)).star())
           .map((v) {

--- a/lib/src/languages/javascript/es/javascript_grammar.dart
+++ b/lib/src/languages/javascript/es/javascript_grammar.dart
@@ -386,6 +386,23 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
   Parser<ASTStatementFunctionDeclaration> statementArrowFunction() =>
       arrowNamedFunction().map((f) => ASTStatementFunctionDeclaration(f));
 
+  /// Anonymous arrow function used as an expression (a closure), e.g.
+  /// `(a, b) => a + b`, `x => x * x`, `() => { ... }`. Captures the enclosing
+  /// scope at runtime and can be passed as a callback or stored in a variable.
+  Parser<ASTExpression> expressionArrowFunction() =>
+      (arrowParameters() & string('=>').trimHidden() & arrowBody()).map((v) {
+        var parameters = v[0] as ASTFunctionParametersDeclaration;
+        var block = v[2] as ASTBlock;
+        var f = ASTFunctionDeclaration(
+          '',
+          parameters,
+          inferReturnType(block),
+          block: block,
+          modifiers: ASTModifiers.modifierStatic,
+        );
+        return ASTExpressionLiteralFunction(f);
+      });
+
   /// Arrow parameters: `(a, b)`, `()`, or a single bare identifier `a`.
   Parser<ASTFunctionParametersDeclaration> arrowParameters() =>
       (functionParametersDeclaration() | arrowSingleParameter())
@@ -516,6 +533,24 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
   Parser<ASTExpression> parseExpressionInString() => ref0(expression);
 
   Parser<ASTExpression> expression() =>
+      (ref0(expressionOperationChain) &
+              (char('?').trimHidden() &
+                      ref0(expression) &
+                      char(':').trimHidden() &
+                      ref0(expression))
+                  .optional())
+          .map((v) {
+            var base = v[0] as ASTExpression;
+            var ternary = v[1] as List?;
+            if (ternary == null) return base;
+            return ASTExpressionConditional(
+              base,
+              ternary[1] as ASTExpression,
+              ternary[3] as ASTExpression,
+            );
+          });
+
+  Parser<ASTExpression> expressionOperationChain() =>
       (ref0(expressionNoOperation) &
               (expressionOperator() & ref0(expressionNoOperation)).star())
           .map((v) {
@@ -564,7 +599,8 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
           });
 
   Parser<ASTExpression> expressionNoOperation() =>
-      (expressionNegate() |
+      (expressionArrowFunction() |
+              expressionNegate() |
               expressionLiteral() |
               expressionGroupFunctionInvocation() |
               expressionGroup() |

--- a/lib/src/languages/kotlin/kotlin_generator.dart
+++ b/lib/src/languages/kotlin/kotlin_generator.dart
@@ -17,6 +17,71 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
     : super('kotlin', codeStorage);
 
   @override
+  StringBuffer generateASTExpressionLiteralFunction(
+    ASTExpressionLiteralFunction expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    var f = expression.function;
+
+    // Kotlin lambda: `{ params -> body }`. Parameters are listed without
+    // parentheses; an empty list omits the `->`.
+    out.write('{ ');
+    if (f.parametersSize > 0) {
+      generateASTParametersDeclaration(f.parameters, out: out);
+      out.write(' -> ');
+    }
+
+    var single = singleReturnExpression(f);
+    if (single != null) {
+      generateASTExpression(single, out: out, headIndented: false);
+      out.write(' }');
+    } else {
+      out.write('\n');
+      var blockCode = generateASTBlock(f, indent: indent, withBrackets: false);
+      out.write(blockCode);
+      out.write(indent);
+      out.write('}');
+    }
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTExpressionConditional(
+    ASTExpressionConditional expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    // Kotlin has no `?:` ternary; `if/else` is an expression that yields a
+    // value: `if (cond) valueIfTrue else valueIfFalse`.
+    out.write('if (');
+    generateASTExpression(expression.condition, out: out, headIndented: false);
+    out.write(') ');
+    generateASTExpression(
+      expression.valueIfTrue,
+      out: out,
+      headIndented: false,
+    );
+    out.write(' else ');
+    generateASTExpression(
+      expression.valueIfFalse,
+      out: out,
+      headIndented: false,
+    );
+
+    return out;
+  }
+
+  @override
   String normalizeTypeName(String typeName, [String? callingFunction]) {
     switch (typeName) {
       case 'int':

--- a/lib/src/languages/kotlin/kotlin_grammar.dart
+++ b/lib/src/languages/kotlin/kotlin_grammar.dart
@@ -498,7 +498,8 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
       expression().map((e) => ParsedString.expression(e));
 
   Parser<ASTExpression> expression() =>
-      (ref0(ifExpression) | ref0(expressionOperationChain)).cast<ASTExpression>();
+      (ref0(ifExpression) | ref0(expressionOperationChain))
+          .cast<ASTExpression>();
 
   /// Kotlin's `if` used as an expression that yields a value:
   /// `if (cond) valueIfTrue else valueIfFalse`. Statement-level `if` with

--- a/lib/src/languages/kotlin/kotlin_grammar.dart
+++ b/lib/src/languages/kotlin/kotlin_grammar.dart
@@ -498,6 +498,28 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
       expression().map((e) => ParsedString.expression(e));
 
   Parser<ASTExpression> expression() =>
+      (ref0(ifExpression) | ref0(expressionOperationChain)).cast<ASTExpression>();
+
+  /// Kotlin's `if` used as an expression that yields a value:
+  /// `if (cond) valueIfTrue else valueIfFalse`. Statement-level `if` with
+  /// `{ ... }` blocks is handled earlier by [branch].
+  Parser<ASTExpression> ifExpression() =>
+      (ifToken().trimHidden() &
+              char('(').trimHidden() &
+              ref0(expression) &
+              char(')').trimHidden() &
+              ref0(expressionOperationChain) &
+              elseToken().trimHidden() &
+              ref0(expression))
+          .map(
+            (v) => ASTExpressionConditional(
+              v[2] as ASTExpression,
+              v[4] as ASTExpression,
+              v[6] as ASTExpression,
+            ),
+          );
+
+  Parser<ASTExpression> expressionOperationChain() =>
       (ref0(expressionNoOperation) &
               (expressionOperator() & ref0(expressionNoOperation)).star())
           .map((v) {

--- a/lib/src/languages/lua/lua_generator.dart
+++ b/lib/src/languages/lua/lua_generator.dart
@@ -627,6 +627,68 @@ class ApolloCodeGeneratorLua extends ApolloCodeGenerator {
   }
 
   @override
+  StringBuffer generateASTExpressionLiteralFunction(
+    ASTExpressionLiteralFunction expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    var f = expression.function;
+
+    // Lua anonymous function: `function(params) ... end`.
+    out.write('function');
+    generateFunctionParametersNames(f, out: out);
+
+    var single = singleReturnExpression(f);
+    if (single != null) {
+      out.write(' return ');
+      generateASTExpression(single, out: out, headIndented: false);
+      out.write(' end');
+    } else {
+      out.write('\n');
+      var blockCode = generateASTBlock(f, indent: indent, withBrackets: false);
+      out.write(blockCode);
+      out.write(indent);
+      out.write('end');
+    }
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTExpressionConditional(
+    ASTExpressionConditional expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    // Lua has no `?:` ternary; the idiomatic form is `cond and a or b`
+    // (short-circuit). NOTE: this differs from a true ternary when `valueIfTrue`
+    // is `false`/`nil` — a known limitation of the Lua idiom.
+    generateASTExpression(expression.condition, out: out, headIndented: false);
+    out.write(' and ');
+    generateASTExpression(
+      expression.valueIfTrue,
+      out: out,
+      headIndented: false,
+    );
+    out.write(' or ');
+    generateASTExpression(
+      expression.valueIfFalse,
+      out: out,
+      headIndented: false,
+    );
+
+    return out;
+  }
+
+  @override
   StringBuffer generateASTExpressionOperation(
     ASTExpressionOperation expression, {
     StringBuffer? out,

--- a/lib/src/languages/python/python_generator.dart
+++ b/lib/src/languages/python/python_generator.dart
@@ -766,6 +766,67 @@ class ApolloCodeGeneratorPython extends ApolloCodeGenerator {
   }
 
   @override
+  StringBuffer generateASTExpressionLiteralFunction(
+    ASTExpressionLiteralFunction expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    var f = expression.function;
+
+    // Python anonymous functions are `lambda params: expr` and can only hold a
+    // single expression.
+    var single = singleReturnExpression(f);
+    if (single == null) {
+      throw UnsupportedError(
+        "Python `lambda` only supports a single-expression body: $f",
+      );
+    }
+
+    out.write('lambda');
+    if (f.parametersSize > 0) {
+      out.write(' ');
+      generateASTParametersDeclaration(f.parameters, out: out);
+    }
+    out.write(': ');
+    generateASTExpression(single, out: out, headIndented: false);
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTExpressionConditional(
+    ASTExpressionConditional expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    // Python's conditional expression: `valueIfTrue if condition else
+    // valueIfFalse`.
+    generateASTExpression(
+      expression.valueIfTrue,
+      out: out,
+      headIndented: false,
+    );
+    out.write(' if ');
+    generateASTExpression(expression.condition, out: out, headIndented: false);
+    out.write(' else ');
+    generateASTExpression(
+      expression.valueIfFalse,
+      out: out,
+      headIndented: false,
+    );
+
+    return out;
+  }
+
+  @override
   StringBuffer generateASTExpressionNegation(
     ASTExpressionNegation expression, {
     StringBuffer? out,

--- a/lib/src/languages/python/python_grammar.dart
+++ b/lib/src/languages/python/python_grammar.dart
@@ -482,6 +482,26 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
   Parser<ASTExpression> parseExpressionInString() => ref0(expression);
 
   Parser<ASTExpression> expression() =>
+      (ref0(expressionOperationChain) &
+              (ifToken().trimHidden() &
+                      ref0(expressionOperationChain) &
+                      elseToken().trimHidden() &
+                      ref0(expression))
+                  .optional())
+          .map((v) {
+            var base = v[0] as ASTExpression;
+            var ternary = v[1] as List?;
+            if (ternary == null) return base;
+            // Python's conditional expression:
+            // `valueIfTrue if condition else valueIfFalse`.
+            return ASTExpressionConditional(
+              ternary[1] as ASTExpression,
+              base,
+              ternary[3] as ASTExpression,
+            );
+          });
+
+  Parser<ASTExpression> expressionOperationChain() =>
       (ref0(expressionNoOperation) &
               (expressionOperator() & ref0(expressionNoOperation)).star())
           .map((v) {
@@ -524,7 +544,8 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
           .cast<ASTExpressionOperator>();
 
   Parser<ASTExpression> expressionNoOperation() =>
-      (expressionNegate() |
+      (expressionLambda() |
+              expressionNegate() |
               expressionLiteral() |
               expressionGroupFunctionInvocation() |
               expressionGroup() |
@@ -540,6 +561,54 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
               expressionVariableAccess() |
               expressionNegative())
           .cast<ASTExpression>();
+
+  /// Python anonymous function: `lambda [params]: expr` (single-expression
+  /// body). Captures the enclosing scope at runtime (closure).
+  Parser<ASTExpression> expressionLambda() =>
+      (lambdaToken().trimHidden() &
+              _lambdaParameters() &
+              char(':').trimHidden() &
+              ref0(expression))
+          .map((v) {
+            var parameters = v[1] as ASTFunctionParametersDeclaration;
+            var body = v[3] as ASTExpression;
+            var block = ASTBlock(null)
+              ..addStatement(ASTStatementReturnWithExpression(body));
+            var f = ASTFunctionDeclaration(
+              '',
+              parameters,
+              inferReturnType(block),
+              block: block,
+              modifiers: ASTModifiers.modifierStatic,
+            );
+            return ASTExpressionLiteralFunction(f);
+          });
+
+  Parser<ASTFunctionParametersDeclaration> _lambdaParameters() =>
+      (identifier().trimHidden() &
+              (char(',').trimHidden() & identifier().trimHidden()).star())
+          .optional()
+          .map((v) {
+            if (v == null) {
+              return ASTFunctionParametersDeclaration(null, null, null);
+            }
+            var names = <String>[v[0] as String];
+            for (var e in (v[1] as List)) {
+              names.add((e as List)[1] as String);
+            }
+            var params = <ASTFunctionParameterDeclaration>[];
+            for (var i = 0; i < names.length; ++i) {
+              params.add(
+                ASTFunctionParameterDeclaration(
+                  ASTTypeDynamic.instance,
+                  names[i],
+                  i,
+                  false,
+                ),
+              );
+            }
+            return ASTFunctionParametersDeclaration(params, null, null);
+          });
 
   Parser<ASTExpressionNegation> expressionNegate() =>
       (notToken() & (ref0(expressionNoOperation) | ref0(expressionGroup))).map((
@@ -598,23 +667,27 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
                 .whereType<ASTExpressionChainFunctionInvocation>()
                 .toList();
 
-            if (obj != null && obj != 'self' && obj != 'this') {
-              var variable = ASTScopeVariable(obj);
-              return ASTExpressionObjectFunctionInvocation(
-                variable,
-                name,
-                args,
-                chainFunctions,
-              );
-            } else {
-              // `self.method(...)`/`this.method(...)` resolve to the class
-              // method (local invocation), mirroring Dart/Java `this`.
+            if (obj == null) {
               return ASTExpressionLocalFunctionInvocation(
                 name,
                 args,
                 chainFunctions,
               );
             }
+
+            // `self.method(...)`/`this.method(...)` invoke on the current
+            // instance; `obj.method(...)` on the named variable's instance.
+            // Keep the receiver so the call round-trips (Python needs the
+            // explicit `self.`), mirroring the Dart/Java grammars.
+            ASTVariable variable = (obj == 'self' || obj == 'this')
+                ? ASTThisVariable()
+                : ASTScopeVariable(obj);
+            return ASTExpressionObjectFunctionInvocation(
+              variable,
+              name,
+              args,
+              chainFunctions,
+            );
           });
 
   Parser<ASTExpression> expressionGetterAccess() =>
@@ -622,22 +695,23 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
               identifier().trimHidden() &
               expressionChainFunctionInvocation().star())
           .map((v) {
-            var obj = (v[0] as List)[0] as String;
-            var name = v[1] as String;
-            var chainFunctions = (v[2] as List)
+            var obj = v[0] as String;
+            var name = v[2] as String;
+            var chainFunctions = (v[3] as List)
                 .whereType<ASTExpressionChainFunctionInvocation>()
                 .toList();
 
-            if (obj != 'self' && obj != 'this') {
-              var variable = ASTScopeVariable(obj);
-              return ASTExpressionObjectGetterAccess(
-                variable,
-                name,
-                chainFunctions,
-              );
-            } else {
-              return ASTExpressionLocalGetterAccess(name, chainFunctions);
-            }
+            // `self.field`/`this.field` reads from the current instance;
+            // `obj.field` from the named variable's instance. Keep the receiver
+            // so the access round-trips, mirroring the Dart/Java grammars.
+            ASTVariable variable = (obj == 'self' || obj == 'this')
+                ? ASTThisVariable()
+                : ASTScopeVariable(obj);
+            return ASTExpressionObjectGetterAccess(
+              variable,
+              name,
+              chainFunctions,
+            );
           });
 
   Parser<List<ASTExpression>> expressionSequence() =>
@@ -957,28 +1031,42 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
     for (var stm in statements) {
       if (stm is ASTStatementVariableDeclaration) {
         var name = stm.name;
-        if (declared.contains(name)) {
-          var value = stm.value;
-          if (value != null) {
-            result.add(
-              ASTStatementExpression(
-                ASTExpressionVariableAssignment(
-                  ASTScopeVariable(name),
-                  ASTAssignmentOperator.set,
-                  value,
-                ),
-              ),
-            );
-            continue;
-          }
-        } else {
+        var value = stm.value;
+
+        // A first binding whose value references the name being bound (e.g.
+        // `s = s + 1`) can't be a real declaration-with-initializer — the name
+        // must already exist in an enclosing scope (a parameter or an outer
+        // binding). Treat it (and any later binding) as a plain assignment;
+        // otherwise it becomes a self-referential declaration that recurses
+        // forever during type resolution / code generation.
+        if (value != null &&
+            (declared.contains(name) || _valueReferences(value, name))) {
           declared.add(name);
+          result.add(
+            ASTStatementExpression(
+              ASTExpressionVariableAssignment(
+                ASTScopeVariable(name),
+                ASTAssignmentOperator.set,
+                value,
+              ),
+            ),
+          );
+          continue;
         }
+
+        declared.add(name);
       }
       result.add(stm);
     }
 
     return result;
+  }
+
+  /// Whether [value] reads the variable [name] anywhere in its expression tree.
+  static bool _valueReferences(ASTExpression value, String name) {
+    bool isRef(ASTNode n) => n is ASTVariable && n.name == name;
+    if (isRef(value)) return true;
+    return value.descendantChildren.any(isRef);
   }
 
   static List _expandListDeeply(List l) {

--- a/lib/src/languages/python/python_grammar_lexer.dart
+++ b/lib/src/languages/python/python_grammar_lexer.dart
@@ -113,6 +113,8 @@ abstract class PythonGrammarLexer extends BaseGrammarLexer {
 
   Parser isToken() => ref1(keyword, 'is');
 
+  Parser lambdaToken() => ref1(keyword, 'lambda');
+
   Parser noneToken() => ref1(keyword, 'None');
 
   Parser notToken() => ref1(keyword, 'not');

--- a/lib/src/languages/typescript/ts/typescript_grammar.dart
+++ b/lib/src/languages/typescript/ts/typescript_grammar.dart
@@ -617,6 +617,27 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
   Parser<ASTStatementFunctionDeclaration> statementArrowFunction() =>
       arrowNamedFunction().map((f) => ASTStatementFunctionDeclaration(f));
 
+  /// Anonymous arrow function used as an expression (a closure), e.g.
+  /// `(a, b) => a + b`, `x => x * x`, `(a): number => a`.
+  Parser<ASTExpression> expressionArrowFunction() =>
+      (arrowParameters() &
+              typeAnnotation().optional() &
+              string('=>').trimHidden() &
+              arrowBody())
+          .map((v) {
+            var parameters = v[0] as ASTFunctionParametersDeclaration;
+            var declaredReturn = v[1] as ASTType?;
+            var block = v[3] as ASTBlock;
+            var f = ASTFunctionDeclaration(
+              '',
+              parameters,
+              declaredReturn ?? inferReturnType(block),
+              block: block,
+              modifiers: ASTModifiers.modifierStatic,
+            );
+            return ASTExpressionLiteralFunction(f);
+          });
+
   /// Arrow parameters: `(a, b)`, `()`, or a single bare identifier `a`.
   Parser<ASTFunctionParametersDeclaration> arrowParameters() =>
       (functionParametersDeclaration() | arrowSingleParameter())
@@ -755,6 +776,24 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
   Parser<ASTExpression> parseExpressionInString() => ref0(expression);
 
   Parser<ASTExpression> expression() =>
+      (ref0(expressionOperationChain) &
+              (char('?').trimHidden() &
+                      ref0(expression) &
+                      char(':').trimHidden() &
+                      ref0(expression))
+                  .optional())
+          .map((v) {
+            var base = v[0] as ASTExpression;
+            var ternary = v[1] as List?;
+            if (ternary == null) return base;
+            return ASTExpressionConditional(
+              base,
+              ternary[1] as ASTExpression,
+              ternary[3] as ASTExpression,
+            );
+          });
+
+  Parser<ASTExpression> expressionOperationChain() =>
       (ref0(expressionNoOperation) &
               (expressionOperator() & ref0(expressionNoOperation)).star())
           .map((v) {
@@ -803,7 +842,8 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
           });
 
   Parser<ASTExpression> expressionNoOperation() =>
-      (expressionNegate() |
+      (expressionArrowFunction() |
+              expressionNegate() |
               expressionLiteral() |
               expressionGroupFunctionInvocation() |
               expressionGroup() |

--- a/lib/src/languages/wasm/wasm.dart
+++ b/lib/src/languages/wasm/wasm.dart
@@ -20,8 +20,7 @@ enum WasmType {
   const WasmType(this.name, this.value);
 
   /// The [WasmType] whose [value] byte is [v].
-  static WasmType fromValue(int v) =>
-      values.firstWhere((t) => t.value == v);
+  static WasmType fromValue(int v) => values.firstWhere((t) => t.value == v);
 }
 
 enum FloatAlign { align1, align2, align3 }

--- a/lib/src/languages/wasm/wasm.dart
+++ b/lib/src/languages/wasm/wasm.dart
@@ -18,6 +18,10 @@ enum WasmType {
   final int value;
 
   const WasmType(this.name, this.value);
+
+  /// The [WasmType] whose [value] byte is [v].
+  static WasmType fromValue(int v) =>
+      values.firstWhere((t) => t.value == v);
 }
 
 enum FloatAlign { align1, align2, align3 }
@@ -36,11 +40,16 @@ class Wasm {
   static const sectionType = 0x01;
   static const sectionImport = 0x02;
   static const sectionFunction = 0x03;
+  static const sectionTable = 0x04;
   static const sectionMemory = 0x05;
   static const sectionGlobal = 0x06;
   static const sectionExport = 0x07;
+  static const sectionElement = 0x09;
   static const sectionCode = 0x0a;
   static const sectionData = 0x0b;
+
+  /// `funcref` element/table type.
+  static const funcRefType = 0x70;
 
   /// Export/import external kinds.
   static const externalKindFunction = 0x00;
@@ -88,6 +97,14 @@ class Wasm {
   ];
 
   static List<int> call(int i) => <int>[0x10, ...Leb128.encodeUnsigned(i)];
+
+  /// `call_indirect typeidx tableidx(0)`: calls the function whose index is on
+  /// top of the stack, in table 0, checked against type [typeIndex].
+  static List<int> callIndirect(int typeIndex) => <int>[
+    0x11,
+    ...Leb128.encodeUnsigned(typeIndex),
+    0x00,
+  ];
 
   static const drop = 0x1a;
   static const select = 0x1b;

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -85,10 +85,7 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     // inferred from the function-typed parameter it is passed to.
     var anonClosures = _collectAnonymousClosures(baseFunctions);
 
-    var functions = [
-      ...baseFunctions,
-      ...anonClosures.map((c) => c.function),
-    ];
+    var functions = [...baseFunctions, ...anonClosures.map((c) => c.function)];
     var module = WasmModuleContext(functions, classLayouts: classLayouts);
     for (var c in anonClosures) {
       module.registerClosure(c);
@@ -594,7 +591,10 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
   /// Table section: a single `funcref` table holding the module's function
   /// values (closures), sized to the number of table functions.
-  BytesOutput generateSectionTable(WasmModuleContext module, {BytesOutput? out}) {
+  BytesOutput generateSectionTable(
+    WasmModuleContext module, {
+    BytesOutput? out,
+  }) {
     out ??= newOutput();
 
     var size = module.tableFunctions.length;
@@ -1958,7 +1958,10 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       ...paramTypes.map((t) => t.wasmCode),
     ];
     var resultCode = returnType.isVoid ? null : returnType.wasmCode;
-    var typeIndex = context.module!.typeIndexForSignature(paramCodes, resultCode);
+    var typeIndex = context.module!.typeIndexForSignature(
+      paramCodes,
+      resultCode,
+    );
     if (typeIndex < 0) {
       throw StateError(
         "Wasm: no function type matches the indirect-call signature of "
@@ -1986,7 +1989,10 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       } else {
         resultType = returnType;
       }
-      context.stackPush(resultType, "call_indirect `${expression.name}` result");
+      context.stackPush(
+        resultType,
+        "call_indirect `${expression.name}` result",
+      );
     }
 
     context.assertStackLength(
@@ -7978,10 +7984,7 @@ class WasmModuleContext {
       // Closures take a hidden env pointer (i32) as their first parameter and
       // use their inferred (concrete) parameter types.
       var params = info != null
-          ? [
-              WasmType.i32Type.value,
-              ...info.paramTypes.map((t) => t.wasmCode),
-            ]
+          ? [WasmType.i32Type.value, ...info.paramTypes.map((t) => t.wasmCode)]
           : f.parametersTypesWasmCode;
       var key = _sigKey(params, rt.isVoid ? null : rt.wasmCode);
       if (key == want) return index;

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -76,8 +76,23 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       classFunctions.addAll(_buildClassFunctions(clazz));
     }
 
-    var functions = [...topFunctions, ...classFunctions];
+    var baseFunctions = [...topFunctions, ...classFunctions];
+
+    // Anonymous functions / closures: each `ASTExpressionLiteralFunction`
+    // becomes a module function with a function-table slot (a function value is
+    // the i32 index of its slot, dispatched via `call_indirect`). Wasm needs a
+    // concrete signature, so rebuild each with the return/parameter types
+    // inferred from the function-typed parameter it is passed to.
+    var anonClosures = _collectAnonymousClosures(baseFunctions);
+
+    var functions = [
+      ...baseFunctions,
+      ...anonClosures.map((c) => c.function),
+    ];
     var module = WasmModuleContext(functions, classLayouts: classLayouts);
+    for (var c in anonClosures) {
+      module.registerClosure(c);
+    }
 
     // A public function with a String or List parameter requires the host to
     // allocate the argument in module memory, so ensure `__alloc` is exported.
@@ -103,6 +118,12 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       );
     }
     out.writeBytes(sectionFunction, description: "Section: Function");
+    if (module.requiresTable) {
+      out.writeBytes(
+        generateSectionTable(module),
+        description: "Section: Table",
+      );
+    }
     if (module.requiresMemory) {
       out.writeBytes(
         generateSectionMemory(module),
@@ -116,6 +137,12 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       );
     }
     out.writeBytes(sectionExports, description: "Section: Export");
+    if (module.requiresTable) {
+      out.writeBytes(
+        generateSectionElement(module),
+        description: "Section: Element",
+      );
+    }
     out.writeBytes(sectionCode, description: "Section: Code");
     if (module.hasData) {
       out.writeBytes(generateSectionData(module), description: "Section: Data");
@@ -460,7 +487,21 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       ...module.importedFunctions.map(
         (imp) => _wasmFuncTypeBytes(imp.params, imp.results),
       ),
-      ...module.functions.map((f) => f.wasmSignature()),
+      ...module.functions.map((f) {
+        // A closure takes a hidden env pointer (i32) as its first parameter and
+        // uses the concrete return/parameter types inferred at registration
+        // (its declared types may be `dynamic`).
+        var info = module.closureInfo(f);
+        if (info == null) return f.wasmSignature();
+        var params = <WasmType>[
+          WasmType.i32Type,
+          ...info.paramTypes.map((t) => WasmType.fromValue(t.wasmCode)),
+        ];
+        var results = info.returnType.isVoid
+            ? const <WasmType>[]
+            : [WasmType.fromValue(info.returnType.wasmCode)];
+        return _wasmFuncTypeBytes(params, results);
+      }),
       ...module.synthFunctions.map(
         (s) => _wasmFuncTypeBytes(s.params, s.results),
       ),
@@ -549,6 +590,289 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     out.writeLeb128Block(indexes, description: "Functions type indexes");
 
     return out;
+  }
+
+  /// Table section: a single `funcref` table holding the module's function
+  /// values (closures), sized to the number of table functions.
+  BytesOutput generateSectionTable(WasmModuleContext module, {BytesOutput? out}) {
+    out ??= newOutput();
+
+    var size = module.tableFunctions.length;
+    var entry = BytesOutput(
+      data: [
+        BytesOutput(data: Wasm.funcRefType, description: "Elem type funcref"),
+        BytesOutput(data: 0x00, description: "Limits flags(min only)"),
+        BytesOutput(
+          data: Leb128.encodeUnsigned(size),
+          description: "Min($size)",
+        ),
+      ],
+      description: "Table 0",
+    );
+
+    out.writeByte(Wasm.sectionTable, description: "Section Table ID");
+    out.writeBytesLeb128Block([
+      BytesOutput(data: Leb128.encodeUnsigned(1), description: "Tables count"),
+      entry,
+    ], description: "Tables");
+
+    return out;
+  }
+
+  /// Element section: one active segment initializing table 0 (from offset 0)
+  /// with the function indices of each table function, slot-by-slot.
+  BytesOutput generateSectionElement(
+    WasmModuleContext module, {
+    BytesOutput? out,
+  }) {
+    out ??= newOutput();
+
+    var funcIndices = module.tableFunctions
+        .map(
+          (f) => BytesOutput(
+            data: Leb128.encodeUnsigned(module.functionIndexByDeclaration(f)),
+            description: "Func index",
+          ),
+        )
+        .toList();
+
+    var segment = BytesOutput(
+      data: [
+        BytesOutput(
+          data: Leb128.encodeUnsigned(0),
+          description: "Segment flags(active, table 0, offset expr)",
+        ),
+        BytesOutput(
+          data: [...Wasm32.i32Const(0), Wasm.end],
+          description: "Offset (i32.const 0)",
+        ),
+        BytesOutput(
+          data: Leb128.encodeUnsigned(funcIndices.length),
+          description: "Functions count",
+        ),
+        ...funcIndices,
+      ],
+      description: "Element segment 0",
+    );
+
+    out.writeByte(Wasm.sectionElement, description: "Section Element ID");
+    out.writeBytesLeb128Block([
+      BytesOutput(
+        data: Leb128.encodeUnsigned(1),
+        description: "Segments count",
+      ),
+      segment,
+    ], description: "Elements");
+
+    return out;
+  }
+
+  /// Collects anonymous functions (closures) and computes their Wasm layout:
+  /// concrete return/parameter types (inferred from the function-typed
+  /// parameter each is passed to) and the captured-variable environment.
+  List<WasmClosureInfo> _collectAnonymousClosures(
+    List<ASTFunctionDeclaration> baseFunctions,
+  ) {
+    var moduleFnNames = baseFunctions.map((f) => f.name).toSet();
+
+    // Map each closure to the function type it is passed as, and to the
+    // function that lexically encloses it (for resolving captured-var types).
+    var expected = <ASTFunctionDeclaration, ASTTypeFunction>{};
+    var enclosingOf = <ASTFunctionDeclaration, ASTFunctionDeclaration>{};
+    for (var encl in baseFunctions) {
+      for (var node in encl.descendantChildren) {
+        if (node is ASTExpressionLiteralFunction) {
+          enclosingOf.putIfAbsent(node.function, () => encl);
+        }
+        if (node is ASTExpressionLocalFunctionInvocation) {
+          var callee = _findModuleFunction(
+            baseFunctions,
+            node.name,
+            node.arguments.length,
+          );
+          if (callee == null) continue;
+          var args = node.arguments;
+          for (var i = 0; i < args.length; ++i) {
+            var arg = args[i];
+            if (arg is ASTExpressionLiteralFunction) {
+              var pt = callee.parameters.getParameterByIndex(i)?.type;
+              if (pt is ASTTypeFunction) expected[arg.function] = pt;
+            }
+          }
+        }
+        // A returned closure takes its signature from the enclosing function's
+        // (concrete) function return type, e.g. `int Function(int) make() { ... }`.
+        if (node is ASTStatementReturnWithExpression) {
+          var ret = node.expression;
+          var enclReturn = encl.returnType;
+          if (ret is ASTExpressionLiteralFunction &&
+              enclReturn is ASTTypeFunction) {
+            expected[ret.function] = enclReturn;
+          }
+        }
+      }
+    }
+
+    var result = <WasmClosureInfo>[];
+    var seen = <ASTFunctionDeclaration>{};
+    for (var encl in baseFunctions) {
+      for (var node in encl.descendantChildren) {
+        if (node is ASTExpressionLiteralFunction) {
+          var fn = node.function;
+          if (!seen.add(fn)) continue;
+
+          var funcType = expected[fn];
+          var returnType = _closureReturnType(fn, funcType);
+          var paramTypes = _closureParamTypes(fn, funcType);
+          var captures = _closureCaptures(fn, enclosingOf[fn], moduleFnNames);
+
+          // Env struct layout: i32 table slot at offset 0, then captures.
+          var offset = 4;
+          var layout = <WasmCapture>[];
+          for (var c in captures) {
+            layout.add((name: c.name, type: c.type, offset: offset));
+            offset += _elemSize(c.type);
+          }
+
+          result.add(
+            WasmClosureInfo(
+              fn,
+              returnType,
+              paramTypes,
+              layout,
+              offset,
+              result.length,
+            ),
+          );
+        }
+      }
+    }
+    return result;
+  }
+
+  ASTFunctionDeclaration? _findModuleFunction(
+    List<ASTFunctionDeclaration> functions,
+    String name,
+    int arity,
+  ) {
+    for (var f in functions) {
+      if (f.name == name && f.parameters.size == arity) return f;
+    }
+    return null;
+  }
+
+  ASTType _closureReturnType(
+    ASTFunctionDeclaration fn,
+    ASTTypeFunction? funcType,
+  ) {
+    var declared = fn.returnType;
+    if (declared is! ASTTypeDynamic && !declared.isVoid) return declared;
+
+    if (funcType != null) {
+      var generics = funcType.generics;
+      if (generics != null && generics.isNotEmpty) {
+        var rt = generics.first;
+        if (rt is! ASTTypeDynamic && !rt.isVoid) return rt;
+      }
+    }
+
+    if (declared.isVoid) return declared;
+
+    throw UnsupportedError(
+      "Wasm: can't infer the return type of an anonymous function. Pass it to a "
+      "typed function parameter with a concrete return type, e.g. "
+      "`int Function(int n)`.",
+    );
+  }
+
+  /// Concrete parameter types for closure [fn]: a declared (typed) parameter
+  /// keeps its type; an untyped parameter takes the type from the function-typed
+  /// parameter [funcType] (`generics[i + 1]`).
+  List<ASTType> _closureParamTypes(
+    ASTFunctionDeclaration fn,
+    ASTTypeFunction? funcType,
+  ) {
+    var params = fn.parameters.allParameters;
+    var fromType = funcType?.generics;
+    var result = <ASTType>[];
+    for (var i = 0; i < params.length; ++i) {
+      var declared = params[i].type;
+      if (declared is! ASTTypeDynamic) {
+        result.add(declared);
+        continue;
+      }
+      // generics[0] is the return type; parameter i is generics[i + 1].
+      if (fromType != null && fromType.length > i + 1) {
+        var t = fromType[i + 1];
+        if (t is! ASTTypeDynamic) {
+          result.add(t);
+          continue;
+        }
+      }
+      throw UnsupportedError(
+        "Wasm: can't infer the type of parameter `${params[i].name}` of an "
+        "anonymous function. Pass it to a typed function parameter, e.g. "
+        "`int Function(int n)`.",
+      );
+    }
+    return result;
+  }
+
+  /// The free variables captured by closure [fn] (referenced in its body but not
+  /// declared as its parameters/locals, nor a module function), paired with the
+  /// type they have in the [enclosing] function's scope.
+  List<({String name, ASTType type})> _closureCaptures(
+    ASTFunctionDeclaration fn,
+    ASTFunctionDeclaration? enclosing,
+    Set<String> moduleFnNames,
+  ) {
+    var declared = <String>{};
+    for (var p in fn.parameters.allParameters) {
+      declared.add(p.name);
+    }
+    for (var v in fn.statements.declaredVariables()) {
+      declared.add(v.key);
+    }
+
+    var used = <String>[];
+    var usedSet = <String>{};
+    for (var node in fn.descendantChildren) {
+      if (node is ASTScopeVariable) {
+        var name = node.name;
+        if (name == 'this' ||
+            declared.contains(name) ||
+            moduleFnNames.contains(name)) {
+          continue;
+        }
+        if (usedSet.add(name)) used.add(name);
+      }
+    }
+
+    if (used.isEmpty) return const [];
+
+    // Resolve captured-variable types from the enclosing function's scope.
+    var scope = <String, ASTType>{};
+    if (enclosing != null) {
+      for (var p in enclosing.parameters.allParameters) {
+        scope[p.name] = p.type;
+      }
+      for (var v in enclosing.statements.declaredVariables()) {
+        scope[v.key] = v.value;
+      }
+    }
+
+    var result = <({String name, ASTType type})>[];
+    for (var name in used) {
+      var type = scope[name];
+      if (type == null || type is ASTTypeDynamic) {
+        throw UnsupportedError(
+          "Wasm: can't capture variable `$name` in a closure (its type isn't "
+          "statically known).",
+        );
+      }
+      result.add((name: name, type: type));
+    }
+    return result;
   }
 
   BytesOutput generateSectionMemory(
@@ -1488,6 +1812,19 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         );
       }
 
+      // A function value held in a local variable (a closure / function-typed
+      // parameter): dispatch via `call_indirect`.
+      var localFn = context.getLocalVariable(name);
+      if (localFn != null && localFn.type is ASTTypeFunction) {
+        return _emitIndirectCall(
+          expression,
+          localFn.type as ASTTypeFunction,
+          localFn.index,
+          out: out,
+          context: context,
+        );
+      }
+
       throw StateError(
         "Can't resolve local function `$name` with $argsCount argument(s) "
         "in the Wasm function index table.",
@@ -1555,6 +1892,106 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     context.assertStackLength(
       stackLng0 + (returnType.isVoid ? 0 : 1),
       "After call `$name` result",
+    );
+
+    return out;
+  }
+
+  /// Calls a function value held in a local (a closure / function-typed
+  /// parameter) via `call_indirect`. The value is the i32 table index; the
+  /// signature comes from the variable's [funcType] (`generics[0]` = return
+  /// type, the rest = parameter types).
+  BytesOutput _emitIndirectCall(
+    ASTExpressionLocalFunctionInvocation expression,
+    ASTTypeFunction funcType,
+    int localIndex, {
+    BytesOutput? out,
+    WasmContext? context,
+  }) {
+    out ??= newOutput();
+    context ??= WasmContext();
+
+    var arguments = expression.arguments;
+    var generics = funcType.generics ?? const <ASTType>[];
+    var returnType = generics.isNotEmpty
+        ? generics.first
+        : ASTTypeDynamic.instance;
+    var paramTypes = generics.length > 1
+        ? generics.sublist(1)
+        : const <ASTType>[];
+
+    final stackLng0 = context.stackLength;
+
+    // The function value is a pointer to the closure struct; it is also passed
+    // as the hidden first argument (the environment).
+    out.write(
+      Wasm.localGet(localIndex),
+      description: "[OP] closure env ptr `${expression.name}`",
+    );
+    context.stackPush(_astTypeInt32, "closure env `${expression.name}`");
+
+    // Push arguments (converting to the declared parameter types).
+    for (var i = 0; i < arguments.length; ++i) {
+      generateASTExpression(arguments[i], out: out, context: context);
+      var stackType = context.stackGet(0)!.type;
+      if (i < paramTypes.length) {
+        _autoConvertStackTypes(
+          stackType,
+          paramTypes[i],
+          out: out,
+          context: context,
+        );
+      }
+    }
+
+    // Push the table slot loaded from the closure struct (`env[0]`).
+    out.write(
+      Wasm.localGet(localIndex),
+      description: "[OP] closure ptr `${expression.name}` (slot load)",
+    );
+    out.write(Wasm32.i32Load(2, 0));
+    context.stackPush(_astTypeInt32, "closure table slot `${expression.name}`");
+
+    // Resolve the type index matching the call signature (env i32 + params).
+    var paramCodes = [
+      WasmType.i32Type.value,
+      ...paramTypes.map((t) => t.wasmCode),
+    ];
+    var resultCode = returnType.isVoid ? null : returnType.wasmCode;
+    var typeIndex = context.module!.typeIndexForSignature(paramCodes, resultCode);
+    if (typeIndex < 0) {
+      throw StateError(
+        "Wasm: no function type matches the indirect-call signature of "
+        "`${expression.name}` ($funcType).",
+      );
+    }
+
+    out.write(
+      Wasm.callIndirect(typeIndex),
+      description: "[OP] call_indirect `${expression.name}` (type $typeIndex)",
+    );
+
+    // Drop the env, the arguments and the table slot; push the return value.
+    context.stackDrop(); // table slot
+    for (var i = 0; i < arguments.length; ++i) {
+      context.stackDrop();
+    }
+    context.stackDrop(); // env pointer
+    if (!returnType.isVoid) {
+      ASTType resultType;
+      if (returnType is ASTTypeInt) {
+        resultType = _astTypeInt64;
+      } else if (returnType is ASTTypeDouble) {
+        resultType = _astTypeDouble64;
+      } else {
+        resultType = returnType;
+      }
+      context.stackPush(resultType, "call_indirect `${expression.name}` result");
+    }
+
+    context.assertStackLength(
+      stackLng0 + (returnType.isVoid ? 0 : 1),
+      "After call_indirect `${expression.name}`",
     );
 
     return out;
@@ -2121,6 +2558,151 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   }
 
   @override
+  BytesOutput generateASTExpressionLiteralFunction(
+    ASTExpressionLiteralFunction expression, {
+    BytesOutput? out,
+    WasmContext? context,
+  }) {
+    out ??= newOutput();
+    context ??= WasmContext();
+
+    var module = context.module;
+    var info = module?.closureInfo(expression.function);
+    if (module == null || info == null) {
+      throw UnsupportedError(
+        "Wasm: this anonymous function wasn't registered as a function value: "
+        "$expression",
+      );
+    }
+
+    module.requiresMemory = true;
+    module.requiresHeapGlobal = true;
+
+    final s0 = context.stackLength;
+
+    // A function value is an i32 pointer to a heap struct
+    // `[tableSlot@0, capture0, capture1, ...]`.
+    out.write(
+      Wasm32.i32Const(info.envSize),
+      description: "[OP] closure env size (${info.envSize})",
+    );
+    _emitInlineAlloc(out, context); // size -> ptr
+
+    var ptrLocal = context.scratchLocal(_astTypeString, 12);
+    out.write(Wasm.localSet(ptrLocal), description: "[OP] save closure ptr");
+
+    // Store the table slot at offset 0.
+    out.write(Wasm.localGet(ptrLocal));
+    out.write(Wasm32.i32Const(info.slot));
+    out.write(
+      Wasm32.i32Store(2, 0),
+      description: "[OP] closure[0] = table slot ${info.slot}",
+    );
+
+    // Store each captured variable's current value into the environment.
+    for (var c in info.captures) {
+      out.write(Wasm.localGet(ptrLocal));
+      _emitCapturedValueRead(out, context, c.name);
+      _emitElemStore(out, c.type, c.offset);
+    }
+
+    // Leave the closure pointer on the stack as the result.
+    out.write(Wasm.localGet(ptrLocal), description: "[OP] closure ptr (value)");
+    context.stackPush(
+      ASTTypeFunction(),
+      "closure value (slot ${info.slot}, env ${info.envSize}B)",
+    );
+    context.assertStackLength(s0 + 1, "After closure value");
+
+    return out;
+  }
+
+  /// Emits (untracked) the current value of [name] for storing into a closure
+  /// environment: a captured variable (nested closure), a class field, or a
+  /// local variable of the enclosing scope.
+  void _emitCapturedValueRead(
+    BytesOutput out,
+    WasmContext context,
+    String name,
+  ) {
+    if (context.isCapturedVariable(name)) {
+      var cap = context.capturedVariables[name]!;
+      out.write(Wasm.localGet(context.closureEnvLocalIndex));
+      _emitElemLoad(out, cap.type, cap.offset);
+      return;
+    }
+    if (context.isFieldAccess(name)) {
+      out.write(Wasm.localGet(context.thisLocalIndex));
+      _emitElemLoad(
+        out,
+        context.classLayout!.types[name]!,
+        context.classLayout!.offsets[name]!,
+      );
+      return;
+    }
+    var localVar = context.getLocalVariable(name);
+    if (localVar == null) {
+      throw StateError("Wasm: can't read captured value `$name`.");
+    }
+    out.write(Wasm.localGet(localVar.index));
+  }
+
+  @override
+  BytesOutput generateASTExpressionConditional(
+    ASTExpressionConditional expression, {
+    BytesOutput? out,
+    WasmContext? context,
+  }) {
+    out ??= newOutput();
+    context ??= WasmContext();
+
+    final stackLng0 = context.stackLength;
+
+    // Condition (i32 boolean).
+    generateASTExpression(expression.condition, out: out, context: context);
+    context.assertStackLength(stackLng0 + 1, "After conditional condition");
+
+    var condType = context.stackGet(0)!.type;
+    if (condType != _astTypeInt32) {
+      throw StateError(
+        "Conditional (ternary) condition is not a boolean (i32): $condType",
+      );
+    }
+
+    // The `if` block yields the value of the selected branch, so it needs the
+    // result type up-front. Both branches must agree on this type.
+    var resultType = expression.resolveType(null);
+    if (resultType is Future) {
+      throw UnsupportedError(
+        "Conditional (ternary) with async type resolution not supported in Wasm",
+      );
+    }
+
+    out.write(
+      Wasm.ifInstruction(resultType.wasmType),
+      description: "[OP] conditional (ternary): $expression",
+    );
+    context.stackDrop(_astTypeInt32);
+
+    // `then` branch value.
+    generateASTExpression(expression.valueIfTrue, out: out, context: context);
+    // The two branches are mutually exclusive: drop the `then` result from the
+    // virtual stack before generating the `else` branch.
+    context.stackDrop();
+
+    out.writeByte(Wasm.elseInstruction, description: "[OP] conditional else");
+
+    // `else` branch value.
+    generateASTExpression(expression.valueIfFalse, out: out, context: context);
+
+    out.writeByte(Wasm.end, description: "[OP] conditional end");
+
+    context.assertStackLength(stackLng0 + 1, "After conditional (ternary)");
+
+    return out;
+  }
+
+  @override
   BytesOutput generateASTExpressionOperation(
     ASTExpressionOperation expression, {
     BytesOutput? out,
@@ -2557,6 +3139,23 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     context ??= WasmContext();
 
     var name = expression.variable.name;
+
+    // A captured variable is read from the closure environment (`env + offset`).
+    if (context.isCapturedVariable(name)) {
+      final s0 = context.stackLength;
+      var cap = context.capturedVariables[name]!;
+      out.write(
+        Wasm.localGet(context.closureEnvLocalIndex),
+        description: "[OP] closure env ptr",
+      );
+      _emitElemLoad(out, cap.type, cap.offset);
+      context.stackPush(
+        _elemStackType(cap.type),
+        "captured `$name` (env + ${cap.offset})",
+      );
+      context.assertStackLength(s0 + 1, "After captured `$name`");
+      return out;
+    }
 
     // A bare name that is a class field (and not a local) reads `this + offset`.
     if (context.isFieldAccess(name)) {
@@ -3463,7 +4062,9 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     // For an `async` function the declared `Future<T>` collapses to `T` (Wasm
     // executes synchronously); compile it as a normal function returning `T`.
-    var effectiveReturnType = f.effectiveReturnType;
+    // Anonymous functions use the concrete return type inferred at registration.
+    var effectiveReturnType =
+        context.module?.returnTypeOverride(f) ?? f.effectiveReturnType;
 
     var return0 = context.returnsLength;
     context.returnsPush(
@@ -3472,10 +4073,30 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     );
     context.assertReturnsLength(return0 + 1);
 
-    var parametersVariables = f.parameters.declaredVariables();
-
-    for (var v in parametersVariables) {
-      context.addLocalVariable(v.key, v.value);
+    var closureInfo = context.module?.closureInfo(f);
+    if (closureInfo != null) {
+      // Hidden environment pointer as parameter 0.
+      context.closureEnvLocalIndex = context.addLocalVariable(
+        '__env',
+        _astTypeInt32,
+      );
+      // Real parameters with their inferred (concrete) types.
+      var params = f.parameters.allParameters;
+      for (var i = 0; i < params.length; ++i) {
+        var t = i < closureInfo.paramTypes.length
+            ? closureInfo.paramTypes[i]
+            : params[i].type;
+        context.addLocalVariable(params[i].name, t);
+      }
+      // Captured variables are read from the environment struct.
+      for (var c in closureInfo.captures) {
+        context.capturedVariables[c.name] = (type: c.type, offset: c.offset);
+      }
+    } else {
+      var parametersVariables = f.parameters.declaredVariables();
+      for (var v in parametersVariables) {
+        context.addLocalVariable(v.key, v.value);
+      }
     }
 
     var localVariables = f.statements.declaredVariables();
@@ -6493,6 +7114,18 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         out: out,
         context: context,
       );
+    } else if (expression is ASTExpressionConditional) {
+      return generateASTExpressionConditional(
+        expression,
+        out: out,
+        context: context,
+      );
+    } else if (expression is ASTExpressionLiteralFunction) {
+      return generateASTExpressionLiteralFunction(
+        expression,
+        out: out,
+        context: context,
+      );
     }
 
     throw UnsupportedError("Can't generate expression: $expression");
@@ -7181,6 +7814,45 @@ class WasmClassLayout {
   WasmClassLayout(this.className, this.offsets, this.types, this.size);
 }
 
+/// A captured variable of a closure: its [name], [type] and byte [offset]
+/// within the closure's heap environment struct.
+typedef WasmCapture = ({String name, ASTType type, int offset});
+
+/// Compile-time info for an anonymous function (closure). A closure value is an
+/// i32 pointer to a heap struct laid out as `[tableSlot@0, capture0, ...]`; the
+/// closure function takes that pointer as a hidden first parameter (`env`) and
+/// reads its captured variables from it.
+class WasmClosureInfo {
+  final ASTFunctionDeclaration function;
+
+  /// Concrete return type (the declared one may be `dynamic`).
+  final ASTType returnType;
+
+  /// Concrete parameter types (the declared ones may be `dynamic` / untyped),
+  /// in declaration order, inferred from the function-typed parameter the
+  /// closure is passed to.
+  final List<ASTType> paramTypes;
+
+  /// Captured (free) variables, with their env-struct offsets.
+  final List<WasmCapture> captures;
+
+  /// Total size of the environment struct in bytes (`4` for the table slot plus
+  /// each capture's size).
+  final int envSize;
+
+  /// The function-table slot (the closure's dispatch index).
+  final int slot;
+
+  WasmClosureInfo(
+    this.function,
+    this.returnType,
+    this.paramTypes,
+    this.captures,
+    this.envSize,
+    this.slot,
+  );
+}
+
 /// A synthesized module function wrapping a class constructor. Its Wasm
 /// signature takes the constructor's value parameters and returns an i32 object
 /// pointer; codegen allocates the struct, stores fields, runs the body and
@@ -7240,6 +7912,94 @@ class WasmModuleContext {
 
   /// The field layout of the class whose instances have type [t], or `null`.
   WasmClassLayout? layoutForType(ASTType t) => classLayouts[t.name];
+
+  // --- Function table (for closures / function values via `call_indirect`) ---
+
+  /// Functions placed in the module's function table, in table-slot order. A
+  /// function value is an i32 pointer to a heap closure struct
+  /// `[tableSlot@0, captured0, captured1, ...]`.
+  final List<ASTFunctionDeclaration> tableFunctions = [];
+
+  /// Closure info per anonymous-function declaration.
+  final Map<ASTFunctionDeclaration, WasmClosureInfo> closures = {};
+
+  bool get requiresTable => tableFunctions.isNotEmpty;
+
+  /// Registers an anonymous function (closure), returning its table slot.
+  int registerClosure(WasmClosureInfo info) {
+    var existing = closures[info.function];
+    if (existing != null) return existing.slot;
+    tableFunctions.add(info.function);
+    closures[info.function] = info;
+    return info.slot;
+  }
+
+  /// The table slot of the anonymous function [f], or -1.
+  int closureSlot(ASTFunctionDeclaration f) => closures[f]?.slot ?? -1;
+
+  /// The closure info for [f], or `null` if [f] is not a closure.
+  WasmClosureInfo? closureInfo(ASTFunctionDeclaration f) => closures[f];
+
+  bool isClosure(ASTFunctionDeclaration f) => closures.containsKey(f);
+
+  /// The concrete return type to use for closure [f] (its declared return type
+  /// may be `dynamic`), or `null` if [f] is not a closure.
+  ASTType? returnTypeOverride(ASTFunctionDeclaration f) =>
+      closures[f]?.returnType;
+
+  /// The Wasm function index of a module-defined function [f] (by identity).
+  int functionIndexByDeclaration(ASTFunctionDeclaration f) {
+    for (var i = 0; i < functions.length; ++i) {
+      if (identical(functions[i], f)) return importCount + i;
+    }
+    return -1;
+  }
+
+  /// Finds the type index whose signature matches [paramCodes] → [resultCode]
+  /// (a Wasm value-type byte, or `null` for void). Used by `call_indirect`,
+  /// which must reference a type index. Reuses an existing function's type
+  /// (every callable-by-value function is a module function, so a match
+  /// exists). Returns -1 if none matches.
+  int typeIndexForSignature(List<int> paramCodes, int? resultCode) {
+    var want = _sigKey(paramCodes, resultCode);
+
+    var index = 0;
+    for (var imp in importedFunctions) {
+      var key = _sigKey(
+        imp.params.map((p) => p.value).toList(),
+        imp.results.isEmpty ? null : imp.results.first.value,
+      );
+      if (key == want) return index;
+      index++;
+    }
+    for (var f in functions) {
+      var info = closures[f];
+      var rt = info?.returnType ?? f.effectiveReturnType;
+      // Closures take a hidden env pointer (i32) as their first parameter and
+      // use their inferred (concrete) parameter types.
+      var params = info != null
+          ? [
+              WasmType.i32Type.value,
+              ...info.paramTypes.map((t) => t.wasmCode),
+            ]
+          : f.parametersTypesWasmCode;
+      var key = _sigKey(params, rt.isVoid ? null : rt.wasmCode);
+      if (key == want) return index;
+      index++;
+    }
+    for (var s in synthFunctions) {
+      var key = _sigKey(
+        s.params.map((p) => p.value).toList(),
+        s.results.isEmpty ? null : s.results.first.value,
+      );
+      if (key == want) return index;
+      index++;
+    }
+    return -1;
+  }
+
+  static String _sigKey(List<int> paramCodes, int? resultCode) =>
+      '${paramCodes.join(',')}>${resultCode ?? ''}';
 
   /// Resolves the Wasm function index of class [className]'s method
   /// [methodName] taking [arity] declared arguments (excluding `this`).
@@ -7633,6 +8393,16 @@ class WasmContext {
   WasmClassLayout? classLayout;
   int thisLocalIndex = -1;
 
+  /// When generating a closure body, the local index of the hidden environment
+  /// pointer (parameter 0), and the captured variables stored in that
+  /// environment (read as `env + offset`). `-1` / empty when not a closure.
+  int closureEnvLocalIndex = -1;
+  final Map<String, ({ASTType type, int offset})> capturedVariables = {};
+
+  /// Whether [name] is a captured variable read from the closure environment.
+  bool isCapturedVariable(String name) =>
+      closureEnvLocalIndex >= 0 && capturedVariables.containsKey(name);
+
   /// Whether [name] resolves to a field of the current method's class (and is
   /// not shadowed by a local variable).
   bool isFieldAccess(String name) =>
@@ -7924,6 +8694,9 @@ extension _ASTTypeExtension on ASTType {
       return WasmType.i32Type;
     } else if (this is ASTTypeMap) {
       // A map is an i32 pointer into linear memory.
+      return WasmType.i32Type;
+    } else if (this is ASTTypeFunction) {
+      // A function value is an i32 index into the module's function table.
       return WasmType.i32Type;
     } else if (this is ASTTypeVoid) {
       return WasmType.voidType;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: apollovm
-description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, JavaScript, TypeScript, Lua with on-the-fly Wasm compilation.
+description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, JavaScript, TypeScript, Lua and Python with on-the-fly Wasm compilation.
 version: 0.1.35
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, JavaScript, TypeScript, Lua and Python with on-the-fly Wasm compilation.
-version: 0.1.35
+version: 0.1.36
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/apollovm_languages_basic_test.dart
+++ b/test/apollovm_languages_basic_test.dart
@@ -370,13 +370,8 @@ List<dynamic> calculate(int x, int y) {
   }
 
   List<dynamic> calculate(int x, int y) {
-    void log(String label, dynamic value) {
-      print('$label: $x, $y -> $value');
-      out.add(value);
-    }
-
     var out = <dynamic>[];
-        void log(String label, dynamic value) {
+    void log(String label, dynamic value) {
       print('$label: $x, $y -> $value');
       out.add(value);
     }
@@ -1441,26 +1436,8 @@ import 'dart:math';
       return ((endValue / startValue) - 1.0) * 100.0;
     }
 
+
     double calculateAverage(List<double> data) {
-      double sum = 0.0;
-      for (int i = 0; i < data.length ; i++) {
-        sum = sum + data[i];
-      }
-      return sum / data.length;
-    }
-
-        double calculateChange(List<double> data) {
-      if (data.length < 2) {
-          return 0.0;
-      }
-
-      double startValue = data[0];
-      double endValue = data[data.length - 1];
-      return ((endValue / startValue) - 1.0) * 100.0;
-    }
-
-
-        double calculateAverage(List<double> data) {
       double sum = 0.0;
       for (int i = 0; i < data.length ; i++) {
         sum = sum + data[i];

--- a/test/apollovm_wasm_test.dart
+++ b/test/apollovm_wasm_test.dart
@@ -1026,6 +1026,124 @@ void main() async {
     );
 
     test(
+      'ternaryConditional',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int ternaryConditional(int a) {
+            return a > 0 ? 10 : 20;
+          }
+
+        ''',
+        functionName: 'ternaryConditional',
+        executions: {
+          [5]: 10,
+          [-5]: 20,
+          [0]: 20,
+        },
+      ),
+    );
+
+    test(
+      'closureCallback',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int f1(int Function(int n) f) {
+            var a = f(10);
+            var b = f(20);
+            return a + b;
+          }
+
+          int run() {
+            return f1((int n) => n * 10);
+          }
+
+        ''',
+        functionName: 'run',
+        executions: {
+          []: 300,
+        },
+      ),
+    );
+
+    test(
+      'closureUntypedParam',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int f1(int Function(int n) f) {
+            var a = f(10);
+            var b = f(20);
+            return a + b;
+          }
+
+          int run() {
+            return f1((n) => n * 10);
+          }
+
+        ''',
+        functionName: 'run',
+        executions: {
+          []: 300,
+        },
+      ),
+    );
+
+    test(
+      'closureCapture',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int apply(int Function(int x) f, int v) {
+            return f(v);
+          }
+
+          int makeAndRun(int n) {
+            return apply((int x) => x + n, 5);
+          }
+
+          int run() {
+            return makeAndRun(100);
+          }
+
+        ''',
+        functionName: 'run',
+        executions: {
+          []: 105,
+        },
+      ),
+    );
+
+    test(
+      'closureReturned',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int Function(int) makeAdder(int n) {
+            return (int x) => x + n;
+          }
+
+          int run() {
+            var a = makeAdder(100);
+            var b = makeAdder(1000);
+            return a(5) + b(7);
+          }
+
+        ''',
+        functionName: 'run',
+        executions: {
+          []: 1112,
+        },
+      ),
+    );
+
+    test(
       'multiIntParams',
       () => _testWasm(
         language: 'dart',

--- a/test/apollovm_wasm_test.dart
+++ b/test/apollovm_wasm_test.dart
@@ -1063,9 +1063,7 @@ void main() async {
 
         ''',
         functionName: 'run',
-        executions: {
-          []: 300,
-        },
+        executions: {[]: 300},
       ),
     );
 
@@ -1087,9 +1085,7 @@ void main() async {
 
         ''',
         functionName: 'run',
-        executions: {
-          []: 300,
-        },
+        executions: {[]: 300},
       ),
     );
 
@@ -1113,9 +1109,7 @@ void main() async {
 
         ''',
         functionName: 'run',
-        executions: {
-          []: 105,
-        },
+        executions: {[]: 105},
       ),
     );
 
@@ -1137,9 +1131,7 @@ void main() async {
 
         ''',
         functionName: 'run',
-        executions: {
-          []: 1112,
-        },
+        executions: {[]: 1112},
       ),
     );
 

--- a/test/tests_definitions/dart_closure_callback.test.xml
+++ b/test/tests_definitions/dart_closure_callback.test.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Anonymous function passed as a callback">
+    <source language="dart">
+        <![CDATA[
+int apply(Function f, int x) {
+  return f(x);
+}
+
+int main() {
+  return apply((a) => a * 2, 5);
+}
+        ]]>
+    </source>
+    <call function="main" return="10">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  int apply(Function f, int x) {
+    return f(x);
+  }
+
+  int main() {
+    return apply((dynamic a) => a * 2, 5);
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  function apply(f, x) {
+    return f(x);
+  }
+
+  function main() {
+    return apply((a) => a * 2, 5);
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  function apply(f: Function, x: number): number {
+    return f(x);
+  }
+
+  function main(): number {
+    return apply((a) => a * 2, 5);
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="python"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+def apply(f: Function, x: int) -> int:
+    return f(x)
+
+def main() -> int:
+    return apply(lambda a: a * 2, 5)
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/dart_closure_capture.test.xml
+++ b/test/tests_definitions/dart_closure_capture.test.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Closure capturing an enclosing variable">
+    <source language="dart">
+        <![CDATA[
+Function makeAdder(int n) {
+  return (x) => x + n;
+}
+
+int main() {
+  var add10 = makeAdder(10);
+  return add10(5);
+}
+        ]]>
+    </source>
+    <call function="main" return="15">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  Function makeAdder(int n) {
+    return (dynamic x) => x + n;
+  }
+
+  int main() {
+    var add10 = makeAdder(10);
+    return add10(5);
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  function makeAdder(n) {
+    return (x) => x + n;
+  }
+
+  function main() {
+    let add10 = makeAdder(10);
+    return add10(5);
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="python"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+def makeAdder(n: int) -> Function:
+    return lambda x: x + n
+
+def main() -> int:
+    add10: Function = makeAdder(10)
+    return add10(5)
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/dart_closure_returned.test.xml
+++ b/test/tests_definitions/dart_closure_returned.test.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Closure returned through a concrete Function return type">
+    <source language="dart">
+        <![CDATA[
+int Function(int) makeAdder(int n) {
+  return (int x) => x + n;
+}
+
+int run() {
+  var add = makeAdder(100);
+  return add(5);
+}
+        ]]>
+    </source>
+    <call function="run" return="105">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  int Function(int) makeAdder(int n) {
+    return (int x) => x + n;
+  }
+
+  int run() {
+    var add = makeAdder(100);
+    return add(5);
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/dart_closure_untyped_param.test.xml
+++ b/test/tests_definitions/dart_closure_untyped_param.test.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Anonymous function with an untyped parameter (inferred)">
+    <source language="dart">
+        <![CDATA[
+int f1(int Function(int n) f) {
+  var a = f(10);
+  var b = f(20);
+  return a + b;
+}
+
+int run() {
+  return f1((n) => n * 10);
+}
+        ]]>
+    </source>
+    <call function="run" return="300">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  int f1(int Function(int) f) {
+    var a = f(10);
+    var b = f(20);
+    return a + b;
+  }
+
+  int run() {
+    return f1((dynamic n) => n * 10);
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/dart_function_type_no_return.test.xml
+++ b/test/tests_definitions/dart_function_type_no_return.test.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Function-type parameter without return type">
+    <source language="dart">
+        <![CDATA[
+int f1(Function(int n) f) {
+  var a = f(10);
+  var b = f(20);
+  print('a: $a');
+  print('b: $b');
+  return a + b;
+}
+
+int run() {
+  return f1((int n) => n * 10);
+}
+        ]]>
+    </source>
+    <call function="run" return="300">
+        []
+    </call>
+    <output>
+        ["a: 100", "b: 200"]
+    </output>
+
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  int f1(Function(int) f) {
+    var a = f(10);
+    var b = f(20);
+    print('a: $a');
+    print('b: $b');
+    return a + b;
+  }
+
+  int run() {
+    return f1((int n) => n * 10);
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/dart_ternary_conditional.test.xml
+++ b/test/tests_definitions/dart_ternary_conditional.test.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Ternary conditional operator">
+    <source language="dart">
+        <![CDATA[
+class Calc {
+  int classify(int a) {
+    return a > 0 ? 1 : -1;
+  }
+}
+        ]]>
+    </source>
+    <call class="Calc" function="classify" return="1">
+        [5]
+    </call>
+    <output>
+        []
+    </output>
+    <call class="Calc" function="classify" return="-1">
+        [-5]
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Calc {
+
+  int classify(int a) {
+    return (a > 0) ? 1 : -1;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="java11"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Calc {
+
+  int classify(int a) {
+    return (a > 0) ? 1 : -1;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Calc {
+
+  classify(a) {
+    return (a > 0) ? 1 : -1;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Calc {
+
+  classify(a: number): number {
+    return (a > 0) ? 1 : -1;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="python"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Calc:
+    def classify(self, a: int) -> int:
+        return 1 if a > 0 else -1
+
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="kotlin"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Calc {
+
+  fun classify(a: Int): Int {
+    return if (a > 0) 1 else -1
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/dart_typed_function_parameter.test.xml
+++ b/test/tests_definitions/dart_typed_function_parameter.test.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Typed function parameter with anonymous function argument">
+    <source language="dart">
+        <![CDATA[
+int f1(int Function(int n) f) {
+  var a = f(10);
+  var b = f(20);
+  return a + b;
+}
+
+int run() {
+  return f1((int n) => n * 10);
+}
+        ]]>
+    </source>
+    <call function="run" return="300">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  int f1(int Function(int) f) {
+    var a = f(10);
+    var b = f(20);
+    return a + b;
+  }
+
+  int run() {
+    return f1((int n) => n * 10);
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  function f1(f) {
+    let a = f(10);
+    let b = f(20);
+    return a + b;
+  }
+
+  function run() {
+    return f1((n) => n * 10);
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/javascript_local_function_no_duplication.test.xml
+++ b/test/tests_definitions/javascript_local_function_no_duplication.test.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Local function is not duplicated after execution">
+    <source language="javascript">
+        <![CDATA[
+function f(a) {
+  const g = (x) => x * 2;
+  return g(a);
+}
+        ]]>
+    </source>
+    <call function="f" return="8">
+        [4]
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  function f(a) {
+    function g(x) {
+      return x * 2;
+    }
+
+
+    return g(a);
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/python_basic_class_method.test.xml
+++ b/test/tests_definitions/python_basic_class_method.test.xml
@@ -28,8 +28,8 @@ class Foo:
         return a * 10
 
     def test(self, a) -> None:
-        b = m10(a)
-        c = m10(b)
+        b = self.m10(a)
+        c = self.m10(b)
         s: str = f'a: {a} ; b: {b} ; c: {c}'
         print(s)
 

--- a/test/tests_definitions/python_lambda_callback.test.xml
+++ b/test/tests_definitions/python_lambda_callback.test.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Python lambda passed as a callback">
+    <source language="python">
+        <![CDATA[
+def apply(f, x):
+    return f(x)
+
+def main():
+    return apply(lambda a: a * 2, 5)
+        ]]>
+    </source>
+    <call function="main" return="10">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="python"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+def apply(f, x):
+    return f(x)
+
+def main():
+    return apply(lambda a: a * 2, 5)
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/python_self_member_access.test.xml
+++ b/test/tests_definitions/python_self_member_access.test.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Self member access: field read and method call">
+    <source language="python">
+        <![CDATA[
+class Counter:
+    base = 100
+
+    def bump(self, n):
+        return n + 1
+
+    def total(self, n):
+        b = self.bump(n)
+        return self.base + b
+        ]]>
+    </source>
+    <call class="Counter" function="total" return="106">
+        [5]
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="python"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Counter:
+    base = 100
+
+    def bump(self, n):
+        return n + 1
+
+    def total(self, n):
+        b = self.bump(n)
+        return self.base + b
+
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Counter {
+
+  dynamic base = 100;
+
+  dynamic bump(dynamic n) {
+    return n + 1;
+  }
+
+  dynamic total(dynamic n) {
+    var b = this.bump(n);
+    return this.base + b;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/python_self_referential_binding.test.xml
+++ b/test/tests_definitions/python_self_referential_binding.test.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Self-referential bindings: parameter reassignment and loop accumulation">
+    <source language="python">
+        <![CDATA[
+def inc(x):
+    x = x + 1
+    return x
+
+def accumulate(items):
+    total = 0
+    for i in items:
+        total = total + i
+    return total
+        ]]>
+    </source>
+    <call function="inc" return="11">
+        [10]
+    </call>
+    <output>
+        []
+    </output>
+    <call function="accumulate" return="10">
+        [[1, 2, 3, 4]]
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="python"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+def inc(x):
+    x = x + 1
+    return x
+
+def accumulate(items):
+    total: int = 0
+    for i in items:
+        total = total + i
+    return total
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/python_ternary_conditional.test.xml
+++ b/test/tests_definitions/python_ternary_conditional.test.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Ternary conditional expression (Python `a if c else b`)">
+    <source language="python">
+        <![CDATA[
+def classify(a):
+    return 1 if a > 0 else -1
+        ]]>
+    </source>
+    <call function="classify" return="1">
+        [5]
+    </call>
+    <output>
+        []
+    </output>
+    <call function="classify" return="-1">
+        [-5]
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="python"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+def classify(a):
+    return 1 if a > 0 else -1
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  dynamic classify(dynamic a) {
+    return (a > 0) ? 1 : -1;
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>


### PR DESCRIPTION
Release **apollovm 0.1.36**.

## Language features (parse → execute → cross-generate)

### Ternary / conditional expressions
- Parse `c ? a : b` (Dart/Java/JS/TS), plus native `a if c else b` (Python) and `if (c) a else b` (Kotlin).
- New `ASTExpressionConditional` (only the selected branch is evaluated); generated idiomatically per target (`?:`, `a if c else b`, `if(c) a else b`, `c and a or b`, and a value-typed Wasm `if`/`else`).

### Anonymous functions / lambdas / closures
- New `ASTExpressionLiteralFunction` capturing the defining scope; function values held in variables/parameters are invocable.
- Parse `(x) => …` / `(x) { … }` (Dart), `(x) => …` / `x => …` (JS/TS), `lambda x: …` (Python); generate for all targets (Java `(x) -> …`, Kotlin `{ x -> … }`, Lua `function(x) … end`, etc.).

### Dart function types
- Parse `int Function(int n)`, `void Function()`, `Function(int n)` (return omitted → `dynamic`); `ASTTypeFunction` accepts any function type; generated as `int Function(int)` (Dart) / bare `Function` elsewhere.

### Wasm closures (function table + `call_indirect`)
- Added Table/Element sections and `call_indirect`. A function value is an i32 pointer to a heap env struct `[tableSlot, captures…]`; closure functions take a hidden env pointer and read captured vars from it.
- Concrete signatures inferred for capture-less, untyped-param, **capturing**, and **returned** closures (concrete `Function` return types). Each closure instance gets its own heap environment.
- *Not yet supported in Wasm:* polymorphic dynamic-return function types (clear error; works on the interpreter).

## Bug fixes
- Python: `self.method()` / `self.field` round-trip; fixed a `self.field` getter parse crash and a stack overflow on self-referential bindings (`s = s + i`).
- Local function declarations duplicated in regenerated code after execution (idempotent `addFunction` + block-generation dedup).
- Doubled indentation of nested function declarations.

## Docs
- Added **Python** to the package description and README (language section + TODO updates).

## Tests
- +17 test definitions and Wasm tests — **837 passing**, analyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)