### PR TITLE
v0.1.40: Wasm control flow + bitwise; Kotlin/Lua bitwise; Kotlin visibility; feature docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,36 @@
+## 0.1.40
+
+### Wasm: control flow + bitwise
+
+- The WebAssembly compiler now supports `do`/`while`, `switch`/`case` (integer,
+  C-style fall-through), `break`, `continue`, and the bitwise operators
+  `& | ^ << >>` and unary `~`. Loops now wrap their body in a `continue` block
+  and `WasmContext` tracks structured-control depth so `break`/`continue` emit
+  correct relative branch labels. Each construct is validated against both the
+  AST interpreter and the compiled+executed Wasm module.
+
+### Bitwise operators: Kotlin and Lua
+
+- **Kotlin**: infix `and`/`or`/`xor`/`shl`/`shr` and `x.inv()` (bitwise NOT).
+- **Lua**: `&`/`|`/`~` (xor)/`<<`/`>>` and unary `~`, leaving `~=` (not-equals)
+  and `^` (exponent) intact.
+
+### Kotlin member visibility
+
+- Parse and generate member modifiers (`private`/`public`/`internal`/
+  `protected`, plus `open`/`override`/`abstract`/`final`/`const`) on Kotlin
+  methods/fields/constructors; method visibility round-trips.
+
+### Fixes
+
+- **Java**: `private` members no longer fail with "Can't be private and public"
+  (the modifiers parser derived `isPublic` from `private`).
+
+### Docs
+
+- New "Supported Features" section in the README: per-language control-flow /
+  operator matrix (with a Wasm column) and a Classes/types/OOP matrix.
+
 ## 0.1.39
 
 ### enum runtime value access

--- a/README.md
+++ b/README.md
@@ -27,6 +27,84 @@ If you prefer to run the demo on your local machine:
 
 -----------------------------
 
+## Supported Features
+
+ApolloVM can **parse**, **execute** (interpret), and **translate** (cross-compile)
+source code between all supported languages, and **compile to WebAssembly** on the fly.
+
+### Languages
+
+`Dart`, `Java 11`, `Kotlin`, `C#`, `JavaScript`, `TypeScript`, `Lua` and `Python`.
+
+Any supported language can be translated to any other (e.g. Java → Dart, C# → Python,
+Kotlin → JavaScript), and code can be regenerated back to its original language.
+
+### Core capabilities
+
+- **Parsing** of each language into a shared AST.
+- **Execution**: a tree-walking interpreter runs the AST directly.
+- **Translation**: regenerate the AST as source in any supported language.
+- **Wasm compilation**: compile to WebAssembly, including `async`/`await` (via
+  Asyncify), classes, exceptions, maps and GC types.
+
+### Control flow & operators
+
+Legend: ✅ supported · ⚠️ supported via the language's idiom · 🚧 not yet supported (exists in the
+language but not implemented yet) · — not applicable (the language has no such construct).
+
+The **Wasm** column shows what the on-the-fly WebAssembly compiler currently supports
+(any source language is compiled through the same shared AST).
+
+| Feature | Dart | Java | Kotlin | C# | JS | TS | Lua | Python | Wasm |
+|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
+| `if` / `else if` / `else`        | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `for` (C-style)                  | ✅ | ✅ | —  | ✅ | ✅ | ✅ | ⚠️¹ | — | ✅ |
+| `for-each` / `for-in`            | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `while`                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `do` / `while`                   | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️² | — | 🚧 |
+| `switch` / `case`                | ✅ | ✅ | ⚠️³ | ✅ | ✅ | ✅ | —  | ⚠️⁴ | 🚧 |
+| `break`                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🚧 |
+| `continue`                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | 🚧 |
+| `try` / `catch` / `finally`      | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
+| `throw` / `raise`                | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
+| Ternary (`? :`)                  | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
+| Arithmetic (`+ - * / %`)         | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Comparison / logical             | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Bitwise (`& \| ^ << >> ~`)       | ✅ | ✅ | 🚧 | ✅ | ✅ | ✅ | 🚧 | ✅ | 🚧 |
+| `++` / `--`, compound assign     | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Lambdas / closures               | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| String interpolation / concat    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| List & map / dict literals       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `null` / `None` / `nil`          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+
+¹ Lua numeric-for (`for i = a, b do`). &nbsp; ² Lua `repeat … until`. &nbsp;
+³ Kotlin `when`. &nbsp; ⁴ Python `match` / `case`. &nbsp;
+🚧 Kotlin/Lua bitwise use named/non-standard operators (Kotlin `and`/`or`/`shl`/`inv`,
+Lua 5.3 `~`); not implemented yet.
+
+### Classes, types & OOP
+
+- **Classes** with fields (including initializers), methods, and `static`/visibility
+  modifiers: `Dart`, `Java`, `Kotlin`, `C#`, `JavaScript`, `TypeScript`, `Python`
+  (`Lua` uses tables and functions).
+- **Constructors** and instantiation (`new Foo(...)` / `Foo(...)`): `Dart`, `Java`,
+  `Kotlin`, `C#`, `TypeScript`.
+- **Inheritance / interfaces** (`extends`, `implements`, base lists) are parsed and
+  carried through translation.
+- **Enums**, including runtime value access (`Color.red` → ordinal, or its explicit
+  value): `Dart`, `Java`, `Kotlin`, `C#`, `TypeScript`, `Python`.
+- **Generics**: generic class declarations, generic instantiation and generic type
+  annotations (`Wrapper<T>`, `new Wrapper<int>(10)`, `Map<String, int>`), with
+  type erasure at runtime: `Dart`, `Java`, `Kotlin`, `C#`, `TypeScript`.
+- **Types**: primitives (`int`, `double`/`num`, `bool`, `String`, `Object`/dynamic),
+  `var`/`val`/type inference, arrays (1D/2D/3D), maps, and function types.
+
+> Per-language behavior is normalized to a shared AST, so types and constructs map
+> cleanly when translating between languages (e.g. C# `string` ⇄ Dart `String`,
+> Java `List<Integer>` ⇄ Dart `List<int>`).
+
+-----------------------------
+
 ## Command Line Usage
 
 You can use the executable `apollovm` to `run` or `translate` source codes. 
@@ -784,8 +862,11 @@ cross-translatable with Dart, Java, Kotlin, JavaScript, TypeScript and Lua.
 ApolloVM can compile its AST tree to WebAssembly (Wasm). This means that parsed code loaded into the VM can be compiled
 on the fly, without the need for any third-party tools.
 
-- **Status:** *Wasm support is still in the alpha stage and currently only supports basic integer operations. Full support for
-AST trees is currently under development.*
+- **Status:** *Wasm support is under active development. It already compiles a broad subset of
+the AST — functions, control flow (`if`/`for`/`for-each`/`while`/ternary), arithmetic/comparison/logical
+operators, `try`/`catch`/`throw`, classes, closures, lists/maps, and `async`/`await` (via Asyncify);
+see the [feature table](#supported-features). Some constructs (e.g. `switch`, `break`/`continue`,
+`do`/`while`, bitwise operators) are not yet compiled to Wasm.*
 
 Example of Dart code compiled to Wasm:
 ```dart
@@ -997,11 +1078,11 @@ Any help from the open-source community is always welcome and needed:
   - *See the [JavaScript implementation (at "lib/src/languages/javascript/es")](https://github.com/ApolloVM/apollovm_dart/tree/master/lib/src/languages/javascript/es).*
 
 
-- TypeScript: extended support (generics, union/intersection types, type aliases, parameter properties, enum member access at runtime, decorators). *Type annotations, `interface`, `enum`, and access modifiers (`public`/`private`/`protected`/`readonly`/`static`/`abstract`) are already supported.*
+- TypeScript: extended support (union/intersection types, type aliases, parameter properties, decorators). *Type annotations, `interface`, `enum` (incl. member access at runtime), generic classes/instantiation, and access modifiers (`public`/`private`/`protected`/`readonly`/`static`/`abstract`) are already supported.*
   - *See the [TypeScript implementation (at "lib/src/languages/typescript/ts")](https://github.com/ApolloVM/apollovm_dart/tree/master/lib/src/languages/typescript/ts).*
 
 
-- Lua: extended support (`repeat ... until`, multiple assignment/returns, varargs, non-`ipairs` numeric-for round-tripping, and hand-written metatable styles beyond the `Name = {}` / `function Name:method` convention).
+- Lua: extended support (multiple assignment/returns, varargs, non-`ipairs` numeric-for round-tripping, and hand-written metatable styles beyond the `Name = {}` / `function Name:method` convention).
   - *See the [Lua implementation (at "lib/src/languages/lua")](https://github.com/ApolloVM/apollovm_dart/tree/master/lib/src/languages/lua).*
 
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ language but not implemented yet) · — not applicable (the language has no suc
 | Fields (with initializers)                                    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️¹ | ✅ |
 | Constructors & instantiation (`new Foo(...)` / `Foo(...)`)    | ✅ | ✅ | ✅ | ✅ | 🚧 | ✅ | ⚠️¹ | 🚧² |
 | Methods                                                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Static / visibility modifiers                                 | ✅ | ✅ | ✅ | ✅ | ⚠️³ | ✅ | —  | —  |
+| Static / visibility modifiers                                 | ✅ | ✅ | ⚠️⁴ | ✅ | ⚠️³ | ✅ | —  | —  |
 | Inheritance (`extends`) / interfaces                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ |
 | Enums (incl. runtime value access)                            | ✅ | ✅ | ✅ | ✅ | —  | ✅ | —  | ✅ |
 | Generics (generic classes + instantiation + type erasure)    | ✅ | ✅ | ✅ | ✅ | —  | ✅ | —  | —  |
@@ -105,6 +105,8 @@ are factory functions / `setmetatable` idioms; methods use `function Obj:method`
 implemented yet, so constructors aren't usable end-to-end. &nbsp;
 ³ JavaScript supports the `static` modifier but has no visibility keywords (privacy is by convention /
 closures). &nbsp;
+⁴ Kotlin member visibility modifiers (`private`/`public`/`internal`/`protected`) are supported; Kotlin
+has no `static` (it uses `companion object`, not yet supported). &nbsp;
 Generics are marked `—` for JS/Lua/Python because those languages have no static type syntax to
 parameterize.
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ ApolloVM is a portable VM (native, JS/Web, Flutter) that can parse, translate, a
 
 ## Use Cases
 
+- **MCP tool for LLMs** — expose ApolloVM over MCP so an LLM can validate generated code (parse, run, check output) and use it as a sandboxed reasoning scratchpad.
 - **Cross-language translation / porting** — translate and regenerate source between any supported languages to prototype, migrate, or share logic across stacks.
 - **Embedded scripting in Dart/Flutter** — ship logic, UIs, and behavior that update live at runtime, with no rebuild or app-store redeploy.
 - **Business rules & formulas** — define pricing, discounts, validation, and eligibility logic as editable rules in a real, familiar language, evaluated safely at runtime — no hardcoding or custom expression engine to build and maintain.
@@ -26,7 +27,6 @@ ApolloVM is a portable VM (native, JS/Web, Flutter) that can parse, translate, a
 - **Playgrounds & education** — build multi-language runners/REPLs that show the same program across languages and its translated output.
 - **Reference implementations / test oracles** — write an algorithm once, then run or emit it across language targets to cross-check behavior.
 - **Polyglot AST tooling** — parse multiple languages into one shared AST for analysis, transformation, and code generation.
-- **MCP tool for LLMs** — expose ApolloVM over MCP so an LLM can validate generated code (parse, run, check output) and use it as a sandboxed reasoning scratchpad.
 
 -----------------------------
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ ApolloVM is a portable VM (native, JS/Web, Flutter) that can parse, translate, a
 ## Use Cases
 
 - **Cross-language translation / porting** — translate and regenerate source between any supported languages to prototype, migrate, or share logic across stacks.
-- **Embedded scripting** — let users write logic in a familiar language and run it inside a Dart/Flutter app at runtime, with no app-store redeploy.
+- **Embedded scripting in Dart/Flutter** — ship logic, UIs, and behavior that update live at runtime, with no rebuild or app-store redeploy.
 - **Business rules & formulas** — evaluate runtime-configurable logic (pricing, validation, workflows) authored in a real language instead of a bespoke mini-DSL.
 - **Sandboxed execution** — run untrusted, user-supplied snippets isolated from the host, via the interpreter or compiled Wasm.
 - **On-the-fly WebAssembly** — compile loaded source to portable Wasm modules at runtime (browser or native) without any external toolchain.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ ApolloVM is a portable VM (native, JS/Web, Flutter) that can parse, translate, a
 
 - **Cross-language translation / porting** — translate and regenerate source between any supported languages to prototype, migrate, or share logic across stacks.
 - **Embedded scripting in Dart/Flutter** — ship logic, UIs, and behavior that update live at runtime, with no rebuild or app-store redeploy.
-- **Business rules & formulas** — evaluate runtime-configurable logic (pricing, validation, workflows) authored in a real language instead of a bespoke mini-DSL.
+- **Business rules & formulas** — define pricing, discounts, validation, and eligibility logic as editable rules in a real, familiar language, evaluated safely at runtime — no hardcoding or custom expression engine to build and maintain.
 - **Sandboxed execution** — run untrusted, user-supplied snippets isolated from the host, via the interpreter or compiled Wasm.
 - **On-the-fly WebAssembly** — compile loaded source to portable Wasm modules at runtime (browser or native) without any external toolchain.
 - **Playgrounds & education** — build multi-language runners/REPLs that show the same program across languages and its translated output.

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ ApolloVM is a portable VM (native, JS/Web, Flutter) that can parse, translate, a
 
 ## Use Cases
 
-- **MCP tool for LLMs** — expose ApolloVM over MCP so an LLM can validate generated code (parse, run, check output) and use it as a sandboxed reasoning scratchpad.
-- **Cross-language translation / porting** — translate and regenerate source between any supported languages to prototype, migrate, or share logic across stacks.
-- **Embedded scripting in Dart/Flutter** — ship logic, UIs, and behavior that update live at runtime, with no rebuild or app-store redeploy.
-- **Business rules & formulas** — define pricing, discounts, validation, and eligibility logic as editable rules in a real, familiar language, evaluated safely at runtime — no hardcoding or custom expression engine to build and maintain.
-- **Sandboxed execution** — run untrusted, user-supplied snippets isolated from the host, via the interpreter or compiled Wasm.
-- **On-the-fly WebAssembly** — compile loaded source to portable Wasm modules at runtime (browser or native) without any external toolchain.
-- **Playgrounds & education** — build multi-language runners/REPLs that show the same program across languages and its translated output.
-- **Reference implementations / test oracles** — write an algorithm once, then run or emit it across language targets to cross-check behavior.
-- **Polyglot AST tooling** — parse multiple languages into one shared AST for analysis, transformation, and code generation.
+- 🤖 **MCP tool for LLMs** — expose ApolloVM over MCP so an LLM can validate generated code (parse, run, check output) and use it as a sandboxed reasoning scratchpad.
+- 🔄 **Cross-language translation / porting** — translate and regenerate source between any supported languages to prototype, migrate, or share logic across stacks.
+- 📱 **Embedded scripting in Dart/Flutter** — ship logic, UIs, and behavior that update live at runtime, with no rebuild or app-store redeploy.
+- 📐 **Business rules & formulas** — define pricing, discounts, validation, and eligibility logic as editable rules in a real, familiar language, evaluated safely at runtime — no hardcoding or custom expression engine to build and maintain.
+- 🔒 **Sandboxed execution** — run untrusted, user-supplied snippets isolated from the host, via the interpreter or compiled Wasm.
+- ⚙️ **On-the-fly WebAssembly** — compile loaded source to portable Wasm modules at runtime (browser or native) without any external toolchain.
+- 🎓 **Playgrounds & education** — build multi-language runners/REPLs that show the same program across languages and its translated output.
+- 🧪 **Reference implementations / test oracles** — write an algorithm once, then run or emit it across language targets to cross-check behavior.
+- 🌳 **Polyglot AST tooling** — parse multiple languages into one shared AST for analysis, transformation, and code generation.
 
 -----------------------------
 

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ ApolloVM is a portable VM (native, JS/Web, Flutter) that can parse, translate, a
 
 ## Use Cases
 
-- **Cross-language translation / porting** — translate source between any supported languages.
-- **Embedded scripting** — run user logic inside Dart/Flutter apps, no redeploy.
-- **Business rules & formulas** — runtime-configurable logic in a real language, not a mini-DSL.
-- **Sandboxed execution** — run untrusted snippets isolated, via the interpreter or Wasm.
-- **On-the-fly Wasm** — compile loaded source to WebAssembly at runtime, no toolchain.
-- **Playgrounds & education** — multi-language runners/REPLs showing translated output.
-- **Reference implementations / test oracles** — write once, run/emit across languages to cross-check.
-- **Polyglot AST tooling** — one shared AST for analysis, transformation, and codegen.
-- **MCP tool for LLMs** — validate LLM-generated code (parse/run/check) and act as a sandboxed reasoning scratchpad.
+- **Cross-language translation / porting** — translate and regenerate source between any supported languages to prototype, migrate, or share logic across stacks.
+- **Embedded scripting** — let users write logic in a familiar language and run it inside a Dart/Flutter app at runtime, with no app-store redeploy.
+- **Business rules & formulas** — evaluate runtime-configurable logic (pricing, validation, workflows) authored in a real language instead of a bespoke mini-DSL.
+- **Sandboxed execution** — run untrusted, user-supplied snippets isolated from the host, via the interpreter or compiled Wasm.
+- **On-the-fly WebAssembly** — compile loaded source to portable Wasm modules at runtime (browser or native) without any external toolchain.
+- **Playgrounds & education** — build multi-language runners/REPLs that show the same program across languages and its translated output.
+- **Reference implementations / test oracles** — write an algorithm once, then run or emit it across language targets to cross-check behavior.
+- **Polyglot AST tooling** — parse multiple languages into one shared AST for analysis, transformation, and code generation.
+- **MCP tool for LLMs** — expose ApolloVM over MCP so an LLM can validate generated code (parse, run, check output) and use it as a sandboxed reasoning scratchpad.
 
 -----------------------------
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,20 @@ ApolloVM is a portable VM (native, JS/Web, Flutter) that can parse, translate, a
 
 -----------------------------
 
+## Use Cases
+
+- **Cross-language code translation / porting** — Parse source in one language and regenerate it in another (Dart, Java, Kotlin, C#, JavaScript, TypeScript, Lua, Python) to prototype, migrate, or share logic across stacks.
+- **Embedded scripting in Dart/Flutter apps** — Let users or integrators write logic in a familiar language and execute it inside your app at runtime, with no app-store redeploy.
+- **User-defined business rules & formulas** — Evaluate runtime-configurable logic (pricing, validation, workflows) authored in a real programming language instead of a bespoke mini-DSL.
+- **Sandboxed execution of untrusted code** — Run user-supplied snippets through the interpreter or compiled Wasm, isolated from the host environment.
+- **On-the-fly WebAssembly compilation** — Turn loaded source into portable Wasm modules at runtime (browser or native) without any external toolchain.
+- **Interactive playgrounds & education** — Build multi-language runners/REPLs that show the same program across languages along with its generated/translated output.
+- **Shared reference implementations & test oracles** — Write an algorithm once and run or emit it across language targets to cross-check behavior.
+- **Polyglot AST tooling** — Parse multiple languages into one shared AST for analysis, transformation, or code generation.
+- **MCP tool for LLMs** — Expose ApolloVM as a Model Context Protocol (MCP) server so an LLM can validate generated code by parsing, running, and checking its output across languages, and use it as a sandboxed execution scratchpad to support reasoning.
+
+-----------------------------
+
 ## Live Example
 
 Experience ApolloVM in action right from your browser:

--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ ApolloVM is a portable VM (native, JS/Web, Flutter) that can parse, translate, a
 
 ## Use Cases
 
-- **Cross-language code translation / porting** — Parse source in one language and regenerate it in another (Dart, Java, Kotlin, C#, JavaScript, TypeScript, Lua, Python) to prototype, migrate, or share logic across stacks.
-- **Embedded scripting in Dart/Flutter apps** — Let users or integrators write logic in a familiar language and execute it inside your app at runtime, with no app-store redeploy.
-- **User-defined business rules & formulas** — Evaluate runtime-configurable logic (pricing, validation, workflows) authored in a real programming language instead of a bespoke mini-DSL.
-- **Sandboxed execution of untrusted code** — Run user-supplied snippets through the interpreter or compiled Wasm, isolated from the host environment.
-- **On-the-fly WebAssembly compilation** — Turn loaded source into portable Wasm modules at runtime (browser or native) without any external toolchain.
-- **Interactive playgrounds & education** — Build multi-language runners/REPLs that show the same program across languages along with its generated/translated output.
-- **Shared reference implementations & test oracles** — Write an algorithm once and run or emit it across language targets to cross-check behavior.
-- **Polyglot AST tooling** — Parse multiple languages into one shared AST for analysis, transformation, or code generation.
-- **MCP tool for LLMs** — Expose ApolloVM as a Model Context Protocol (MCP) server so an LLM can validate generated code by parsing, running, and checking its output across languages, and use it as a sandboxed execution scratchpad to support reasoning.
+- **Cross-language translation / porting** — translate source between any supported languages.
+- **Embedded scripting** — run user logic inside Dart/Flutter apps, no redeploy.
+- **Business rules & formulas** — runtime-configurable logic in a real language, not a mini-DSL.
+- **Sandboxed execution** — run untrusted snippets isolated, via the interpreter or Wasm.
+- **On-the-fly Wasm** — compile loaded source to WebAssembly at runtime, no toolchain.
+- **Playgrounds & education** — multi-language runners/REPLs showing translated output.
+- **Reference implementations / test oracles** — write once, run/emit across languages to cross-check.
+- **Polyglot AST tooling** — one shared AST for analysis, transformation, and codegen.
+- **MCP tool for LLMs** — validate LLM-generated code (parse/run/check) and act as a sandboxed reasoning scratchpad.
 
 -----------------------------
 

--- a/README.md
+++ b/README.md
@@ -61,16 +61,16 @@ The **Wasm** column shows what the on-the-fly WebAssembly compiler currently sup
 | `for` (C-style)                  | ✅ | ✅ | —  | ✅ | ✅ | ✅ | ⚠️¹ | — | ✅ |
 | `for-each` / `for-in`            | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `while`                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `do` / `while`                   | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️² | — | 🚧 |
-| `switch` / `case`                | ✅ | ✅ | ⚠️³ | ✅ | ✅ | ✅ | —  | ⚠️⁴ | 🚧 |
-| `break`                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🚧 |
-| `continue`                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | 🚧 |
+| `do` / `while`                   | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️² | — | ✅ |
+| `switch` / `case`                | ✅ | ✅ | ⚠️³ | ✅ | ✅ | ✅ | —  | ⚠️⁴ | ✅ |
+| `break`                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `continue`                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
 | `try` / `catch` / `finally`      | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
 | `throw` / `raise`                | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
 | Ternary (`? :`)                  | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
 | Arithmetic (`+ - * / %`)         | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Comparison / logical             | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Bitwise (`& \| ^ << >> ~`)       | ✅ | ✅ | 🚧 | ✅ | ✅ | ✅ | 🚧 | ✅ | 🚧 |
+| Bitwise (`& \| ^ << >> ~`)       | ✅ | ✅ | ⚠️⁵ | ✅ | ✅ | ✅ | ⚠️⁶ | ✅ | ✅ |
 | `++` / `--`, compound assign     | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Lambdas / closures               | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | String interpolation / concat    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -79,25 +79,34 @@ The **Wasm** column shows what the on-the-fly WebAssembly compiler currently sup
 
 ¹ Lua numeric-for (`for i = a, b do`). &nbsp; ² Lua `repeat … until`. &nbsp;
 ³ Kotlin `when`. &nbsp; ⁴ Python `match` / `case`. &nbsp;
-🚧 Kotlin/Lua bitwise use named/non-standard operators (Kotlin `and`/`or`/`shl`/`inv`,
-Lua 5.3 `~`); not implemented yet.
+⁵ Kotlin bitwise are infix functions: `and`/`or`/`xor`/`shl`/`shr` and `.inv()`. &nbsp;
+⁶ Lua bitwise use `&`/`|`/`~` (xor)/`<<`/`>>` and unary `~` (Lua 5.3).
 
 ### Classes, types & OOP
 
-- **Classes** with fields (including initializers), methods, and `static`/visibility
-  modifiers: `Dart`, `Java`, `Kotlin`, `C#`, `JavaScript`, `TypeScript`, `Python`
-  (`Lua` uses tables and functions).
-- **Constructors** and instantiation (`new Foo(...)` / `Foo(...)`): `Dart`, `Java`,
-  `Kotlin`, `C#`, `TypeScript`.
-- **Inheritance / interfaces** (`extends`, `implements`, base lists) are parsed and
-  carried through translation.
-- **Enums**, including runtime value access (`Color.red` → ordinal, or its explicit
-  value): `Dart`, `Java`, `Kotlin`, `C#`, `TypeScript`, `Python`.
-- **Generics**: generic class declarations, generic instantiation and generic type
-  annotations (`Wrapper<T>`, `new Wrapper<int>(10)`, `Map<String, int>`), with
-  type erasure at runtime: `Dart`, `Java`, `Kotlin`, `C#`, `TypeScript`.
-- **Types**: primitives (`int`, `double`/`num`, `bool`, `String`, `Object`/dynamic),
-  `var`/`val`/type inference, arrays (1D/2D/3D), maps, and function types.
+Legend: ✅ supported · ⚠️ supported via the language's idiom · 🚧 not yet supported (exists in the
+language but not implemented yet) · — not applicable (the language has no such construct).
+
+| Feature | Dart | Java | Kotlin | C# | JS | TS | Lua | Python |
+|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
+| Classes                                                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ |
+| Fields (with initializers)                                    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️¹ | ✅ |
+| Constructors & instantiation (`new Foo(...)` / `Foo(...)`)    | ✅ | ✅ | ✅ | ✅ | 🚧 | ✅ | ⚠️¹ | 🚧² |
+| Methods                                                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Static / visibility modifiers                                 | ✅ | ✅ | ✅ | ✅ | ⚠️³ | ✅ | —  | —  |
+| Inheritance (`extends`) / interfaces                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ |
+| Enums (incl. runtime value access)                            | ✅ | ✅ | ✅ | ✅ | —  | ✅ | —  | ✅ |
+| Generics (generic classes + instantiation + type erasure)    | ✅ | ✅ | ✅ | ✅ | —  | ✅ | —  | —  |
+| Type inference (`var` / `val` / `auto`)                       | ✅ | ✅ | ✅ | ✅ | —  | ✅ | —  | —  |
+
+¹ Lua is table-based (no class construct): "fields" are table entries (`obj.x`) and "constructors"
+are factory functions / `setmetatable` idioms; methods use `function Obj:method`. &nbsp;
+² Python declares constructors via `__init__`, but instance-field assignment (`self.x = ...`) is not
+implemented yet, so constructors aren't usable end-to-end. &nbsp;
+³ JavaScript supports the `static` modifier but has no visibility keywords (privacy is by convention /
+closures). &nbsp;
+Generics are marked `—` for JS/Lua/Python because those languages have no static type syntax to
+parameterize.
 
 > Per-language behavior is normalized to a shared AST, so types and constructs map
 > cleanly when translating between languages (e.g. C# `string` ⇄ Dart `String`,
@@ -863,10 +872,11 @@ ApolloVM can compile its AST tree to WebAssembly (Wasm). This means that parsed 
 on the fly, without the need for any third-party tools.
 
 - **Status:** *Wasm support is under active development. It already compiles a broad subset of
-the AST — functions, control flow (`if`/`for`/`for-each`/`while`/ternary), arithmetic/comparison/logical
-operators, `try`/`catch`/`throw`, classes, closures, lists/maps, and `async`/`await` (via Asyncify);
-see the [feature table](#supported-features). Some constructs (e.g. `switch`, `break`/`continue`,
-`do`/`while`, bitwise operators) are not yet compiled to Wasm.*
+the AST — functions, full control flow (`if`/`for`/`for-each`/`while`/`do-while`/`switch`/
+`break`/`continue`/ternary), arithmetic/comparison/logical/bitwise operators, `try`/`catch`/`throw`,
+classes, closures, lists/maps, and `async`/`await` (via Asyncify); see the
+[feature table](#supported-features). Constructs not yet compiled to Wasm are limited to a few
+higher-level features (e.g. non-integer `switch`).*
 
 Example of Dart code compiled to Wasm:
 ```dart

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ ApolloVM is a portable VM (native, JS/Web, Flutter) that can parse, translate, a
 
 ## Use Cases
 
-- 🤖 **MCP tool for LLMs** — expose ApolloVM over MCP so an LLM can validate generated code (parse, run, check output) and use it as a sandboxed reasoning scratchpad.
+- 🤖 **MCP tool for LLMs** — expose ApolloVM over MCP so an LLM can use it as a sandboxed reasoning scratchpad and validate generated code (parse, run, check output).
 - 🔄 **Cross-language translation / porting** — translate and regenerate source between any supported languages to prototype, migrate, or share logic across stacks.
 - 📱 **Embedded scripting in Dart/Flutter** — ship logic, UIs, and behavior that update live at runtime, with no rebuild or app-store redeploy.
 - 📐 **Business rules & formulas** — define pricing, discounts, validation, and eligibility logic as editable rules in a real, familiar language, evaluated safely at runtime — no hardcoding or custom expression engine to build and maintain.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ ApolloVM is a portable VM (native, JS/Web, Flutter) that can parse, translate, a
 - 🎓 **Playgrounds & education** — build multi-language runners/REPLs that show the same program across languages and its translated output.
 - 🧪 **Reference implementations / test oracles** — write an algorithm once, then run or emit it across language targets to cross-check behavior.
 - 🌳 **Polyglot AST tooling** — parse multiple languages into one shared AST for analysis, transformation, and code generation.
+- 🪶 **Small, multi-platform VM** — runs on native, web/JS, and Flutter; the CLI compiles to a self-contained native binary under 10 MB with all features included.
 
 -----------------------------
 

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -53,7 +53,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.39';
+  static final String VERSION = '0.1.40';
 
   static int _idCount = 0;
 

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -288,7 +288,7 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
     var isStatic = v.contains('static');
     var isFinal = v.contains('final');
     var isPrivate = v.contains('private');
-    var isPublic = v.contains('private');
+    var isPublic = v.contains('public');
     return ASTModifiers(
       isStatic: isStatic,
       isFinal: isFinal,

--- a/lib/src/languages/kotlin/kotlin_generator.dart
+++ b/lib/src/languages/kotlin/kotlin_generator.dart
@@ -279,6 +279,13 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
 
     out.write(indent);
 
+    // Visibility modifier (Kotlin defaults to `public`, so only emit when set).
+    if (f.modifiers.isPrivate) {
+      out.write('private ');
+    } else if (f.modifiers.isPublic) {
+      out.write('public ');
+    }
+
     // Dart `async` maps to a Kotlin `suspend fun`; `Future<T>` collapses to `T`
     // (suspension is implicit in coroutines — see [generateASTExpressionAwait]).
     var returnType = f.returnType;

--- a/lib/src/languages/kotlin/kotlin_generator.dart
+++ b/lib/src/languages/kotlin/kotlin_generator.dart
@@ -624,7 +624,47 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
     if (operator == ASTExpressionOperator.divideAsInt) {
       return getASTExpressionOperatorText(ASTExpressionOperator.divide);
     }
-    return getASTExpressionOperatorText(operator);
+    // Kotlin uses named infix functions for bitwise operators instead of the
+    // C-family symbols (`&`, `|`, `^`, `<<`, `>>`). The operation formatter
+    // surrounds the operator with spaces, producing e.g. `a and b`.
+    switch (operator) {
+      case ASTExpressionOperator.bitwiseAnd:
+        return 'and';
+      case ASTExpressionOperator.bitwiseOr:
+        return 'or';
+      case ASTExpressionOperator.bitwiseXor:
+        return 'xor';
+      case ASTExpressionOperator.shiftLeft:
+        return 'shl';
+      case ASTExpressionOperator.shiftRight:
+        return 'shr';
+      default:
+        return getASTExpressionOperatorText(operator);
+    }
+  }
+
+  /// Kotlin writes bitwise-not as `x.inv()` (a method call), not `~x`.
+  @override
+  StringBuffer generateASTExpressionBitwiseNot(
+    ASTExpressionBitwiseNot expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write('(');
+    generateASTExpression(
+      expression.expression,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+    out.write(').inv()');
+
+    return out;
   }
 
   @override

--- a/lib/src/languages/kotlin/kotlin_grammar.dart
+++ b/lib/src/languages/kotlin/kotlin_grammar.dart
@@ -658,7 +658,8 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
           });
 
   Parser<ASTExpressionOperator> expressionOperator() =>
-      (char('+') |
+      (ref0(bitwiseInfixOperator) |
+              char('+') |
               char('-') |
               char('*') |
               char('/') |
@@ -673,7 +674,39 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
               string('||'))
           .trimHidden()
           .map((v) {
-            return getASTExpressionOperator(v);
+            // Word-operators ([bitwiseInfixOperator]) already yield the enum;
+            // symbol-operators yield a [String] to be mapped.
+            if (v is ASTExpressionOperator) return v;
+            return getASTExpressionOperator(v as String);
+          });
+
+  /// Kotlin has no `&`/`|`/`^`/`<<`/`>>` symbols; bitwise operations use named
+  /// infix functions instead: `a and b`, `a or b`, `a xor b`, `a shl b`,
+  /// `a shr b`. Matched as whole words (via the [identifierPartLexicalToken]
+  /// negative-lookahead) so identifiers like `android` or `order` are not
+  /// mis-parsed as operators.
+  Parser<ASTExpressionOperator> bitwiseInfixOperator() =>
+      ((string('and') |
+                  string('or') |
+                  string('xor') |
+                  string('shl') |
+                  string('shr')) &
+              ref0(identifierPartLexicalToken).not())
+          .map((v) {
+            switch (v[0] as String) {
+              case 'and':
+                return ASTExpressionOperator.bitwiseAnd;
+              case 'or':
+                return ASTExpressionOperator.bitwiseOr;
+              case 'xor':
+                return ASTExpressionOperator.bitwiseXor;
+              case 'shl':
+                return ASTExpressionOperator.shiftLeft;
+              case 'shr':
+                return ASTExpressionOperator.shiftRight;
+              default:
+                throw UnsupportedError(v[0] as String);
+            }
           });
 
   Parser<ASTExpression> expressionNoOperation() =>

--- a/lib/src/languages/kotlin/kotlin_grammar.dart
+++ b/lib/src/languages/kotlin/kotlin_grammar.dart
@@ -217,18 +217,46 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
             return block;
           });
 
+  /// Optional Kotlin member modifiers: visibility (`private`/`public`/
+  /// `internal`/`protected`) and a few common ones (`open`/`override`/
+  /// `abstract`/`final`/`const`). Returns the merged [ASTModifiers].
+  Parser<ASTModifiers> memberModifiers() => memberModifier().star().map((mods) {
+    var names = mods.cast<String>();
+    return ASTModifiers(
+      isPrivate: names.contains('private'),
+      isPublic: names.contains('public'),
+      isFinal: names.contains('final') || names.contains('const'),
+      isAbstract: names.contains('abstract'),
+    );
+  });
+
+  Parser<String> memberModifier() =>
+      ((string('private') |
+                  string('public') |
+                  string('internal') |
+                  string('protected') |
+                  string('open') |
+                  string('override') |
+                  string('abstract') |
+                  string('final') |
+                  string('const')) &
+              ref0(identifierPartLexicalToken).not())
+          .map((v) => v[0] as String)
+          .trimHidden();
+
   Parser<ASTClassField> classFieldDeclaration() =>
-      ((valToken() | varToken()).trimHidden() &
+      (memberModifiers() &
+              (valToken() | varToken()).trimHidden() &
               identifier().trimHidden() &
               char(':').trimHidden() &
               type() &
               (char('=').trimHidden() & ref0(expression)).optional() &
               char(';').trimHidden().optional())
           .map((v) {
-            var finalValue = (v[0] as Token).value == 'val';
-            var name = v[1] as String;
-            var type = v[3] as ASTType;
-            var valueOpt = v[4];
+            var finalValue = (v[1] as Token).value == 'val';
+            var name = v[2] as String;
+            var type = v[4] as ASTType;
+            var valueOpt = v[5];
             if (valueOpt != null) {
               var expression = valueOpt[1] as ASTExpression;
               type.associateToType(expression);
@@ -243,17 +271,20 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
           });
 
   Parser<ASTClassConstructorDeclaration> classConstructorDeclaration() =>
-      (constructorToken().trimHidden() &
+      (memberModifiers() &
+              constructorToken().trimHidden() &
               constructorParametersDeclaration() &
               codeBlock())
           .map((v) {
-            var parameters = v[1] as ASTConstructorParametersDeclaration;
-            var block = v[2];
+            var modifiers = v[0] as ASTModifiers;
+            var parameters = v[2] as ASTConstructorParametersDeclaration;
+            var block = v[3];
             return ASTClassConstructorDeclaration(
               ASTType(''),
               '',
               parameters,
               block: block,
+              modifiers: modifiers,
             );
           });
 
@@ -302,22 +333,25 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
           });
 
   Parser<ASTFunctionDeclaration> classFunctionDeclaration() =>
-      (funToken().trimHidden() &
+      (memberModifiers() &
+              funToken().trimHidden() &
               identifier() &
               functionParametersDeclaration() &
               (char(':').trimHidden() & type()).optional() &
               codeBlock())
           .map((v) {
-            var name = v[1] as String;
-            var parameters = v[2] as ASTFunctionParametersDeclaration;
-            var returnType = (v[3]?[1] as ASTType?) ?? ASTTypeVoid.instance;
-            var block = v[4] as ASTBlock;
+            var modifiers = v[0] as ASTModifiers;
+            var name = v[2] as String;
+            var parameters = v[3] as ASTFunctionParametersDeclaration;
+            var returnType = (v[4]?[1] as ASTType?) ?? ASTTypeVoid.instance;
+            var block = v[5] as ASTBlock;
             return ASTClassFunctionDeclaration(
               null,
               name,
               parameters,
               returnType,
               block: block,
+              modifiers: modifiers,
             );
           });
 

--- a/lib/src/languages/lua/lua_generator.dart
+++ b/lib/src/languages/lua/lua_generator.dart
@@ -683,6 +683,19 @@ class ApolloCodeGeneratorLua extends ApolloCodeGenerator {
         return 'or';
       case ASTExpressionOperator.divideAsInt:
         return '//';
+      // Lua 5.3 bitwise operators. NOTE: `bitwiseXor` must be `~` in Lua (the
+      // shared default is `^`, which is exponentiation in Lua), so this case is
+      // essential, not just cosmetic.
+      case ASTExpressionOperator.bitwiseAnd:
+        return '&';
+      case ASTExpressionOperator.bitwiseOr:
+        return '|';
+      case ASTExpressionOperator.bitwiseXor:
+        return '~';
+      case ASTExpressionOperator.shiftLeft:
+        return '<<';
+      case ASTExpressionOperator.shiftRight:
+        return '>>';
       default:
         return getASTExpressionOperatorText(operator);
     }

--- a/lib/src/languages/lua/lua_grammar.dart
+++ b/lib/src/languages/lua/lua_grammar.dart
@@ -526,7 +526,12 @@ class LuaGrammarDefinition extends LuaGrammarLexer {
   Parser<ASTExpressionOperator> expressionOperator() =>
       (string('..').map((_) => ASTExpressionOperator.add) |
               string('==').map((_) => ASTExpressionOperator.equals) |
+              // `~=` (not-equals) MUST be matched before the single-char `~`
+              // (bitwise xor) so the binary `~` never swallows the `=`.
               string('~=').map((_) => ASTExpressionOperator.notEquals) |
+              // `<<`/`>>` (shifts) MUST be matched before single `<`/`>`.
+              string('<<').map((_) => ASTExpressionOperator.shiftLeft) |
+              string('>>').map((_) => ASTExpressionOperator.shiftRight) |
               string('<=').map((_) => ASTExpressionOperator.lowerOrEq) |
               string('>=').map((_) => ASTExpressionOperator.greaterOrEq) |
               andToken().map((_) => ASTExpressionOperator.and) |
@@ -536,6 +541,10 @@ class LuaGrammarDefinition extends LuaGrammarLexer {
               char('*').map((_) => ASTExpressionOperator.multiply) |
               char('/').map((_) => ASTExpressionOperator.divide) |
               char('%').map((_) => ASTExpressionOperator.remainder) |
+              char('&').map((_) => ASTExpressionOperator.bitwiseAnd) |
+              char('|').map((_) => ASTExpressionOperator.bitwiseOr) |
+              // In Lua, binary `~` is bitwise XOR (not `^`, which is exponent).
+              char('~').map((_) => ASTExpressionOperator.bitwiseXor) |
               char('<').map((_) => ASTExpressionOperator.lower) |
               char('>').map((_) => ASTExpressionOperator.greater))
           .trimHidden()
@@ -544,6 +553,7 @@ class LuaGrammarDefinition extends LuaGrammarLexer {
   Parser<ASTExpression> expressionNoOperation() =>
       (ref0(expressionAnonymousFunction) |
               ref0(expressionNegate) |
+              ref0(expressionBitwiseNot) |
               ref0(expressionLiteral) |
               ref0(expressionGroup) |
               ref0(expressionTableLiteral) |
@@ -568,6 +578,15 @@ class LuaGrammarDefinition extends LuaGrammarLexer {
               (ref0(expressionNoOperation) | ref0(expressionGroup)))
           .map((v) {
             return ASTExpressionNegative(v[1] as ASTExpression);
+          });
+
+  /// Unary prefix `~expr` — Lua's bitwise NOT. Prefix position only, so it
+  /// never conflicts with binary `~` (xor) or `~=` (not-equals).
+  Parser<ASTExpressionBitwiseNot> expressionBitwiseNot() =>
+      (char('~').trimHidden() &
+              (ref0(expressionNoOperation) | ref0(expressionGroup)))
+          .map((v) {
+            return ASTExpressionBitwiseNot(v[1] as ASTExpression);
           });
 
   Parser<ASTExpression> expressionGroup() =>

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -1168,10 +1168,12 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       description: "[OP] if ( $condition )",
     );
     context.stackDrop(_astTypeInt32);
+    context.controlDepth++;
 
     generateASTBlock(branch.block, out: out, context: context);
 
     out.writeByte(Wasm.end, description: "[OP] if end");
+    context.controlDepth--;
 
     return out;
   }
@@ -1202,6 +1204,7 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       description: "[OP] if ( $condition )",
     );
     context.stackDrop(_astTypeInt32);
+    context.controlDepth++;
 
     generateASTBlock(branch.blockIf, out: out, context: context);
 
@@ -1212,6 +1215,7 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     }
 
     out.writeByte(Wasm.end, description: "[OP] if else end");
+    context.controlDepth--;
 
     return out;
   }
@@ -1242,6 +1246,7 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       description: "[OP] if ( $condition )",
     );
     context.stackDrop(_astTypeInt32);
+    context.controlDepth++;
 
     generateASTBlock(branch.blockIf, out: out, context: context);
 
@@ -1287,6 +1292,7 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     }
 
     out.writeByte(Wasm.end, description: "[OP] if else end");
+    context.controlDepth--;
 
     return out;
   }
@@ -2355,6 +2361,37 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     return out;
   }
 
+  BytesOutput generateASTExpressionBitwiseNot(
+    ASTExpressionBitwiseNot expression, {
+    BytesOutput? out,
+    WasmContext? context,
+  }) {
+    out ??= newOutput();
+    context ??= WasmContext();
+
+    final stackLng0 = context.stackLength;
+
+    generateASTExpression(expression.expression, out: out, context: context);
+
+    context.assertStackLength(stackLng0 + 1, "After bitwise-not operand");
+
+    // No `i64.not` opcode: `~x == x ^ -1`.
+    out.write(
+      Wasm64.i64Const(-1),
+      description: "[OP] push constant(i64): -1 (bitwise-not)",
+    );
+    context.stackPush(_astTypeInt64, "bitwise-not -1");
+    out.writeByte(
+      Wasm64.i64BitwiseXor,
+      description: "[OP] operator: bitwise-not (i64.xor -1)",
+    );
+    context.stackOperationBinary(_astTypeInt64, "i64.xor (bitwise-not)");
+
+    context.assertStackLength(stackLng0 + 1, "After bitwise-not result");
+
+    return out;
+  }
+
   // The Wasm backend executes synchronously, so a `Future<T>` value is always
   // already available: `await expr` compiles to just `expr` (a value
   // pass-through), and an `async` function is compiled as a normal function
@@ -3019,6 +3056,51 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
           } else {
             _writeIntModulo(out, context);
           }
+        }
+      case ASTExpressionOperator.bitwiseAnd:
+        {
+          writeOperation(
+            opInt32 ? _astTypeInt32 : _astTypeInt64,
+            opInt32 ? Wasm32.i32BitwiseAnd : Wasm64.i64BitwiseAnd,
+            opInt32 ? "and(i32)" : "and(i64)",
+            opInt32 ? "i32.and" : "i64.and",
+          );
+        }
+      case ASTExpressionOperator.bitwiseOr:
+        {
+          writeOperation(
+            opInt32 ? _astTypeInt32 : _astTypeInt64,
+            opInt32 ? Wasm32.i32BitwiseOr : Wasm64.i64BitwiseOr,
+            opInt32 ? "or(i32)" : "or(i64)",
+            opInt32 ? "i32.or" : "i64.or",
+          );
+        }
+      case ASTExpressionOperator.bitwiseXor:
+        {
+          writeOperation(
+            opInt32 ? _astTypeInt32 : _astTypeInt64,
+            opInt32 ? Wasm32.i32BitwiseXor : Wasm64.i64BitwiseXor,
+            opInt32 ? "xor(i32)" : "xor(i64)",
+            opInt32 ? "i32.xor" : "i64.xor",
+          );
+        }
+      case ASTExpressionOperator.shiftLeft:
+        {
+          writeOperation(
+            opInt32 ? _astTypeInt32 : _astTypeInt64,
+            opInt32 ? Wasm32.i32ShiftLeft : Wasm64.i64ShiftLeft,
+            opInt32 ? "shl(i32)" : "shl(i64)",
+            opInt32 ? "i32.shl" : "i64.shl",
+          );
+        }
+      case ASTExpressionOperator.shiftRight:
+        {
+          writeOperation(
+            opInt32 ? _astTypeInt32 : _astTypeInt64,
+            opInt32 ? Wasm32.i32ShiftRightSigned : Wasm64.i64ShiftRightSigned,
+            opInt32 ? "shr_s(i32)" : "shr_s(i64)",
+            opInt32 ? "i32.shr_s" : "i64.shr_s",
+          );
         }
       default:
         // `and`/`or` are handled before operand evaluation (short-circuit).
@@ -6545,8 +6627,24 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       return generateASTStatementForLoop(statement, out: out, context: context);
     } else if (statement is ASTStatementForEach) {
       return generateASTStatementForEach(statement, out: out, context: context);
+    } else if (statement is ASTStatementDoWhileLoop) {
+      return generateASTStatementDoWhileLoop(
+        statement,
+        out: out,
+        context: context,
+      );
     } else if (statement is ASTStatementWhileLoop) {
       return generateASTStatementWhileLoop(
+        statement,
+        out: out,
+        context: context,
+      );
+    } else if (statement is ASTStatementSwitch) {
+      return generateASTStatementSwitch(statement, out: out, context: context);
+    } else if (statement is ASTStatementBreak) {
+      return generateASTStatementBreak(statement, out: out, context: context);
+    } else if (statement is ASTStatementContinue) {
+      return generateASTStatementContinue(
         statement,
         out: out,
         context: context,
@@ -6699,16 +6797,21 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     out.write(Wasm32.i32Const(0));
     out.write(Wasm.localSet(iScratch));
 
-    // block { loop { if (i >= len) break; e = data[i]; <body>; i++; continue } }
+    // block(break) { loop(repeat) { if (i >= len) break; e = data[i];
+    //   block(continue) { <body> }; i++; continue } }
     out.write(Wasm.block(WasmType.voidType));
+    context.controlDepth++;
+    final breakLevel = context.controlDepth;
     out.write(Wasm.loop(WasmType.voidType));
+    context.controlDepth++;
+    final repeatLevel = context.controlDepth;
 
-    // if (i >= len) br 1
+    // if (i >= len) br break
     out.write(Wasm.localGet(iScratch));
     out.write(Wasm.localGet(listScratch));
     out.write(Wasm32.i32Load(2, 0)); // length
     out.writeByte(Wasm32.i32GreaterThanOrEqualsUnsigned);
-    out.write(Wasm.brIf(1));
+    out.write(Wasm.brIf(context.controlDepth - breakLevel));
 
     // e = data[i*size]
     out.write(Wasm.localGet(dataScratch));
@@ -6719,8 +6822,18 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     _emitElemLoad(out, elemType, 0);
     out.write(Wasm.localSet(eLocal.index));
 
+    // continue target wrapping the body.
+    out.write(Wasm.block(WasmType.voidType));
+    context.controlDepth++;
+    final continueLevel = context.controlDepth;
+
     // body (a `return` inside emits `return` directly; no extra check needed)
+    context.pushLoopFrame(breakLevel: breakLevel, continueLevel: continueLevel);
     generateASTBlock(forEach.loopBlock, out: out, context: context);
+    context.popLoopFrame();
+
+    out.writeByte(Wasm.end); // continue block
+    context.controlDepth--;
 
     // i++
     out.write(Wasm.localGet(iScratch));
@@ -6728,13 +6841,172 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     out.writeByte(Wasm32.i32Add);
     out.write(Wasm.localSet(iScratch));
 
-    out.write(Wasm.br(0)); // continue
+    out.write(Wasm.br(context.controlDepth - repeatLevel)); // continue/repeat
     out.writeByte(Wasm.end); // loop
+    context.controlDepth--;
     out.writeByte(Wasm.end); // block
+    context.controlDepth--;
 
     // The body may leave phantom virtual-stack entries (assignments use
     // `local.set` without a matching virtual drop), like the for/while loops;
     // the real Wasm stack stays balanced, so no post-body assertion here.
+    return out;
+  }
+
+  BytesOutput generateASTStatementDoWhileLoop(
+    ASTStatementDoWhileLoop doWhileLoop, {
+    BytesOutput? out,
+    WasmContext? context,
+  }) {
+    out ??= newOutput();
+    context ??= WasmContext();
+
+    _generateLoop(
+      out: out,
+      context: context,
+      conditionExpression: doWhileLoop.conditionExpression,
+      loopBlock: doWhileLoop.loopBlock,
+      continueExpression: null,
+      description: "do-while",
+      conditionAfterBody: true,
+    );
+
+    return out;
+  }
+
+  BytesOutput generateASTStatementBreak(
+    ASTStatementBreak statement, {
+    BytesOutput? out,
+    WasmContext? context,
+  }) {
+    out ??= newOutput();
+    context ??= WasmContext();
+    out.write(Wasm.br(context.breakBranchLabel), description: "[OP] break");
+    return out;
+  }
+
+  BytesOutput generateASTStatementContinue(
+    ASTStatementContinue statement, {
+    BytesOutput? out,
+    WasmContext? context,
+  }) {
+    out ??= newOutput();
+    context ??= WasmContext();
+    out.write(
+      Wasm.br(context.continueBranchLabel),
+      description: "[OP] continue",
+    );
+    return out;
+  }
+
+  /// Integer `switch` (C-style fall-through). Encoded as nested blocks with an
+  /// inner dispatch that compares the value to each `case` and branches to the
+  /// matching case block; cases fall through to the next unless they `break`.
+  BytesOutput generateASTStatementSwitch(
+    ASTStatementSwitch statement, {
+    BytesOutput? out,
+    WasmContext? context,
+  }) {
+    out ??= newOutput();
+    context ??= WasmContext();
+
+    // Evaluate the switch value once into a scratch local (int only).
+    generateASTExpression(statement.expression, out: out, context: context);
+    var valueType = context.stackGet(0)!.type;
+    if (valueType != _astTypeInt64 && valueType != _astTypeInt) {
+      throw UnimplementedError(
+        "Wasm switch on $valueType is not supported (int only).",
+      );
+    }
+    var valueLocal = context.scratchLocal(_astTypeInt64, 17);
+    out.write(Wasm.localSet(valueLocal));
+    context.stackDrop();
+
+    final cases = statement.cases;
+    final n = cases.length;
+
+    // Outer `block` is the break/exit target.
+    out.write(
+      Wasm.block(WasmType.voidType),
+      description: "[OP] block (switch)",
+    );
+    context.controlDepth++;
+    final exitLevel = context.controlDepth;
+
+    // One `block` per case, in reverse source order, so falling out of case i's
+    // block lands in case i+1's code (fall-through).
+    final caseLevel = List<int>.filled(n, 0);
+    for (var i = n - 1; i >= 0; --i) {
+      out.write(
+        Wasm.block(WasmType.voidType),
+        description: "[OP] block (switch case $i)",
+      );
+      context.controlDepth++;
+      caseLevel[i] = context.controlDepth;
+    }
+
+    // Dispatch block: compare and branch to the matching case.
+    out.write(
+      Wasm.block(WasmType.voidType),
+      description: "[OP] block (switch dispatch)",
+    );
+    context.controlDepth++;
+    final dispatchLevel = context.controlDepth;
+
+    // Branching to a `block` lands *after* its `end`. Case i's code starts right
+    // after the `end` of the previous block, so the entry target for case i is
+    // the dispatch block (i == 0) or the previous case's block (i > 0).
+    int entryLevel(int i) => i == 0 ? dispatchLevel : caseLevel[i - 1];
+
+    int? defaultIndex;
+    for (var i = 0; i < n; ++i) {
+      var c = cases[i];
+      if (c.isDefault) {
+        defaultIndex = i;
+        continue;
+      }
+      out.write(Wasm.localGet(valueLocal));
+      context.stackPush(_astTypeInt64, "switch value");
+      generateASTExpression(c.value!, out: out, context: context);
+      out.writeByte(Wasm64.i64Equals, description: "[OP] switch case == ");
+      context.stackOperationBinary(_astTypeInt32, "i64.eq (switch)");
+      out.write(
+        Wasm.brIf(context.controlDepth - entryLevel(i)),
+        description: "[OP] switch br_if case $i",
+      );
+      context.stackDrop(_astTypeInt32);
+    }
+    // No case matched: go to `default` (if any), else exit the switch.
+    var fallbackLevel = defaultIndex != null
+        ? entryLevel(defaultIndex)
+        : exitLevel;
+    out.write(
+      Wasm.br(context.controlDepth - fallbackLevel),
+      description: "[OP] switch dispatch fallback",
+    );
+
+    out.writeByte(Wasm.end, description: "[OP] block end (switch dispatch)");
+    context.controlDepth--;
+
+    // Case bodies, emitted as the case blocks close (so they fall through).
+    context.pushSwitchFrame(breakLevel: exitLevel);
+    for (var i = 0; i < n; ++i) {
+      generateASTBlock(cases[i].block, out: out, context: context);
+      if (!statement.fallThrough) {
+        // Non-fall-through (`when`/`match`): jump to exit after the matched case.
+        out.write(
+          Wasm.br(context.controlDepth - exitLevel),
+          description: "[OP] switch case $i exit (no fall-through)",
+        );
+      }
+      out.writeByte(Wasm.end, description: "[OP] block end (switch case $i)");
+      context.controlDepth--;
+    }
+    context.popLoopFrame();
+
+    out.writeByte(Wasm.end, description: "[OP] block end (switch)");
+    context.controlDepth--;
+
     return out;
   }
 
@@ -6781,60 +7053,103 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     required ASTBlock loopBlock,
     required ASTExpression? continueExpression,
     required String description,
+    bool conditionAfterBody = false,
   }) {
+    // Structure (void blocks); the inner `block` is the `continue` target so
+    // `continue` still runs the post-step (increment / do-while condition):
+    //   block (break)
+    //     loop (repeat)
+    //       [pre-cond: eqz; br_if break]        ; while / for
+    //       block (continue) <body> end
+    //       [continueExpression]                ; for
+    //       [post-cond: br_if repeat] | br repeat
+    //     end
+    //   end
     out.write(
       Wasm.block(WasmType.voidType),
-      description: "[OP] block ($description loop)",
+      description: "[OP] block ($description break)",
     );
+    context.controlDepth++;
+    final breakLevel = context.controlDepth;
+
     out.write(
       Wasm.loop(WasmType.voidType),
-      description: "[OP] loop ($description loop)",
+      description: "[OP] loop ($description repeat)",
     );
+    context.controlDepth++;
+    final repeatLevel = context.controlDepth;
 
-    final stackLng0 = context.stackLength;
-
-    // Condition: pushes an i32 (boolean).
-    generateASTExpression(conditionExpression, out: out, context: context);
-
-    context.assertStackLength(
-      stackLng0 + 1,
-      "After $description loop condition",
-    );
-    var stackType = context.stackGet(0)!.type;
-    if (stackType != _astTypeInt32) {
-      throw StateError("Stack type error> not a boolean type: $stackType");
+    void writeCondition() {
+      final stackLng0 = context.stackLength;
+      generateASTExpression(conditionExpression, out: out, context: context);
+      context.assertStackLength(
+        stackLng0 + 1,
+        "After $description loop condition",
+      );
+      var stackType = context.stackGet(0)!.type;
+      if (stackType != _astTypeInt32) {
+        throw StateError("Stack type error> not a boolean type: $stackType");
+      }
     }
 
-    // Negate the condition: `i32.eqz` consumes 1 i32 and pushes 1 i32
-    // (net zero on the virtual stack).
-    out.writeByte(
-      Wasm32.i32EqualsToZero,
-      description: "[OP] i32.eqz ( !($conditionExpression) )",
+    // Pre-condition (while / for): break out of the loop when false.
+    if (!conditionAfterBody) {
+      writeCondition();
+      out.writeByte(
+        Wasm32.i32EqualsToZero,
+        description: "[OP] i32.eqz ( !($conditionExpression) )",
+      );
+      out.write(
+        Wasm.brIf(context.controlDepth - breakLevel),
+        description: "[OP] br_if ($description break)",
+      );
+      context.stackDrop(_astTypeInt32);
+    }
+
+    // `continue` target wrapping the body.
+    out.write(
+      Wasm.block(WasmType.voidType),
+      description: "[OP] block ($description continue)",
     );
+    context.controlDepth++;
+    final continueLevel = context.controlDepth;
 
-    // Break out of the `block` (label 1) when the condition is false:
-    out.write(Wasm.brIf(1), description: "[OP] br_if 1 ($description break)");
-    context.stackDrop(_astTypeInt32);
-
-    context.assertStackLength(
-      stackLng0,
-      "After $description loop condition br",
-    );
-
-    // Loop body:
+    context.pushLoopFrame(breakLevel: breakLevel, continueLevel: continueLevel);
     generateASTBlock(loopBlock, out: out, context: context);
+    context.popLoopFrame();
+
+    out.writeByte(
+      Wasm.end,
+      description: "[OP] block end ($description continue)",
+    );
+    context.controlDepth--;
 
     // Continue expression (for-loops only), e.g. `i++`:
     if (continueExpression != null) {
       generateASTExpression(continueExpression, out: out, context: context);
     }
 
-    // Jump back to the top of the `loop` (label 0). Any leaked operand-stack
-    // values are unwound by this branch (loop is void).
-    out.write(Wasm.br(0), description: "[OP] br 0 ($description continue)");
+    if (conditionAfterBody) {
+      // do-while: repeat while the condition is true.
+      writeCondition();
+      out.write(
+        Wasm.brIf(context.controlDepth - repeatLevel),
+        description: "[OP] br_if ($description repeat)",
+      );
+      context.stackDrop(_astTypeInt32);
+    } else {
+      // Jump back to the top of the `loop`. Any leaked operand-stack values are
+      // unwound by this branch (loop is void).
+      out.write(
+        Wasm.br(context.controlDepth - repeatLevel),
+        description: "[OP] br ($description repeat)",
+      );
+    }
 
     out.writeByte(Wasm.end, description: "[OP] loop end ($description)");
+    context.controlDepth--;
     out.writeByte(Wasm.end, description: "[OP] block end ($description)");
+    context.controlDepth--;
   }
 
   @override
@@ -7216,6 +7531,12 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       );
     } else if (expression is ASTExpressionNegative) {
       return generateASTExpressionNegative(
+        expression,
+        out: out,
+        context: context,
+      );
+    } else if (expression is ASTExpressionBitwiseNot) {
+      return generateASTExpressionBitwiseNot(
         expression,
         out: out,
         context: context,
@@ -8514,6 +8835,52 @@ class WasmContext {
   /// set, integer division emits a non-trapping guard that raises a catchable
   /// exception on a zero/overflowing divisor instead of trapping the module.
   bool exceptionMode = false;
+
+  /// Number of currently-open structured control instructions (`block`/`loop`/
+  /// `if`). A Wasm `br L` targets the structure `L` levels up from the innermost,
+  /// so the relative label for a target opened at depth `K` is `controlDepth - K`.
+  /// Maintained by the loop and `if`-branch generators so `break`/`continue` can
+  /// compute correct relative branch labels regardless of nesting.
+  int controlDepth = 0;
+
+  /// Stack of enclosing loops, innermost last. Each frame records the
+  /// [controlDepth] of the loop's break target (the outer `block`) and of its
+  /// continue target (the inner `block` wrapping the body).
+  final List<({int breakLevel, int continueLevel})> _loopFrames = [];
+
+  void pushLoopFrame({required int breakLevel, required int continueLevel}) {
+    _loopFrames.add((breakLevel: breakLevel, continueLevel: continueLevel));
+  }
+
+  /// Pushes a `switch` frame: `break` targets the switch exit ([breakLevel]),
+  /// but `continue` keeps targeting the enclosing loop (inherited from the
+  /// current innermost frame, if any).
+  void pushSwitchFrame({required int breakLevel}) {
+    var continueLevel = _loopFrames.isNotEmpty
+        ? _loopFrames.last.continueLevel
+        : -1;
+    _loopFrames.add((breakLevel: breakLevel, continueLevel: continueLevel));
+  }
+
+  void popLoopFrame() => _loopFrames.removeLast();
+
+  /// Relative branch label from the current [controlDepth] to the innermost
+  /// loop's break target, for a `break` statement.
+  int get breakBranchLabel {
+    if (_loopFrames.isEmpty) {
+      throw StateError("`break` outside of a loop/switch");
+    }
+    return controlDepth - _loopFrames.last.breakLevel;
+  }
+
+  /// Relative branch label to the innermost loop's continue target, for a
+  /// `continue` statement.
+  int get continueBranchLabel {
+    if (_loopFrames.isEmpty) {
+      throw StateError("`continue` outside of a loop");
+    }
+    return controlDepth - _loopFrames.last.continueLevel;
+  }
 
   /// Resolves the Wasm function index for a function with [name] and [arity].
   int? functionIndex(String name, int arity) =>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, C#, JavaScript, TypeScript, Lua and Python with on-the-fly Wasm compilation.
-version: 0.1.39
+version: 0.1.40
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/apollovm_wasm_ops_test.dart
+++ b/test/apollovm_wasm_ops_test.dart
@@ -293,4 +293,120 @@ void main() {
       );
     });
   });
+
+  group('Wasm OPS: bitwise', () {
+    test('& | ^ << >> and unary ~', () async {
+      await _testWasm(
+        r'''
+        int bitOps(int a, int b) {
+          int r = a & b;
+          r = r + (a | b);
+          r = r + (a ^ b);
+          r = r + (a << 2);
+          r = r + (a >> 1);
+          r = r + (~a);
+          return r;
+        }
+      ''',
+        'bitOps',
+        {
+          // a=12 (1100), b=10 (1010): 8 + 14 + 6 + 48 + 6 + (-13) = 69
+          [12, 10]: 69,
+          // a=6 (0110), b=3 (0011): 2 + 7 + 5 + 24 + 3 + (-7) = 34
+          [6, 3]: 34,
+        },
+      );
+    });
+  });
+
+  group('Wasm control flow: do-while / break / continue / switch', () {
+    test('do-while runs body at least once', () async {
+      await _testWasm(
+        r'''
+        int dw(int n) {
+          int sum = 0;
+          int i = 0;
+          do {
+            sum = sum + i;
+            i = i + 1;
+          } while (i < n);
+          return sum;
+        }
+      ''',
+        'dw',
+        {
+          [3]: 3, // 0+1+2
+          [1]: 0, // body once with i=0
+          [0]: 0, // still runs once
+        },
+      );
+    });
+
+    test('break and continue in a for loop', () async {
+      await _testWasm(
+        r'''
+        int bc(int n) {
+          int sum = 0;
+          for (int i = 0; i < n; i++) {
+            if (i == 2) { continue; }
+            if (i == 5) { break; }
+            sum = sum + i;
+          }
+          return sum;
+        }
+      ''',
+        'bc',
+        {
+          [10]: 8, // 0+1+3+4 (skip 2, stop at 5)
+          [2]: 1, // 0 + (skip 1? no) -> i=0 sum0, i=1 sum1
+        },
+      );
+    });
+
+    test('switch with default', () async {
+      await _testWasm(
+        r'''
+        int sw(int x) {
+          int r = 0;
+          switch (x) {
+            case 1: { r = 10; break; }
+            case 2: { r = 20; break; }
+            default: { r = 99; break; }
+          }
+          return r;
+        }
+      ''',
+        'sw',
+        {
+          [1]: 10,
+          [2]: 20,
+          [7]: 99,
+        },
+      );
+    });
+
+    test('switch fall-through', () async {
+      await _testWasm(
+        r'''
+        int fall(int x) {
+          int r = 0;
+          switch (x) {
+            case 1: { r = r + 1; }
+            case 2: { r = r + 2; break; }
+            case 3: { r = r + 3; }
+            default: { r = r + 100; }
+          }
+          return r;
+        }
+      ''',
+        'fall',
+        {
+          [1]: 3, // 1 -> falls into 2 -> break
+          [2]: 2,
+          [3]: 103, // 3 -> falls into default
+          [9]: 100,
+        },
+      );
+    });
+  });
 }

--- a/test/tests_definitions/kotlin_bitwise.test.xml
+++ b/test/tests_definitions/kotlin_bitwise.test.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Kotlin bitwise infix operators">
+    <source language="kotlin">
+        <![CDATA[
+class C {
+  fun run(): Int {
+    var r = 12 and 10
+    r = r + (12 or 10)
+    r = r + (12 xor 10)
+    r = r + (1 shl 4)
+    r = r + (32 shr 2)
+    return r
+  }
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="52">
+        []
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="kotlin"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class C {
+
+  fun run(): Int {
+    var r = 12 and 10
+    r = r + (12 or 10)
+    r = r + (12 xor 10)
+    r = r + (1 shl 4)
+    r = r + (32 shr 2)
+    return r
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/kotlin_member_visibility.test.xml
+++ b/test/tests_definitions/kotlin_member_visibility.test.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Kotlin member visibility modifiers">
+    <source language="kotlin">
+        <![CDATA[
+class C {
+  private fun helper(): Int {
+    return 7
+  }
+
+  fun run(): Int {
+    return helper() + 3
+  }
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="10">
+        []
+    </call>
+    <output>
+        []
+    </output>
+    <source-generated language="kotlin"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class C {
+
+  private fun helper(): Int {
+    return 7
+  }
+
+  fun run(): Int {
+    return helper() + 3
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/lua_bitwise.test.xml
+++ b/test/tests_definitions/lua_bitwise.test.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Lua bitwise operators: &amp; | ~ (xor) &lt;&lt; &gt;&gt; and unary ~">
+    <source language="lua">
+        <![CDATA[
+function run()
+  local a = 12
+  local b = 10
+  local andv = a & b
+  local orv = a | b
+  local xorv = a ~ b
+  local shl = a << 2
+  local shr = a >> 1
+  local notv = ~a
+  return andv + orv + xorv + shl + shr + notv
+end
+        ]]>
+    </source>
+    <call function="run" return="69">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="lua"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  function run()
+    local a = 12
+    local b = 10
+    local andv = a & b
+    local orv = a | b
+    local xorv = a ~ b
+    local shl = a << 2
+    local shr = a >> 1
+    local notv = ~a
+    return ((((andv + orv) + xorv) + shl) + shr) + notv
+  end
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>


### PR DESCRIPTION
## Summary

Release **0.1.40**. Extends the WebAssembly backend and bitwise coverage, plus docs and fixes. Full suite green: **891 tests**; `dart analyze` clean; `dart format` applied.

### Wasm: control flow + bitwise
The WebAssembly compiler now supports `do`/`while`, `switch`/`case` (integer, C-style fall-through), `break`, `continue`, and bitwise `& | ^ << >>` + unary `~`. Loops wrap their body in a `continue` block and `WasmContext` tracks structured-control depth so `break`/`continue` emit correct relative branch labels. Every construct is validated against **both** the AST interpreter and the compiled+executed Wasm module (async/asyncify unaffected).

### Bitwise operators: Kotlin & Lua
- **Kotlin**: infix `and`/`or`/`xor`/`shl`/`shr` + `x.inv()`.
- **Lua**: `&`/`|`/`~`(xor)/`<<`/`>>` + unary `~`, with `~=` and `^` left intact.

### Kotlin member visibility
Parse + generate `private`/`public`/`internal`/`protected` (and `open`/`override`/`abstract`/`final`/`const`) on Kotlin members; method visibility round-trips.

### Fixes
- **Java** `private` members no longer fail with "Can't be private and public" (the modifiers parser derived `isPublic` from `private`).

### Docs
- New **Supported Features** section: per-language control-flow/operator matrix (with a **Wasm** column) and a Classes/types/OOP matrix, with a ✅/⚠️/🚧/— legend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)