### PR TITLE
Lambda input parsing (Java/Kotlin/Lua) + Wasm import-index fix (0.1.37)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 0.1.37
+
+### Lambda / anonymous-function input parsing (Java, Kotlin, Lua)
+
+- **Java**: parse lambdas as expressions — `(a, b) -> expr`, `(int a) -> { ... }`,
+  `x -> x * 2`, `() -> 0` (typed or untyped parameters).
+- **Kotlin**: parse lambdas `{ x -> x * 2 }`, `{ x: Int, y: Int -> x + y }`,
+  `{ 42 }`; the last expression is the implicit return value.
+- **Lua**: parse anonymous functions `function(x) ... end`.
+- Closures now round-trip (parse → execute → regenerate) in these languages, not
+  just generate.
+
+### Wasm: host imports no longer corrupt module-function call indices
+
+- A module-function `call` index is `importCount + position`, but host imports
+  (`env.print`, `env.int_to_str`, …) are registered lazily while bodies are
+  generated. A call emitted *before* an import was registered (e.g. calling a
+  function and then `print`-ing, including across `await` points) got a stale
+  index and produced invalid Wasm (`type mismatch`). The import-discovery pass
+  that freezes `importCount` before the real pass now runs for all modules (it
+  only touches idempotent state, so import-free modules stay byte-identical).
+- Fixes `async`/`await` functions that call other functions and `print` between
+  awaits, which now run identically on the interpreter and Wasm.
+
 ## 0.1.36
 
 ### Ternary / conditional expressions

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -50,7 +50,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.36';
+  static final String VERSION = '0.1.37';
 
   static int _idCount = 0;
 

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -529,7 +529,8 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
           });
 
   Parser<ASTExpression> expressionNoOperation() =>
-      (expressionNegate() |
+      (expressionLambda() |
+              expressionNegate() |
               expressionLiteral() |
               expressionGroupFunctionInvocation() |
               expressionGroup() |
@@ -905,6 +906,88 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
   Parser<ASTScopeVariable> scopeVariable() => (identifier()).map((v) {
     return ASTScopeVariable(v);
   });
+
+  /// Java lambda used as an expression (a closure): `(a, b) -> expr`,
+  /// `(int a) -> { ... }`, `x -> x * 2`, `() -> 0`. Captures the enclosing scope.
+  Parser<ASTExpression> expressionLambda() =>
+      (lambdaParameters() & string('->').trimHidden() & lambdaBody()).map((v) {
+        var parameters = v[0] as ASTFunctionParametersDeclaration;
+        var block = v[2] as ASTBlock;
+        var f = ASTFunctionDeclaration(
+          '',
+          parameters,
+          ASTTypeDynamic.instance,
+          block: block,
+          modifiers: ASTModifiers.modifierStatic,
+        );
+        return ASTExpressionLiteralFunction(f);
+      });
+
+  Parser<ASTBlock> lambdaBody() =>
+      (codeBlock() | lambdaExpressionBody()).cast<ASTBlock>();
+
+  Parser<ASTBlock> lambdaExpressionBody() => ref0(expression).map(
+    (e) => ASTBlock(null)..addStatement(ASTStatementReturnWithExpression(e)),
+  );
+
+  Parser<ASTFunctionParametersDeclaration> lambdaParameters() =>
+      (lambdaParenParameters() | lambdaSingleParameter())
+          .cast<ASTFunctionParametersDeclaration>();
+
+  Parser<ASTFunctionParametersDeclaration> lambdaSingleParameter() =>
+      identifier().trim().map(
+        (name) => ASTFunctionParametersDeclaration(
+          [
+            ASTFunctionParameterDeclaration(
+              ASTTypeDynamic.instance,
+              name,
+              -1,
+              false,
+            ),
+          ],
+          null,
+          null,
+        ),
+      );
+
+  Parser<ASTFunctionParametersDeclaration> lambdaParenParameters() =>
+      (char('(').trimHidden() &
+              (lambdaParameter() &
+                      (char(',').trimHidden() & lambdaParameter()).star())
+                  .optional() &
+              char(')').trimHidden())
+          .map((v) {
+            var first = v[1];
+            if (first == null) {
+              return ASTFunctionParametersDeclaration(null, null, null);
+            }
+            var params = <ASTFunctionParameterDeclaration>[
+              (first as List)[0] as ASTFunctionParameterDeclaration,
+            ];
+            for (var e in (first[1] as List)) {
+              params.add((e as List)[1] as ASTFunctionParameterDeclaration);
+            }
+            return ASTFunctionParametersDeclaration(params, null, null);
+          });
+
+  /// A lambda parameter: typed (`int a`) or untyped (`a`).
+  Parser<ASTFunctionParameterDeclaration> lambdaParameter() =>
+      ((type().trim() & identifier()) | identifier().trim()).map((v) {
+        if (v is List) {
+          return ASTFunctionParameterDeclaration(
+            v[0] as ASTType,
+            v[1] as String,
+            -1,
+            false,
+          );
+        }
+        return ASTFunctionParameterDeclaration(
+          ASTTypeDynamic.instance,
+          v,
+          -1,
+          false,
+        );
+      });
 
   Parser<ASTFunctionParametersDeclaration> functionParametersDeclaration() =>
       (functionEmptyParametersDeclaration() |

--- a/lib/src/languages/kotlin/kotlin_grammar.dart
+++ b/lib/src/languages/kotlin/kotlin_grammar.dart
@@ -557,7 +557,8 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
           });
 
   Parser<ASTExpression> expressionNoOperation() =>
-      (expressionNegate() |
+      (expressionLambda() |
+              expressionNegate() |
               expressionLiteral() |
               expressionGroupFunctionInvocation() |
               expressionGroup() |
@@ -909,6 +910,65 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
       (identifier().trimHidden() & char(':').trimHidden() & type()).map((v) {
         return ASTFunctionParameterDeclaration(v[2], v[0], -1, false);
       });
+
+  /// Kotlin lambda used as an expression (a closure): `{ x -> x * 2 }`,
+  /// `{ x: Int, y: Int -> x + y }`, `{ 42 }` (no parameters). The last
+  /// expression is the implicit return value. Captures the enclosing scope.
+  Parser<ASTExpression> expressionLambda() =>
+      (char('{').trimHidden() &
+              (lambdaParameters() & string('->').trimHidden()).optional() &
+              ref0(statement).star() &
+              char('}').trimHidden())
+          .map((v) {
+            var paramsOpt = v[1] as List?;
+            var parameters = paramsOpt != null
+                ? paramsOpt[0] as ASTFunctionParametersDeclaration
+                : ASTFunctionParametersDeclaration(null, null, null);
+            var statements = (v[2] as List).cast<ASTStatement>().toList();
+            // Kotlin returns the last expression of the lambda body.
+            if (statements.isNotEmpty &&
+                statements.last is ASTStatementExpression) {
+              var last = statements.removeLast() as ASTStatementExpression;
+              statements.add(ASTStatementReturnWithExpression(last.expression));
+            }
+            var block = ASTBlock(null)..addAllStatements(statements);
+            var f = ASTFunctionDeclaration(
+              '',
+              parameters,
+              ASTTypeDynamic.instance,
+              block: block,
+              modifiers: ASTModifiers.modifierStatic,
+            );
+            return ASTExpressionLiteralFunction(f);
+          });
+
+  Parser<ASTFunctionParametersDeclaration> lambdaParameters() =>
+      (lambdaParameter() & (char(',').trimHidden() & lambdaParameter()).star())
+          .map((v) {
+            var params = <ASTFunctionParameterDeclaration>[
+              v[0] as ASTFunctionParameterDeclaration,
+            ];
+            for (var e in (v[1] as List)) {
+              params.add((e as List)[1] as ASTFunctionParameterDeclaration);
+            }
+            return ASTFunctionParametersDeclaration(params, null, null);
+          });
+
+  /// A lambda parameter: typed (`x: Int`) or untyped (`x`).
+  Parser<ASTFunctionParameterDeclaration> lambdaParameter() =>
+      (identifier().trimHidden() & (char(':').trimHidden() & type()).optional())
+          .map((v) {
+            var typeOpt = v[1] as List?;
+            var type = typeOpt != null
+                ? typeOpt[1] as ASTType
+                : ASTTypeDynamic.instance;
+            return ASTFunctionParameterDeclaration(
+              type,
+              v[0] as String,
+              -1,
+              false,
+            );
+          });
 
   Parser<ASTType> type() =>
       ((mapTyped() | arrayTyped() | simpleType()) & char('?').optional()).map((

--- a/lib/src/languages/lua/lua_grammar.dart
+++ b/lib/src/languages/lua/lua_grammar.dart
@@ -156,6 +156,26 @@ class LuaGrammarDefinition extends LuaGrammarLexer {
             );
           });
 
+  /// An anonymous function used as an expression (a closure):
+  /// `function(params) ... end`. Captures the enclosing scope.
+  Parser<ASTExpression> expressionAnonymousFunction() =>
+      (functionToken().trimHidden() &
+              functionParametersDeclaration() &
+              ref0(block) &
+              endToken().trimHidden())
+          .map((v) {
+            var parameters = v[1] as ASTFunctionParametersDeclaration;
+            var body = v[2] as ASTBlock;
+            var f = ASTFunctionDeclaration(
+              '',
+              parameters,
+              _inferReturnType(body),
+              block: body,
+              modifiers: ASTModifiers.modifierStatic,
+            );
+            return ASTExpressionLiteralFunction(f);
+          });
+
   Parser<ASTFunctionDeclaration> localFunctionDeclaration() =>
       (localToken().trimHidden() &
               functionToken().trimHidden() &
@@ -501,7 +521,8 @@ class LuaGrammarDefinition extends LuaGrammarLexer {
           .cast<ASTExpressionOperator>();
 
   Parser<ASTExpression> expressionNoOperation() =>
-      (ref0(expressionNegate) |
+      (ref0(expressionAnonymousFunction) |
+              ref0(expressionNegate) |
               ref0(expressionLiteral) |
               ref0(expressionGroup) |
               ref0(expressionTableLiteral) |

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -979,14 +979,14 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     // A function's call indices are `importCount + position`, but host imports
     // (`env.print`, `env.int_to_str`, …) are registered lazily as bodies are
-    // generated. With classes a function may call another that is generated
-    // later (and registers imports), so emit a discovery pass first to register
-    // all imports — making `importCount` final — before the real pass. Scoped
-    // to class modules so import-free / single-function modules stay byte-stable.
-    if (module.classLayouts.isNotEmpty) {
-      for (var f in module.functions) {
-        _generateModuleFunctionBody(f, module);
-      }
+    // generated. A function may call another (or itself) and register an import
+    // *after* that call is emitted, which would shift `importCount` and corrupt
+    // the already-emitted index. So emit a discovery pass first to register all
+    // imports — making `importCount` final — before the real pass. The discovery
+    // pass only mutates idempotent module state (imports, interned strings,
+    // synth functions), so import-free modules stay byte-identical.
+    for (var f in module.functions) {
+      _generateModuleFunctionBody(f, module);
     }
 
     var entries = module.functions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, JavaScript, TypeScript, Lua and Python with on-the-fly Wasm compilation.
-version: 0.1.36
+version: 0.1.37
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/apollovm_wasm_asyncify_runner_test.dart
+++ b/test/apollovm_wasm_asyncify_runner_test.dart
@@ -647,5 +647,42 @@ void main() {
 
       expect(r.getValueNoContext(), equals(42));
     });
+
+    test('async fn awaiting module fns with print between awaits', () async {
+      // `print` (a host import) registered after a module-function call must not
+      // shift the import index space and corrupt the call's index.
+      var runner = await _wasmRunner(r'''
+        Future<int> doubleIt(int n) async {
+          return n * 2;
+        }
+
+        Future<int> increment(int n) async {
+          return n + 1;
+        }
+
+        Future<int> run(int x) async {
+          var doubled = await doubleIt(x);
+          print('doubled: $doubled');
+          var result = await increment(doubled);
+          print('incremented: $result');
+          return result;
+        }
+      ''');
+      if (runner == null) {
+        fail('Wasm runtime not supported.');
+      }
+
+      var out = <String>[];
+      runner.externalPrintFunction = (o) => out.add('$o');
+
+      var r = await runner.executeFunction(
+        '',
+        'run',
+        positionalParameters: [10],
+      );
+
+      expect(r.getValueNoContext(), equals(21));
+      expect(out, equals(['doubled: 20', 'incremented: 21']));
+    });
   });
 }

--- a/test/apollovm_wasm_test.dart
+++ b/test/apollovm_wasm_test.dart
@@ -1114,6 +1114,30 @@ void main() async {
     );
 
     test(
+      'callThenPrint',
+      () => _testWasm(
+        language: 'dart',
+        code: r'''
+
+          int dbl(int n) {
+            return n * 2;
+          }
+
+          int run(int x) {
+            var d = dbl(x);
+            print('d: $d');
+            return d;
+          }
+
+        ''',
+        functionName: 'run',
+        executions: {
+          [10]: 20,
+        },
+      ),
+    );
+
+    test(
       'closureReturned',
       () => _testWasm(
         language: 'dart',

--- a/test/tests_definitions/java_lambda_input.test.xml
+++ b/test/tests_definitions/java_lambda_input.test.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Java lambda input">
+    <source language="java11">
+        <![CDATA[
+class C {
+  static int apply(Function f, int v){ return f(v); }
+  static int run(){ return apply((x) -> x * 2, 21); }
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="42">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="java11"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class C {
+
+  static int apply(Function f, int v) {
+    return f(v);
+  }
+
+  static int run() {
+    return apply((Object x) -> x * 2, 21);
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/kotlin_lambda_input.test.xml
+++ b/test/tests_definitions/kotlin_lambda_input.test.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Kotlin lambda input">
+    <source language="kotlin">
+        <![CDATA[
+class C {
+  fun run(): Int {
+    val f = { x: Int -> x * 2 }
+    return f(21)
+  }
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="42">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="kotlin"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class C {
+
+  fun run(): Int {
+    val f = { x: Int -> x * 2 }
+    return f(21)
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/lua_anonymous_function_input.test.xml
+++ b/test/tests_definitions/lua_anonymous_function_input.test.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Lua anonymous function input">
+    <source language="lua">
+        <![CDATA[
+function run()
+  local f = function(x) return x * 2 end
+  return f(21)
+end
+        ]]>
+    </source>
+    <call function="run" return="42">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="lua"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  function run()
+    local f = function(x) return x * 2 end
+    return f(21)
+  end
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>


### PR DESCRIPTION
Release **apollovm 0.1.37**.

## Lambda / anonymous-function input parsing (Java, Kotlin, Lua)
Closures previously **generated** for these targets but couldn't be **parsed back**. Now they round-trip (parse → execute → regenerate):
- **Java**: `(a, b) -> expr`, `(int a) -> { ... }`, `x -> x * 2`, `() -> 0` (typed or untyped params).
- **Kotlin**: `{ x -> x * 2 }`, `{ x: Int, y: Int -> x + y }`, `{ 42 }` — last expression is the implicit return.
- **Lua**: `function(x) ... end`.

Tests: `java_lambda_input`, `kotlin_lambda_input`, `lua_anonymous_function_input`.

## Wasm: host imports no longer corrupt module-function call indices
A module-function `call` index is `importCount + position`, but host imports (`env.print`, `env.int_to_str`, …) are registered **lazily** as bodies are generated. A `call` emitted **before** an import was registered (e.g. calling a function and then `print`-ing — including across `await` points) got a stale index and produced invalid Wasm (`type mismatch: expected i64, found i32`).

The import-discovery pass that freezes `importCount` before the real pass was scoped to *class* modules only; it now runs for **all** modules. It only mutates idempotent state (imports, interned strings, synth functions), so import-free modules stay **byte-identical** — all golden hex tests still pass.

This fixes `async`/`await` functions that call other functions and `print` between awaits, e.g.:
```dart
Future<int> doubleIt(int n) async { return n * 2; }
Future<int> increment(int n) async { return n + 1; }
Future<void> main(int x) async {
  var doubled = await doubleIt(x);
  var result = await increment(doubled);
  print('doubled: $doubled');
  print('incremented: $result');
}
```
which now runs identically on the interpreter and Wasm.

Tests: `callThenPrint` (sync root cause) + an async+print case in the asyncify runner suite.

## Version
Bump to **0.1.37**; CHANGELOG updated. **842 tests passing**, analyzer clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)