### PR TITLE
v0.1.38: C# lambda, control flow (switch/break/continue/do-while), bitwise operators, enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,27 @@
 - New golden tests under `test/tests_definitions/*_control_flow*.test.xml` for
   all eight languages.
 
+### Bitwise operators
+
+- New operators `&`, `|`, `^`, `<<`, `>>` (binary) and `~` (unary complement),
+  with shared AST/runtime evaluation (`int` operands) and precedence (shift,
+  then AND/XOR/OR, between arithmetic and comparison).
+- Parsed and generated in **Dart, Java, C#, JavaScript, TypeScript, Python**.
+  Java additionally gains the previously-missing `%`, `&&` and `||` operators.
+- Not added for Kotlin (bitwise are infix functions `and`/`or`/`shl`/`inv`) or
+  Lua (`~` is xor and `^` is exponentiation) — their non-symbolic forms need
+  bespoke handling.
+- New golden tests `test/tests_definitions/*_bitwise.test.xml`.
+
+### enum (Java, C#, Kotlin, Python)
+
+- Enum declaration parsing + generation extended to **Java** (`enum E { … }`),
+  **C#** (`enum E { A = 1, … }`), **Kotlin** (`enum class E { … }`) and
+  **Python** (`class E(Enum): …`), joining the existing Dart/TypeScript support.
+- Declaration + round-trip only (matching the prior Dart/TS level); runtime
+  enum-value access is a separate future enhancement.
+- New golden tests `test/tests_definitions/*_enum.test.xml`.
+
 ## 0.1.37
 
 ### Language: C#

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,34 @@
+## 0.1.38
+
+### Language: C# — lambda parsing
+
+- Parse C# lambda expressions (`x => x * 2`, `(a, b) => a + b`, `(int a) => { ... }`,
+  `() => 0`); previously C# could only *generate* lambda syntax, not read it.
+- Delegate type names (`Func`, `Action`, `Delegate`, `Function`) map to the shared
+  function type, so a lambda value binds to a delegate-typed parameter.
+
+### Control flow: `switch`/`case`, `break`, `continue`, `do`/`while`
+
+- New shared AST/runtime nodes (`ASTStatementBreak`, `ASTStatementContinue`,
+  `ASTStatementDoWhileLoop`, `ASTStatementSwitch`/`ASTSwitchCase`). `break`/
+  `continue` propagate through `ASTBlock` and are consumed by the enclosing
+  loop/switch; `for` still runs its increment on `continue`.
+- `switch` uses C-style fall-through (`break` ends a case; `default` runs when no
+  case matches). An `ASTStatementSwitch.fallThrough` flag disables fall-through
+  for languages whose construct has none.
+- Parsing + code generation added to the C-style languages: **Dart, Java, C#,
+  JavaScript, TypeScript** (each `case` body accepts a braced block or a bare run
+  of statements).
+- Mapped to each non-C-style language's idiom:
+  - **Kotlin**: `break`/`continue`, `do { } while (c)`, and `when (e) { v -> …;
+    else -> … }` (no fall-through).
+  - **Python**: `break`/`continue`, and `match`/`case` (`case _:` is the
+    default; no fall-through). Python has no `do`/`while`.
+  - **Lua**: `break`, and `repeat … until <cond>` mapped to a do-while (the
+    condition is negated; the generator unwraps it to emit `until <cond>`).
+- New golden tests under `test/tests_definitions/*_control_flow*.test.xml` for
+  all eight languages.
+
 ## 0.1.37
 
 ### Language: C#

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -53,7 +53,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.37';
+  static final String VERSION = '0.1.38';
 
   static int _idCount = 0;
 

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -722,7 +722,9 @@ abstract class ApolloCodeGenerator
         out.write(': {\n');
       }
 
-      out.write(generateASTBlock(c.block, indent: indent2, withBrackets: false));
+      out.write(
+        generateASTBlock(c.block, indent: indent2, withBrackets: false),
+      );
       out.write(indent2);
       out.write('}\n');
     }

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -1342,6 +1342,13 @@ abstract class ApolloCodeGenerator
         indent: indent,
         headIndented: headIndented,
       );
+    } else if (expression is ASTExpressionBitwiseNot) {
+      return generateASTExpressionBitwiseNot(
+        expression,
+        out: out,
+        indent: indent,
+        headIndented: headIndented,
+      );
     } else if (expression is ASTExpressionAwait) {
       return generateASTExpressionAwait(
         expression,
@@ -1705,6 +1712,29 @@ abstract class ApolloCodeGenerator
 
     // Parenthesize a complex operand so `!(a > b)` is not emitted as `!a > b`
     // (which would re-parse as `(!a) > b`).
+    final inner = expression.expression;
+    final group = inner.isComplex;
+
+    if (group) out.write('(');
+    generateASTExpression(inner, out: out, indent: indent, headIndented: false);
+    if (group) out.write(')');
+
+    return out;
+  }
+
+  StringBuffer generateASTExpressionBitwiseNot(
+    ASTExpressionBitwiseNot expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write('~');
+
+    // Parenthesize a complex operand so `~(a + b)` is not emitted as `~a + b`.
     final inner = expression.expression;
     final group = inner.isComplex;
 

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -404,8 +404,36 @@ abstract class ApolloCodeGenerator
         indent: indent,
         headIndented: headIndented,
       );
+    } else if (statement is ASTStatementDoWhileLoop) {
+      return generateASTStatementDoWhileLoop(
+        statement,
+        out: out,
+        indent: indent,
+        headIndented: headIndented,
+      );
     } else if (statement is ASTStatementWhileLoop) {
       return generateASTStatementWhileLoop(
+        statement,
+        out: out,
+        indent: indent,
+        headIndented: headIndented,
+      );
+    } else if (statement is ASTStatementSwitch) {
+      return generateASTStatementSwitch(
+        statement,
+        out: out,
+        indent: indent,
+        headIndented: headIndented,
+      );
+    } else if (statement is ASTStatementBreak) {
+      return generateASTStatementBreak(
+        statement,
+        out: out,
+        indent: indent,
+        headIndented: headIndented,
+      );
+    } else if (statement is ASTStatementContinue) {
+      return generateASTStatementContinue(
         statement,
         out: out,
         indent: indent,
@@ -625,6 +653,112 @@ abstract class ApolloCodeGenerator
     out.write(blockCode);
     out.write(indent);
     out.write('}');
+
+    return out;
+  }
+
+  StringBuffer generateASTStatementDoWhileLoop(
+    ASTStatementDoWhileLoop doWhileLoop, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write('do {\n');
+
+    var blockCode = generateASTBlock(
+      doWhileLoop.loopBlock,
+      indent: indent,
+      withBrackets: false,
+    );
+
+    out.write(blockCode);
+    out.write(indent);
+    out.write('} while (');
+
+    generateASTExpression(
+      doWhileLoop.conditionExpression,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+
+    out.write(');');
+
+    return out;
+  }
+
+  StringBuffer generateASTStatementSwitch(
+    ASTStatementSwitch statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    var indent2 = '$indent  ';
+
+    out.write('switch (');
+    generateASTExpression(
+      statement.expression,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+    out.write(') {\n');
+
+    for (var c in statement.cases) {
+      out.write(indent2);
+      if (c.isDefault) {
+        out.write('default: {\n');
+      } else {
+        out.write('case ');
+        generateASTExpression(c.value!, out: out, headIndented: false);
+        out.write(': {\n');
+      }
+
+      out.write(generateASTBlock(c.block, indent: indent2, withBrackets: false));
+      out.write(indent2);
+      out.write('}\n');
+    }
+
+    out.write(indent);
+    out.write('}');
+
+    return out;
+  }
+
+  StringBuffer generateASTStatementBreak(
+    ASTStatementBreak statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write('break;');
+
+    return out;
+  }
+
+  StringBuffer generateASTStatementContinue(
+    ASTStatementContinue statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write('continue;');
 
     return out;
   }

--- a/lib/src/ast/apollovm_ast_base.dart
+++ b/lib/src/ast/apollovm_ast_base.dart
@@ -109,6 +109,21 @@ class ASTRunStatus {
 
   /// Returns true if some statement demands loop interruption (break).
   bool broke = false;
+
+  /// Signals a `continue` (skip to the next loop iteration).
+  ASTValueVoid markContinue() {
+    continued = true;
+    return ASTValueVoid.instance;
+  }
+
+  /// Signals a `break` (interrupt the enclosing loop or switch).
+  ASTValueVoid markBreak() {
+    broke = true;
+    return ASTValueVoid.instance;
+  }
+
+  /// `true` if any control-flow flag interrupts normal block execution.
+  bool get interrupted => returned || broke || continued;
 }
 
 abstract class ASTTypedNode {

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -631,6 +631,11 @@ enum ASTExpressionOperator {
   remainder,
   and,
   or,
+  bitwiseAnd,
+  bitwiseOr,
+  bitwiseXor,
+  shiftLeft,
+  shiftRight,
 }
 
 ASTExpressionOperator getASTExpressionOperator(String op) {
@@ -664,6 +669,16 @@ ASTExpressionOperator getASTExpressionOperator(String op) {
       return ASTExpressionOperator.and;
     case '||':
       return ASTExpressionOperator.or;
+    case '&':
+      return ASTExpressionOperator.bitwiseAnd;
+    case '|':
+      return ASTExpressionOperator.bitwiseOr;
+    case '^':
+      return ASTExpressionOperator.bitwiseXor;
+    case '<<':
+      return ASTExpressionOperator.shiftLeft;
+    case '>>':
+      return ASTExpressionOperator.shiftRight;
     default:
       throw UnsupportedError(op);
   }
@@ -700,6 +715,16 @@ String getASTExpressionOperatorText(ASTExpressionOperator op) {
       return '&&';
     case ASTExpressionOperator.or:
       return '||';
+    case ASTExpressionOperator.bitwiseAnd:
+      return '&';
+    case ASTExpressionOperator.bitwiseOr:
+      return '|';
+    case ASTExpressionOperator.bitwiseXor:
+      return '^';
+    case ASTExpressionOperator.shiftLeft:
+      return '<<';
+    case ASTExpressionOperator.shiftRight:
+      return '>>';
   }
 }
 
@@ -813,6 +838,49 @@ class ASTExpressionNegative extends ASTExpression {
   @override
   String toString({bool asGroup = false}) {
     var s = '-$expression';
+    return asGroup ? '($s)' : s;
+  }
+}
+
+/// [ASTExpression] for the bitwise complement (`~expression`).
+class ASTExpressionBitwiseNot extends ASTExpression {
+  ASTExpression expression;
+
+  ASTExpressionBitwiseNot(this.expression);
+
+  @override
+  bool get isComplex => true;
+
+  @override
+  Iterable<ASTNode> get children => [expression];
+
+  @override
+  FutureOr<ASTType> resolveType(VMContext? context) => ASTTypeInt.instance;
+
+  @override
+  FutureOr<ASTValue> run(VMContext parentContext, ASTRunStatus runStatus) {
+    var context = defineRunContext(parentContext);
+
+    var retVal = expression.run(context, runStatus);
+
+    return retVal.resolveMapped((val) {
+      var t = val.type;
+      if (t is ASTTypeInt) {
+        var v1 = val.getValue(context) as int;
+        return ASTValueInt(~v1);
+      }
+
+      var message = "Can't perform bitwise-not operation with type: $t";
+      if (t is ASTTypeNull) {
+        throw ApolloVMNullPointerException(message);
+      }
+      throw UnsupportedError(message);
+    });
+  }
+
+  @override
+  String toString({bool asGroup = false}) {
+    var s = '~$expression';
     return asGroup ? '($s)' : s;
   }
 }
@@ -1007,6 +1075,11 @@ class ASTExpressionOperation extends ASTExpression {
           );
         }
       case ASTExpressionOperator.divideAsInt:
+      case ASTExpressionOperator.bitwiseAnd:
+      case ASTExpressionOperator.bitwiseOr:
+      case ASTExpressionOperator.bitwiseXor:
+      case ASTExpressionOperator.shiftLeft:
+      case ASTExpressionOperator.shiftRight:
         return ASTTypeInt.instance;
       case ASTExpressionOperator.divideAsDouble:
         return ASTTypeDouble.instance;
@@ -1040,6 +1113,11 @@ class ASTExpressionOperation extends ASTExpression {
           );
         }
       case ASTExpressionOperator.divideAsInt:
+      case ASTExpressionOperator.bitwiseAnd:
+      case ASTExpressionOperator.bitwiseOr:
+      case ASTExpressionOperator.bitwiseXor:
+      case ASTExpressionOperator.shiftLeft:
+      case ASTExpressionOperator.shiftRight:
         return ASTTypeInt.instance;
       case ASTExpressionOperator.divideAsDouble:
         return ASTTypeDouble.instance;
@@ -1198,6 +1276,16 @@ class ASTExpressionOperation extends ASTExpression {
               return operatorAnd(parentContext, c1, c2);
             case ASTExpressionOperator.or:
               return operatorOr(parentContext, c1, c2);
+            case ASTExpressionOperator.bitwiseAnd:
+              return operatorBitwiseAnd(parentContext, c1, c2);
+            case ASTExpressionOperator.bitwiseOr:
+              return operatorBitwiseOr(parentContext, c1, c2);
+            case ASTExpressionOperator.bitwiseXor:
+              return operatorBitwiseXor(parentContext, c1, c2);
+            case ASTExpressionOperator.shiftLeft:
+              return operatorShiftLeft(parentContext, c1, c2);
+            case ASTExpressionOperator.shiftRight:
+              return operatorShiftRight(parentContext, c1, c2);
           }
         });
       });
@@ -1531,6 +1619,64 @@ class ASTExpressionOperation extends ASTExpression {
       var val = a || b;
       return ASTValueBool(val);
     });
+  }
+
+  /// Reads an operand as an `int` for a bitwise operation, or throws.
+  int _bitwiseOperand(VMContext context, ASTValue val, String op) {
+    if (val.type is ASTTypeInt) {
+      return val.getValue(context) as int;
+    }
+    throwOperationError(op, val.type, val.type);
+  }
+
+  FutureOr<ASTValue> operatorBitwiseAnd(
+    VMContext context,
+    ASTValue val1,
+    ASTValue val2,
+  ) {
+    var v1 = _bitwiseOperand(context, val1, '&');
+    var v2 = _bitwiseOperand(context, val2, '&');
+    return ASTValueInt(v1 & v2);
+  }
+
+  FutureOr<ASTValue> operatorBitwiseOr(
+    VMContext context,
+    ASTValue val1,
+    ASTValue val2,
+  ) {
+    var v1 = _bitwiseOperand(context, val1, '|');
+    var v2 = _bitwiseOperand(context, val2, '|');
+    return ASTValueInt(v1 | v2);
+  }
+
+  FutureOr<ASTValue> operatorBitwiseXor(
+    VMContext context,
+    ASTValue val1,
+    ASTValue val2,
+  ) {
+    var v1 = _bitwiseOperand(context, val1, '^');
+    var v2 = _bitwiseOperand(context, val2, '^');
+    return ASTValueInt(v1 ^ v2);
+  }
+
+  FutureOr<ASTValue> operatorShiftLeft(
+    VMContext context,
+    ASTValue val1,
+    ASTValue val2,
+  ) {
+    var v1 = _bitwiseOperand(context, val1, '<<');
+    var v2 = _bitwiseOperand(context, val2, '<<');
+    return ASTValueInt(v1 << v2);
+  }
+
+  FutureOr<ASTValue> operatorShiftRight(
+    VMContext context,
+    ASTValue val1,
+    ASTValue val2,
+  ) {
+    var v1 = _bitwiseOperand(context, val1, '>>');
+    var v2 = _bitwiseOperand(context, val2, '>>');
+    return ASTValueInt(v1 >> v2);
   }
 
   FutureOr<bool> _toBoolean(ASTValue val, VMContext context) {

--- a/lib/src/ast/apollovm_ast_statement.dart
+++ b/lib/src/ast/apollovm_ast_statement.dart
@@ -1455,14 +1455,20 @@ class ASTSwitchCase {
 
 /// [ASTStatement] for `switch (exp) { case v: ... break; default: ... }`.
 ///
-/// Uses C-style fall-through: once a `case` matches, its block and the blocks of
-/// the following clauses run in order until a `break` (or `return`). If no
-/// `case` matches, the `default` clause (if present) runs.
+/// With [fallThrough] (the default, C-style `switch`): once a `case` matches,
+/// its block and the blocks of the following clauses run in order until a
+/// `break` (or `return`). With [fallThrough] `false` (e.g. Kotlin `when`,
+/// Python `match`): only the matched clause runs — there is no fall-through and
+/// `break` is implicit. If no `case` matches, the `default` clause (if present)
+/// runs.
 class ASTStatementSwitch extends ASTStatement {
   final ASTExpression expression;
   final List<ASTSwitchCase> cases;
 
-  ASTStatementSwitch(this.expression, this.cases);
+  /// Whether matched clauses fall through to the next clause (C-style).
+  final bool fallThrough;
+
+  ASTStatementSwitch(this.expression, this.cases, {this.fallThrough = true});
 
   @override
   Iterable<ASTNode> get children => [
@@ -1513,6 +1519,14 @@ class ASTStatementSwitch extends ASTStatement {
       }
 
       if (startIndex < 0) return ASTValueVoid.instance;
+
+      if (!fallThrough) {
+        // Only the matched clause runs (Kotlin `when` / Python `match`).
+        await cases[startIndex].block.run(context, runStatus);
+        // `break` is implicit here, so consume any that bubbled up.
+        if (runStatus.broke) runStatus.broke = false;
+        return ASTValueVoid.instance;
+      }
 
       // Fall-through: run from the matched clause onward until break/return.
       for (var i = startIndex; i < cases.length; ++i) {

--- a/lib/src/ast/apollovm_ast_statement.dart
+++ b/lib/src/ast/apollovm_ast_statement.dart
@@ -300,6 +300,12 @@ class ASTBlock extends ASTStatement {
         return (runStatus.returnedFutureValue ?? runStatus.returnedValue)!;
       }
 
+      // A `break`/`continue` interrupts this block and propagates up to the
+      // enclosing loop/switch, which consumes the corresponding flag.
+      if (runStatus.broke || runStatus.continued) {
+        return ret;
+      }
+
       returnValue = ret;
     }
 
@@ -1096,6 +1102,93 @@ class ASTStatementWhileLoop extends ASTStatement {
         VMContext.setCurrent(context);
 
         if (runStatus.returned) break;
+        if (runStatus.broke) {
+          runStatus.broke = false;
+          break;
+        }
+        if (runStatus.continued) {
+          runStatus.continued = false;
+          continue;
+        }
+      }
+    } finally {
+      VMContext.setCurrent(prevContext);
+    }
+
+    return ASTValueVoid.instance;
+  }
+
+  @override
+  ASTType resolveType(VMContext? context) => ASTTypeVoid.instance;
+}
+
+/// [ASTStatement] for a `do { } while (cond)` loop: the body runs at least once.
+class ASTStatementDoWhileLoop extends ASTStatement {
+  final ASTBlock loopBlock;
+
+  final ASTExpression conditionExpression;
+
+  ASTStatementDoWhileLoop(this.loopBlock, this.conditionExpression);
+
+  @override
+  Iterable<ASTNode> get children => [loopBlock, conditionExpression];
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+
+    loopBlock.resolveNode(parentNode);
+    conditionExpression.resolveNode(parentNode);
+  }
+
+  @override
+  VMContext defineRunContext(VMContext parentContext) {
+    return parentContext;
+  }
+
+  @override
+  FutureOr<ASTValue> run(
+    VMContext parentContext,
+    ASTRunStatus runStatus,
+  ) async {
+    var context = VMScopeContext(parentContext.block, parent: parentContext);
+
+    var prevContext = VMContext.setCurrent(context);
+    try {
+      while (true) {
+        var loopContext = VMScopeContext(parentContext.block, parent: context);
+
+        VMContext.setCurrent(loopContext);
+
+        await loopBlock.run(loopContext, runStatus);
+
+        VMContext.setCurrent(context);
+
+        if (runStatus.returned) break;
+        if (runStatus.broke) {
+          runStatus.broke = false;
+          break;
+        }
+        if (runStatus.continued) {
+          runStatus.continued = false;
+          // Falls through to the condition check below.
+        }
+
+        var cond = await conditionExpression.run(context, runStatus);
+
+        if (cond is ASTValueBool) {
+          if (!cond.value) break;
+        } else {
+          var condOK = await cond.getValue(context);
+
+          if (condOK is bool) {
+            if (!condOK) break;
+          } else {
+            throw ApolloVMRuntimeError(
+              'Condition not returning a boolean: $condOK',
+            );
+          }
+        }
       }
     } finally {
       VMContext.setCurrent(prevContext);
@@ -1185,6 +1278,14 @@ class ASTStatementForLoop extends ASTStatement {
         VMContext.setCurrent(context);
 
         if (runStatus.returned) break;
+        if (runStatus.broke) {
+          runStatus.broke = false;
+          break;
+        }
+        // `continue` still runs the loop's continue/increment expression below.
+        if (runStatus.continued) {
+          runStatus.continued = false;
+        }
 
         await continueExpression.run(context, runStatus);
       }
@@ -1281,6 +1382,14 @@ class ASTStatementForEach extends ASTStatement {
         VMContext.setCurrent(context);
 
         if (runStatus.returned) break;
+        if (runStatus.broke) {
+          runStatus.broke = false;
+          break;
+        }
+        if (runStatus.continued) {
+          runStatus.continued = false;
+          continue;
+        }
       }
     } finally {
       VMContext.setCurrent(prevContext);
@@ -1291,6 +1400,152 @@ class ASTStatementForEach extends ASTStatement {
 
   @override
   ASTType resolveType(VMContext? context) => ASTTypeVoid.instance;
+}
+
+/// [ASTStatement] for `break;` — interrupts the enclosing loop or switch.
+class ASTStatementBreak extends ASTStatement {
+  @override
+  Iterable<ASTNode> get children => [];
+
+  @override
+  FutureOr<ASTValue> run(VMContext parentContext, ASTRunStatus runStatus) {
+    return runStatus.markBreak();
+  }
+
+  @override
+  ASTType resolveType(VMContext? context) => ASTTypeVoid.instance;
+
+  @override
+  String toString() => 'break;';
+}
+
+/// [ASTStatement] for `continue;` — skips to the next loop iteration.
+class ASTStatementContinue extends ASTStatement {
+  @override
+  Iterable<ASTNode> get children => [];
+
+  @override
+  FutureOr<ASTValue> run(VMContext parentContext, ASTRunStatus runStatus) {
+    return runStatus.markContinue();
+  }
+
+  @override
+  ASTType resolveType(VMContext? context) => ASTTypeVoid.instance;
+
+  @override
+  String toString() => 'continue;';
+}
+
+/// A single `case <value>:` (or `default:`) clause of an [ASTStatementSwitch].
+///
+/// A [value] of `null` marks the `default` clause.
+class ASTSwitchCase {
+  final ASTExpression? value;
+  final ASTBlock block;
+
+  ASTSwitchCase(this.value, this.block);
+
+  bool get isDefault => value == null;
+
+  void resolveNode(ASTNode? parentNode) {
+    value?.resolveNode(parentNode);
+    block.resolveNode(parentNode);
+  }
+}
+
+/// [ASTStatement] for `switch (exp) { case v: ... break; default: ... }`.
+///
+/// Uses C-style fall-through: once a `case` matches, its block and the blocks of
+/// the following clauses run in order until a `break` (or `return`). If no
+/// `case` matches, the `default` clause (if present) runs.
+class ASTStatementSwitch extends ASTStatement {
+  final ASTExpression expression;
+  final List<ASTSwitchCase> cases;
+
+  ASTStatementSwitch(this.expression, this.cases);
+
+  @override
+  Iterable<ASTNode> get children => [
+    expression,
+    ...cases.map((e) => e.block),
+  ];
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+
+    expression.resolveNode(parentNode);
+    for (var c in cases) {
+      c.resolveNode(parentNode);
+    }
+  }
+
+  @override
+  VMContext defineRunContext(VMContext parentContext) => parentContext;
+
+  @override
+  FutureOr<ASTValue> run(
+    VMContext parentContext,
+    ASTRunStatus runStatus,
+  ) async {
+    var context = VMScopeContext(parentContext.block, parent: parentContext);
+    var prevContext = VMContext.setCurrent(context);
+
+    try {
+      var switchValue = await expression.run(context, runStatus);
+      var rawSwitch = await switchValue.getValue(context);
+
+      // Find the matching case, or fall back to `default`.
+      var startIndex = -1;
+      for (var i = 0; i < cases.length; ++i) {
+        var c = cases[i];
+        if (c.isDefault) continue;
+        var caseValue = await c.value!.run(context, runStatus);
+        var rawCase = await caseValue.getValue(context);
+        if (rawSwitch == rawCase) {
+          startIndex = i;
+          break;
+        }
+      }
+
+      if (startIndex < 0) {
+        startIndex = cases.indexWhere((c) => c.isDefault);
+      }
+
+      if (startIndex < 0) return ASTValueVoid.instance;
+
+      // Fall-through: run from the matched clause onward until break/return.
+      for (var i = startIndex; i < cases.length; ++i) {
+        await cases[i].block.run(context, runStatus);
+
+        // `return`/`continue` propagate up (e.g. `continue` of an enclosing
+        // loop); `break` is consumed here as it targets this switch.
+        if (runStatus.returned || runStatus.continued) break;
+        if (runStatus.broke) {
+          runStatus.broke = false;
+          break;
+        }
+      }
+    } finally {
+      VMContext.setCurrent(prevContext);
+    }
+
+    return ASTValueVoid.instance;
+  }
+
+  @override
+  ASTType resolveType(VMContext? context) => ASTTypeVoid.instance;
+
+  @override
+  String toString() {
+    var str = StringBuffer('switch ( $expression ) {\n');
+    for (var c in cases) {
+      str.write(c.isDefault ? 'default: ' : 'case ${c.value}: ');
+      str.write('${c.block}\n');
+    }
+    str.write('}');
+    return str.toString();
+  }
 }
 
 /// [ASTStatement] for `throw <expression>;`.

--- a/lib/src/ast/apollovm_ast_statement.dart
+++ b/lib/src/ast/apollovm_ast_statement.dart
@@ -1471,10 +1471,7 @@ class ASTStatementSwitch extends ASTStatement {
   ASTStatementSwitch(this.expression, this.cases, {this.fallThrough = true});
 
   @override
-  Iterable<ASTNode> get children => [
-    expression,
-    ...cases.map((e) => e.block),
-  ];
+  Iterable<ASTNode> get children => [expression, ...cases.map((e) => e.block)];
 
   @override
   void resolveNode(ASTNode? parentNode) {

--- a/lib/src/languages/csharp/csharp_generator.dart
+++ b/lib/src/languages/csharp/csharp_generator.dart
@@ -108,6 +108,10 @@ class ApolloCodeGeneratorCSharp extends ApolloCodeGenerator {
   }) {
     out ??= newOutput();
 
+    if (clazz is ASTClassEnum) {
+      return generateASTClassEnum(clazz, out: out, indent: indent);
+    }
+
     var code = generateASTBlock(
       clazz,
       withBrackets: true,
@@ -118,6 +122,37 @@ class ApolloCodeGeneratorCSharp extends ApolloCodeGenerator {
     out.write(clazz.name);
     out.write(' ');
     out.write(code);
+
+    return out;
+  }
+
+  /// Generates a C# `enum` declaration (with optional `= value` entries).
+  StringBuffer generateASTClassEnum(
+    ASTClassEnum clazz, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    out.write(indent);
+    out.write('enum ');
+    out.write(clazz.name);
+    out.write(' {\n');
+
+    var entries = clazz.entries;
+    for (var i = 0; i < entries.length; ++i) {
+      var e = entries[i];
+      out.write('$indent  ');
+      out.write(e.name);
+      if (e.value != null) {
+        out.write(' = ');
+        generateASTExpression(e.value!, out: out, headIndented: false);
+      }
+      if (i < entries.length - 1) out.write(',');
+      out.write('\n');
+    }
+
+    out.write('$indent}\n');
 
     return out;
   }

--- a/lib/src/languages/csharp/csharp_grammar.dart
+++ b/lib/src/languages/csharp/csharp_grammar.dart
@@ -370,9 +370,7 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
       });
 
   Parser<ASTExpression?> switchCaseLabel() =>
-      ((string('case').trimHidden() &
-                      ref0(expression) &
-                      char(':').trimHidden())
+      ((string('case').trimHidden() & ref0(expression) & char(':').trimHidden())
                   .map((v) => v[1] as ASTExpression?) |
               (string('default').trimHidden() & char(':').trimHidden()).map(
                 (v) => null,

--- a/lib/src/languages/csharp/csharp_grammar.dart
+++ b/lib/src/languages/csharp/csharp_grammar.dart
@@ -44,6 +44,11 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
         return ASTTypeString.instance;
       case 'List':
         return ASTTypeArray(ASTTypeDynamic.instance);
+      case 'Func':
+      case 'Action':
+      case 'Delegate':
+      case 'Function':
+        return ASTTypeFunction();
       case 'var':
         return ASTTypeVar();
       case 'dynamic':
@@ -570,7 +575,8 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
           });
 
   Parser<ASTExpression> expressionNoOperation() =>
-      (expressionNegate() |
+      (expressionLambda() |
+              expressionNegate() |
               expressionLiteral() |
               expressionGroupFunctionInvocation() |
               expressionGroup() |
@@ -956,6 +962,88 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
   Parser<ASTScopeVariable> scopeVariable() => (identifier()).map((v) {
     return ASTScopeVariable(v);
   });
+
+  /// C# lambda used as an expression (a closure): `(a, b) => expr`,
+  /// `(int a) => { ... }`, `x => x * 2`, `() => 0`. Captures the enclosing scope.
+  Parser<ASTExpression> expressionLambda() =>
+      (lambdaParameters() & string('=>').trimHidden() & lambdaBody()).map((v) {
+        var parameters = v[0] as ASTFunctionParametersDeclaration;
+        var block = v[2] as ASTBlock;
+        var f = ASTFunctionDeclaration(
+          '',
+          parameters,
+          ASTTypeDynamic.instance,
+          block: block,
+          modifiers: ASTModifiers.modifierStatic,
+        );
+        return ASTExpressionLiteralFunction(f);
+      });
+
+  Parser<ASTBlock> lambdaBody() =>
+      (codeBlock() | lambdaExpressionBody()).cast<ASTBlock>();
+
+  Parser<ASTBlock> lambdaExpressionBody() => ref0(expression).map(
+    (e) => ASTBlock(null)..addStatement(ASTStatementReturnWithExpression(e)),
+  );
+
+  Parser<ASTFunctionParametersDeclaration> lambdaParameters() =>
+      (lambdaParenParameters() | lambdaSingleParameter())
+          .cast<ASTFunctionParametersDeclaration>();
+
+  Parser<ASTFunctionParametersDeclaration> lambdaSingleParameter() =>
+      identifier().trim().map(
+        (name) => ASTFunctionParametersDeclaration(
+          [
+            ASTFunctionParameterDeclaration(
+              ASTTypeDynamic.instance,
+              name,
+              -1,
+              false,
+            ),
+          ],
+          null,
+          null,
+        ),
+      );
+
+  Parser<ASTFunctionParametersDeclaration> lambdaParenParameters() =>
+      (char('(').trimHidden() &
+              (lambdaParameter() &
+                      (char(',').trimHidden() & lambdaParameter()).star())
+                  .optional() &
+              char(')').trimHidden())
+          .map((v) {
+            var first = v[1];
+            if (first == null) {
+              return ASTFunctionParametersDeclaration(null, null, null);
+            }
+            var params = <ASTFunctionParameterDeclaration>[
+              (first as List)[0] as ASTFunctionParameterDeclaration,
+            ];
+            for (var e in (first[1] as List)) {
+              params.add((e as List)[1] as ASTFunctionParameterDeclaration);
+            }
+            return ASTFunctionParametersDeclaration(params, null, null);
+          });
+
+  /// A lambda parameter: typed (`int a`) or untyped (`a`).
+  Parser<ASTFunctionParameterDeclaration> lambdaParameter() =>
+      ((type().trim() & identifier()) | identifier().trim()).map((v) {
+        if (v is List) {
+          return ASTFunctionParameterDeclaration(
+            v[0] as ASTType,
+            v[1] as String,
+            -1,
+            false,
+          );
+        }
+        return ASTFunctionParameterDeclaration(
+          ASTTypeDynamic.instance,
+          v,
+          -1,
+          false,
+        );
+      });
 
   Parser<ASTFunctionParametersDeclaration> functionParametersDeclaration() =>
       (functionEmptyParametersDeclaration() |

--- a/lib/src/languages/csharp/csharp_grammar.dart
+++ b/lib/src/languages/csharp/csharp_grammar.dart
@@ -83,7 +83,41 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
       (char('.').trimHidden() & identifier()).star() &
       char(';').trimHidden());
 
-  Parser topLevelDefinition() => (classDeclaration());
+  Parser topLevelDefinition() => (enumDeclaration() | classDeclaration());
+
+  Parser<ASTClassEnum> enumDeclaration() =>
+      (classVisibilityModifier().star() &
+              string('enum') &
+              ref0(identifierPartLexicalToken).not() &
+              identifier().trimHidden() &
+              char('{').trimHidden() &
+              enumEntry() &
+              (char(',').trimHidden() & enumEntry()).star() &
+              char(',').trimHidden().optional() &
+              char('}').trimHidden())
+          .map((v) {
+            var name = v[3] as String;
+            var entries = <ASTEnumEntry>[v[5] as ASTEnumEntry];
+            for (var e in (v[6] as List)) {
+              entries.add(e[1] as ASTEnumEntry);
+            }
+            return ASTClassEnum(
+              name,
+              ASTType<VMObject>(name),
+              null,
+              entries: entries,
+            );
+          });
+
+  Parser<ASTEnumEntry> enumEntry() =>
+      (identifier().trimHidden() &
+              (char('=').trimHidden() & ref0(expression)).optional())
+          .map((v) {
+            var name = v[0] as String;
+            var valueOpt = v[1] as List?;
+            var value = valueOpt != null ? valueOpt[1] as ASTExpression : null;
+            return ASTEnumEntry(name, value);
+          });
 
   Parser<ASTClassNormal> classDeclaration() =>
       (classVisibilityModifier().star() &
@@ -632,12 +666,17 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
               char('%') |
               string('==') |
               string('!=') |
+              string('<<') |
+              string('>>') |
               string('<=') |
               string('>=') |
               string('&&') |
               string('||') |
               char('<') |
-              char('>'))
+              char('>') |
+              char('&') |
+              char('|') |
+              char('^'))
           .trimHidden()
           .map((v) {
             return getASTExpressionOperator(v);
@@ -646,6 +685,7 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
   Parser<ASTExpression> expressionNoOperation() =>
       (expressionLambda() |
               expressionNegate() |
+              expressionBitwiseNot() |
               expressionLiteral() |
               expressionGroupFunctionInvocation() |
               expressionGroup() |
@@ -679,6 +719,14 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
           .map((v) {
             var exp = v[1] as ASTExpression;
             return ASTExpressionNegative(exp);
+          });
+
+  Parser<ASTExpressionBitwiseNot> expressionBitwiseNot() =>
+      (char('~').trimHidden() &
+              (ref0(expressionNoOperation) | ref0(expressionGroup)))
+          .map((v) {
+            var exp = v[1] as ASTExpression;
+            return ASTExpressionBitwiseNot(exp);
           });
 
   Parser<ASTExpression> expressionGroup() =>

--- a/lib/src/languages/csharp/csharp_grammar.dart
+++ b/lib/src/languages/csharp/csharp_grammar.dart
@@ -309,14 +309,85 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
   Parser<ASTStatement> statement() =>
       (statementTryCatch() |
               statementThrow() |
+              statementSwitch() |
               branch() |
+              statementBreak() |
+              statementContinue() |
               statementReturn() |
+              statementDoWhileLoop() |
               statementForLoop() |
               statementForEach() |
               statementWhileLoop() |
               statementVariableDeclaration() |
               statementExpression())
           .cast<ASTStatement>();
+
+  Parser<ASTStatementBreak> statementBreak() =>
+      (string('break') &
+              ref0(identifierPartLexicalToken).not() &
+              char(';').trimHidden())
+          .map((v) => ASTStatementBreak());
+
+  Parser<ASTStatementContinue> statementContinue() =>
+      (string('continue') &
+              ref0(identifierPartLexicalToken).not() &
+              char(';').trimHidden())
+          .map((v) => ASTStatementContinue());
+
+  Parser<ASTStatementDoWhileLoop> statementDoWhileLoop() =>
+      (string('do').trimHidden() &
+              codeBlock() &
+              string('while').trimHidden() &
+              char('(').trimHidden() &
+              ref0(expression) &
+              char(')').trimHidden() &
+              char(';').trimHidden())
+          .map((v) {
+            var block = v[1] as ASTBlock;
+            var cond = v[4] as ASTExpression;
+            return ASTStatementDoWhileLoop(block, cond);
+          });
+
+  Parser<ASTStatementSwitch> statementSwitch() =>
+      (string('switch').trimHidden() &
+              char('(').trimHidden() &
+              ref0(expression) &
+              char(')').trimHidden() &
+              char('{').trimHidden() &
+              switchCase().star() &
+              char('}').trimHidden())
+          .map((v) {
+            var exp = v[2] as ASTExpression;
+            var cases = (v[5] as List).cast<ASTSwitchCase>();
+            return ASTStatementSwitch(exp, cases);
+          });
+
+  Parser<ASTSwitchCase> switchCase() =>
+      (switchCaseLabel() & switchCaseBody()).map((v) {
+        var value = v[0] as ASTExpression?;
+        var block = v[1] as ASTBlock;
+        return ASTSwitchCase(value, block);
+      });
+
+  Parser<ASTExpression?> switchCaseLabel() =>
+      ((string('case').trimHidden() &
+                      ref0(expression) &
+                      char(':').trimHidden())
+                  .map((v) => v[1] as ASTExpression?) |
+              (string('default').trimHidden() & char(':').trimHidden()).map(
+                (v) => null,
+              ))
+          .cast<ASTExpression?>();
+
+  /// A `case`/`default` body: a braced block (`{ ... }`) or a bare run of
+  /// statements up to the next `case`/`default`/`}`.
+  Parser<ASTBlock> switchCaseBody() =>
+      (codeBlock() | switchCaseStatements()).cast<ASTBlock>();
+
+  Parser<ASTBlock> switchCaseStatements() => ref0(statement).star().map((v) {
+    var statements = v.cast<ASTStatement>();
+    return ASTBlock(null)..addAllStatements(statements);
+  });
 
   Parser<ASTStatementThrow> statementThrow() =>
       (string('throw').trimHidden() & ref0(expression) & char(';').trimHidden())

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -397,7 +397,11 @@ class DartGrammarDefinition extends DartGrammarLexer {
   Parser<ASTStatement> statement() =>
       (statementTryCatch() |
               statementThrow() |
+              statementSwitch() |
               branch() |
+              statementBreak() |
+              statementContinue() |
+              statementDoWhileLoop() |
               statementForLoop() |
               statementForEach() |
               statementWhileLoop() |
@@ -407,6 +411,73 @@ class DartGrammarDefinition extends DartGrammarLexer {
               statementBlock() |
               statementExpression())
           .cast<ASTStatement>();
+
+  Parser<ASTStatementBreak> statementBreak() =>
+      (string('break') &
+              ref0(identifierPartLexicalToken).not() &
+              char(';').trimHidden())
+          .map((v) => ASTStatementBreak());
+
+  Parser<ASTStatementContinue> statementContinue() =>
+      (string('continue') &
+              ref0(identifierPartLexicalToken).not() &
+              char(';').trimHidden())
+          .map((v) => ASTStatementContinue());
+
+  Parser<ASTStatementDoWhileLoop> statementDoWhileLoop() =>
+      (string('do').trimHidden() &
+              codeBlock() &
+              string('while').trimHidden() &
+              char('(').trimHidden() &
+              ref0(expression) &
+              char(')').trimHidden() &
+              char(';').trimHidden())
+          .map((v) {
+            var block = v[1] as ASTBlock;
+            var cond = v[4] as ASTExpression;
+            return ASTStatementDoWhileLoop(block, cond);
+          });
+
+  Parser<ASTStatementSwitch> statementSwitch() =>
+      (string('switch').trimHidden() &
+              char('(').trimHidden() &
+              ref0(expression) &
+              char(')').trimHidden() &
+              char('{').trimHidden() &
+              switchCase().star() &
+              char('}').trimHidden())
+          .map((v) {
+            var exp = v[2] as ASTExpression;
+            var cases = (v[5] as List).cast<ASTSwitchCase>();
+            return ASTStatementSwitch(exp, cases);
+          });
+
+  Parser<ASTSwitchCase> switchCase() =>
+      (switchCaseLabel() & switchCaseBody()).map((v) {
+        var value = v[0] as ASTExpression?;
+        var block = v[1] as ASTBlock;
+        return ASTSwitchCase(value, block);
+      });
+
+  Parser<ASTExpression?> switchCaseLabel() =>
+      ((string('case').trimHidden() &
+                      ref0(expression) &
+                      char(':').trimHidden())
+                  .map((v) => v[1] as ASTExpression?) |
+              (string('default').trimHidden() & char(':').trimHidden()).map(
+                (v) => null,
+              ))
+          .cast<ASTExpression?>();
+
+  /// A `case`/`default` body: a braced block (`{ ... }`) or a bare run of
+  /// statements up to the next `case`/`default`/`}`.
+  Parser<ASTBlock> switchCaseBody() =>
+      (codeBlock() | switchCaseStatements()).cast<ASTBlock>();
+
+  Parser<ASTBlock> switchCaseStatements() => ref0(statement).star().map((v) {
+    var statements = v.cast<ASTStatement>();
+    return ASTBlock(null)..addAllStatements(statements);
+  });
 
   Parser<ASTStatementThrow> statementThrow() =>
       (string('throw').trimHidden() & ref0(expression) & char(';').trimHidden())

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -892,13 +892,18 @@ class DartGrammarDefinition extends DartGrammarLexer {
               string('~/') |
               string('==') |
               string('!=') |
+              string('<<') |
+              string('>>') |
               string('>=') |
               string('<=') |
               char('>') |
               char('<') |
               char('%') |
               string('&&') |
-              string('||'))
+              string('||') |
+              char('&') |
+              char('|') |
+              char('^'))
           .trimHidden()
           .map((v) {
             var op = getASTExpressionOperator(v);
@@ -916,6 +921,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
       (expressionAwait() |
               expressionAnonymousFunction() |
               expressionNegate() |
+              expressionBitwiseNot() |
               expressionLiteral() |
               expressionGroupFunctionInvocation() |
               expressionGroup() |
@@ -950,6 +956,14 @@ class DartGrammarDefinition extends DartGrammarLexer {
           .map((v) {
             var exp = v[1] as ASTExpression;
             return ASTExpressionNegative(exp);
+          });
+
+  Parser<ASTExpressionBitwiseNot> expressionBitwiseNot() =>
+      (char('~').trimHidden() &
+              (ref0(expressionNoOperation) | ref0(expressionGroup)))
+          .map((v) {
+            var exp = v[1] as ASTExpression;
+            return ASTExpressionBitwiseNot(exp);
           });
 
   Parser<ASTExpression> expressionGroup() =>

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -460,9 +460,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
       });
 
   Parser<ASTExpression?> switchCaseLabel() =>
-      ((string('case').trimHidden() &
-                      ref0(expression) &
-                      char(':').trimHidden())
+      ((string('case').trimHidden() & ref0(expression) & char(':').trimHidden())
                   .map((v) => v[1] as ASTExpression?) |
               (string('default').trimHidden() & char(':').trimHidden()).map(
                 (v) => null,

--- a/lib/src/languages/grammar.dart
+++ b/lib/src/languages/grammar.dart
@@ -106,6 +106,16 @@ abstract class BaseGrammarLexer extends GrammarDefinition {
       ASTExpressionOperator.subtract,
     });
 
+    // Bitwise precedence (tighter than comparisons): shift, then AND, XOR, OR.
+    _reduceOps(block, {
+      ASTExpressionOperator.shiftLeft,
+      ASTExpressionOperator.shiftRight,
+    });
+
+    _reduceOps(block, {ASTExpressionOperator.bitwiseAnd});
+    _reduceOps(block, {ASTExpressionOperator.bitwiseXor});
+    _reduceOps(block, {ASTExpressionOperator.bitwiseOr});
+
     // Final left-to-right fallback
     while (block.length >= 3) {
       var e1 = block.removeAt(0);

--- a/lib/src/languages/java/java11/java11_generator.dart
+++ b/lib/src/languages/java/java11/java11_generator.dart
@@ -110,6 +110,10 @@ class ApolloCodeGeneratorJava11 extends ApolloCodeGenerator {
   }) {
     out ??= newOutput();
 
+    if (clazz is ASTClassEnum) {
+      return generateASTClassEnum(clazz, out: out, indent: indent);
+    }
+
     var code = generateASTBlock(
       clazz,
       withBrackets: true,
@@ -120,6 +124,32 @@ class ApolloCodeGeneratorJava11 extends ApolloCodeGenerator {
     out.write(clazz.name);
     out.write(' ');
     out.write(code);
+
+    return out;
+  }
+
+  /// Generates a Java `enum` declaration.
+  StringBuffer generateASTClassEnum(
+    ASTClassEnum clazz, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    out.write(indent);
+    out.write('enum ');
+    out.write(clazz.name);
+    out.write(' {\n');
+
+    var entries = clazz.entries;
+    for (var i = 0; i < entries.length; ++i) {
+      out.write('$indent  ');
+      out.write(entries[i].name);
+      if (i < entries.length - 1) out.write(',');
+      out.write('\n');
+    }
+
+    out.write('$indent}\n');
 
     return out;
   }

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -61,7 +61,33 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
   Parser importDirective() =>
       (string('import') & literalString() & char(';').trimHidden());
 
-  Parser topLevelDefinition() => (classDeclaration());
+  Parser topLevelDefinition() => (enumDeclaration() | classDeclaration());
+
+  Parser<ASTClassEnum> enumDeclaration() =>
+      (string('enum') &
+              ref0(identifierPartLexicalToken).not() &
+              identifier().trimHidden() &
+              char('{').trimHidden() &
+              enumEntry() &
+              (char(',').trimHidden() & enumEntry()).star() &
+              char(',').trimHidden().optional() &
+              char('}').trimHidden())
+          .map((v) {
+            var name = v[2] as String;
+            var entries = <ASTEnumEntry>[v[4] as ASTEnumEntry];
+            for (var e in (v[5] as List)) {
+              entries.add(e[1] as ASTEnumEntry);
+            }
+            return ASTClassEnum(
+              name,
+              ASTType<VMObject>(name),
+              null,
+              entries: entries,
+            );
+          });
+
+  Parser<ASTEnumEntry> enumEntry() =>
+      identifier().trimHidden().map((v) => ASTEnumEntry(v));
 
   Parser<ASTClassNormal> classDeclaration() =>
       (string('class').trimHidden() & identifier() & classCodeBlock()).map((v) {
@@ -586,12 +612,20 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
               char('-') |
               char('*') |
               char('/') |
+              char('%') |
               string('==') |
               string('!=') |
+              string('<<') |
+              string('>>') |
               string('<=') |
               string('>=') |
+              string('&&') |
+              string('||') |
               char('<') |
-              char('>'))
+              char('>') |
+              char('&') |
+              char('|') |
+              char('^'))
           .trimHidden()
           .map((v) {
             return getASTExpressionOperator(v);
@@ -600,6 +634,7 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
   Parser<ASTExpression> expressionNoOperation() =>
       (expressionLambda() |
               expressionNegate() |
+              expressionBitwiseNot() |
               expressionLiteral() |
               expressionGroupFunctionInvocation() |
               expressionGroup() |
@@ -633,6 +668,14 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
           .map((v) {
             var exp = v[1] as ASTExpression;
             return ASTExpressionNegative(exp);
+          });
+
+  Parser<ASTExpressionBitwiseNot> expressionBitwiseNot() =>
+      (char('~').trimHidden() &
+              (ref0(expressionNoOperation) | ref0(expressionGroup)))
+          .map((v) {
+            var exp = v[1] as ASTExpression;
+            return ASTExpressionBitwiseNot(exp);
           });
 
   Parser<ASTExpression> expressionGroup() =>

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -267,14 +267,85 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
   Parser<ASTStatement> statement() =>
       (statementTryCatch() |
               statementThrow() |
+              statementSwitch() |
               branch() |
+              statementBreak() |
+              statementContinue() |
               statementReturn() |
+              statementDoWhileLoop() |
               statementForLoop() |
               statementForEach() |
               statementWhileLoop() |
               statementVariableDeclaration() |
               statementExpression())
           .cast<ASTStatement>();
+
+  Parser<ASTStatementBreak> statementBreak() =>
+      (string('break') &
+              ref0(identifierPartLexicalToken).not() &
+              char(';').trimHidden())
+          .map((v) => ASTStatementBreak());
+
+  Parser<ASTStatementContinue> statementContinue() =>
+      (string('continue') &
+              ref0(identifierPartLexicalToken).not() &
+              char(';').trimHidden())
+          .map((v) => ASTStatementContinue());
+
+  Parser<ASTStatementDoWhileLoop> statementDoWhileLoop() =>
+      (string('do').trimHidden() &
+              codeBlock() &
+              string('while').trimHidden() &
+              char('(').trimHidden() &
+              ref0(expression) &
+              char(')').trimHidden() &
+              char(';').trimHidden())
+          .map((v) {
+            var block = v[1] as ASTBlock;
+            var cond = v[4] as ASTExpression;
+            return ASTStatementDoWhileLoop(block, cond);
+          });
+
+  Parser<ASTStatementSwitch> statementSwitch() =>
+      (string('switch').trimHidden() &
+              char('(').trimHidden() &
+              ref0(expression) &
+              char(')').trimHidden() &
+              char('{').trimHidden() &
+              switchCase().star() &
+              char('}').trimHidden())
+          .map((v) {
+            var exp = v[2] as ASTExpression;
+            var cases = (v[5] as List).cast<ASTSwitchCase>();
+            return ASTStatementSwitch(exp, cases);
+          });
+
+  Parser<ASTSwitchCase> switchCase() =>
+      (switchCaseLabel() & switchCaseBody()).map((v) {
+        var value = v[0] as ASTExpression?;
+        var block = v[1] as ASTBlock;
+        return ASTSwitchCase(value, block);
+      });
+
+  Parser<ASTExpression?> switchCaseLabel() =>
+      ((string('case').trimHidden() &
+                      ref0(expression) &
+                      char(':').trimHidden())
+                  .map((v) => v[1] as ASTExpression?) |
+              (string('default').trimHidden() & char(':').trimHidden()).map(
+                (v) => null,
+              ))
+          .cast<ASTExpression?>();
+
+  /// A `case`/`default` body: a braced block (`{ ... }`) or a bare run of
+  /// statements up to the next `case`/`default`/`}`.
+  Parser<ASTBlock> switchCaseBody() =>
+      (codeBlock() | switchCaseStatements()).cast<ASTBlock>();
+
+  Parser<ASTBlock> switchCaseStatements() => ref0(statement).star().map((v) {
+    var statements = v.cast<ASTStatement>();
+    return ASTBlock(null)..addAllStatements(statements);
+  });
 
   Parser<ASTStatementThrow> statementThrow() =>
       (string('throw').trimHidden() & ref0(expression) & char(';').trimHidden())

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -328,9 +328,7 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
       });
 
   Parser<ASTExpression?> switchCaseLabel() =>
-      ((string('case').trimHidden() &
-                      ref0(expression) &
-                      char(':').trimHidden())
+      ((string('case').trimHidden() & ref0(expression) & char(':').trimHidden())
                   .map((v) => v[1] as ASTExpression?) |
               (string('default').trimHidden() & char(':').trimHidden()).map(
                 (v) => null,

--- a/lib/src/languages/javascript/es/javascript_grammar.dart
+++ b/lib/src/languages/javascript/es/javascript_grammar.dart
@@ -641,6 +641,8 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
               string('!==') |
               string('==') |
               string('!=') |
+              string('<<') |
+              string('>>') |
               string('>=') |
               string('<=') |
               string('&&') |
@@ -651,7 +653,10 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
               char('/') |
               char('>') |
               char('<') |
-              char('%'))
+              char('%') |
+              char('&') |
+              char('|') |
+              char('^'))
           .trimHidden()
           .map((v) {
             switch (v) {
@@ -670,6 +675,7 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
   Parser<ASTExpression> expressionNoOperation() =>
       (expressionArrowFunction() |
               expressionNegate() |
+              expressionBitwiseNot() |
               expressionLiteral() |
               expressionGroupFunctionInvocation() |
               expressionGroup() |
@@ -695,6 +701,11 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
       (char('-').trimHidden() &
               (ref0(expressionNoOperation) | ref0(expressionGroup)))
           .map((v) => ASTExpressionNegative(v[1] as ASTExpression));
+
+  Parser<ASTExpressionBitwiseNot> expressionBitwiseNot() =>
+      (char('~').trimHidden() &
+              (ref0(expressionNoOperation) | ref0(expressionGroup)))
+          .map((v) => ASTExpressionBitwiseNot(v[1] as ASTExpression));
 
   Parser<ASTExpression> expressionGroup() =>
       (char('(').trimHidden() & ref0(expression) & char(')').trimHidden()).map(

--- a/lib/src/languages/javascript/es/javascript_grammar.dart
+++ b/lib/src/languages/javascript/es/javascript_grammar.dart
@@ -262,9 +262,7 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
       });
 
   Parser<ASTExpression?> switchCaseLabel() =>
-      ((string('case').trimHidden() &
-                      ref0(expression) &
-                      char(':').trimHidden())
+      ((string('case').trimHidden() & ref0(expression) & char(':').trimHidden())
                   .map((v) => v[1] as ASTExpression?) |
               (string('default').trimHidden() & char(':').trimHidden()).map(
                 (v) => null,

--- a/lib/src/languages/javascript/es/javascript_grammar.dart
+++ b/lib/src/languages/javascript/es/javascript_grammar.dart
@@ -198,7 +198,11 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
   Parser<ASTStatement> statement() =>
       (statementTryCatch() |
               statementThrow() |
+              statementSwitch() |
               branch() |
+              statementBreak() |
+              statementContinue() |
+              statementDoWhileLoop() |
               statementForLoop() |
               statementForEach() |
               statementWhileLoop() |
@@ -209,6 +213,73 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
               statementBlock() |
               statementExpression())
           .cast<ASTStatement>();
+
+  Parser<ASTStatementBreak> statementBreak() =>
+      (string('break') &
+              ref0(identifierPartLexicalToken).not() &
+              char(';').trimHidden().optional())
+          .map((v) => ASTStatementBreak());
+
+  Parser<ASTStatementContinue> statementContinue() =>
+      (string('continue') &
+              ref0(identifierPartLexicalToken).not() &
+              char(';').trimHidden().optional())
+          .map((v) => ASTStatementContinue());
+
+  Parser<ASTStatementDoWhileLoop> statementDoWhileLoop() =>
+      (string('do').trimHidden() &
+              codeBlock() &
+              string('while').trimHidden() &
+              char('(').trimHidden() &
+              ref0(expression) &
+              char(')').trimHidden() &
+              char(';').trimHidden().optional())
+          .map((v) {
+            var block = v[1] as ASTBlock;
+            var cond = v[4] as ASTExpression;
+            return ASTStatementDoWhileLoop(block, cond);
+          });
+
+  Parser<ASTStatementSwitch> statementSwitch() =>
+      (string('switch').trimHidden() &
+              char('(').trimHidden() &
+              ref0(expression) &
+              char(')').trimHidden() &
+              char('{').trimHidden() &
+              switchCase().star() &
+              char('}').trimHidden())
+          .map((v) {
+            var exp = v[2] as ASTExpression;
+            var cases = (v[5] as List).cast<ASTSwitchCase>();
+            return ASTStatementSwitch(exp, cases);
+          });
+
+  Parser<ASTSwitchCase> switchCase() =>
+      (switchCaseLabel() & switchCaseBody()).map((v) {
+        var value = v[0] as ASTExpression?;
+        var block = v[1] as ASTBlock;
+        return ASTSwitchCase(value, block);
+      });
+
+  Parser<ASTExpression?> switchCaseLabel() =>
+      ((string('case').trimHidden() &
+                      ref0(expression) &
+                      char(':').trimHidden())
+                  .map((v) => v[1] as ASTExpression?) |
+              (string('default').trimHidden() & char(':').trimHidden()).map(
+                (v) => null,
+              ))
+          .cast<ASTExpression?>();
+
+  /// A `case`/`default` body: a braced block (`{ ... }`) or a bare run of
+  /// statements up to the next `case`/`default`/`}`.
+  Parser<ASTBlock> switchCaseBody() =>
+      (codeBlock() | switchCaseStatements()).cast<ASTBlock>();
+
+  Parser<ASTBlock> switchCaseStatements() => ref0(statement).star().map((v) {
+    var statements = v.cast<ASTStatement>();
+    return ASTBlock(null)..addAllStatements(statements);
+  });
 
   Parser<ASTStatementThrow> statementThrow() =>
       (throwToken().trimHidden() &

--- a/lib/src/languages/kotlin/kotlin_generator.dart
+++ b/lib/src/languages/kotlin/kotlin_generator.dart
@@ -156,6 +156,10 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
   }) {
     out ??= newOutput();
 
+    if (clazz is ASTClassEnum) {
+      return generateASTClassEnum(clazz, out: out, indent: indent);
+    }
+
     var code = generateASTBlock(
       clazz,
       withBrackets: true,
@@ -166,6 +170,32 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
     out.write(clazz.name);
     out.write(' ');
     out.write(code);
+
+    return out;
+  }
+
+  /// Generates a Kotlin `enum class` declaration.
+  StringBuffer generateASTClassEnum(
+    ASTClassEnum clazz, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    out.write(indent);
+    out.write('enum class ');
+    out.write(clazz.name);
+    out.write(' {\n');
+
+    var entries = clazz.entries;
+    for (var i = 0; i < entries.length; ++i) {
+      out.write('$indent  ');
+      out.write(entries[i].name);
+      if (i < entries.length - 1) out.write(',');
+      out.write('\n');
+    }
+
+    out.write('$indent}\n');
 
     return out;
   }

--- a/lib/src/languages/kotlin/kotlin_generator.dart
+++ b/lib/src/languages/kotlin/kotlin_generator.dart
@@ -457,6 +457,50 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
     return out;
   }
 
+  /// Kotlin uses `when` instead of `switch` (no fall-through).
+  @override
+  StringBuffer generateASTStatementSwitch(
+    ASTStatementSwitch statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    var indent2 = '$indent  ';
+
+    out.write('when (');
+    generateASTExpression(
+      statement.expression,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+    out.write(') {\n');
+
+    for (var c in statement.cases) {
+      out.write(indent2);
+      if (c.isDefault) {
+        out.write('else -> {\n');
+      } else {
+        generateASTExpression(c.value!, out: out, headIndented: false);
+        out.write(' -> {\n');
+      }
+      out.write(
+        generateASTBlock(c.block, indent: indent2, withBrackets: false),
+      );
+      out.write(indent2);
+      out.write('}\n');
+    }
+
+    out.write(indent);
+    out.write('}');
+
+    return out;
+  }
+
   @override
   StringBuffer generateASTStatementReturnValue(
     ASTStatementReturnValue statement, {

--- a/lib/src/languages/kotlin/kotlin_grammar.dart
+++ b/lib/src/languages/kotlin/kotlin_grammar.dart
@@ -286,13 +286,76 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
   Parser<ASTStatement> statement() =>
       (statementTryCatch() |
               statementThrow() |
+              statementWhen() |
               branch() |
+              statementBreak() |
+              statementContinue() |
+              statementDoWhileLoop() |
               statementForEach() |
               statementWhileLoop() |
               statementReturn() |
               statementVariableDeclaration() |
               statementExpression())
           .cast<ASTStatement>();
+
+  Parser<ASTStatementBreak> statementBreak() =>
+      (string('break') &
+              ref0(identifierPartLexicalToken).not() &
+              char(';').trimHidden().optional())
+          .map((v) => ASTStatementBreak());
+
+  Parser<ASTStatementContinue> statementContinue() =>
+      (string('continue') &
+              ref0(identifierPartLexicalToken).not() &
+              char(';').trimHidden().optional())
+          .map((v) => ASTStatementContinue());
+
+  /// Kotlin `do { ... } while (cond)`.
+  Parser<ASTStatementDoWhileLoop> statementDoWhileLoop() =>
+      (string('do') &
+              ref0(identifierPartLexicalToken).not() &
+              codeBlock().trimHidden() &
+              whileToken().trimHidden() &
+              char('(').trimHidden() &
+              ref0(expression) &
+              char(')').trimHidden() &
+              char(';').trimHidden().optional())
+          .map((v) {
+            var block = v[2] as ASTBlock;
+            var cond = v[5] as ASTExpression;
+            return ASTStatementDoWhileLoop(block, cond);
+          });
+
+  /// Kotlin `when (exp) { v -> ...; else -> ... }` (no fall-through).
+  Parser<ASTStatementSwitch> statementWhen() =>
+      (string('when') &
+              ref0(identifierPartLexicalToken).not() &
+              char('(').trimHidden() &
+              ref0(expression) &
+              char(')').trimHidden() &
+              char('{').trimHidden() &
+              whenEntry().star() &
+              char('}').trimHidden())
+          .map((v) {
+            var exp = v[3] as ASTExpression;
+            var cases = (v[6] as List).cast<ASTSwitchCase>();
+            return ASTStatementSwitch(exp, cases, fallThrough: false);
+          });
+
+  Parser<ASTSwitchCase> whenEntry() =>
+      (whenEntryLabel() &
+              string('->').trimHidden() &
+              codeBlockOrSingleLineBlock())
+          .map((v) {
+            var value = v[0] as ASTExpression?;
+            var block = v[2] as ASTBlock;
+            return ASTSwitchCase(value, block);
+          });
+
+  Parser<ASTExpression?> whenEntryLabel() =>
+      ((elseToken().trimHidden()).map((v) => null) |
+              ref0(expression).map((v) => v as ASTExpression?))
+          .cast<ASTExpression?>();
 
   Parser<ASTStatementThrow> statementThrow() =>
       (throwToken().trimHidden() &

--- a/lib/src/languages/kotlin/kotlin_grammar.dart
+++ b/lib/src/languages/kotlin/kotlin_grammar.dart
@@ -102,10 +102,39 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
           });
 
   Parser topLevelDefinition() =>
-      (functionDeclaration() |
+      (enumDeclaration() |
+              functionDeclaration() |
               classDeclaration() |
               statementVariableDeclaration())
           .plus();
+
+  /// Kotlin `enum class Name { A, B, C }`.
+  Parser<ASTClassEnum> enumDeclaration() =>
+      (string('enum') &
+              ref0(identifierPartLexicalToken).not() &
+              classToken().trimHidden() &
+              identifier().trimHidden() &
+              char('{').trimHidden() &
+              enumEntry() &
+              (char(',').trimHidden() & enumEntry()).star() &
+              char(',').trimHidden().optional() &
+              char('}').trimHidden())
+          .map((v) {
+            var name = v[3] as String;
+            var entries = <ASTEnumEntry>[v[5] as ASTEnumEntry];
+            for (var e in (v[6] as List)) {
+              entries.add(e[1] as ASTEnumEntry);
+            }
+            return ASTClassEnum(
+              name,
+              ASTType<VMObject>(name),
+              null,
+              entries: entries,
+            );
+          });
+
+  Parser<ASTEnumEntry> enumEntry() =>
+      identifier().trimHidden().map((v) => ASTEnumEntry(v));
 
   Parser<ASTFunctionDeclaration> functionDeclaration() =>
       (funToken().trimHidden() &

--- a/lib/src/languages/lua/lua_generator.dart
+++ b/lib/src/languages/lua/lua_generator.dart
@@ -316,6 +316,68 @@ class ApolloCodeGeneratorLua extends ApolloCodeGenerator {
     return out;
   }
 
+  /// Lua `break` (no statement terminator).
+  @override
+  StringBuffer generateASTStatementBreak(
+    ASTStatementBreak statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+    out.write('break');
+    return out;
+  }
+
+  /// Lua has no do-while; it is emitted as `repeat <block> until <not cond>`.
+  @override
+  StringBuffer generateASTStatementDoWhileLoop(
+    ASTStatementDoWhileLoop doWhileLoop, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write('repeat\n');
+
+    var blockCode = generateASTBlock(
+      doWhileLoop.loopBlock,
+      indent: indent,
+      withBrackets: false,
+    );
+
+    out.write(blockCode);
+    out.write(indent);
+    out.write('until ');
+
+    // do-while loops while `cond`; Lua's `repeat` loops until its condition is
+    // true (i.e. while false), so emit the negation of `cond`. When `cond` is
+    // already a negation (the common round-trip case), unwrap it.
+    var cond = doWhileLoop.conditionExpression;
+    if (cond is ASTExpressionNegation) {
+      generateASTExpression(
+        cond.expression,
+        out: out,
+        indent: indent,
+        headIndented: false,
+      );
+    } else {
+      out.write('not ');
+      generateASTExpression(
+        cond,
+        out: out,
+        indent: indent,
+        headIndented: false,
+      );
+    }
+
+    return out;
+  }
+
   @override
   StringBuffer generateASTStatementForEach(
     ASTStatementForEach forEach, {

--- a/lib/src/languages/lua/lua_grammar.dart
+++ b/lib/src/languages/lua/lua_grammar.dart
@@ -280,12 +280,33 @@ class LuaGrammarDefinition extends LuaGrammarLexer {
   Parser<ASTStatement> statement() =>
       (ref0(branch) |
               ref0(statementWhileLoop) |
+              ref0(statementRepeatUntil) |
               ref0(statementForNumeric) |
               ref0(statementForEach) |
+              ref0(statementBreak) |
               ref0(statementReturn) |
               ref0(statementVariableDeclaration) |
               ref0(statementExpression))
           .cast<ASTStatement>();
+
+  Parser<ASTStatementBreak> statementBreak() =>
+      breakToken().trimHidden().map((_) => ASTStatementBreak());
+
+  /// Lua `repeat <block> until <cond>` — a do-while that loops while the
+  /// condition is false, i.e. `do { } while (not cond)`.
+  Parser<ASTStatementDoWhileLoop> statementRepeatUntil() =>
+      (repeatToken().trimHidden() &
+              ref0(block) &
+              untilToken().trimHidden() &
+              ref0(expression))
+          .map((v) {
+            var loopBlock = v[1] as ASTBlock;
+            var untilCond = v[3] as ASTExpression;
+            return ASTStatementDoWhileLoop(
+              loopBlock,
+              ASTExpressionNegation(untilCond),
+            );
+          });
 
   Parser<ASTStatementVariableDeclaration> statementVariableDeclaration() =>
       (localToken().trimHidden() &

--- a/lib/src/languages/python/python_generator.dart
+++ b/lib/src/languages/python/python_generator.dart
@@ -500,11 +500,7 @@ class ApolloCodeGeneratorPython extends ApolloCodeGenerator {
     if (headIndented) out.write(indent);
 
     out.write('match ');
-    generateASTExpression(
-      statement.expression,
-      out: out,
-      headIndented: false,
-    );
+    generateASTExpression(statement.expression, out: out, headIndented: false);
     out.write(':\n');
 
     var caseIndent = '$indent$_tab';

--- a/lib/src/languages/python/python_generator.dart
+++ b/lib/src/languages/python/python_generator.dart
@@ -296,6 +296,10 @@ class ApolloCodeGeneratorPython extends ApolloCodeGenerator {
   }) {
     out ??= newOutput();
 
+    if (clazz is ASTClassEnum) {
+      return generateASTClassEnum(clazz, out: out, indent: indent);
+    }
+
     out.write(indent);
     out.write('class ');
     out.write(clazz.name);
@@ -328,6 +332,43 @@ class ApolloCodeGeneratorPython extends ApolloCodeGenerator {
       out.write('pass\n');
     }
 
+    out.write('\n');
+
+    return out;
+  }
+
+  /// Generates a Python enum: `class Name(Enum):` with `NAME = value` members.
+  /// Members without an explicit value get their ordinal index.
+  StringBuffer generateASTClassEnum(
+    ASTClassEnum clazz, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    out.write(indent);
+    out.write('class ');
+    out.write(clazz.name);
+    out.write('(Enum):\n');
+
+    var bodyIndent = '$indent$_tab';
+    var entries = clazz.entries;
+    if (entries.isEmpty) {
+      out.write(bodyIndent);
+      out.write('pass\n');
+    }
+    for (var i = 0; i < entries.length; ++i) {
+      var e = entries[i];
+      out.write(bodyIndent);
+      out.write(e.name);
+      out.write(' = ');
+      if (e.value != null) {
+        generateASTExpression(e.value!, out: out, headIndented: false);
+      } else {
+        out.write('$i');
+      }
+      out.write('\n');
+    }
     out.write('\n');
 
     return out;

--- a/lib/src/languages/python/python_generator.dart
+++ b/lib/src/languages/python/python_generator.dart
@@ -463,6 +463,68 @@ class ApolloCodeGeneratorPython extends ApolloCodeGenerator {
   }
 
   @override
+  StringBuffer generateASTStatementBreak(
+    ASTStatementBreak statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+    out.write('break\n');
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTStatementContinue(
+    ASTStatementContinue statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+    out.write('continue\n');
+    return out;
+  }
+
+  /// Python uses `match`/`case` (no fall-through); `case _:` is the default.
+  @override
+  StringBuffer generateASTStatementSwitch(
+    ASTStatementSwitch statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    out.write('match ');
+    generateASTExpression(
+      statement.expression,
+      out: out,
+      headIndented: false,
+    );
+    out.write(':\n');
+
+    var caseIndent = '$indent$_tab';
+    var bodyIndent = '$caseIndent$_tab';
+    for (var c in statement.cases) {
+      out.write(caseIndent);
+      if (c.isDefault) {
+        out.write('case _:\n');
+      } else {
+        out.write('case ');
+        generateASTExpression(c.value!, out: out, headIndented: false);
+        out.write(':\n');
+      }
+      _writeSuite(c.block, out, bodyIndent);
+    }
+
+    return out;
+  }
+
+  @override
   StringBuffer generateASTStatementReturnNull(
     ASTStatementReturnNull statement, {
     StringBuffer? out,

--- a/lib/src/languages/python/python_grammar.dart
+++ b/lib/src/languages/python/python_grammar.dart
@@ -283,6 +283,7 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
 
   Parser<ASTStatement> statement() =>
       (statementTryCatch() |
+              statementMatch() |
               branch() |
               statementForEach() |
               statementWhileLoop() |
@@ -291,13 +292,62 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
 
   /// A simple (single-line) statement terminated by NEWLINE.
   Parser<ASTStatement> simpleStatementLine() =>
-      ((statementReturn() |
+      ((statementBreak() |
+                      statementContinue() |
+                      statementReturn() |
                       statementRaise() |
                       statementVariableDeclaration() |
                       statementExpression())
                   .cast<ASTStatement>() &
               newlineToken())
           .map((v) => v[0] as ASTStatement);
+
+  Parser<ASTStatementBreak> statementBreak() =>
+      breakToken().trimHidden().map((_) => ASTStatementBreak());
+
+  Parser<ASTStatementContinue> statementContinue() =>
+      continueToken().trimHidden().map((_) => ASTStatementContinue());
+
+  /// Python `match exp: NEWLINE INDENT (case <pattern>: suite)+ DEDENT`
+  /// (no fall-through). `case _:` is the default clause.
+  Parser<ASTStatementSwitch> statementMatch() =>
+      (matchKeyword() &
+              ref0(expression) &
+              char(':').trimHidden() &
+              newlineToken() &
+              indentToken() &
+              matchCase().plus() &
+              dedentToken())
+          .map((v) {
+            var exp = v[1] as ASTExpression;
+            var cases = (v[5] as List).cast<ASTSwitchCase>();
+            return ASTStatementSwitch(exp, cases, fallThrough: false);
+          });
+
+  Parser<ASTSwitchCase> matchCase() =>
+      (caseKeyword() & matchPattern() & char(':').trimHidden() & suite()).map((
+        v,
+      ) {
+        var value = v[1] as ASTExpression?;
+        var block = v[3] as ASTBlock;
+        return ASTSwitchCase(value, block);
+      });
+
+  /// A `case` pattern: `_` (wildcard/default) or a value expression.
+  Parser<ASTExpression?> matchPattern() =>
+      ((char('_') & ref0(identifierPartLexicalToken).not())
+                  .trimHidden()
+                  .map((v) => null) |
+              ref0(expression).map((v) => v as ASTExpression?))
+          .cast<ASTExpression?>();
+
+  /// Soft keyword `match` (only at a statement head).
+  Parser matchKeyword() =>
+      (string('match') & ref0(identifierPartLexicalToken).not()).trimHidden();
+
+  /// Soft keyword `case`.
+  Parser caseKeyword() =>
+      (string('case') & ref0(identifierPartLexicalToken).not()).trimHidden();
 
   Parser<ASTStatementThrow> statementRaise() =>
       (raiseToken().trimHidden() & ref0(expression)).map((v) {

--- a/lib/src/languages/python/python_grammar.dart
+++ b/lib/src/languages/python/python_grammar.dart
@@ -92,7 +92,42 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
       });
 
   Parser topLevelDefinition() =>
-      (functionDeclaration() | classDeclaration() | ref0(statement)).plus();
+      (enumDeclaration() |
+              functionDeclaration() |
+              classDeclaration() |
+              ref0(statement))
+          .plus();
+
+  /// Python enum: `class Name(Enum): NEWLINE INDENT (NAME = value)+ DEDENT`.
+  Parser<ASTClassEnum> enumDeclaration() =>
+      (classToken().trimHidden() &
+              identifier() &
+              char('(').trimHidden() &
+              string('Enum') &
+              ref0(identifierPartLexicalToken).not() &
+              char(')').trimHidden() &
+              char(':').trimHidden() &
+              newlineToken() &
+              indentToken() &
+              enumEntry().plus() &
+              dedentToken())
+          .map((v) {
+            var name = v[1] as String;
+            var entries = (v[9] as List).cast<ASTEnumEntry>();
+            return ASTClassEnum(
+              name,
+              ASTType<VMObject>(name),
+              null,
+              entries: entries,
+            );
+          });
+
+  Parser<ASTEnumEntry> enumEntry() =>
+      (identifier().trimHidden() &
+              char('=').trimHidden() &
+              ref0(expression) &
+              newlineToken())
+          .map((v) => ASTEnumEntry(v[0] as String, v[2] as ASTExpression));
 
   // ---------------------------------------------------------------------------
   // Imports: `import x [as y]` and `from x import y`.
@@ -568,6 +603,8 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
       ((string('//') |
                       string('==') |
                       string('!=') |
+                      string('<<') |
+                      string('>>') |
                       string('>=') |
                       string('<=') |
                       char('+') |
@@ -576,7 +613,10 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
                       char('/') |
                       char('>') |
                       char('<') |
-                      char('%'))
+                      char('%') |
+                      char('&') |
+                      char('|') |
+                      char('^'))
                   .trimHidden()
                   .map((v) {
                     switch (v) {
@@ -596,6 +636,7 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
   Parser<ASTExpression> expressionNoOperation() =>
       (expressionLambda() |
               expressionNegate() |
+              expressionBitwiseNot() |
               expressionLiteral() |
               expressionGroupFunctionInvocation() |
               expressionGroup() |
@@ -671,6 +712,11 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
       (char('-').trimHidden() &
               (ref0(expressionNoOperation) | ref0(expressionGroup)))
           .map((v) => ASTExpressionNegative(v[1] as ASTExpression));
+
+  Parser<ASTExpressionBitwiseNot> expressionBitwiseNot() =>
+      (char('~').trimHidden() &
+              (ref0(expressionNoOperation) | ref0(expressionGroup)))
+          .map((v) => ASTExpressionBitwiseNot(v[1] as ASTExpression));
 
   Parser<ASTExpression> expressionGroup() =>
       (char('(').trimHidden() & ref0(expression) & char(')').trimHidden()).map(

--- a/lib/src/languages/python/python_grammar.dart
+++ b/lib/src/languages/python/python_grammar.dart
@@ -335,9 +335,9 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
 
   /// A `case` pattern: `_` (wildcard/default) or a value expression.
   Parser<ASTExpression?> matchPattern() =>
-      ((char('_') & ref0(identifierPartLexicalToken).not())
-                  .trimHidden()
-                  .map((v) => null) |
+      ((char('_') & ref0(identifierPartLexicalToken).not()).trimHidden().map(
+                (v) => null,
+              ) |
               ref0(expression).map((v) => v as ASTExpression?))
           .cast<ASTExpression?>();
 

--- a/lib/src/languages/typescript/ts/typescript_grammar.dart
+++ b/lib/src/languages/typescript/ts/typescript_grammar.dart
@@ -423,7 +423,11 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
   Parser<ASTStatement> statement() =>
       (statementTryCatch() |
               statementThrow() |
+              statementSwitch() |
               branch() |
+              statementBreak() |
+              statementContinue() |
+              statementDoWhileLoop() |
               statementForLoop() |
               statementForEach() |
               statementWhileLoop() |
@@ -434,6 +438,73 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
               statementBlock() |
               statementExpression())
           .cast<ASTStatement>();
+
+  Parser<ASTStatementBreak> statementBreak() =>
+      (string('break') &
+              ref0(identifierPartLexicalToken).not() &
+              char(';').trimHidden().optional())
+          .map((v) => ASTStatementBreak());
+
+  Parser<ASTStatementContinue> statementContinue() =>
+      (string('continue') &
+              ref0(identifierPartLexicalToken).not() &
+              char(';').trimHidden().optional())
+          .map((v) => ASTStatementContinue());
+
+  Parser<ASTStatementDoWhileLoop> statementDoWhileLoop() =>
+      (string('do').trimHidden() &
+              codeBlock() &
+              string('while').trimHidden() &
+              char('(').trimHidden() &
+              ref0(expression) &
+              char(')').trimHidden() &
+              char(';').trimHidden().optional())
+          .map((v) {
+            var block = v[1] as ASTBlock;
+            var cond = v[4] as ASTExpression;
+            return ASTStatementDoWhileLoop(block, cond);
+          });
+
+  Parser<ASTStatementSwitch> statementSwitch() =>
+      (string('switch').trimHidden() &
+              char('(').trimHidden() &
+              ref0(expression) &
+              char(')').trimHidden() &
+              char('{').trimHidden() &
+              switchCase().star() &
+              char('}').trimHidden())
+          .map((v) {
+            var exp = v[2] as ASTExpression;
+            var cases = (v[5] as List).cast<ASTSwitchCase>();
+            return ASTStatementSwitch(exp, cases);
+          });
+
+  Parser<ASTSwitchCase> switchCase() =>
+      (switchCaseLabel() & switchCaseBody()).map((v) {
+        var value = v[0] as ASTExpression?;
+        var block = v[1] as ASTBlock;
+        return ASTSwitchCase(value, block);
+      });
+
+  Parser<ASTExpression?> switchCaseLabel() =>
+      ((string('case').trimHidden() &
+                      ref0(expression) &
+                      char(':').trimHidden())
+                  .map((v) => v[1] as ASTExpression?) |
+              (string('default').trimHidden() & char(':').trimHidden()).map(
+                (v) => null,
+              ))
+          .cast<ASTExpression?>();
+
+  /// A `case`/`default` body: a braced block (`{ ... }`) or a bare run of
+  /// statements up to the next `case`/`default`/`}`.
+  Parser<ASTBlock> switchCaseBody() =>
+      (codeBlock() | switchCaseStatements()).cast<ASTBlock>();
+
+  Parser<ASTBlock> switchCaseStatements() => ref0(statement).star().map((v) {
+    var statements = v.cast<ASTStatement>();
+    return ASTBlock(null)..addAllStatements(statements);
+  });
 
   Parser<ASTStatementThrow> statementThrow() =>
       (throwToken().trimHidden() &

--- a/lib/src/languages/typescript/ts/typescript_grammar.dart
+++ b/lib/src/languages/typescript/ts/typescript_grammar.dart
@@ -884,6 +884,8 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
               string('!==') |
               string('==') |
               string('!=') |
+              string('<<') |
+              string('>>') |
               string('>=') |
               string('<=') |
               string('&&') |
@@ -894,7 +896,10 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
               char('/') |
               char('>') |
               char('<') |
-              char('%'))
+              char('%') |
+              char('&') |
+              char('|') |
+              char('^'))
           .trimHidden()
           .map((v) {
             switch (v) {
@@ -913,6 +918,7 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
   Parser<ASTExpression> expressionNoOperation() =>
       (expressionArrowFunction() |
               expressionNegate() |
+              expressionBitwiseNot() |
               expressionLiteral() |
               expressionGroupFunctionInvocation() |
               expressionGroup() |
@@ -938,6 +944,11 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
       (char('-').trimHidden() &
               (ref0(expressionNoOperation) | ref0(expressionGroup)))
           .map((v) => ASTExpressionNegative(v[1] as ASTExpression));
+
+  Parser<ASTExpressionBitwiseNot> expressionBitwiseNot() =>
+      (char('~').trimHidden() &
+              (ref0(expressionNoOperation) | ref0(expressionGroup)))
+          .map((v) => ASTExpressionBitwiseNot(v[1] as ASTExpression));
 
   Parser<ASTExpression> expressionGroup() =>
       (char('(').trimHidden() & ref0(expression) & char(')').trimHidden()).map(

--- a/lib/src/languages/typescript/ts/typescript_grammar.dart
+++ b/lib/src/languages/typescript/ts/typescript_grammar.dart
@@ -487,9 +487,7 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
       });
 
   Parser<ASTExpression?> switchCaseLabel() =>
-      ((string('case').trimHidden() &
-                      ref0(expression) &
-                      char(':').trimHidden())
+      ((string('case').trimHidden() & ref0(expression) & char(':').trimHidden())
                   .map((v) => v[1] as ASTExpression?) |
               (string('default').trimHidden() & char(':').trimHidden()).map(
                 (v) => null,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, C#, JavaScript, TypeScript, Lua and Python with on-the-fly Wasm compilation.
-version: 0.1.37
+version: 0.1.38
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/tests_definitions/csharp_bitwise.test.xml
+++ b/test/tests_definitions/csharp_bitwise.test.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="C# bitwise operators">
+    <source language="csharp">
+        <![CDATA[
+class C {
+  static int run(){
+    int r = 12 & 10;
+    r = r + (12 | 10);
+    r = r + (12 ^ 10);
+    r = r + (1 << 4);
+    r = r + (32 >> 2);
+    r = r + (~5);
+    return r;
+  }
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="46">
+        []
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="csharp"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class C {
+
+  static int run() {
+    int r = 12 & 10;
+    r = r + (12 | 10);
+    r = r + (12 ^ 10);
+    r = r + (1 << 4);
+    r = r + (32 >> 2);
+    r = r + (~5);
+    return r;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/csharp_control_flow.test.xml
+++ b/test/tests_definitions/csharp_control_flow.test.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="C# control flow: switch, break, continue, do-while">
+    <source language="csharp">
+        <![CDATA[
+class C {
+  static int run(){
+    int sum = 0;
+    for (int i = 0; i < 10; i++) {
+      if (i == 2) { continue; }
+      if (i == 5) { break; }
+      sum = sum + i;
+    }
+    int j = 0;
+    do {
+      sum = sum + 10;
+      j++;
+    } while (j < 3);
+    switch (j) {
+      case 3: { sum = sum + 100; break; }
+      default: { sum = sum + 1; break; }
+    }
+    return sum;
+  }
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="138">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="csharp"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class C {
+
+  static int run() {
+    int sum = 0;
+    for (int i = 0; i < 10 ; i++) {
+      if (i == 2) {
+          continue;
+      }
+
+      if (i == 5) {
+          break;
+      }
+
+      sum = sum + i;
+    }
+    int j = 0;
+    do {
+      sum = sum + 10;
+      j++;
+    } while (j < 3);
+    switch (j) {
+      case 3: {
+        sum = sum + 100;
+        break;
+      }
+      default: {
+        sum = sum + 1;
+        break;
+      }
+    }
+    return sum;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/csharp_enum.test.xml
+++ b/test/tests_definitions/csharp_enum.test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="C# enum declaration">
+    <source language="csharp">
+        <![CDATA[
+enum Color {
+  Red = 1,
+  Green = 2,
+  Blue = 3
+}
+        ]]>
+    </source>
+    <source-generated language="csharp"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+enum Color {
+  Red = 1,
+  Green = 2,
+  Blue = 3
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/csharp_lambda_capture.test.xml
+++ b/test/tests_definitions/csharp_lambda_capture.test.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="C# lambda capturing an enclosing variable">
+    <source language="csharp">
+        <![CDATA[
+class C {
+  static Func makeAdder(int n){ return (x) => x + n; }
+  static int run(){ var add10 = makeAdder(10); return add10(5); }
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="15">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="csharp"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class C {
+
+  static Function makeAdder(int n) {
+    return (object x) => x + n;
+  }
+
+  static int run() {
+    var add10 = makeAdder(10);
+    return add10(5);
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/csharp_lambda_input.test.xml
+++ b/test/tests_definitions/csharp_lambda_input.test.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="C# lambda input">
+    <source language="csharp">
+        <![CDATA[
+class C {
+  static int apply(Func f, int v){ return f(v); }
+  static int run(){ return apply((x) => x * 2, 21); }
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="42">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="csharp"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class C {
+
+  static int apply(Function f, int v) {
+    return f(v);
+  }
+
+  static int run() {
+    return apply((object x) => x * 2, 21);
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/dart_bitwise.test.xml
+++ b/test/tests_definitions/dart_bitwise.test.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Dart bitwise operators">
+    <source language="dart">
+        <![CDATA[
+int run() {
+  int r = 12 & 10;
+  r = r + (12 | 10);
+  r = r + (12 ^ 10);
+  r = r + (1 << 4);
+  r = r + (32 >> 2);
+  r = r + (~5);
+  return r;
+}
+        ]]>
+    </source>
+    <call function="run" return="46">
+        []
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  int run() {
+    int r = 12 & 10;
+    r = r + (12 | 10);
+    r = r + (12 ^ 10);
+    r = r + (1 << 4);
+    r = r + (32 >> 2);
+    r = r + (~5);
+    return r;
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/dart_control_flow.test.xml
+++ b/test/tests_definitions/dart_control_flow.test.xml
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Dart control flow: switch, break, continue, do-while">
+    <source language="dart">
+        <![CDATA[
+int run() {
+  int sum = 0;
+  for (int i = 0; i < 10; i++) {
+    if (i == 2) { continue; }
+    if (i == 5) { break; }
+    sum = sum + i;
+  }
+  int j = 0;
+  do {
+    sum = sum + 10;
+    j++;
+  } while (j < 3);
+  switch (j) {
+    case 3: { sum = sum + 100; break; }
+    default: { sum = sum + 1; break; }
+  }
+  return sum;
+}
+        ]]>
+    </source>
+    <call function="run" return="138">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  int run() {
+    int sum = 0;
+    for (int i = 0; i < 10 ; i++) {
+      if (i == 2) {
+          continue;
+      }
+
+      if (i == 5) {
+          break;
+      }
+
+      sum = sum + i;
+    }
+    int j = 0;
+    do {
+      sum = sum + 10;
+      j++;
+    } while (j < 3);
+    switch (j) {
+      case 3: {
+        sum = sum + 100;
+        break;
+      }
+      default: {
+        sum = sum + 1;
+        break;
+      }
+    }
+    return sum;
+  }
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/java_bitwise.test.xml
+++ b/test/tests_definitions/java_bitwise.test.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Java bitwise operators">
+    <source language="java11">
+        <![CDATA[
+class C {
+  static int run(){
+    int r = 12 & 10;
+    r = r + (12 | 10);
+    r = r + (12 ^ 10);
+    r = r + (1 << 4);
+    r = r + (32 >> 2);
+    r = r + (~5);
+    return r;
+  }
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="46">
+        []
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="java11"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class C {
+
+  static int run() {
+    int r = 12 & 10;
+    r = r + (12 | 10);
+    r = r + (12 ^ 10);
+    r = r + (1 << 4);
+    r = r + (32 >> 2);
+    r = r + (~5);
+    return r;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/java_control_flow.test.xml
+++ b/test/tests_definitions/java_control_flow.test.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Java control flow: switch, break, continue, do-while">
+    <source language="java11">
+        <![CDATA[
+class C {
+  static int run(){
+    int sum = 0;
+    for (int i = 0; i < 10; i++) {
+      if (i == 2) { continue; }
+      if (i == 5) { break; }
+      sum = sum + i;
+    }
+    int j = 0;
+    do {
+      sum = sum + 10;
+      j++;
+    } while (j < 3);
+    switch (j) {
+      case 3: { sum = sum + 100; break; }
+      default: { sum = sum + 1; break; }
+    }
+    return sum;
+  }
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="138">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="java11"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class C {
+
+  static int run() {
+    int sum = 0;
+    for (int i = 0; i < 10 ; i++) {
+      if (i == 2) {
+          continue;
+      }
+
+      if (i == 5) {
+          break;
+      }
+
+      sum = sum + i;
+    }
+    int j = 0;
+    do {
+      sum = sum + 10;
+      j++;
+    } while (j < 3);
+    switch (j) {
+      case 3: {
+        sum = sum + 100;
+        break;
+      }
+      default: {
+        sum = sum + 1;
+        break;
+      }
+    }
+    return sum;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/java_enum.test.xml
+++ b/test/tests_definitions/java_enum.test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Java enum declaration">
+    <source language="java11">
+        <![CDATA[
+enum Color {
+  Red,
+  Green,
+  Blue
+}
+        ]]>
+    </source>
+    <source-generated language="java11"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+enum Color {
+  Red,
+  Green,
+  Blue
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/javascript_bitwise.test.xml
+++ b/test/tests_definitions/javascript_bitwise.test.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="JavaScript bitwise operators">
+    <source language="javascript">
+        <![CDATA[
+class C {
+  run() {
+    let r = 12 & 10;
+    r = r + (12 | 10);
+    r = r + (12 ^ 10);
+    r = r + (1 << 4);
+    r = r + (32 >> 2);
+    r = r + (~5);
+    return r;
+  }
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="46">
+        []
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class C {
+
+  run() {
+    let r = 12 & 10;
+    r = r + (12 | 10);
+    r = r + (12 ^ 10);
+    r = r + (1 << 4);
+    r = r + (32 >> 2);
+    r = r + (~5);
+    return r;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/javascript_control_flow_extra.test.xml
+++ b/test/tests_definitions/javascript_control_flow_extra.test.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="JavaScript control flow: switch, break, continue, do-while">
+    <source language="javascript">
+        <![CDATA[
+class C {
+  run() {
+    let sum = 0;
+    for (let i = 0; i < 10; i++) {
+      if (i == 2) { continue; }
+      if (i == 5) { break; }
+      sum = sum + i;
+    }
+    let j = 0;
+    do {
+      sum = sum + 10;
+      j++;
+    } while (j < 3);
+    switch (j) {
+      case 3: { sum = sum + 100; break; }
+      default: { sum = sum + 1; break; }
+    }
+    return sum;
+  }
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="138">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class C {
+
+  run() {
+    let sum = 0;
+    for (let i = 0; i < 10 ; i++) {
+      if (i === 2) {
+          continue;
+      }
+
+      if (i === 5) {
+          break;
+      }
+
+      sum = sum + i;
+    }
+    let j = 0;
+    do {
+      sum = sum + 10;
+      j++;
+    } while (j < 3);
+    switch (j) {
+      case 3: {
+        sum = sum + 100;
+        break;
+      }
+      default: {
+        sum = sum + 1;
+        break;
+      }
+    }
+    return sum;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/kotlin_control_flow.test.xml
+++ b/test/tests_definitions/kotlin_control_flow.test.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Kotlin control flow: when, break, continue, do-while">
+    <source language="kotlin">
+        <![CDATA[
+class C {
+  fun run(): Int {
+    var sum = 0
+    var i = 0
+    while (i < 10) {
+      i = i + 1
+      if (i == 3) { continue }
+      if (i == 6) { break }
+      sum = sum + i
+    }
+    var j = 0
+    do {
+      sum = sum + 10
+      j = j + 1
+    } while (j < 3)
+    when (j) {
+      3 -> { sum = sum + 100 }
+      else -> { sum = sum + 1 }
+    }
+    return sum
+  }
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="142">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="kotlin"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class C {
+
+  fun run(): Int {
+    var sum = 0
+    var i = 0
+    while( i < 10 ) {
+      i = i + 1
+      if (i == 3) {
+          continue;
+      }
+
+      if (i == 6) {
+          break;
+      }
+
+      sum = sum + i
+    }
+    var j = 0
+    do {
+      sum = sum + 10
+      j = j + 1
+    } while (j < 3);
+    when (j) {
+      3 -> {
+        sum = sum + 100
+      }
+      else -> {
+        sum = sum + 1
+      }
+    }
+    return sum
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/kotlin_enum.test.xml
+++ b/test/tests_definitions/kotlin_enum.test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Kotlin enum declaration">
+    <source language="kotlin">
+        <![CDATA[
+enum class Color {
+  Red,
+  Green,
+  Blue
+}
+        ]]>
+    </source>
+    <source-generated language="kotlin"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+enum class Color {
+  Red,
+  Green,
+  Blue
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/lua_control_flow.test.xml
+++ b/test/tests_definitions/lua_control_flow.test.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Lua control flow: break, repeat/until (do-while)">
+    <source language="lua">
+        <![CDATA[
+function run()
+  local total = 0
+  local i = 0
+  while i < 10 do
+    i = i + 1
+    if i == 6 then
+      break
+    end
+    total = total + i
+  end
+  local j = 0
+  repeat
+    total = total + 10
+    j = j + 1
+  until j >= 3
+  return total
+end
+        ]]>
+    </source>
+    <call function="run" return="45">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="lua"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  function run()
+    local total = 0
+    local i = 0
+    while i < 10 do
+      i = i + 1
+      if i == 6 then
+          break
+      end
+      total = total + i
+    end
+    local j = 0
+    repeat
+      total = total + 10
+      j = j + 1
+    until j >= 3
+    return total
+  end
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/python_bitwise.test.xml
+++ b/test/tests_definitions/python_bitwise.test.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Python bitwise operators">
+    <source language="python">
+        <![CDATA[
+def run():
+    r = 12 & 10
+    r = r + (12 | 10)
+    r = r + (12 ^ 10)
+    r = r + (1 << 4)
+    r = r + (32 >> 2)
+    r = r + (~5)
+    return r
+        ]]>
+    </source>
+    <call function="run" return="46">
+        []
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="python"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+def run():
+    r: int = 12 & 10
+    r = r + (12 | 10)
+    r = r + (12 ^ 10)
+    r = r + (1 << 4)
+    r = r + (32 >> 2)
+    r = r + (~5)
+    return r
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/python_control_flow.test.xml
+++ b/test/tests_definitions/python_control_flow.test.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Python control flow: match, break, continue">
+    <source language="python">
+        <![CDATA[
+def run():
+    total = 0
+    i = 0
+    while i < 10:
+        i = i + 1
+        if i == 3:
+            continue
+        if i == 6:
+            break
+        total = total + i
+    match i:
+        case 6:
+            total = total + 100
+        case _:
+            total = total + 1
+    return total
+        ]]>
+    </source>
+    <call function="run" return="112">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="python"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+def run():
+    total: int = 0
+    i: int = 0
+    while i < 10:
+        i = i + 1
+        if i == 3:
+            continue
+        if i == 6:
+            break
+        total = total + i
+    match i:
+        case 6:
+            total = total + 100
+        case _:
+            total = total + 1
+    return total
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/python_enum.test.xml
+++ b/test/tests_definitions/python_enum.test.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Python enum declaration">
+    <source language="python">
+        <![CDATA[
+class Color(Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+        ]]>
+    </source>
+    <source-generated language="python"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Color(Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/typescript_bitwise.test.xml
+++ b/test/tests_definitions/typescript_bitwise.test.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="TypeScript bitwise operators">
+    <source language="typescript">
+        <![CDATA[
+class C {
+  run(): number {
+    let r: number = 12 & 10;
+    r = r + (12 | 10);
+    r = r + (12 ^ 10);
+    r = r + (1 << 4);
+    r = r + (32 >> 2);
+    r = r + (~5);
+    return r;
+  }
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="46">
+        []
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class C {
+
+  run(): number {
+    let r: number = 12 & 10;
+    r = r + (12 | 10);
+    r = r + (12 ^ 10);
+    r = r + (1 << 4);
+    r = r + (32 >> 2);
+    r = r + (~5);
+    return r;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/typescript_control_flow.test.xml
+++ b/test/tests_definitions/typescript_control_flow.test.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="TypeScript control flow: switch, break, continue, do-while">
+    <source language="typescript">
+        <![CDATA[
+class C {
+  run(): number {
+    let sum: number = 0;
+    for (let i = 0; i < 10; i++) {
+      if (i == 2) { continue; }
+      if (i == 5) { break; }
+      sum = sum + i;
+    }
+    let j: number = 0;
+    do {
+      sum = sum + 10;
+      j++;
+    } while (j < 3);
+    switch (j) {
+      case 3: { sum = sum + 100; break; }
+      default: { sum = sum + 1; break; }
+    }
+    return sum;
+  }
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="138">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class C {
+
+  run(): number {
+    let sum: number = 0;
+    for (let i = 0; i < 10 ; i++) {
+      if (i === 2) {
+          continue;
+      }
+
+      if (i === 5) {
+          break;
+      }
+
+      sum = sum + i;
+    }
+    let j: number = 0;
+    do {
+      sum = sum + 10;
+      j++;
+    } while (j < 3);
+    switch (j) {
+      case 3: {
+        sum = sum + 100;
+        break;
+      }
+      default: {
+        sum = sum + 1;
+        break;
+      }
+    }
+    return sum;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>


### PR DESCRIPTION
## Summary

Release **0.1.38**. Several feature areas, all delivered end-to-end (parse → run → regenerate → re-parse → re-run) with golden tests. Full suite green: **871 tests**; `dart analyze` clean; `dart format` applied.

### 1. C# lambda parsing
- Parse C# lambdas: `x => x * 2`, `(a, b) => a + b`, `(int a) => { ... }`, `() => 0`. Delegate type names (`Func`/`Action`/`Delegate`/`Function`) bind to the shared function type.

### 2. Control flow: `switch`/`case`, `break`, `continue`, `do`/`while`
- Shared AST/runtime nodes; `break`/`continue` propagate through `ASTBlock` and are consumed by the enclosing loop/switch (`for` still runs its increment on `continue`). `switch` fall-through with an `ASTStatementSwitch.fallThrough` flag.
- **C-style** (Dart, Java, C#, JavaScript, TypeScript): full `switch`/`break`/`continue`/`do-while`.
- **Kotlin**: `break`/`continue`, `do { } while (c)`, `when` (no fall-through).
- **Python**: `break`/`continue`, `match`/`case` (`case _:` default). No `do`/`while` in Python.
- **Lua**: `break`, and `repeat … until` mapped to do-while. No continue/switch in Lua.

### 3. Bitwise operators (`& | ^ << >> ~`)
- Shared AST/runtime + precedence (shift, then `&`/`^`/`|`).
- Parsed + generated in Dart, Java, C#, JavaScript, TypeScript, Python. Java also gains the previously-missing `%`, `&&`, `||`.
- Excluded: Kotlin (infix-function bitwise), Lua (`~` is xor, `^` is power).

### 4. enum
- Declaration + round-trip extended to Java, C#, Kotlin, Python (joining existing Dart/TypeScript). Runtime value access is a separate future enhancement.

### Not covered (genuine language limitations)
Python do-while; Lua continue/switch; Kotlin/Lua symbolic bitwise; JS/Lua enum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)