### PR TITLE
v0.1.39: enum value access, generics (annotations + generic classes), runtime fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+## 0.1.39
+
+### enum runtime value access
+
+- `EnumType.entry` now resolves at runtime to the entry's value: its explicit
+  value when present (C# `Level.Medium` → `5`), otherwise its ordinal index
+  (Dart `Color.blue` → `2`). `ASTRoot.getNodeIdentifier` resolves user
+  classes/enums by name; enum entry access short-circuits in
+  `ASTExpressionObjectGetterAccess`.
+
+### Generics
+
+- Parse generic type annotations in Java and C# (`List<Integer>`,
+  `Map<String,Integer> m`, `Box<T>`); well-known collections map to the shared
+  array/map types, other generic types keep their type arguments and round-trip.
+- Support generic class declarations and instantiation across the languages that
+  have generics: `class Wrapper<T> { T value; … }` plus `new Wrapper<int>(10)` /
+  `Wrapper<int>(10)`. Class type parameters are erased to `dynamic` in member
+  types; generic type arguments on calls are parsed. Runs end-to-end in Dart,
+  Java, C#, Kotlin and TypeScript.
+- Type system: generic erasure in `ASTType.acceptsType` — a raw type and a
+  parameterized one of the same name are mutually compatible (so a `Wrapper`
+  instance binds to a `Wrapper<int>` variable).
+
+### Fixes
+
+- Java for-each now generates the colon form `for (Type x : coll)` instead of the
+  invalid `for (var x in coll)`, so generated Java re-parses.
+- Kotlin `val`/`var` keywords now require a word boundary, so identifiers like
+  `value` are no longer mangled (e.g. a constructor parameter `value` was read as
+  `ue`).
+- Kotlin and TypeScript class instantiation/constructors now execute: a
+  constructor with an omitted class name (`constructor(...)`) resolves its type
+  from the enclosing class, and TypeScript `constructor(...)` is parsed as a real
+  constructor so `new Foo(...)` works.
+
 ## 0.1.38
 
 ### Language: C# — lambda parsing

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -53,7 +53,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.38';
+  static final String VERSION = '0.1.39';
 
   static int _idCount = 0;
 

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -2778,6 +2778,41 @@ class ASTExpressionObjectGetterAccess extends ASTExpressionGetterAccess
     });
   }
 
+  /// If [variable] names an enum type, returns it; otherwise `null`.
+  ASTClassEnum? _enumClass() {
+    final v = variable;
+    if (v is! ASTScopeVariable) return null;
+    var node = getNodeIdentifier(v.name);
+    return node is ASTClassEnum ? node : null;
+  }
+
+  /// Resolves an enum entry reference (`EnumType.entry`) to its value: the
+  /// explicit value expression when present, otherwise the entry's ordinal
+  /// index. Returns `null` if this is not an enum entry reference.
+  FutureOr<ASTValue>? _resolveEnumEntry(
+    VMContext context,
+    ASTRunStatus runStatus,
+  ) {
+    var enumClass = _enumClass();
+    if (enumClass == null) return null;
+
+    var entries = enumClass.entries;
+    for (var i = 0; i < entries.length; ++i) {
+      if (entries[i].name == name) {
+        var value = entries[i].value;
+        if (value != null) return value.run(context, runStatus);
+        return ASTValueInt(i);
+      }
+    }
+    return null;
+  }
+
+  /// `true` if this access is an enum entry reference (`EnumType.entry`).
+  bool _isEnumEntry() {
+    var e = _enumClass();
+    return e != null && e.entries.any((entry) => entry.name == name);
+  }
+
   ASTClass? _getterClass;
 
   FutureOr<ASTClass> _getGetterClass(VMContext parentContext) {
@@ -2810,6 +2845,8 @@ class ASTExpressionObjectGetterAccess extends ASTExpressionGetterAccess
 
   @override
   FutureOr<ASTType> resolveType(VMContext? context) {
+    if (_isEnumEntry()) return ASTTypeInt.instance;
+
     if (context == null) {
       return super.resolveType(context);
     }
@@ -2834,6 +2871,8 @@ class ASTExpressionObjectGetterAccess extends ASTExpressionGetterAccess
     VMContext context,
     ASTNode? node,
   ) {
+    if (_isEnumEntry()) return ASTTypeInt.instance;
+
     return _getVariableValue(context).resolveMapped((obj) {
       if (obj is ASTClassInstance) {
         var classContext = obj.createContext(context);
@@ -2851,6 +2890,13 @@ class ASTExpressionObjectGetterAccess extends ASTExpressionGetterAccess
 
   @override
   FutureOr<ASTValue> run(VMContext parentContext, ASTRunStatus runStatus) {
+    var enumEntry = _resolveEnumEntry(parentContext, runStatus);
+    if (enumEntry != null) {
+      return enumEntry.resolveMapped(
+        (ret) => _callChainFunction(parentContext, runStatus, ret),
+      );
+    }
+
     return _getVariableValue(parentContext).resolveMapped((obj) {
       if (obj is ASTClassInstance) {
         var classContext = obj.createContext(parentContext);

--- a/lib/src/ast/apollovm_ast_toplevel.dart
+++ b/lib/src/ast/apollovm_ast_toplevel.dart
@@ -1021,6 +1021,11 @@ class ASTRoot extends ASTEntryPointBlock {
     var identifier = super.getNodeIdentifier(name, requester: requester);
     if (identifier != null) return identifier;
 
+    // A user-defined class/enum referenced by name (e.g. `Color` in
+    // `Color.Red`).
+    var userClass = getClass(name);
+    if (userClass != null) return userClass;
+
     var clazz = ApolloVMCore.getClass(name);
     if (clazz != null) return clazz;
 

--- a/lib/src/ast/apollovm_ast_toplevel.dart
+++ b/lib/src/ast/apollovm_ast_toplevel.dart
@@ -2368,7 +2368,16 @@ class ASTClassConstructorDeclaration<T>
   }
 
   @override
-  ASTType resolveType(VMContext? context) => classType;
+  ASTType resolveType(VMContext? context) {
+    // Languages whose constructor syntax omits the class name (Kotlin/TS
+    // `constructor(...)`) create the declaration with an empty [classType];
+    // fall back to the enclosing class so instantiation resolves the real type.
+    if (classType.name.isEmpty) {
+      var parentClass = this.parentClass;
+      if (parentClass != null) return parentClass.type;
+    }
+    return classType;
+  }
 
   @override
   FutureOr<ASTClassInstance<ASTValue<T>>> initializeVariables(

--- a/lib/src/ast/apollovm_ast_type.dart
+++ b/lib/src/ast/apollovm_ast_type.dart
@@ -242,13 +242,11 @@ class ASTType<V> with ASTNode implements ASTTypedNode {
     var generics = this.generics;
     var typeGenerics = type.generics;
 
-    if (generics == null || generics.isEmpty) {
-      return typeGenerics == null || typeGenerics.isEmpty;
-    }
-
-    if (typeGenerics == null || typeGenerics.isEmpty) {
-      return false;
-    }
+    // Generic erasure: a raw type (no type arguments) is compatible with a
+    // parameterized one of the same name, and vice-versa — so `Wrapper`
+    // accepts `Wrapper<int>` and `Wrapper<int>` accepts `Wrapper`.
+    if (generics == null || generics.isEmpty) return true;
+    if (typeGenerics == null || typeGenerics.isEmpty) return true;
 
     if (generics.length != typeGenerics.length) return false;
 

--- a/lib/src/languages/csharp/csharp_grammar.dart
+++ b/lib/src/languages/csharp/csharp_grammar.dart
@@ -119,18 +119,43 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
             return ASTEnumEntry(name, value);
           });
 
+  /// Type-parameter names of the class currently being parsed (e.g. `T` in
+  /// `class Wrapper<T>`). Used by [simpleType] to erase them to `dynamic`.
+  final Set<String> _classTypeParameters = <String>{};
+
   Parser<ASTClassNormal> classDeclaration() =>
       (classVisibilityModifier().star() &
-              string('class').trimHidden() &
+              string('class').trimHidden().map((v) {
+                _classTypeParameters.clear();
+                return v;
+              }) &
               identifier() &
+              typeParameters().optional() &
               classBaseList().optional() &
               classCodeBlock())
           .map((v) {
             var name = v[2] as String;
-            var block = v[4];
+            var block = v[5];
             var clazz = ASTClassNormal(name, ASTType<VMObject>(name), null);
             clazz.set(block);
+            _classTypeParameters.clear();
             return clazz;
+          });
+
+  /// Generic type parameters in a declaration: `<T>`, `<K, V>`. Records the
+  /// names so member types using them are erased to `dynamic`.
+  Parser<List<String>> typeParameters() =>
+      (char('<').trimHidden() &
+              identifier().trimHidden() &
+              (char(',').trimHidden() & identifier().trimHidden()).star() &
+              char('>').trimHidden())
+          .map((v) {
+            var names = <String>[v[1] as String];
+            for (var e in (v[2] as List)) {
+              names.add((e as List)[1] as String);
+            }
+            _classTypeParameters.addAll(names);
+            return names;
           });
 
   /// `class Foo : Base, IInterface` (parsed and ignored, like Java's
@@ -767,6 +792,7 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
       (newToken().optional() &
               (identifier() & char('.')).optional() &
               identifier() &
+              genericArguments().optional() &
               char('(').trimHidden() &
               ref0(expressionSequence).optional() &
               char(')').trimHidden() &
@@ -775,9 +801,11 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
             var objOpt = v[1] as List?;
             var obj = objOpt != null ? objOpt[0] as String : null;
             var name = v[2] as String;
-            var args = v[4] as List<ASTExpression>?;
+            // v[3]: optional generic type arguments (`<int>`), discarded — the
+            // constructor/function resolves by name.
+            var args = v[5] as List<ASTExpression>?;
             args ??= <ASTExpression>[];
-            var chainFunctions = (v[6] as List)
+            var chainFunctions = (v[7] as List)
                 .whereType<ASTExpressionChainFunctionInvocation>()
                 .toList();
 
@@ -1197,6 +1225,10 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
         var name = v[0] as String;
         var generics = v[1] as List<ASTType>?;
         if (generics == null || generics.isEmpty) {
+          // A class type parameter (`T`) is erased to `dynamic`.
+          if (_classTypeParameters.contains(name)) {
+            return ASTTypeDynamic.instance;
+          }
           return getTypeByName(name);
         }
         return typeWithGenerics(name, generics);

--- a/lib/src/languages/csharp/csharp_grammar.dart
+++ b/lib/src/languages/csharp/csharp_grammar.dart
@@ -1192,9 +1192,50 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
 
   Parser<ASTType> type() => (arrayType() | simpleType()).cast<ASTType>();
 
-  Parser<ASTType> simpleType() => identifier().map((v) {
-    return getTypeByName(v);
-  });
+  Parser<ASTType> simpleType() =>
+      (identifier() & genericArguments().optional()).map((v) {
+        var name = v[0] as String;
+        var generics = v[1] as List<ASTType>?;
+        if (generics == null || generics.isEmpty) {
+          return getTypeByName(name);
+        }
+        return typeWithGenerics(name, generics);
+      });
+
+  /// Generic type arguments: `<T>`, `<K, V>`, `<List<int>>`, … (recursive).
+  Parser<List<ASTType>> genericArguments() =>
+      (char('<').trimHidden() &
+              ref0(type) &
+              (char(',').trimHidden() & ref0(type)).star() &
+              char('>').trimHidden())
+          .map((v) {
+            var list = <ASTType>[v[1] as ASTType];
+            for (var e in (v[2] as List)) {
+              list.add((e as List)[1] as ASTType);
+            }
+            return list;
+          });
+
+  /// Maps a generic type usage to the shared AST type: well-known collections
+  /// become [ASTTypeArray]/[ASTTypeMap]; anything else keeps its [generics].
+  static ASTType typeWithGenerics(String name, List<ASTType> generics) {
+    switch (name) {
+      case 'List':
+      case 'IList':
+      case 'IEnumerable':
+      case 'ICollection':
+      case 'HashSet':
+        return ASTTypeArray(generics.first);
+      case 'Dictionary':
+      case 'IDictionary':
+        return ASTTypeMap(
+          generics[0],
+          generics.length > 1 ? generics[1] : ASTTypeDynamic.instance,
+        );
+      default:
+        return ASTType(name, generics: generics);
+    }
+  }
 
   Parser<ASTTypeArray> arrayType() =>
       (identifier() & string('[]').plus()).map((v) {

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -125,10 +125,20 @@ class DartGrammarDefinition extends DartGrammarLexer {
             return ASTStatementImport(path);
           });
 
+  /// Type-parameter names of the class currently being parsed (e.g. `T` in
+  /// `class Wrapper<T>`). Used by [simpleType] to erase them to `dynamic`.
+  final Set<String> _classTypeParameters = <String>{};
+
   Parser<ASTClassNormal> classDeclaration() =>
       (abstractToken().trimHidden().optional() &
-              string('class').trimHidden() &
+              string('class').trimHidden().map((v) {
+                // Reset at each class head; type parameters (if any) are added
+                // next, before the body is parsed.
+                _classTypeParameters.clear();
+                return v;
+              }) &
               identifier() &
+              typeParameters().optional() &
               (extendsToken().trimHidden() & identifier()).optional() &
               (implementsToken().trimHidden() &
                       identifier() &
@@ -139,10 +149,10 @@ class DartGrammarDefinition extends DartGrammarLexer {
             var isAbstract = v[0] != null;
             var name = v[2] as String;
 
-            var extendsOpt = v[3] as List?;
+            var extendsOpt = v[4] as List?;
             var superName = extendsOpt != null ? extendsOpt[1] as String : null;
 
-            var implementsOpt = v[4] as List?;
+            var implementsOpt = v[5] as List?;
             var interfaces = <String>[];
             if (implementsOpt != null) {
               interfaces.add(implementsOpt[1] as String);
@@ -151,7 +161,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
               }
             }
 
-            var block = v[5];
+            var block = v[6];
             var clazz = ASTClassNormal(
               name,
               ASTType<VMObject>(name),
@@ -163,7 +173,44 @@ class DartGrammarDefinition extends DartGrammarLexer {
               implementsTypes: interfaces.isEmpty ? null : interfaces,
             );
             clazz.set(block);
+            _classTypeParameters.clear();
             return clazz;
+          });
+
+  /// Generic type parameters in a declaration: `<T>`, `<K, V>` (names only;
+  /// bounds like `<T extends Foo>` keep just the name). Records the names so
+  /// member types using them are erased to `dynamic`.
+  Parser<List<String>> typeParameters() =>
+      (char('<').trimHidden() &
+              typeParameter() &
+              (char(',').trimHidden() & typeParameter()).star() &
+              char('>').trimHidden())
+          .map((v) {
+            var names = <String>[v[1] as String];
+            for (var e in (v[2] as List)) {
+              names.add((e as List)[1] as String);
+            }
+            _classTypeParameters.addAll(names);
+            return names;
+          });
+
+  Parser<String> typeParameter() =>
+      (identifier().trimHidden() &
+              (extendsToken().trimHidden() & ref0(type)).optional())
+          .map((v) => v[0] as String);
+
+  /// Generic type arguments on a usage/invocation: `<int>`, `<String, int>`.
+  Parser<List<ASTType>> typeArguments() =>
+      (char('<').trimHidden() &
+              ref0(type) &
+              (char(',').trimHidden() & ref0(type)).star() &
+              char('>').trimHidden())
+          .map((v) {
+            var list = <ASTType>[v[1] as ASTType];
+            for (var e in (v[2] as List)) {
+              list.add((e as List)[1] as ASTType);
+            }
+            return list;
           });
 
   Parser<ASTClassEnum> enumDeclaration() =>
@@ -1004,6 +1051,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
       (newToken().optional() &
               (identifier() & char('.')).optional() &
               identifier() &
+              ref0(typeArguments).optional() &
               char('(').trimHidden() &
               ref0(expressionSequence).optional() &
               char(')').trimHidden() &
@@ -1012,9 +1060,11 @@ class DartGrammarDefinition extends DartGrammarLexer {
             var objOpt = v[1] as List?;
             var obj = objOpt != null ? objOpt[0] as String : null;
             var name = v[2] as String;
-            var args = v[4] as List<ASTExpression>?;
+            // v[3]: optional generic type arguments (`<int>`), discarded — the
+            // constructor/function resolves by name.
+            var args = v[5] as List<ASTExpression>?;
             args ??= <ASTExpression>[];
-            var chainFunctions = (v[6] as List)
+            var chainFunctions = (v[7] as List)
                 .whereType<ASTExpressionChainFunctionInvocation>()
                 .toList();
 
@@ -1425,7 +1475,12 @@ class DartGrammarDefinition extends DartGrammarLexer {
       // (so `await x;` parses as an await expression, not a `await x` variable
       // declaration).
       (awaitToken().not() & identifier()).map((v) {
-        return getTypeByName(v[1] as String);
+        var name = v[1] as String;
+        // A class type parameter (`T`) is erased to `dynamic`.
+        if (_classTypeParameters.contains(name)) {
+          return ASTTypeDynamic.instance;
+        }
+        return getTypeByName(name);
       });
 
   Parser<ASTTypeArray> arrayTyped() =>

--- a/lib/src/languages/java/java11/java11_generator.dart
+++ b/lib/src/languages/java/java11/java11_generator.dart
@@ -102,6 +102,54 @@ class ApolloCodeGeneratorJava11 extends ApolloCodeGenerator {
     return out;
   }
 
+  /// Java for-each uses `for (Type x : coll)` (colon), not the default
+  /// `for (var x in coll)`.
+  @override
+  StringBuffer generateASTStatementForEach(
+    ASTStatementForEach forEach, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write('for (');
+
+    var t = forEach.variableType;
+    if (t is ASTTypeDynamic || t is ASTTypeVar) {
+      out.write('var ');
+    } else {
+      generateASTType(t, out: out);
+      out.write(' ');
+    }
+    out.write(forEach.variableName);
+
+    out.write(' : ');
+
+    generateASTExpression(
+      forEach.iterableExpression,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+
+    out.write(') {\n');
+
+    var blockCode = generateASTBlock(
+      forEach.loopBlock,
+      indent: indent,
+      withBrackets: false,
+    );
+
+    out.write(blockCode);
+    out.write(indent);
+    out.write('}');
+
+    return out;
+  }
+
   @override
   StringBuffer generateASTClass(
     ASTClassNormal clazz, {

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -1131,9 +1131,51 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
 
   Parser<ASTType> type() => (arrayType() | simpleType()).cast<ASTType>();
 
-  Parser<ASTType> simpleType() => identifier().map((v) {
-    return getTypeByName(v);
-  });
+  Parser<ASTType> simpleType() =>
+      (identifier() & genericArguments().optional()).map((v) {
+        var name = v[0] as String;
+        var generics = v[1] as List<ASTType>?;
+        if (generics == null || generics.isEmpty) {
+          return getTypeByName(name);
+        }
+        return typeWithGenerics(name, generics);
+      });
+
+  /// Generic type arguments: `<T>`, `<K, V>`, `<List<int>>`, … (recursive).
+  Parser<List<ASTType>> genericArguments() =>
+      (char('<').trimHidden() &
+              ref0(type) &
+              (char(',').trimHidden() & ref0(type)).star() &
+              char('>').trimHidden())
+          .map((v) {
+            var list = <ASTType>[v[1] as ASTType];
+            for (var e in (v[2] as List)) {
+              list.add((e as List)[1] as ASTType);
+            }
+            return list;
+          });
+
+  /// Maps a generic type usage to the shared AST type: well-known collections
+  /// become [ASTTypeArray]/[ASTTypeMap]; anything else keeps its [generics].
+  static ASTType typeWithGenerics(String name, List<ASTType> generics) {
+    switch (name) {
+      case 'List':
+      case 'ArrayList':
+      case 'Iterable':
+      case 'Collection':
+      case 'Set':
+      case 'HashSet':
+        return ASTTypeArray(generics.first);
+      case 'Map':
+      case 'HashMap':
+        return ASTTypeMap(
+          generics[0],
+          generics.length > 1 ? generics[1] : ASTTypeDynamic.instance,
+        );
+      default:
+        return ASTType(name, generics: generics);
+    }
+  }
 
   Parser<ASTTypeArray> arrayType() =>
       (identifier() & string('[]').plus()).map((v) {

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -89,14 +89,48 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
   Parser<ASTEnumEntry> enumEntry() =>
       identifier().trimHidden().map((v) => ASTEnumEntry(v));
 
+  /// Type-parameter names of the class currently being parsed (e.g. `T` in
+  /// `class Wrapper<T>`). Used by [simpleType] to erase them to `dynamic`.
+  final Set<String> _classTypeParameters = <String>{};
+
   Parser<ASTClassNormal> classDeclaration() =>
-      (string('class').trimHidden() & identifier() & classCodeBlock()).map((v) {
-        var name = v[1] as String;
-        var block = v[2];
-        var clazz = ASTClassNormal(name, ASTType<VMObject>(name), null);
-        clazz.set(block);
-        return clazz;
-      });
+      (string('class').trimHidden().map((v) {
+                _classTypeParameters.clear();
+                return v;
+              }) &
+              identifier() &
+              typeParameters().optional() &
+              classCodeBlock())
+          .map((v) {
+            var name = v[1] as String;
+            var block = v[3];
+            var clazz = ASTClassNormal(name, ASTType<VMObject>(name), null);
+            clazz.set(block);
+            _classTypeParameters.clear();
+            return clazz;
+          });
+
+  /// Generic type parameters in a declaration: `<T>`, `<K, V>` (names only;
+  /// bounds like `<T extends Foo>` keep just the name). Records the names so
+  /// member types using them are erased to `dynamic`.
+  Parser<List<String>> typeParameters() =>
+      (char('<').trimHidden() &
+              typeParameter() &
+              (char(',').trimHidden() & typeParameter()).star() &
+              char('>').trimHidden())
+          .map((v) {
+            var names = <String>[v[1] as String];
+            for (var e in (v[2] as List)) {
+              names.add((e as List)[1] as String);
+            }
+            _classTypeParameters.addAll(names);
+            return names;
+          });
+
+  Parser<String> typeParameter() =>
+      (identifier().trimHidden() &
+              (string('extends').trimHidden() & ref0(type)).optional())
+          .map((v) => v[0] as String);
 
   Parser<ASTBlock> classCodeBlock() =>
       (char('{').trimHidden() &
@@ -716,6 +750,7 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
       (newToken().optional() &
               (identifier() & char('.')).optional() &
               identifier() &
+              genericArguments().optional() &
               char('(').trimHidden() &
               ref0(expressionSequence).optional() &
               char(')').trimHidden() &
@@ -724,9 +759,11 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
             var objOpt = v[1] as List?;
             var obj = objOpt != null ? objOpt[0] as String : null;
             var name = v[2] as String;
-            var args = v[4] as List<ASTExpression>?;
+            // v[3]: optional generic type arguments (`<Integer>`), discarded —
+            // the constructor/function resolves by name.
+            var args = v[5] as List<ASTExpression>?;
             args ??= <ASTExpression>[];
-            var chainFunctions = (v[6] as List)
+            var chainFunctions = (v[7] as List)
                 .whereType<ASTExpressionChainFunctionInvocation>()
                 .toList();
 
@@ -1136,6 +1173,10 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
         var name = v[0] as String;
         var generics = v[1] as List<ASTType>?;
         if (generics == null || generics.isEmpty) {
+          // A class type parameter (`T`) is erased to `dynamic`.
+          if (_classTypeParameters.contains(name)) {
+            return ASTTypeDynamic.instance;
+          }
           return getTypeByName(name);
         }
         return typeWithGenerics(name, generics);

--- a/lib/src/languages/kotlin/kotlin_grammar.dart
+++ b/lib/src/languages/kotlin/kotlin_grammar.dart
@@ -156,14 +156,42 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
             );
           });
 
+  /// Type-parameter names of the class currently being parsed (e.g. `T` in
+  /// `class Wrapper<T>`). Used by [simpleType] to erase them to `dynamic`.
+  final Set<String> _classTypeParameters = <String>{};
+
   Parser<ASTClassNormal> classDeclaration() =>
-      (classToken().trimHidden() & identifier() & classCodeBlock()).map((v) {
-        var name = v[1] as String;
-        var block = v[2];
-        var clazz = ASTClassNormal(name, ASTType<VMObject>(name), null);
-        clazz.set(block);
-        return clazz;
-      });
+      (classToken().trimHidden().map((v) {
+                _classTypeParameters.clear();
+                return v;
+              }) &
+              identifier() &
+              typeParameters().optional() &
+              classCodeBlock())
+          .map((v) {
+            var name = v[1] as String;
+            var block = v[3];
+            var clazz = ASTClassNormal(name, ASTType<VMObject>(name), null);
+            clazz.set(block);
+            _classTypeParameters.clear();
+            return clazz;
+          });
+
+  /// Generic type parameters in a declaration: `<T>`, `<K, V>`. Records the
+  /// names so member types using them are erased to `dynamic`.
+  Parser<List<String>> typeParameters() =>
+      (char('<').trimHidden() &
+              identifier().trimHidden() &
+              (char(',').trimHidden() & identifier().trimHidden()).star() &
+              char('>').trimHidden())
+          .map((v) {
+            var names = <String>[v[1] as String];
+            for (var e in (v[2] as List)) {
+              names.add((e as List)[1] as String);
+            }
+            _classTypeParameters.addAll(names);
+            return names;
+          });
 
   Parser<ASTBlock> classCodeBlock() =>
       (char('{').trimHidden() &
@@ -718,6 +746,7 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
   Parser<ASTExpressionFunctionInvocation> expressionFunctionInvocation() =>
       ((identifier() & char('.')).optional() &
               identifier() &
+              typeArguments().optional() &
               char('(').trimHidden() &
               ref0(expressionSequence).optional() &
               char(')').trimHidden() &
@@ -726,9 +755,10 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
             var objOpt = v[0] as List?;
             var obj = objOpt != null ? objOpt[0] as String : null;
             var name = normalizeFunctionName(v[1] as String);
-            var args = v[3] as List<ASTExpression>?;
+            // v[2]: optional generic type arguments (`<Int>`), discarded.
+            var args = v[4] as List<ASTExpression>?;
             args ??= <ASTExpression>[];
-            var chainFunctions = (v[5] as List)
+            var chainFunctions = (v[6] as List)
                 .whereType<ASTExpressionChainFunctionInvocation>()
                 .toList();
 
@@ -1069,9 +1099,47 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
         return v[0] as ASTType;
       });
 
-  Parser<ASTType> simpleType() => identifier().map((v) {
-    return getTypeByName(v);
-  });
+  Parser<ASTType> simpleType() =>
+      (identifier() & typeArguments().optional()).map((v) {
+        var name = v[0] as String;
+        if (_classTypeParameters.contains(name)) {
+          return ASTTypeDynamic.instance;
+        }
+        var generics = v[1] as List<ASTType>?;
+        if (generics == null || generics.isEmpty) {
+          return getTypeByName(name);
+        }
+        switch (name) {
+          case 'List':
+          case 'MutableList':
+          case 'Set':
+          case 'Array':
+          case 'Iterable':
+            return ASTTypeArray(generics.first);
+          case 'Map':
+          case 'MutableMap':
+            return ASTTypeMap(
+              generics[0],
+              generics.length > 1 ? generics[1] : ASTTypeDynamic.instance,
+            );
+          default:
+            return ASTType(name, generics: generics);
+        }
+      });
+
+  /// Generic type arguments on a usage/invocation: `<Int>`, `<String, Int>`.
+  Parser<List<ASTType>> typeArguments() =>
+      (char('<').trimHidden() &
+              ref0(type) &
+              (char(',').trimHidden() & ref0(type)).star() &
+              char('>').trimHidden())
+          .map((v) {
+            var list = <ASTType>[v[1] as ASTType];
+            for (var e in (v[2] as List)) {
+              list.add((e as List)[1] as ASTType);
+            }
+            return list;
+          });
 
   Parser<ASTTypeArray> arrayTyped() =>
       ((string('List') | string('MutableList') | string('Array')) &

--- a/lib/src/languages/kotlin/kotlin_grammar_lexer.dart
+++ b/lib/src/languages/kotlin/kotlin_grammar_lexer.dart
@@ -43,9 +43,17 @@ abstract class KotlinGrammarLexer extends BaseGrammarLexer {
 
   Parser trueToken() => ref1(token, 'true');
 
-  Parser valToken() => ref1(token, 'val');
+  // Whole-word match so identifiers like `value`/`variant` are not read as
+  // `val`/`var` followed by the rest (which mangled constructor/field names).
+  Parser valToken() => _wordKeyword('val');
 
-  Parser varToken() => ref1(token, 'var');
+  Parser varToken() => _wordKeyword('var');
+
+  Parser _wordKeyword(String word) =>
+      (string(word) & ref0(identifierPartLexicalToken).not())
+          .map((v) => v[0])
+          .token()
+          .trim(ref0(hiddenStuffWhitespace));
 
   Parser whileToken() => ref1(token, 'while');
 

--- a/lib/src/languages/typescript/ts/typescript_grammar.dart
+++ b/lib/src/languages/typescript/ts/typescript_grammar.dart
@@ -95,8 +95,15 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
       (identifier() & ref0(typeGenerics).optional()).map((v) {
         var name = v[0] as String;
         var generics = (v[1] as List<ASTType>?) ?? const <ASTType>[];
+        // A class type parameter (`T`) is erased to `dynamic`.
+        if (generics.isEmpty && _classTypeParameters.contains(name)) {
+          return ASTTypeDynamic.instance;
+        }
         if ((name == 'Array' || name == 'List') && generics.isNotEmpty) {
           return ASTTypeArray(generics.first);
+        }
+        if (generics.isNotEmpty) {
+          return ASTType(name, generics: generics);
         }
         return getTypeByName(name);
       });
@@ -198,20 +205,29 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
             );
           });
 
+  /// Type-parameter names of the class currently being parsed (e.g. `T` in
+  /// `class Wrapper<T>`). Used by [genericOrSimpleType] to erase them to
+  /// `dynamic`.
+  final Set<String> _classTypeParameters = <String>{};
+
   Parser<ASTClassNormal> classDeclaration() =>
       (abstractToken().trimHidden().optional() &
-              classToken().trimHidden() &
+              classToken().trimHidden().map((v) {
+                _classTypeParameters.clear();
+                return v;
+              }) &
               identifier() &
+              typeParameters().optional() &
               (extendsToken().trimHidden() & identifier()).optional() &
               implementsClause().optional() &
               classCodeBlock())
           .map((v) {
             var isAbstract = v[0] != null;
             var name = v[2] as String;
-            var extendsOpt = v[3] as List?;
+            var extendsOpt = v[4] as List?;
             var superName = extendsOpt != null ? extendsOpt[1] as String : null;
-            var interfaces = (v[4] as List<String>?) ?? const <String>[];
-            var block = v[5] as ASTBlock;
+            var interfaces = (v[5] as List<String>?) ?? const <String>[];
+            var block = v[6] as ASTBlock;
             var clazz = ASTClassNormal(
               name,
               ASTType<VMObject>(name),
@@ -223,7 +239,24 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
               implementsTypes: interfaces.isEmpty ? null : interfaces,
             );
             clazz.set(block);
+            _classTypeParameters.clear();
             return clazz;
+          });
+
+  /// Generic type parameters in a declaration: `<T>`, `<K, V>`. Records the
+  /// names so member types using them are erased to `dynamic`.
+  Parser<List<String>> typeParameters() =>
+      (char('<').trimHidden() &
+              identifier().trimHidden() &
+              (char(',').trimHidden() & identifier().trimHidden()).star() &
+              char('>').trimHidden())
+          .map((v) {
+            var names = <String>[v[1] as String];
+            for (var e in (v[2] as List)) {
+              names.add((e as List)[1] as String);
+            }
+            _classTypeParameters.addAll(names);
+            return names;
           });
 
   /// `implements A, B, C`.
@@ -981,18 +1014,25 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
           });
 
   Parser<ASTExpressionFunctionInvocation> expressionFunctionInvocation() =>
-      ((identifier() & char('.')).optional() &
+      // Optional `new` prefix for class instantiation (`new Wrapper<T>(…)`);
+      // consumed and discarded — the constructor resolves by name.
+      ((string('new') & ref0(identifierPartLexicalToken).not())
+                  .trimHidden()
+                  .optional() &
+              (identifier() & char('.')).optional() &
               identifier() &
+              ref0(typeGenerics).optional() &
               char('(').trimHidden() &
               ref0(expressionSequence).optional() &
               char(')').trimHidden() &
               expressionChainFunctionInvocation().star())
           .map((v) {
-            var objOpt = v[0] as List?;
+            var objOpt = v[1] as List?;
             var obj = objOpt != null ? objOpt[0] as String : null;
-            var name = v[1] as String;
-            var args = (v[3] as List<ASTExpression>?) ?? <ASTExpression>[];
-            var chainFunctions = (v[5] as List)
+            var name = v[2] as String;
+            // v[3]: optional generic type arguments (`<number>`), discarded.
+            var args = (v[5] as List<ASTExpression>?) ?? <ASTExpression>[];
+            var chainFunctions = (v[7] as List)
                 .whereType<ASTExpressionChainFunctionInvocation>()
                 .toList();
 

--- a/lib/src/languages/typescript/ts/typescript_grammar.dart
+++ b/lib/src/languages/typescript/ts/typescript_grammar.dart
@@ -341,7 +341,8 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
 
   Parser<ASTBlock> classCodeBlock() =>
       (char('{').trimHidden() &
-              (ref0(classFunctionDeclaration) |
+              (ref0(classConstructorDeclaration) |
+                      ref0(classFunctionDeclaration) |
                       ref0(classFieldDeclarationWithValue) |
                       ref0(classFieldDeclaration))
                   .star() &
@@ -349,15 +350,56 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
           .map((v) {
             var list = v[1] as List;
             var fields = list.whereType<ASTClassField>().toList();
+            var constructors = list
+                .whereType<ASTClassConstructorDeclaration>()
+                .toList();
             var functions = list.whereType<ASTFunctionDeclaration>().toList();
 
             var block = ASTClassNormal('?', ASTType<VMObject>('?'), null);
 
             block.addAllFields(fields);
+            block.addAllConstructors(constructors);
             block.addAllFunctions(functions);
 
             return block;
           });
+
+  /// TypeScript `constructor(params) { ... }` — a real constructor (not a
+  /// method), so `new Foo(...)` resolves and runs it. The class type is filled
+  /// in from the enclosing class at resolution time.
+  Parser<ASTClassConstructorDeclaration> classConstructorDeclaration() =>
+      (memberModifiers() &
+              string('constructor') &
+              ref0(identifierPartLexicalToken).not() &
+              functionParametersDeclaration().trimHidden() &
+              typeAnnotation().optional() &
+              codeBlock())
+          .map((v) {
+            var fnParams = v[3] as ASTFunctionParametersDeclaration;
+            var block = v[5] as ASTBlock;
+            return ASTClassConstructorDeclaration(
+              ASTType(''),
+              '',
+              _toConstructorParameters(fnParams),
+              block: block,
+            );
+          });
+
+  ASTConstructorParametersDeclaration _toConstructorParameters(
+    ASTFunctionParametersDeclaration fn,
+  ) {
+    var positional = fn.positionalParameters
+        ?.map(
+          (p) => ASTConstructorParameterDeclaration(
+            p.type,
+            p.name,
+            p.index,
+            p.optional,
+          ),
+        )
+        .toList();
+    return ASTConstructorParametersDeclaration(positional, null, null);
+  }
 
   /// `[modifiers] name[: type];` — a class/interface field.
   Parser<ASTClassField> classFieldDeclaration() =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, C#, JavaScript, TypeScript, Lua and Python with on-the-fly Wasm compilation.
-version: 0.1.38
+version: 0.1.39
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/tests_definitions/csharp_enum_value_access.test.xml
+++ b/test/tests_definitions/csharp_enum_value_access.test.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="C# enum value access (explicit values)">
+    <source language="csharp">
+        <![CDATA[
+enum Level {
+  Low = 1,
+  Medium = 5,
+  High = 10
+}
+
+class C {
+  static int run(){
+    int x = Level.Medium;
+    return x + Level.High;
+  }
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="15">
+        []
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="csharp"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+enum Level {
+  Low = 1,
+  Medium = 5,
+  High = 10
+}
+class C {
+
+  static int run() {
+    int x = Level.Medium;
+    return x + Level.High;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/csharp_generic_class.test.xml
+++ b/test/tests_definitions/csharp_generic_class.test.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="C# generic class (declaration, type param field, instantiation)">
+    <source language="csharp">
+        <![CDATA[
+class Wrapper<T> {
+  T value;
+
+  Wrapper(T value){
+    this.value = value;
+  }
+}
+
+class Main {
+  static int run(){
+    Wrapper<int> wInt = new Wrapper<int>(10);
+    Wrapper<string> wStr = new Wrapper<string>("abc");
+    return wInt.value + 5;
+  }
+}
+        ]]>
+    </source>
+    <call class="Main" function="run" return="15">
+        []
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="csharp"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Wrapper {
+
+  object value;
+
+  Wrapper(object value) {
+    this.value = value;
+  }
+
+}
+class Main {
+
+  static int run() {
+    Wrapper<int> wInt = Wrapper(10);
+    Wrapper<String> wStr = Wrapper("abc");
+    return wInt.value + 5;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/csharp_generics.test.xml
+++ b/test/tests_definitions/csharp_generics.test.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="C# generic type annotations">
+    <source language="csharp">
+        <![CDATA[
+class C {
+  static int run(){
+    List<int> xs = new List<int>(){ 10, 20, 12 };
+    int total = 0;
+    foreach (int x in xs) {
+      total = total + x;
+    }
+    return total;
+  }
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="42">
+        []
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="csharp"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class C {
+
+  static int run() {
+    int[] xs = new List<int>(){10, 20, 12};
+    int total = 0;
+    foreach (var x in xs) {
+      total = total + x;
+    }
+    return total;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/dart_enum_value_access.test.xml
+++ b/test/tests_definitions/dart_enum_value_access.test.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Dart enum value access (ordinal)">
+    <source language="dart">
+        <![CDATA[
+enum Color {
+  red,
+  green,
+  blue
+}
+
+int run() {
+  int a = Color.red;
+  int b = Color.green;
+  int c = Color.blue;
+  int total = a + b + c;
+  if (Color.green == 1) {
+    total = total + 100;
+  }
+  return total;
+}
+        ]]>
+    </source>
+    <call function="run" return="103">
+        []
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  int run() {
+    int a = Color.red;
+    int b = Color.green;
+    int c = Color.blue;
+    int total = (a + b) + c;
+    if (Color.green == 1) {
+        total = total + 100;
+    }
+
+    return total;
+  }
+
+enum Color {
+  red,
+  green,
+  blue
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/dart_generic_class.test.xml
+++ b/test/tests_definitions/dart_generic_class.test.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Dart generic class (declaration, type param field, instantiation)">
+    <source language="dart">
+        <![CDATA[
+class Wrapper<T> {
+  T value;
+
+  Wrapper(this.value);
+
+  String toString() => '<$value>';
+}
+
+void main() {
+  var wInt = Wrapper<int>(10);
+  var wDouble = Wrapper<double>(10.23);
+  var wString = Wrapper<String>('abc');
+
+  print(wInt);
+  print(wDouble);
+  print(wString);
+}
+        ]]>
+    </source>
+    <call function="main">
+        []
+    </call>
+    <output><![CDATA[["<10>", "<10.23>", "<abc>"]]]></output>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  void main() {
+    var wInt = Wrapper(10);
+    var wDouble = Wrapper(10.23);
+    var wString = Wrapper('abc');
+    print(wInt);
+    print(wDouble);
+    print(wString);
+  }
+
+class Wrapper {
+
+  dynamic value;
+
+  Wrapper(this.value);
+
+  String toString() {
+    return '<$value>';
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/java_enum_value_access.test.xml
+++ b/test/tests_definitions/java_enum_value_access.test.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Java enum value access (ordinal)">
+    <source language="java11">
+        <![CDATA[
+enum Day {
+  Mon,
+  Tue,
+  Wed
+}
+
+class C {
+  static int run(){
+    int d = Day.Wed;
+    return d;
+  }
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="2">
+        []
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="java11"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+enum Day {
+  Mon,
+  Tue,
+  Wed
+}
+class C {
+
+  static int run() {
+    int d = Day.Wed;
+    return d;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/java_foreach.test.xml
+++ b/test/tests_definitions/java_foreach.test.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Java for-each round-trip">
+    <source language="java11">
+        <![CDATA[
+class C {
+  static int run(){
+    List<Integer> xs = new ArrayList<Integer>(){{ add(10); add(20); add(12); }};
+    int total = 0;
+    for (Integer x : xs) {
+      total = total + x;
+    }
+    return total;
+  }
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="42">
+        []
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="java11"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class C {
+
+  static int run() {
+    int[] xs = new ArrayList<int>(){{
+      add(10);
+      add(20);
+      add(12);
+    }};
+    int total = 0;
+    for (int x : xs) {
+      total = total + x;
+    }
+    return total;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/java_generic_class.test.xml
+++ b/test/tests_definitions/java_generic_class.test.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Java generic class (declaration, type param field, instantiation)">
+    <source language="java11">
+        <![CDATA[
+class Wrapper<T> {
+  T value;
+
+  Wrapper(T value){
+    this.value = value;
+  }
+
+  public String toString(){
+    return "<" + value + ">";
+  }
+}
+
+class Main {
+  static void run(){
+    Wrapper<Integer> wInt = new Wrapper<Integer>(10);
+    Wrapper<Double> wDouble = new Wrapper<Double>(10.23);
+    Wrapper<String> wString = new Wrapper<String>("abc");
+
+    print(wInt);
+    print(wDouble);
+    print(wString);
+  }
+}
+        ]]>
+    </source>
+    <call class="Main" function="run">
+        []
+    </call>
+    <output><![CDATA[["<10>", "<10.23>", "<abc>"]]]></output>
+    <source-generated language="java11"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Wrapper {
+
+  Object value;
+
+  Wrapper(Object value) {
+    this.value = value;
+  }
+
+  String toString() {
+    return "<" + value + ">";
+  }
+
+}
+class Main {
+
+  static void run() {
+    Wrapper<int> wInt = Wrapper(10);
+    Wrapper<double> wDouble = Wrapper(10.23);
+    Wrapper<String> wString = Wrapper("abc");
+    print(wInt);
+    print(wDouble);
+    print(wString);
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/java_generics.test.xml
+++ b/test/tests_definitions/java_generics.test.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Java generic type annotations">
+    <source language="java11">
+        <![CDATA[
+class C {
+  static int run(){
+    List<Integer> xs = new ArrayList<Integer>(){{ add(10); add(20); add(12); }};
+    int total = 0;
+    for (int i = 0; i < 3; i++) {
+      total = total + xs[i];
+    }
+    return total;
+  }
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="42">
+        []
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="java11"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class C {
+
+  static int run() {
+    int[] xs = new ArrayList<int>(){{
+      add(10);
+      add(20);
+      add(12);
+    }};
+    int total = 0;
+    for (int i = 0; i < 3 ; i++) {
+      total = total + xs[i];
+    }
+    return total;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/java_generics_user.test.xml
+++ b/test/tests_definitions/java_generics_user.test.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Java user generic type preserved">
+    <source language="java11">
+        <![CDATA[
+class C {
+  static int unwrap(Box<Integer> b){
+    return 0;
+  }
+}
+        ]]>
+    </source>
+    <source-generated language="java11"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class C {
+
+  static int unwrap(Box<int> b) {
+    return 0;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/kotlin_generic_class.test.xml
+++ b/test/tests_definitions/kotlin_generic_class.test.xml
@@ -1,21 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<test title="Kotlin generic class declaration">
+<test title="Kotlin generic class (declaration, instantiation, value access)">
     <source language="kotlin">
         <![CDATA[
-class Box<T> {
-  fun wrap(x: T): T {
-    return x
+class Wrapper<T> {
+  var value: T
+
+  constructor(value: T){
+    this.value = value
+  }
+}
+
+class Main {
+  fun run(): Int {
+    val w = Wrapper<Int>(10)
+    return w.value + 5
   }
 }
         ]]>
     </source>
+    <call class="Main" function="run" return="15">
+        []
+    </call>
+    <output>
+        []
+    </output>
     <source-generated language="kotlin"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
 <<<< NAMESPACE="" >>>>
 <<<< CODE_UNIT_START="/test" >>>>
-class Box {
+class Wrapper {
 
-  fun wrap(x: Any): Any {
-    return x
+  var value: Any
+
+  constructor(value: Any) {
+    this.value = value
+  }
+
+}
+class Main {
+
+  fun run(): Int {
+    val w = Wrapper(10)
+    return w.value + 5
   }
 
 }

--- a/test/tests_definitions/kotlin_generic_class.test.xml
+++ b/test/tests_definitions/kotlin_generic_class.test.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Kotlin generic class declaration">
+    <source language="kotlin">
+        <![CDATA[
+class Box<T> {
+  fun wrap(x: T): T {
+    return x
+  }
+}
+        ]]>
+    </source>
+    <source-generated language="kotlin"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Box {
+
+  fun wrap(x: Any): Any {
+    return x
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/typescript_generic_class.test.xml
+++ b/test/tests_definitions/typescript_generic_class.test.xml
@@ -1,21 +1,46 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<test title="TypeScript generic class declaration">
+<test title="TypeScript generic class (declaration, instantiation, value access)">
     <source language="typescript">
         <![CDATA[
-class Box<T> {
-  wrap(x: T): T {
-    return x;
+class Wrapper<T> {
+  value: T;
+
+  constructor(value: T){
+    this.value = value;
+  }
+}
+
+class Main {
+  run(): number {
+    let w: Wrapper<number> = new Wrapper<number>(10);
+    return w.value + 5;
   }
 }
         ]]>
     </source>
+    <call class="Main" function="run" return="15">
+        []
+    </call>
+    <output>
+        []
+    </output>
     <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
 <<<< NAMESPACE="" >>>>
 <<<< CODE_UNIT_START="/test" >>>>
-class Box {
+class Wrapper {
 
-  wrap(x) {
-    return x;
+  value;
+
+  constructor(value) {
+    this.value = value;
+  }
+
+}
+class Main {
+
+  run(): number {
+    let w: Wrapper<number> = Wrapper(10);
+    return w.value + 5;
   }
 
 }

--- a/test/tests_definitions/typescript_generic_class.test.xml
+++ b/test/tests_definitions/typescript_generic_class.test.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="TypeScript generic class declaration">
+    <source language="typescript">
+        <![CDATA[
+class Box<T> {
+  wrap(x: T): T {
+    return x;
+  }
+}
+        ]]>
+    </source>
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Box {
+
+  wrap(x) {
+    return x;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>


### PR DESCRIPTION
## Summary

Release **0.1.39**. Builds out generics support and fixes several runtime/codegen bugs. All work is end-to-end (parse → run → regenerate → re-parse → re-run) with golden tests. Full suite green: **883 tests**; `dart analyze` clean; `dart format` applied.

### enum runtime value access
- `EnumType.entry` resolves at runtime to its value — explicit when present (C# `Level.Medium` → `5`), else ordinal index (Dart `Color.blue` → `2`).

### Generics
- **Type annotations** parse in Java & C# (`Map<String,Integer> m`, `List<Integer>`, `Box<T>`); collections map to the shared array/map types, others keep their type args and round-trip.
- **Generic classes** declaration + instantiation across Dart, Java, C#, Kotlin, TypeScript: `class Wrapper<T> { T value; … }` + `new Wrapper<int>(10)`. Type parameters erase to `dynamic`; runs end-to-end.
- **Generic erasure** in `ASTType.acceptsType`: a raw type and a parameterized one of the same name are mutually compatible (`Wrapper` ↔ `Wrapper<int>`).

### Fixes
- **Java for-each** generates `for (Type x : coll)` (was the invalid `for (var x in coll)`), so generated Java re-parses.
- **Kotlin `val`/`var`** now require a word boundary — identifiers like `value` were mangled (constructor param `value` → `ue`).
- **Kotlin & TypeScript class instantiation/constructors** now execute: a constructor with an omitted class name resolves its type from the enclosing class, and TS `constructor(...)` is parsed as a real constructor so `new Foo(...)` works.

### Tests
New golden tests: enum value access (Dart/Java/C#), generic collections (Java/C#), generic classes (Dart/Java/C#/Kotlin/TypeScript), Java for-each round-trip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)