### PR TITLE
feat: async/await for JavaScript, TypeScript, C# and Python (+ feature-table updates)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## 0.1.41
 
+### Constructors & instantiation for JavaScript and Python
+
+- **JavaScript**: a `constructor(...)` class method is now parsed as a real
+  constructor, and `new Foo(...)` / `Foo(...)` instantiate the class (running the
+  constructor, which can assign `this.x = …`). Round-trips to `constructor(...)`
+  and translates to other languages.
+- **Python**: `self.x = …` attribute assignment is now parsed, `__init__` is
+  treated as the constructor, and `Foo(...)` instantiates the class. The
+  generator emits `def __init__(self, …)`. (Previously instance-field assignment
+  was unimplemented, so `__init__` wasn't usable end-to-end.)
+- Both round-trip across languages (e.g. a JS/Python class with a constructor
+  translates to a runnable Dart class). The README OOP table marks JS and Python
+  "Constructors & instantiation" as supported.
+
 ### `async`/`await` for JavaScript, TypeScript, C# and Python
 
 - These languages now **parse** `async` functions/methods (and `async` arrows /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 ## 0.1.41
 
+### `async`/`await` for JavaScript, TypeScript, C# and Python
+
+- These languages now **parse** `async` functions/methods (and `async` arrows /
+  lambdas) and the `await` expression, joining Dart. Parsed code executes on the
+  shared async runtime, round-trips back to its source language, and translates
+  across languages (e.g. C# `async Task<int>` ⇄ Dart `Future<int> … async`).
+- C# and Python also gained `async` code generation (`async`/`async def`); the
+  JavaScript and TypeScript generators already emitted it.
+- `await` now unwraps any awaitable type — `Future<T>`, `Promise<T>` (TypeScript)
+  and `Task<T>` (C#) — to its value type `T`, so awaiting a typed result infers
+  the correct type. A shared word-boundary keyword token keeps identifiers like
+  `awaiter` from being read as `await` + `er`.
+- The README "Control flow & operators" table gains an `async`/`await` row.
+
 ### Wasm: static methods + boxed `Object`
 
 - The WebAssembly compiler now supports `static` class methods: each is

--- a/README.md
+++ b/README.md
@@ -115,26 +115,24 @@ The **Wasm** column shows what the on-the-fly WebAssembly compiler currently sup
 |---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
 | Classes                                                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | ✅ |
 | Fields (with initializers)                                    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🧩¹ | ✅ | ✅ |
-| Constructors & instantiation (`new Foo(...)` / `Foo(...)`)    | ✅ | ✅ | ✅ | ✅ | 🚧 | ✅ | 🧩¹ | 🚧² | ✅ |
+| Constructors & instantiation (`new Foo(...)` / `Foo(...)`)    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🧩¹ | ✅ | ✅ |
 | Methods                                                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Static / visibility modifiers                                 | ✅ | ✅ | 🧩⁴ | ✅ | 🧩³ | ✅ | 🚫  | 🚫  | 🧩⁵ |
+| Static / visibility modifiers                                 | ✅ | ✅ | 🧩³ | ✅ | 🧩² | ✅ | 🚫  | 🚫  | 🧩⁴ |
 | Inheritance (`extends`) / interfaces                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚧 |
 | Enums (incl. runtime value access)                            | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚫  | ✅ | 🚧 |
 | Generics (generic classes + instantiation + type erasure)    | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚫  | 🚫  | 🚧 |
-| Type inference (`var` / `val` / `auto`)                       | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚫  | 🚫  | ✅⁶ |
+| Type inference (`var` / `val` / `auto`)                       | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚫  | 🚫  | ✅⁵ |
 
 ¹ Lua is table-based (no class construct): "fields" are table entries (`obj.x`) and "constructors"
 are factory functions / `setmetatable` idioms; methods use `function Obj:method`. &nbsp;
-² Python declares constructors via `__init__`, but instance-field assignment (`self.x = ...`) is not
-implemented yet, so constructors aren't usable end-to-end. &nbsp;
-³ JavaScript supports the `static` modifier but has no visibility keywords (privacy is by convention /
+² JavaScript supports the `static` modifier but has no visibility keywords (privacy is by convention /
 closures). &nbsp;
-⁴ Kotlin `private`/`public` member visibility round-trips; `internal`/`protected` are parsed but not
+³ Kotlin `private`/`public` member visibility round-trips; `internal`/`protected` are parsed but not
 yet preserved in the AST. Kotlin has no `static` (it uses `companion object`, not yet supported). &nbsp;
-⁵ Wasm compiles `static` methods (exported as `Class.method`) and instance methods (called with a
+⁴ Wasm compiles `static` methods (exported as `Class.method`) and instance methods (called with a
 receiver); only static methods are callable as entry points, and there is no source-level visibility
 concept in the module. &nbsp;
-⁶ Wasm consumes the already type-resolved AST, so `var`/`val`-typed code compiles unchanged. &nbsp;
+⁵ Wasm consumes the already type-resolved AST, so `var`/`val`-typed code compiles unchanged. &nbsp;
 Generics are marked `🚫` for JS/Lua/Python because those languages have no static type syntax to
 parameterize.
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ The **Wasm** column shows what the on-the-fly WebAssembly compiler currently sup
 | `continue`                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
 | `try` / `catch` / `finally`      | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
 | `throw` / `raise`                | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
+| `async` / `await`                | ✅ | —  | ⚠️⁷ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
 | Ternary (`? :`)                  | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
 | Arithmetic (`+ - * / %`)         | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Comparison / logical             | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -97,7 +98,10 @@ The **Wasm** column shows what the on-the-fly WebAssembly compiler currently sup
 ¹ Lua numeric-for (`for i = a, b do`). &nbsp; ² Lua `repeat … until`. &nbsp;
 ³ Kotlin `when`. &nbsp; ⁴ Python `match` / `case`. &nbsp;
 ⁵ Kotlin bitwise are infix functions: `and`/`or`/`xor`/`shl`/`shr` and `.inv()`. &nbsp;
-⁶ Lua bitwise use `&`/`|`/`~` (xor)/`<<`/`>>` and unary `~` (Lua 5.3).
+⁶ Lua bitwise use `&`/`|`/`~` (xor)/`<<`/`>>` and unary `~` (Lua 5.3). &nbsp;
+⁷ Kotlin's async idiom is `suspend` / coroutines: ApolloVM generates `suspend fun`
+(dropping `await`) when translating to Kotlin, but does not yet parse Kotlin `suspend`.
+`await` unwraps the awaitable (`Future<T>` / `Promise<T>` / `Task<T>`) to `T`.
 
 ### Classes, types & OOP
 
@@ -1116,7 +1120,7 @@ Any help from the open-source community is always welcome and needed:
 
 ## TODO
 
-- JavaScript: extended support (destructuring, spread, async/await, `this.x` constructor parameters, full ESM modules). *Named arrow functions (`const f = (a, b) => a + b;`), anonymous arrow callbacks/closures (`(x) => x * 2`), and the ternary operator (`c ? a : b`) are already supported.*
+- JavaScript: extended support (destructuring, spread, `this.x` constructor parameters, full ESM modules). *Named arrow functions (`const f = (a, b) => a + b;`), anonymous arrow callbacks/closures (`(x) => x * 2`), the ternary operator (`c ? a : b`), and `async`/`await` are already supported.*
   - *See the [JavaScript implementation (at "lib/src/languages/javascript/es")](https://github.com/ApolloVM/apollovm_dart/tree/master/lib/src/languages/javascript/es).*
 
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Kotlin → JavaScript), and code can be regenerated back to its original languag
 - **Execution**: a tree-walking interpreter runs the AST directly.
 - **Translation**: regenerate the AST as source in any supported language.
 - **Wasm compilation**: compile to WebAssembly, including `async`/`await` (via
-  Asyncify), classes, exceptions, maps and GC types.
+  Asyncify), classes (fields, constructors, instance & `static` methods,
+  `toString()` dispatch, `Object`/`dynamic` boxing), exceptions, closures,
+  lists/maps and GC types.
 
 ### Control flow & operators
 
@@ -102,17 +104,20 @@ The **Wasm** column shows what the on-the-fly WebAssembly compiler currently sup
 Legend: ✅ supported · ⚠️ supported via the language's idiom · 🚧 not yet supported (exists in the
 language but not implemented yet) · — not applicable (the language has no such construct).
 
-| Feature | Dart | Java | Kotlin | C# | JS | TS | Lua | Python |
-|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
-| Classes                                                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ |
-| Fields (with initializers)                                    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️¹ | ✅ |
-| Constructors & instantiation (`new Foo(...)` / `Foo(...)`)    | ✅ | ✅ | ✅ | ✅ | 🚧 | ✅ | ⚠️¹ | 🚧² |
-| Methods                                                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Static / visibility modifiers                                 | ✅ | ✅ | ⚠️⁴ | ✅ | ⚠️³ | ✅ | —  | —  |
-| Inheritance (`extends`) / interfaces                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ |
-| Enums (incl. runtime value access)                            | ✅ | ✅ | ✅ | ✅ | —  | ✅ | —  | ✅ |
-| Generics (generic classes + instantiation + type erasure)    | ✅ | ✅ | ✅ | ✅ | —  | ✅ | —  | —  |
-| Type inference (`var` / `val` / `auto`)                       | ✅ | ✅ | ✅ | ✅ | —  | ✅ | —  | —  |
+The **Wasm** column shows what the on-the-fly WebAssembly compiler currently supports
+(any source language is compiled through the same shared AST).
+
+| Feature | Dart | Java | Kotlin | C# | JS | TS | Lua | Python | Wasm |
+|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
+| Classes                                                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
+| Fields (with initializers)                                    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️¹ | ✅ | ✅ |
+| Constructors & instantiation (`new Foo(...)` / `Foo(...)`)    | ✅ | ✅ | ✅ | ✅ | 🚧 | ✅ | ⚠️¹ | 🚧² | ✅ |
+| Methods                                                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Static / visibility modifiers                                 | ✅ | ✅ | ⚠️⁴ | ✅ | ⚠️³ | ✅ | —  | —  | ⚠️⁵ |
+| Inheritance (`extends`) / interfaces                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | 🚧 |
+| Enums (incl. runtime value access)                            | ✅ | ✅ | ✅ | ✅ | —  | ✅ | —  | ✅ | 🚧 |
+| Generics (generic classes + instantiation + type erasure)    | ✅ | ✅ | ✅ | ✅ | —  | ✅ | —  | —  | 🚧 |
+| Type inference (`var` / `val` / `auto`)                       | ✅ | ✅ | ✅ | ✅ | —  | ✅ | —  | —  | ✅⁶ |
 
 ¹ Lua is table-based (no class construct): "fields" are table entries (`obj.x`) and "constructors"
 are factory functions / `setmetatable` idioms; methods use `function Obj:method`. &nbsp;
@@ -120,8 +125,12 @@ are factory functions / `setmetatable` idioms; methods use `function Obj:method`
 implemented yet, so constructors aren't usable end-to-end. &nbsp;
 ³ JavaScript supports the `static` modifier but has no visibility keywords (privacy is by convention /
 closures). &nbsp;
-⁴ Kotlin member visibility modifiers (`private`/`public`/`internal`/`protected`) are supported; Kotlin
-has no `static` (it uses `companion object`, not yet supported). &nbsp;
+⁴ Kotlin `private`/`public` member visibility round-trips; `internal`/`protected` are parsed but not
+yet preserved in the AST. Kotlin has no `static` (it uses `companion object`, not yet supported). &nbsp;
+⁵ Wasm compiles `static` methods (exported as `Class.method`) and instance methods (called with a
+receiver); only static methods are callable as entry points, and there is no source-level visibility
+concept in the module. &nbsp;
+⁶ Wasm consumes the already type-resolved AST, so `var`/`val`-typed code compiles unchanged. &nbsp;
 Generics are marked `—` for JS/Lua/Python because those languages have no static type syntax to
 parameterize.
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Kotlin → JavaScript), and code can be regenerated back to its original languag
 
 ### Control flow & operators
 
-Legend: ✅ supported · ⚠️ supported via the language's idiom · 🚧 not yet supported (exists in the
+Legend: ✅ supported · 🧩 supported via the language's idiom · 🚧 not yet supported (exists in the
 language but not implemented yet) · — not applicable (the language has no such construct).
 
 The **Wasm** column shows what the on-the-fly WebAssembly compiler currently supports
@@ -75,20 +75,20 @@ The **Wasm** column shows what the on-the-fly WebAssembly compiler currently sup
 | Feature | Dart | Java | Kotlin | C# | JS | TS | Lua | Python | Wasm |
 |---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
 | `if` / `else if` / `else`        | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `for` (C-style)                  | ✅ | ✅ | —  | ✅ | ✅ | ✅ | ⚠️¹ | — | ✅ |
+| `for` (C-style)                  | ✅ | ✅ | —  | ✅ | ✅ | ✅ | 🧩¹ | — | ✅ |
 | `for-each` / `for-in`            | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `while`                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `do` / `while`                   | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️² | — | ✅ |
-| `switch` / `case`                | ✅ | ✅ | ⚠️³ | ✅ | ✅ | ✅ | —  | ⚠️⁴ | ✅ |
+| `do` / `while`                   | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🧩² | — | ✅ |
+| `switch` / `case`                | ✅ | ✅ | 🧩³ | ✅ | ✅ | ✅ | —  | 🧩⁴ | ✅ |
 | `break`                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `continue`                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
 | `try` / `catch` / `finally`      | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
 | `throw` / `raise`                | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
-| `async` / `await`                | ✅ | —  | ⚠️⁷ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
+| `async` / `await`                | ✅ | —  | 🧩⁷ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
 | Ternary (`? :`)                  | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
 | Arithmetic (`+ - * / %`)         | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Comparison / logical             | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Bitwise (`& \| ^ << >> ~`)       | ✅ | ✅ | ⚠️⁵ | ✅ | ✅ | ✅ | ⚠️⁶ | ✅ | ✅ |
+| Bitwise (`& \| ^ << >> ~`)       | ✅ | ✅ | 🧩⁵ | ✅ | ✅ | ✅ | 🧩⁶ | ✅ | ✅ |
 | `++` / `--`, compound assign     | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Lambdas / closures               | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | String interpolation / concat    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -105,7 +105,7 @@ The **Wasm** column shows what the on-the-fly WebAssembly compiler currently sup
 
 ### Classes, types & OOP
 
-Legend: ✅ supported · ⚠️ supported via the language's idiom · 🚧 not yet supported (exists in the
+Legend: ✅ supported · 🧩 supported via the language's idiom · 🚧 not yet supported (exists in the
 language but not implemented yet) · — not applicable (the language has no such construct).
 
 The **Wasm** column shows what the on-the-fly WebAssembly compiler currently supports
@@ -114,10 +114,10 @@ The **Wasm** column shows what the on-the-fly WebAssembly compiler currently sup
 | Feature | Dart | Java | Kotlin | C# | JS | TS | Lua | Python | Wasm |
 |---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
 | Classes                                                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
-| Fields (with initializers)                                    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ⚠️¹ | ✅ | ✅ |
-| Constructors & instantiation (`new Foo(...)` / `Foo(...)`)    | ✅ | ✅ | ✅ | ✅ | 🚧 | ✅ | ⚠️¹ | 🚧² | ✅ |
+| Fields (with initializers)                                    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🧩¹ | ✅ | ✅ |
+| Constructors & instantiation (`new Foo(...)` / `Foo(...)`)    | ✅ | ✅ | ✅ | ✅ | 🚧 | ✅ | 🧩¹ | 🚧² | ✅ |
 | Methods                                                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Static / visibility modifiers                                 | ✅ | ✅ | ⚠️⁴ | ✅ | ⚠️³ | ✅ | —  | —  | ⚠️⁵ |
+| Static / visibility modifiers                                 | ✅ | ✅ | 🧩⁴ | ✅ | 🧩³ | ✅ | —  | —  | 🧩⁵ |
 | Inheritance (`extends`) / interfaces                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | 🚧 |
 | Enums (incl. runtime value access)                            | ✅ | ✅ | ✅ | ✅ | —  | ✅ | —  | ✅ | 🚧 |
 | Generics (generic classes + instantiation + type erasure)    | ✅ | ✅ | ✅ | ✅ | —  | ✅ | —  | —  | 🚧 |

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Kotlin → JavaScript), and code can be regenerated back to its original languag
 ### Control flow & operators
 
 Legend: ✅ supported · 🧩 supported via the language's idiom · 🚧 not yet supported (exists in the
-language but not implemented yet) · — not applicable (the language has no such construct).
+language but not implemented yet) · 🚫 not applicable (the language has no such construct).
 
 The **Wasm** column shows what the on-the-fly WebAssembly compiler currently supports
 (any source language is compiled through the same shared AST).
@@ -75,17 +75,17 @@ The **Wasm** column shows what the on-the-fly WebAssembly compiler currently sup
 | Feature | Dart | Java | Kotlin | C# | JS | TS | Lua | Python | Wasm |
 |---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
 | `if` / `else if` / `else`        | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `for` (C-style)                  | ✅ | ✅ | —  | ✅ | ✅ | ✅ | 🧩¹ | — | ✅ |
+| `for` (C-style)                  | ✅ | ✅ | 🚫  | ✅ | ✅ | ✅ | 🧩¹ | 🚫 | ✅ |
 | `for-each` / `for-in`            | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `while`                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `do` / `while`                   | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🧩² | — | ✅ |
-| `switch` / `case`                | ✅ | ✅ | 🧩³ | ✅ | ✅ | ✅ | —  | 🧩⁴ | ✅ |
+| `do` / `while`                   | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🧩² | 🚫 | ✅ |
+| `switch` / `case`                | ✅ | ✅ | 🧩³ | ✅ | ✅ | ✅ | 🚫  | 🧩⁴ | ✅ |
 | `break`                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `continue`                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
-| `try` / `catch` / `finally`      | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
-| `throw` / `raise`                | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
-| `async` / `await`                | ✅ | —  | 🧩⁷ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
-| Ternary (`? :`)                  | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
+| `continue`                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | ✅ |
+| `try` / `catch` / `finally`      | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | ✅ |
+| `throw` / `raise`                | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | ✅ |
+| `async` / `await`                | ✅ | 🚫  | 🧩⁷ | ✅ | ✅ | ✅ | 🚫  | ✅ | ✅ |
+| Ternary (`? :`)                  | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | ✅ |
 | Arithmetic (`+ - * / %`)         | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Comparison / logical             | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Bitwise (`& \| ^ << >> ~`)       | ✅ | ✅ | 🧩⁵ | ✅ | ✅ | ✅ | 🧩⁶ | ✅ | ✅ |
@@ -106,22 +106,22 @@ The **Wasm** column shows what the on-the-fly WebAssembly compiler currently sup
 ### Classes, types & OOP
 
 Legend: ✅ supported · 🧩 supported via the language's idiom · 🚧 not yet supported (exists in the
-language but not implemented yet) · — not applicable (the language has no such construct).
+language but not implemented yet) · 🚫 not applicable (the language has no such construct).
 
 The **Wasm** column shows what the on-the-fly WebAssembly compiler currently supports
 (any source language is compiled through the same shared AST).
 
 | Feature | Dart | Java | Kotlin | C# | JS | TS | Lua | Python | Wasm |
 |---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
-| Classes                                                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | ✅ |
+| Classes                                                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | ✅ |
 | Fields (with initializers)                                    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🧩¹ | ✅ | ✅ |
 | Constructors & instantiation (`new Foo(...)` / `Foo(...)`)    | ✅ | ✅ | ✅ | ✅ | 🚧 | ✅ | 🧩¹ | 🚧² | ✅ |
 | Methods                                                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Static / visibility modifiers                                 | ✅ | ✅ | 🧩⁴ | ✅ | 🧩³ | ✅ | —  | —  | 🧩⁵ |
-| Inheritance (`extends`) / interfaces                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | —  | ✅ | 🚧 |
-| Enums (incl. runtime value access)                            | ✅ | ✅ | ✅ | ✅ | —  | ✅ | —  | ✅ | 🚧 |
-| Generics (generic classes + instantiation + type erasure)    | ✅ | ✅ | ✅ | ✅ | —  | ✅ | —  | —  | 🚧 |
-| Type inference (`var` / `val` / `auto`)                       | ✅ | ✅ | ✅ | ✅ | —  | ✅ | —  | —  | ✅⁶ |
+| Static / visibility modifiers                                 | ✅ | ✅ | 🧩⁴ | ✅ | 🧩³ | ✅ | 🚫  | 🚫  | 🧩⁵ |
+| Inheritance (`extends`) / interfaces                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚧 |
+| Enums (incl. runtime value access)                            | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚫  | ✅ | 🚧 |
+| Generics (generic classes + instantiation + type erasure)    | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚫  | 🚫  | 🚧 |
+| Type inference (`var` / `val` / `auto`)                       | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚫  | 🚫  | ✅⁶ |
 
 ¹ Lua is table-based (no class construct): "fields" are table entries (`obj.x`) and "constructors"
 are factory functions / `setmetatable` idioms; methods use `function Obj:method`. &nbsp;
@@ -135,7 +135,7 @@ yet preserved in the AST. Kotlin has no `static` (it uses `companion object`, no
 receiver); only static methods are callable as entry points, and there is no source-level visibility
 concept in the module. &nbsp;
 ⁶ Wasm consumes the already type-resolved AST, so `var`/`val`-typed code compiles unchanged. &nbsp;
-Generics are marked `—` for JS/Lua/Python because those languages have no static type syntax to
+Generics are marked `🚫` for JS/Lua/Python because those languages have no static type syntax to
 parameterize.
 
 > Per-language behavior is normalized to a shared AST, so types and constructs map

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -1002,7 +1002,17 @@ class ASTExpressionAwait extends ASTExpression {
   @override
   FutureOr<ASTType> resolveType(VMContext? context) {
     return expression.resolveType(context).resolveMapped((t) {
-      return t is ASTTypeFuture ? t.futureValueType : t;
+      if (t is ASTTypeFuture) return t.futureValueType;
+      // Other languages name the awaitable differently (TypeScript
+      // `Promise<T>`, C# `Task<T>`); awaiting any of them yields its value
+      // type `T`, so the inferred type of `await expr` unwraps the generic.
+      var generics = t.generics;
+      if (generics != null &&
+          generics.isNotEmpty &&
+          (t.name == 'Future' || t.name == 'Promise' || t.name == 'Task')) {
+        return generics.first;
+      }
+      return t;
     });
   }
 

--- a/lib/src/languages/csharp/csharp_generator.dart
+++ b/lib/src/languages/csharp/csharp_generator.dart
@@ -237,6 +237,10 @@ class ApolloCodeGeneratorCSharp extends ApolloCodeGenerator {
       out.write('static ');
     }
 
+    if (f.modifiers.isAsync) {
+      out.write('async ');
+    }
+
     out.write(typeCode);
     out.write(' ');
     out.write(f.name);

--- a/lib/src/languages/csharp/csharp_grammar.dart
+++ b/lib/src/languages/csharp/csharp_grammar.dart
@@ -323,11 +323,13 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
         v.contains('readonly') || v.contains('const') || v.contains('sealed');
     var isPrivate = v.contains('private');
     var isPublic = v.contains('public');
+    var isAsync = v.contains('async');
     return ASTModifiers(
       isStatic: isStatic,
       isFinal: isFinal,
       isPrivate: isPrivate,
       isPublic: isPublic,
+      isAsync: isAsync,
     );
   });
 
@@ -342,6 +344,7 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
               string('override') |
               string('abstract') |
               string('sealed') |
+              string('async') |
               string('static'))
           .trimHidden()
           .flatten();
@@ -708,7 +711,8 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
           });
 
   Parser<ASTExpression> expressionNoOperation() =>
-      (expressionLambda() |
+      (expressionAwait() |
+              expressionLambda() |
               expressionNegate() |
               expressionBitwiseNot() |
               expressionLiteral() |
@@ -729,6 +733,10 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
               expressionVariableAccess() |
               expressionNegative())
           .cast<ASTExpression>();
+
+  Parser<ASTExpressionAwait> expressionAwait() =>
+      (awaitToken() & (ref0(expressionNoOperation) | ref0(expressionGroup)))
+          .map((v) => ASTExpressionAwait(v[1] as ASTExpression));
 
   Parser<ASTExpressionNegation> expressionNegate() =>
       (char('!').trimHidden() &
@@ -1111,18 +1119,23 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
   /// C# lambda used as an expression (a closure): `(a, b) => expr`,
   /// `(int a) => { ... }`, `x => x * 2`, `() => 0`. Captures the enclosing scope.
   Parser<ASTExpression> expressionLambda() =>
-      (lambdaParameters() & string('=>').trimHidden() & lambdaBody()).map((v) {
-        var parameters = v[0] as ASTFunctionParametersDeclaration;
-        var block = v[2] as ASTBlock;
-        var f = ASTFunctionDeclaration(
-          '',
-          parameters,
-          ASTTypeDynamic.instance,
-          block: block,
-          modifiers: ASTModifiers.modifierStatic,
-        );
-        return ASTExpressionLiteralFunction(f);
-      });
+      (asyncToken().trimHidden().optional() &
+              lambdaParameters() &
+              string('=>').trimHidden() &
+              lambdaBody())
+          .map((v) {
+            var isAsync = v[0] != null;
+            var parameters = v[1] as ASTFunctionParametersDeclaration;
+            var block = v[3] as ASTBlock;
+            var f = ASTFunctionDeclaration(
+              '',
+              parameters,
+              ASTTypeDynamic.instance,
+              block: block,
+              modifiers: ASTModifiers(isStatic: true, isAsync: isAsync),
+            );
+            return ASTExpressionLiteralFunction(f);
+          });
 
   Parser<ASTBlock> lambdaBody() =>
       (codeBlock() | lambdaExpressionBody()).cast<ASTBlock>();

--- a/lib/src/languages/csharp/csharp_grammar_lexer.dart
+++ b/lib/src/languages/csharp/csharp_grammar_lexer.dart
@@ -100,6 +100,11 @@ abstract class CSharpGrammarLexer extends BaseGrammarLexer {
 
   Parser staticToken() => ref1(token, 'static');
 
+  // Whole-word match so identifiers like `awaiter` aren't read as `await` + …
+  Parser asyncToken() => keywordToken('async');
+
+  Parser awaitToken() => keywordToken('await');
+
   Parser hexNumberLexicalToken() =>
       string('0x') & ref0(hexDigitLexicalToken).plus() |
       string('0X') & ref0(hexDigitLexicalToken).plus();

--- a/lib/src/languages/grammar.dart
+++ b/lib/src/languages/grammar.dart
@@ -25,6 +25,14 @@ abstract class BaseGrammarLexer extends GrammarDefinition {
         return t is Token ? t.value : '$t';
       });
 
+  /// A whole-word keyword token for [word]: matches only when [word] is not
+  /// immediately followed by an identifier part, so contextual keywords like
+  /// `await` are not read inside identifiers such as `awaiter`.
+  Parser keywordToken(String word) =>
+      (string(word) & ref0(identifierPartLexicalToken).not())
+          .map((v) => v[0])
+          .trim(ref0(hiddenStuffWhitespace));
+
   Parser<String> identifierLexicalToken() =>
       (ref0(identifierStartLexicalToken) &
               ref0(identifierPartLexicalToken).star())

--- a/lib/src/languages/javascript/es/javascript_grammar.dart
+++ b/lib/src/languages/javascript/es/javascript_grammar.dart
@@ -100,9 +100,19 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
             );
           });
 
+  /// Name of the class currently being parsed. Captured when the class name is
+  /// matched (before its body) so that a `constructor` method — whose own name
+  /// is the keyword `constructor`, not the class name — can be built with the
+  /// correct class type. This is required for translation to typed languages
+  /// (e.g. Dart/Java), whose generators emit the constructor's `classType.name`.
+  String _currentClassName = '';
+
   Parser<ASTClassNormal> classDeclaration() =>
       (classToken().trimHidden() &
-              identifier() &
+              identifier().map((name) {
+                _currentClassName = name;
+                return name;
+              }) &
               (extendsToken().trimHidden() & identifier()).optional() &
               classCodeBlock())
           .map((v) {
@@ -123,11 +133,15 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
           .map((v) {
             var list = v[1] as List;
             var fields = list.whereType<ASTClassField>().toList();
+            var constructors = list
+                .whereType<ASTClassConstructorDeclaration>()
+                .toList();
             var functions = list.whereType<ASTFunctionDeclaration>().toList();
 
             var block = ASTClassNormal('?', ASTType<VMObject>('?'), null);
 
             block.addAllFields(fields);
+            block.addAllConstructors(constructors);
             block.addAllFunctions(functions);
 
             return block;
@@ -155,9 +169,11 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
 
   /// `[static] name(params) { block }` — a class method.
   ///
-  /// A method named `constructor` is parsed as a regular method; the JS code
-  /// generator emits it back as the `constructor` keyword.
-  Parser<ASTFunctionDeclaration> classFunctionDeclaration() =>
+  /// A method named `constructor` is parsed as an [ASTClassConstructorDeclaration]
+  /// (with an empty name; the enclosing class fixes up its type), so that
+  /// `new Foo(...)` / `Foo(...)` instantiate the class. The JS code generator
+  /// emits it back as the `constructor` keyword.
+  Parser<Object> classFunctionDeclaration() =>
       (staticToken().trimHidden().optional() &
               asyncToken().trimHidden().optional() &
               identifier() &
@@ -169,6 +185,17 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
             var name = v[2] as String;
             var parameters = v[3] as ASTFunctionParametersDeclaration;
             var block = v[4] as ASTBlock;
+
+            if (name == 'constructor') {
+              return ASTClassConstructorDeclaration(
+                ASTType(_currentClassName),
+                '',
+                _toConstructorParameters(parameters),
+                block: block,
+                modifiers: ASTModifiers(isAsync: isAsync),
+              );
+            }
+
             return ASTClassFunctionDeclaration(
               null,
               name,
@@ -178,6 +205,25 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
               modifiers: ASTModifiers(isStatic: isStatic, isAsync: isAsync),
             );
           });
+
+  /// Converts parsed function parameters into constructor parameters (the
+  /// `constructor` method name is untyped, so each becomes a positional
+  /// `dynamic` constructor parameter).
+  ASTConstructorParametersDeclaration _toConstructorParameters(
+    ASTFunctionParametersDeclaration fn,
+  ) {
+    var positional = fn.positionalParameters
+        ?.map(
+          (p) => ASTConstructorParameterDeclaration(
+            p.type,
+            p.name,
+            p.index,
+            p.optional,
+          ),
+        )
+        .toList();
+    return ASTConstructorParametersDeclaration(positional, null, null);
+  }
 
   Parser<ASTBlock> codeBlock() =>
       (char('{').trimHidden() & ref0(statement).star() & char('}').trimHidden())
@@ -751,19 +797,24 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
             );
           });
 
+  /// A function/method call, optionally prefixed with `new` (e.g.
+  /// `new Foo(...)`). The `new` keyword is consumed and ignored: a call to a
+  /// class name resolves to its constructor (instantiation) at runtime, exactly
+  /// like `Foo(...)`.
   Parser<ASTExpressionFunctionInvocation> expressionFunctionInvocation() =>
-      ((identifier() & char('.')).optional() &
+      (newToken().trimHidden().optional() &
+              (identifier() & char('.')).optional() &
               identifier() &
               char('(').trimHidden() &
               ref0(expressionSequence).optional() &
               char(')').trimHidden() &
               expressionChainFunctionInvocation().star())
           .map((v) {
-            var objOpt = v[0] as List?;
+            var objOpt = v[1] as List?;
             var obj = objOpt != null ? objOpt[0] as String : null;
-            var name = v[1] as String;
-            var args = (v[3] as List<ASTExpression>?) ?? <ASTExpression>[];
-            var chainFunctions = (v[5] as List)
+            var name = v[2] as String;
+            var args = (v[4] as List<ASTExpression>?) ?? <ASTExpression>[];
+            var chainFunctions = (v[6] as List)
                 .whereType<ASTExpressionChainFunctionInvocation>()
                 .toList();
 

--- a/lib/src/languages/javascript/es/javascript_grammar.dart
+++ b/lib/src/languages/javascript/es/javascript_grammar.dart
@@ -81,20 +81,22 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
           });
 
   Parser<ASTFunctionDeclaration> functionDeclaration() =>
-      (functionToken().trimHidden() &
+      (asyncToken().trimHidden().optional() &
+              functionToken().trimHidden() &
               identifier() &
               functionParametersDeclaration() &
               codeBlock())
           .map((v) {
-            var name = v[1] as String;
-            var parameters = v[2] as ASTFunctionParametersDeclaration;
-            var block = v[3] as ASTBlock;
+            var isAsync = v[0] != null;
+            var name = v[2] as String;
+            var parameters = v[3] as ASTFunctionParametersDeclaration;
+            var block = v[4] as ASTBlock;
             return ASTFunctionDeclaration(
               name,
               parameters,
               inferReturnType(block),
               block: block,
-              modifiers: ASTModifiers.modifierStatic,
+              modifiers: ASTModifiers(isStatic: true, isAsync: isAsync),
             );
           });
 
@@ -157,23 +159,23 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
   /// generator emits it back as the `constructor` keyword.
   Parser<ASTFunctionDeclaration> classFunctionDeclaration() =>
       (staticToken().trimHidden().optional() &
+              asyncToken().trimHidden().optional() &
               identifier() &
               functionParametersDeclaration() &
               codeBlock())
           .map((v) {
             var isStatic = v[0] != null;
-            var name = v[1] as String;
-            var parameters = v[2] as ASTFunctionParametersDeclaration;
-            var block = v[3] as ASTBlock;
+            var isAsync = v[1] != null;
+            var name = v[2] as String;
+            var parameters = v[3] as ASTFunctionParametersDeclaration;
+            var block = v[4] as ASTBlock;
             return ASTClassFunctionDeclaration(
               null,
               name,
               parameters,
               inferReturnType(block),
               block: block,
-              modifiers: isStatic
-                  ? ASTModifiers.modifierStatic
-                  : ASTModifiers.modifiersNone,
+              modifiers: ASTModifiers(isStatic: isStatic, isAsync: isAsync),
             );
           });
 
@@ -433,20 +435,22 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
       ((constToken() | letToken() | varToken()).trimHidden() &
               identifier().trimHidden() &
               char('=').trimHidden() &
+              asyncToken().trimHidden().optional() &
               arrowParameters() &
               string('=>').trimHidden() &
               arrowBody() &
               char(';').trimHidden())
           .map((v) {
             var name = v[1] as String;
-            var parameters = v[3] as ASTFunctionParametersDeclaration;
-            var block = v[5] as ASTBlock;
+            var isAsync = v[3] != null;
+            var parameters = v[4] as ASTFunctionParametersDeclaration;
+            var block = v[6] as ASTBlock;
             return ASTFunctionDeclaration(
               name,
               parameters,
               inferReturnType(block),
               block: block,
-              modifiers: ASTModifiers.modifierStatic,
+              modifiers: ASTModifiers(isStatic: true, isAsync: isAsync),
             );
           });
 
@@ -459,18 +463,23 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
   /// `(a, b) => a + b`, `x => x * x`, `() => { ... }`. Captures the enclosing
   /// scope at runtime and can be passed as a callback or stored in a variable.
   Parser<ASTExpression> expressionArrowFunction() =>
-      (arrowParameters() & string('=>').trimHidden() & arrowBody()).map((v) {
-        var parameters = v[0] as ASTFunctionParametersDeclaration;
-        var block = v[2] as ASTBlock;
-        var f = ASTFunctionDeclaration(
-          '',
-          parameters,
-          inferReturnType(block),
-          block: block,
-          modifiers: ASTModifiers.modifierStatic,
-        );
-        return ASTExpressionLiteralFunction(f);
-      });
+      (asyncToken().trimHidden().optional() &
+              arrowParameters() &
+              string('=>').trimHidden() &
+              arrowBody())
+          .map((v) {
+            var isAsync = v[0] != null;
+            var parameters = v[1] as ASTFunctionParametersDeclaration;
+            var block = v[3] as ASTBlock;
+            var f = ASTFunctionDeclaration(
+              '',
+              parameters,
+              inferReturnType(block),
+              block: block,
+              modifiers: ASTModifiers(isStatic: true, isAsync: isAsync),
+            );
+            return ASTExpressionLiteralFunction(f);
+          });
 
   /// Arrow parameters: `(a, b)`, `()`, or a single bare identifier `a`.
   Parser<ASTFunctionParametersDeclaration> arrowParameters() =>
@@ -673,7 +682,8 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
           });
 
   Parser<ASTExpression> expressionNoOperation() =>
-      (expressionArrowFunction() |
+      (expressionAwait() |
+              expressionArrowFunction() |
               expressionNegate() |
               expressionBitwiseNot() |
               expressionLiteral() |
@@ -691,6 +701,10 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
               expressionVariableAccess() |
               expressionNegative())
           .cast<ASTExpression>();
+
+  Parser<ASTExpressionAwait> expressionAwait() =>
+      (awaitToken() & (ref0(expressionNoOperation) | ref0(expressionGroup)))
+          .map((v) => ASTExpressionAwait(v[1] as ASTExpression));
 
   Parser<ASTExpressionNegation> expressionNegate() =>
       (char('!').trimHidden() &

--- a/lib/src/languages/javascript/es/javascript_grammar_lexer.dart
+++ b/lib/src/languages/javascript/es/javascript_grammar_lexer.dart
@@ -79,6 +79,11 @@ abstract class JavaScriptGrammarLexer extends BaseGrammarLexer {
 
   Parser throwToken() => ref1(token, 'throw');
 
+  // Whole-word match so identifiers like `awaiter` aren't read as `await` + …
+  Parser asyncToken() => keywordToken('async');
+
+  Parser awaitToken() => keywordToken('await');
+
   // -----------------------------------------------------------------
   // Numbers.
   // -----------------------------------------------------------------

--- a/lib/src/languages/python/python_generator.dart
+++ b/lib/src/languages/python/python_generator.dart
@@ -324,6 +324,12 @@ class ApolloCodeGeneratorPython extends ApolloCodeGenerator {
     }
     if (clazz.fields.isNotEmpty) out.write('\n');
 
+    for (var set in clazz.constructors) {
+      for (var c in set.functions) {
+        generateASTClassConstructorDeclaration(c, out: out, indent: bodyIndent);
+      }
+    }
+
     for (var set in clazz.functions) {
       for (var f in set.functions) {
         _generateFunction(f, out: out, indent: bodyIndent, isMethod: true);
@@ -410,6 +416,19 @@ class ApolloCodeGeneratorPython extends ApolloCodeGenerator {
     String indent = '',
   }) {
     out ??= newOutput();
+
+    // Python's constructor is the `__init__(self, ...)` method.
+    out.write(indent);
+    out.write('def __init__(self');
+    if (constructor.parametersSize > 0) {
+      out.write(', ');
+      generateASTParametersDeclaration(constructor.parameters, out: out);
+    }
+    out.write('):\n');
+
+    _writeSuite(constructor, out, '$indent$_tab');
+    out.write('\n');
+
     return out;
   }
 

--- a/lib/src/languages/python/python_generator.dart
+++ b/lib/src/languages/python/python_generator.dart
@@ -211,6 +211,9 @@ class ApolloCodeGeneratorPython extends ApolloCodeGenerator {
     out ??= newOutput();
 
     out.write(indent);
+    if (f.modifiers.isAsync) {
+      out.write('async ');
+    }
     out.write('def ');
     out.write(f.name);
     out.write('(');

--- a/lib/src/languages/python/python_grammar.dart
+++ b/lib/src/languages/python/python_grammar.dart
@@ -213,7 +213,7 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
             var name = v[1] as String;
             var superOpt = v[2] as List?;
             var superName = superOpt != null ? superOpt[1] as String? : null;
-            var block = v[4] as ASTBlock;
+            var block = v[4] as ASTClassNormal;
 
             var clazz = ASTClassNormal(
               name,
@@ -221,7 +221,22 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
               null,
               superClassName: superName,
             );
-            clazz.set(block);
+
+            clazz.addAllFields(block.fields);
+
+            // Python's `__init__` is the class constructor; everything else is
+            // a regular method. The constructor needs the real class name so it
+            // round-trips to languages whose constructors are named (Dart/Java).
+            for (var set in block.functions) {
+              for (var f in set.functions) {
+                if (f.name == '__init__') {
+                  clazz.addConstructor(_toConstructor(name, f));
+                } else {
+                  clazz.addFunction(f);
+                }
+              }
+            }
+
             return clazz;
           });
 
@@ -243,6 +258,39 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
             block.addAllFunctions(functions);
             return block;
           });
+
+  /// Builds an [ASTClassConstructorDeclaration] from a parsed `__init__`
+  /// method of class [className]. (`self` was already dropped by
+  /// [methodDeclaration].)
+  static ASTClassConstructorDeclaration _toConstructor(
+    String className,
+    ASTFunctionDeclaration init,
+  ) {
+    var positional = init.parameters.positionalParameters
+        ?.map(
+          (p) => ASTConstructorParameterDeclaration(
+            p.type,
+            p.name,
+            p.index,
+            p.optional,
+          ),
+        )
+        .toList();
+
+    var parameters = ASTConstructorParametersDeclaration(
+      positional == null || positional.isEmpty ? null : positional,
+      null,
+      null,
+    );
+
+    return ASTClassConstructorDeclaration(
+      ASTType<VMObject>(className),
+      '',
+      parameters,
+      block: init,
+      modifiers: init.modifiers,
+    );
+  }
 
   Parser<ASTClassFunctionDeclaration> methodDeclaration() =>
       (asyncToken().trimHidden().optional() &
@@ -649,6 +697,7 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
               expressionListLiteral() |
               expressionMapLiteral() |
               expressionVariableEntryAssignment() |
+              expressionObjectFieldAssignment() |
               expressionVariableAssigment() |
               expressionFunctionInvocation() |
               expressionObjectEntryFunctionInvocation() |
@@ -953,6 +1002,32 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
       (variable() & assigmentOperator() & ref0(expression)).map((v) {
         return ASTExpressionVariableAssignment(v[0], v[1], v[2]);
       });
+
+  /// `self.x = value` / `obj.field = value` (and `+=`, `-=`, `*=`, `//=`, `/=`).
+  /// `self`/`this` target the current instance; `obj` the named variable's
+  /// instance. Mirrors the Dart/Java object field assignment.
+  Parser<ASTExpressionObjectSetterAssignment>
+  expressionObjectFieldAssignment() =>
+      (identifier() &
+              char('.') &
+              identifier().trimHidden() &
+              assigmentOperator() &
+              ref0(expression))
+          .map((v) {
+            var obj = v[0] as String;
+            var name = v[2] as String;
+            var op = v[3] as ASTAssignmentOperator;
+            var valueExpr = v[4] as ASTExpression;
+            ASTVariable variable = (obj == 'self' || obj == 'this')
+                ? ASTThisVariable()
+                : ASTScopeVariable(obj);
+            return ASTExpressionObjectSetterAssignment(
+              variable,
+              name,
+              op,
+              valueExpr,
+            );
+          });
 
   Parser<ASTExpressionVariableEntryAssignment>
   expressionVariableEntryAssignment() =>

--- a/lib/src/languages/python/python_grammar.dart
+++ b/lib/src/languages/python/python_grammar.dart
@@ -169,26 +169,28 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
   // Functions.
   // ---------------------------------------------------------------------------
   Parser<ASTFunctionDeclaration> functionDeclaration() =>
-      (defToken().trimHidden() &
+      (asyncToken().trimHidden().optional() &
+              defToken().trimHidden() &
               identifier() &
               functionParametersDeclaration() &
               returnAnnotation().optional() &
               char(':').trimHidden() &
               suite())
           .map((v) {
-            var name = v[1] as String;
+            var isAsync = v[0] != null;
+            var name = v[2] as String;
             var parameters = _dropSelf(
-              v[2] as ASTFunctionParametersDeclaration,
+              v[3] as ASTFunctionParametersDeclaration,
             );
-            var block = v[5] as ASTBlock;
-            var declared = v[3] as ASTType?;
+            var block = v[6] as ASTBlock;
+            var declared = v[4] as ASTType?;
             var returnType = declared ?? inferReturnType(block);
             return ASTFunctionDeclaration(
               name,
               parameters,
               returnType,
               block: block,
-              modifiers: ASTModifiers.modifierStatic,
+              modifiers: ASTModifiers(isStatic: true, isAsync: isAsync),
             );
           });
 
@@ -243,19 +245,21 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
           });
 
   Parser<ASTClassFunctionDeclaration> methodDeclaration() =>
-      (defToken().trimHidden() &
+      (asyncToken().trimHidden().optional() &
+              defToken().trimHidden() &
               identifier() &
               functionParametersDeclaration() &
               returnAnnotation().optional() &
               char(':').trimHidden() &
               suite())
           .map((v) {
-            var name = v[1] as String;
+            var isAsync = v[0] != null;
+            var name = v[2] as String;
             var parameters = _dropSelf(
-              v[2] as ASTFunctionParametersDeclaration,
+              v[3] as ASTFunctionParametersDeclaration,
             );
-            var block = v[5] as ASTBlock;
-            var declared = v[3] as ASTType?;
+            var block = v[6] as ASTBlock;
+            var declared = v[4] as ASTType?;
             var returnType = declared ?? inferReturnType(block);
             return ASTClassFunctionDeclaration(
               null,
@@ -263,6 +267,7 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
               parameters,
               returnType,
               block: block,
+              modifiers: ASTModifiers(isAsync: isAsync),
             );
           });
 
@@ -634,7 +639,8 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
           .cast<ASTExpressionOperator>();
 
   Parser<ASTExpression> expressionNoOperation() =>
-      (expressionLambda() |
+      (expressionAwait() |
+              expressionLambda() |
               expressionNegate() |
               expressionBitwiseNot() |
               expressionLiteral() |
@@ -652,6 +658,11 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
               expressionVariableAccess() |
               expressionNegative())
           .cast<ASTExpression>();
+
+  /// Python `await expr` — suspends until the awaited awaitable completes.
+  Parser<ASTExpressionAwait> expressionAwait() =>
+      (awaitToken() & (ref0(expressionNoOperation) | ref0(expressionGroup)))
+          .map((v) => ASTExpressionAwait(v[1] as ASTExpression));
 
   /// Python anonymous function: `lambda [params]: expr` (single-expression
   /// body). Captures the enclosing scope at runtime (closure).

--- a/lib/src/languages/python/python_grammar_lexer.dart
+++ b/lib/src/languages/python/python_grammar_lexer.dart
@@ -83,6 +83,10 @@ abstract class PythonGrammarLexer extends BaseGrammarLexer {
 
   Parser asToken() => ref1(keyword, 'as');
 
+  Parser asyncToken() => ref1(keyword, 'async');
+
+  Parser awaitToken() => ref1(keyword, 'await');
+
   Parser breakToken() => ref1(keyword, 'break');
 
   Parser classToken() => ref1(keyword, 'class');

--- a/lib/src/languages/typescript/ts/typescript_grammar.dart
+++ b/lib/src/languages/typescript/ts/typescript_grammar.dart
@@ -151,6 +151,7 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
       isProtected: names.contains('protected'),
       isAbstract: names.contains('abstract'),
       isFinal: names.contains('readonly'),
+      isAsync: names.contains('async'),
     );
   });
 
@@ -160,9 +161,10 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
               protectedToken() |
               readonlyToken() |
               staticToken() |
-              abstractToken())
+              abstractToken() |
+              asyncToken())
           .trimHidden()
-          .map((t) => (t as Token).value as String);
+          .map((t) => (t is Token ? t.value : t) as String);
 
   Parser<ASTStatementImport> statementImport() =>
       (importToken().trimHidden() &
@@ -186,22 +188,24 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
           });
 
   Parser<ASTFunctionDeclaration> functionDeclaration() =>
-      (functionToken().trimHidden() &
+      (asyncToken().trimHidden().optional() &
+              functionToken().trimHidden() &
               identifier() &
               functionParametersDeclaration() &
               typeAnnotation().optional() &
               codeBlock())
           .map((v) {
-            var name = v[1] as String;
-            var parameters = v[2] as ASTFunctionParametersDeclaration;
-            var declaredReturn = v[3] as ASTType?;
-            var block = v[4] as ASTBlock;
+            var isAsync = v[0] != null;
+            var name = v[2] as String;
+            var parameters = v[3] as ASTFunctionParametersDeclaration;
+            var declaredReturn = v[4] as ASTType?;
+            var block = v[5] as ASTBlock;
             return ASTFunctionDeclaration(
               name,
               parameters,
               declaredReturn ?? inferReturnType(block),
               block: block,
-              modifiers: ASTModifiers.modifierStatic,
+              modifiers: ASTModifiers(isStatic: true, isAsync: isAsync),
             );
           });
 
@@ -737,6 +741,7 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
       ((constToken() | letToken() | varToken()).trimHidden() &
               identifier().trimHidden() &
               char('=').trimHidden() &
+              asyncToken().trimHidden().optional() &
               arrowParameters() &
               typeAnnotation().optional() &
               string('=>').trimHidden() &
@@ -744,15 +749,16 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
               char(';').trimHidden())
           .map((v) {
             var name = v[1] as String;
-            var parameters = v[3] as ASTFunctionParametersDeclaration;
-            var declaredReturn = v[4] as ASTType?;
-            var block = v[6] as ASTBlock;
+            var isAsync = v[3] != null;
+            var parameters = v[4] as ASTFunctionParametersDeclaration;
+            var declaredReturn = v[5] as ASTType?;
+            var block = v[7] as ASTBlock;
             return ASTFunctionDeclaration(
               name,
               parameters,
               declaredReturn ?? inferReturnType(block),
               block: block,
-              modifiers: ASTModifiers.modifierStatic,
+              modifiers: ASTModifiers(isStatic: true, isAsync: isAsync),
             );
           });
 
@@ -764,20 +770,22 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
   /// Anonymous arrow function used as an expression (a closure), e.g.
   /// `(a, b) => a + b`, `x => x * x`, `(a): number => a`.
   Parser<ASTExpression> expressionArrowFunction() =>
-      (arrowParameters() &
+      (asyncToken().trimHidden().optional() &
+              arrowParameters() &
               typeAnnotation().optional() &
               string('=>').trimHidden() &
               arrowBody())
           .map((v) {
-            var parameters = v[0] as ASTFunctionParametersDeclaration;
-            var declaredReturn = v[1] as ASTType?;
-            var block = v[3] as ASTBlock;
+            var isAsync = v[0] != null;
+            var parameters = v[1] as ASTFunctionParametersDeclaration;
+            var declaredReturn = v[2] as ASTType?;
+            var block = v[4] as ASTBlock;
             var f = ASTFunctionDeclaration(
               '',
               parameters,
               declaredReturn ?? inferReturnType(block),
               block: block,
-              modifiers: ASTModifiers.modifierStatic,
+              modifiers: ASTModifiers(isStatic: true, isAsync: isAsync),
             );
             return ASTExpressionLiteralFunction(f);
           });
@@ -991,7 +999,8 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
           });
 
   Parser<ASTExpression> expressionNoOperation() =>
-      (expressionArrowFunction() |
+      (expressionAwait() |
+              expressionArrowFunction() |
               expressionNegate() |
               expressionBitwiseNot() |
               expressionLiteral() |
@@ -1009,6 +1018,10 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
               expressionVariableAccess() |
               expressionNegative())
           .cast<ASTExpression>();
+
+  Parser<ASTExpressionAwait> expressionAwait() =>
+      (awaitToken() & (ref0(expressionNoOperation) | ref0(expressionGroup)))
+          .map((v) => ASTExpressionAwait(v[1] as ASTExpression));
 
   Parser<ASTExpressionNegation> expressionNegate() =>
       (char('!').trimHidden() &

--- a/lib/src/languages/typescript/ts/typescript_grammar_lexer.dart
+++ b/lib/src/languages/typescript/ts/typescript_grammar_lexer.dart
@@ -79,6 +79,10 @@ abstract class TypeScriptGrammarLexer extends BaseGrammarLexer {
 
   Parser throwToken() => ref1(token, 'throw');
 
+  Parser asyncToken() => keywordToken('async');
+
+  Parser awaitToken() => keywordToken('await');
+
   // TypeScript-specific keywords.
   Parser abstractToken() => ref1(token, 'abstract');
 

--- a/test/apollovm_async_languages_test.dart
+++ b/test/apollovm_async_languages_test.dart
@@ -1,0 +1,158 @@
+@Tags(['dart', 'javascript', 'typescript', 'csharp', 'python'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Loads [src] in [language], runs `C.run(41)` (an `async` method that
+/// `await`s `compute`), and returns the result. The entry method is non-static,
+/// so it runs against a (field-less) instance.
+Future<Object?> _runAsyncMethod(String language, String src) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit(language, src, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load $language source");
+  var runner = vm.createRunner(language)!;
+  var res = await runner.executeClassMethod(
+    '',
+    'C',
+    'run',
+    positionalParameters: [41],
+    classInstanceFields: const {},
+  );
+  return res.getValueNoContext();
+}
+
+/// Regenerates the loaded [language] source from [src] as text.
+Future<String> _regen(String language, String src, String target) async {
+  var vm = ApolloVM();
+  await vm.loadCodeUnit(SourceCodeUnit(language, src, id: 'test'));
+  var storage = vm.generateAllCodeIn(target);
+  return (await storage.writeAllSources()).toString();
+}
+
+void main() {
+  // Each language declares an `async` method that `await`s another method.
+  // ApolloVM parses `async`/`await`, executes via the shared async runtime
+  // (`await` unwraps the awaitable), round-trips the source, and translates to
+  // Dart (which keeps `async`/`await`).
+  const cases = <({String lang, String label, String src})>[
+    (
+      lang: 'javascript',
+      label: 'JavaScript',
+      src: r'''
+        class C {
+          async compute(x) { return x + 1; }
+          async run(args) {
+            var v = await compute(args);
+            return v;
+          }
+        }
+      ''',
+    ),
+    (
+      lang: 'typescript',
+      label: 'TypeScript',
+      src: r'''
+        class C {
+          async compute(x: number): Promise<number> { return x + 1; }
+          async run(args: number): Promise<number> {
+            let v = await compute(args);
+            return v;
+          }
+        }
+      ''',
+    ),
+    (
+      lang: 'csharp',
+      label: 'C#',
+      src: r'''
+        class C {
+          int compute(int x) { return x + 1; }
+          async Task<int> run(int args) {
+            var v = await compute(args);
+            return v;
+          }
+        }
+      ''',
+    ),
+    (
+      lang: 'python',
+      label: 'Python',
+      src: '''
+class C:
+    def compute(self, x):
+        return x + 1
+    async def run(self, args):
+        v = await self.compute(args)
+        return v
+''',
+    ),
+  ];
+
+  for (var c in cases) {
+    group('${c.label}: async / await', () {
+      test('parses + executes (await returns the value)', () async {
+        expect(await _runAsyncMethod(c.lang, c.src), equals(42));
+      });
+
+      test('round-trips `async`/`await` back to ${c.label}', () async {
+        var out = await _regen(c.lang, c.src, c.lang);
+        expect(out, contains('async'));
+        expect(out, contains('await '));
+      });
+
+      test('translates to Dart with `async`/`await`', () async {
+        var dart = await _regen(c.lang, c.src, 'dart');
+        expect(dart, contains('async'));
+        expect(dart, contains('await '));
+      });
+    });
+  }
+
+  group('await keyword boundary', () {
+    test('JavaScript: `awaiter` is an identifier, not `await er`', () async {
+      var vm = ApolloVM();
+      var ok = await vm.loadCodeUnit(
+        SourceCodeUnit('javascript', r'''
+          class C {
+            run(args) {
+              var awaiter = args + 1;
+              return awaiter;
+            }
+          }
+        ''', id: 'test'),
+      );
+      expect(ok, isTrue);
+      var runner = vm.createRunner('javascript')!;
+      var res = await runner.executeClassMethod(
+        '',
+        'C',
+        'run',
+        positionalParameters: [41],
+        classInstanceFields: const {},
+      );
+      expect(res.getValueNoContext(), equals(42));
+    });
+  });
+
+  group('await unwraps the awaitable type', () {
+    // Regression: `await` on a method declared to return a named awaitable
+    // (`Promise<T>` / `Task<T>` / `Future<T>`) must infer the value type `T`,
+    // so assigning the awaited value to an inferred variable does not fail a
+    // type cast. (TypeScript `Promise<number>` reproduces this.)
+    test('TypeScript Promise<number> awaited into an inferred var', () async {
+      expect(
+        await _runAsyncMethod('typescript', r'''
+          class C {
+            async compute(x: number): Promise<number> { return x + 1; }
+            async run(args: number): Promise<number> {
+              let v = await compute(args);
+              return v;
+            }
+          }
+        '''),
+        equals(42),
+      );
+    });
+  });
+}

--- a/test/apollovm_constructors_test.dart
+++ b/test/apollovm_constructors_test.dart
@@ -1,0 +1,129 @@
+@Tags(['javascript', 'python', 'dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Loads [src] in [language] and runs `Main.run([])`, which instantiates a
+/// `Point(10, 32)` and returns `point.sum()` (== 42). Exercises constructors,
+/// `this`/`self` field assignment, and instantiation.
+Future<Object?> _runMain(String language, String src) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit(language, src, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load $language source");
+  var runner = vm.createRunner(language)!;
+  var res = await runner.executeClassMethod(
+    '',
+    'Main',
+    'run',
+    positionalParameters: [const []],
+    classInstanceFields: const {},
+  );
+  return res.getValueNoContext();
+}
+
+/// Translates [src] from [language] to Dart, reloads the generated Dart in a
+/// fresh VM, and runs `Main.run([])` — proving the constructor and field
+/// assignment round-trip across languages.
+Future<Object?> _runViaDart(String language, String src) async {
+  var vm = ApolloVM();
+  await vm.loadCodeUnit(SourceCodeUnit(language, src, id: 'test'));
+  var dart = (await vm
+      .generateAllCodeIn('dart')
+      .getNamespaceCodeUnit('', 'test'))!;
+
+  var vm2 = ApolloVM();
+  var ok = await vm2.loadCodeUnit(SourceCodeUnit('dart', dart, id: 'test'));
+  expect(ok, isTrue, reason: 'Generated Dart should load:\n$dart');
+  var runner = vm2.createRunner('dart')!;
+  var res = await runner.executeClassMethod(
+    '',
+    'Main',
+    'run',
+    positionalParameters: [const []],
+    classInstanceFields: const {},
+  );
+  return res.getValueNoContext();
+}
+
+const _jsSource = r'''
+  class Point {
+    constructor(x, y) {
+      this.x = x;
+      this.y = y;
+    }
+    sum() { return this.x + this.y; }
+  }
+  class Main {
+    run(args) {
+      var p = new Point(10, 32);
+      return p.sum();
+    }
+  }
+''';
+
+const _pySource = '''
+class Point:
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+    def sum(self):
+        return self.x + self.y
+
+class Main:
+    def run(self, args):
+        p = Point(10, 32)
+        return p.sum()
+''';
+
+void main() {
+  group('JavaScript: constructors & instantiation', () {
+    test('`new Foo(...)` constructs, assigns fields, and runs', () async {
+      expect(await _runMain('javascript', _jsSource), equals(42));
+    });
+
+    test('`Foo(...)` without `new` also constructs', () async {
+      var src = _jsSource.replaceFirst('new Point(10, 32)', 'Point(10, 32)');
+      expect(await _runMain('javascript', src), equals(42));
+    });
+
+    test('round-trips `constructor` and `this.x`', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(
+        SourceCodeUnit('javascript', _jsSource, id: 'test'),
+      );
+      var js = (await vm
+          .generateAllCodeIn('javascript')
+          .getNamespaceCodeUnit('', 'test'))!;
+      expect(js, contains('constructor('));
+      expect(js, contains('this.x'));
+    });
+
+    test('translates to Dart and runs (constructor round-trips)', () async {
+      expect(await _runViaDart('javascript', _jsSource), equals(42));
+    });
+  });
+
+  group('Python: constructors & instantiation', () {
+    test(
+      '`__init__` + `self.x = …` + `Foo(...)` constructs and runs',
+      () async {
+        expect(await _runMain('python', _pySource), equals(42));
+      },
+    );
+
+    test('round-trips `def __init__(self` and `self.x`', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(SourceCodeUnit('python', _pySource, id: 'test'));
+      var py = (await vm
+          .generateAllCodeIn('python')
+          .getNamespaceCodeUnit('', 'test'))!;
+      expect(py, contains('def __init__(self'));
+      expect(py, contains('self.x'));
+    });
+
+    test('translates to Dart and runs (constructor round-trips)', () async {
+      expect(await _runViaDart('python', _pySource), equals(42));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds `async`/`await` **parsing** to JavaScript, TypeScript, C# and Python (Dart already had it). Parsed code executes on the shared async runtime, round-trips to its source language, and translates across languages (e.g. C# `async Task<int>` ⇄ Dart `Future<int> … async`).

### Parsing
- New shared word-boundary `keywordToken` in the base lexer so contextual keywords like `await` aren't read inside identifiers (`awaiter`).
- Each grammar gains `async`/`await` tokens, an optional `async` modifier on functions / methods / arrows / lambdas, and an `await` prefix expression — mapped onto the existing `ASTModifiers.isAsync` / `ASTExpressionAwait`.

### Generation
- C# and Python now emit `async` / `async def`; JS and TS already emitted `async`, and the shared base generator emits `await`.

### Runtime
- `ASTExpressionAwait.resolveType` now unwraps **any** awaitable — `Future<T>`, `Promise<T>` (TS), `Task<T>` (C#) — to its value type `T`, so awaiting a typed result infers the correct type (fixes a real cast failure for typed languages).

### Docs
- README "Control flow & operators" table gains an `async`/`await` row (Kotlin noted as `suspend`/generate-only); removed from the JS TODO.
- Also included: the earlier OOP-table Wasm column + Kotlin visibility-footnote fix.

## Testing
- New `test/apollovm_async_languages_test.dart` (14 cases): parse + execute (`await` → 42) + round-trip + Dart translation for JS/TS/C#/Python, plus keyword-boundary and awaitable-unwrap regressions.
- No regressions: `apollovm_languages_extended` (162) + `apollovm_languages_basic` (30) + `apollovm_async`/`apollovm_async_extra` (24) pass. `dart analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)