### PR TITLE
feat(enums): rich enums as classes with const instance entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,23 +123,20 @@ The **Wasm** column shows what the on-the-fly WebAssembly compiler currently sup
 | Generics (generic classes + instantiation + type erasure)    | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚫  | 🚫  | 🚧 |
 | Type inference (`var` / `val` / `auto`)                       | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚫  | 🚫  | ✅⁵ |
 
-¹ Lua is table-based (no class construct): "fields" are table entries (`obj.x`) and "constructors"
-are factory functions / `setmetatable` idioms; methods use `function Obj:method`. &nbsp;
-² JavaScript supports the `static` modifier but has no visibility keywords (privacy is by convention /
-closures). &nbsp;
-³ Kotlin `private`/`public` member visibility round-trips; `internal`/`protected` are parsed but not
-yet preserved in the AST. Kotlin has no `static` (it uses `companion object`, not yet supported). &nbsp;
+¹ Lua is table-based: "fields" are table entries (`obj.x`), "constructors" are factory/`setmetatable`
+idioms, methods are `function Obj:method`. &nbsp;
+² JavaScript has `static` but no visibility keywords (privacy is by convention/closures). &nbsp;
+³ Kotlin `private`/`public` visibility round-trips; `internal`/`protected` are parsed but not preserved
+yet; no `static` (uses `companion object`, not yet supported). &nbsp;
 ⁴ Wasm compiles `static` methods (exported as `Class.method`) and instance methods (called with a
-receiver); only static methods are callable as entry points, and there is no source-level visibility
-concept in the module. &nbsp;
+receiver); only static methods are callable as entry points, with no source-level visibility. &nbsp;
 ⁵ Wasm consumes the already type-resolved AST, so `var`/`val`-typed code compiles unchanged. &nbsp;
 ⁶ Each enum entry is a `const` **instance** of the enum's class (Dart enhanced enums): `.index`,
 `.name`, `EnumName.values`, identity `==`, plus rich-enum constructor args, fields and methods.
 Java/Kotlin emit native rich enums; C#/TS/Python use a class + `static`-const-instances idiom; Wasm
 compiles entries to heap instances (a method chained directly on an entry needs a variable first).
 **Breaking change**: an entry is no longer an `int` — use `.index` (and `.value` for `= N` entries). &nbsp;
-Generics are marked `🚫` for JS/Lua/Python because those languages have no static type syntax to
-parameterize.
+Generics are `🚫` for JS/Lua/Python: no static type syntax to parameterize.
 
 > Per-language behavior is normalized to a shared AST, so types and constructs map
 > cleanly when translating between languages (e.g. C# `string` ⇄ Dart `String`,

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The **Wasm** column shows what the on-the-fly WebAssembly compiler currently sup
 | Methods                                                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Static / visibility modifiers                                 | ✅ | ✅ | 🧩³ | ✅ | 🧩² | ✅ | 🚫  | 🚫  | 🧩⁴ |
 | Inheritance (`extends`) / interfaces                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚧 |
-| Enums (incl. runtime value access)                            | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚫  | ✅ | 🚧 |
+| Enums (rich: ctor args, fields, methods)⁶                     | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚫  | ✅ | ✅⁶ |
 | Generics (generic classes + instantiation + type erasure)    | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚫  | 🚫  | 🚧 |
 | Type inference (`var` / `val` / `auto`)                       | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚫  | 🚫  | ✅⁵ |
 
@@ -133,6 +133,11 @@ yet preserved in the AST. Kotlin has no `static` (it uses `companion object`, no
 receiver); only static methods are callable as entry points, and there is no source-level visibility
 concept in the module. &nbsp;
 ⁵ Wasm consumes the already type-resolved AST, so `var`/`val`-typed code compiles unchanged. &nbsp;
+⁶ Each enum entry is a `const` **instance** of the enum's class (Dart enhanced enums): `.index`,
+`.name`, `EnumName.values`, identity `==`, plus rich-enum constructor args, fields and methods.
+Java/Kotlin emit native rich enums; C#/TS/Python use a class + `static`-const-instances idiom; Wasm
+compiles entries to heap instances (a method chained directly on an entry needs a variable first).
+**Breaking change**: an entry is no longer an `int` — use `.index` (and `.value` for `= N` entries). &nbsp;
 Generics are marked `🚫` for JS/Lua/Python because those languages have no static type syntax to
 parameterize.
 

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -2796,9 +2796,11 @@ class ASTExpressionObjectGetterAccess extends ASTExpressionGetterAccess
     return node is ASTClassEnum ? node : null;
   }
 
-  /// Resolves an enum entry reference (`EnumType.entry`) to its value: the
-  /// explicit value expression when present, otherwise the entry's ordinal
-  /// index. Returns `null` if this is not an enum entry reference.
+  /// Resolves an enum static access (`EnumType.entry` or `EnumType.values`):
+  /// an entry yields its cached `const` instance (a singleton, so `==` is
+  /// identity); `values` yields the list of all instances in declaration order.
+  /// Returns `null` if the receiver is not an enum, or the member is neither an
+  /// entry nor `values` (e.g. a static member — handled by the normal path).
   FutureOr<ASTValue>? _resolveEnumEntry(
     VMContext context,
     ASTRunStatus runStatus,
@@ -2806,21 +2808,17 @@ class ASTExpressionObjectGetterAccess extends ASTExpressionGetterAccess
     var enumClass = _enumClass();
     if (enumClass == null) return null;
 
-    var entries = enumClass.entries;
-    for (var i = 0; i < entries.length; ++i) {
-      if (entries[i].name == name) {
-        var value = entries[i].value;
-        if (value != null) return value.run(context, runStatus);
-        return ASTValueInt(i);
-      }
+    if (name == 'values') {
+      return enumClass
+          .getValues(context)
+          .resolveMapped(
+            (list) => ASTValueArray(ASTTypeDynamic.instance, list),
+          );
     }
-    return null;
-  }
 
-  /// `true` if this access is an enum entry reference (`EnumType.entry`).
-  bool _isEnumEntry() {
-    var e = _enumClass();
-    return e != null && e.entries.any((entry) => entry.name == name);
+    if (enumClass.entries.every((e) => e.name != name)) return null;
+
+    return enumClass.getEntryInstance(context, name).resolveMapped((i) => i!);
   }
 
   ASTClass? _getterClass;
@@ -2855,7 +2853,11 @@ class ASTExpressionObjectGetterAccess extends ASTExpressionGetterAccess
 
   @override
   FutureOr<ASTType> resolveType(VMContext? context) {
-    if (_isEnumEntry()) return ASTTypeInt.instance;
+    var enumClass = _enumClass();
+    if (enumClass != null) {
+      if (name == 'values') return ASTTypeArray(enumClass.type);
+      if (enumClass.entries.any((e) => e.name == name)) return enumClass.type;
+    }
 
     if (context == null) {
       return super.resolveType(context);
@@ -2881,7 +2883,11 @@ class ASTExpressionObjectGetterAccess extends ASTExpressionGetterAccess
     VMContext context,
     ASTNode? node,
   ) {
-    if (_isEnumEntry()) return ASTTypeInt.instance;
+    var enumClass = _enumClass();
+    if (enumClass != null) {
+      if (name == 'values') return ASTTypeArray(enumClass.type);
+      if (enumClass.entries.any((e) => e.name == name)) return enumClass.type;
+    }
 
     return _getVariableValue(context).resolveMapped((obj) {
       if (obj is ASTClassInstance) {

--- a/lib/src/ast/apollovm_ast_toplevel.dart
+++ b/lib/src/ast/apollovm_ast_toplevel.dart
@@ -1091,6 +1091,16 @@ class ASTClassEnum extends ASTClassNormal {
     // Seed the synthetic `index` (ordinal) and `name` fields.
     instance.vmObject.setFieldValue('index', ASTValueInt(index));
     instance.vmObject.setFieldValue('name', ASTValueString(entry.name));
+
+    // An explicit-value entry (e.g. C#/TypeScript `Medium = 5`) exposes its
+    // value via the synthetic `value` field.
+    var explicitValue = entry.value;
+    if (explicitValue != null) {
+      instance.vmObject.setFieldValue(
+        'value',
+        await explicitValue.run(classContext, runStatus),
+      );
+    }
     return instance;
   }
 

--- a/lib/src/ast/apollovm_ast_toplevel.dart
+++ b/lib/src/ast/apollovm_ast_toplevel.dart
@@ -972,7 +972,12 @@ class ASTClassNormal extends ASTClass<VMObject> {
   }
 }
 
-/// An entry of an [ASTClassEnum] (e.g. `Red` or `Red = 1`).
+/// An entry of an [ASTClassEnum].
+///
+/// - A simple entry is just a name (`red`).
+/// - An explicit-value entry (C#/TS `Red = 1`) carries [value].
+/// - A rich/enhanced entry (Dart `earth(5.97, 6371)`) carries constructor
+///   [arguments].
 class ASTEnumEntry {
   /// The entry name.
   final String name;
@@ -980,16 +985,27 @@ class ASTEnumEntry {
   /// The optional explicit value expression (e.g. `1` in `Red = 1`).
   final ASTExpression? value;
 
-  ASTEnumEntry(this.name, [this.value]);
+  /// The optional constructor arguments of a rich/enhanced enum entry
+  /// (e.g. `(5.97, 6371)` in `earth(5.97, 6371)`).
+  final List<ASTExpression>? arguments;
+
+  ASTEnumEntry(this.name, {this.value, this.arguments});
 
   @override
-  String toString() => value != null ? '$name = $value' : name;
+  String toString() {
+    if (value != null) return '$name = $value';
+    if (arguments != null) return '$name(${arguments!.join(', ')})';
+    return name;
+  }
 }
 
 /// AST of an enum class (e.g. Dart/TypeScript `enum`).
 ///
 /// Extends [ASTClassNormal] so it flows through the existing class generation
-/// and resolution; the [entries] hold the enum constants.
+/// and resolution; the [entries] hold the enum constants. Each entry resolves
+/// at runtime to a cached `const` instance of this class (a singleton, so `==`
+/// is identity), carrying the synthetic fields `index` (ordinal) and `name`,
+/// plus any declared fields initialized by the enum's `const` constructor.
 class ASTClassEnum extends ASTClassNormal {
   /// The enum entries (constants), in declaration order.
   final List<ASTEnumEntry> entries;
@@ -1002,6 +1018,81 @@ class ASTClassEnum extends ASTClassNormal {
     super.superClassName,
     super.implementsTypes,
   }) : entries = entries ?? <ASTEnumEntry>[];
+
+  /// Cached entry instances (one singleton per entry name → const + identity).
+  /// The build *future* is memoized (not just the result) so two concurrent
+  /// resolutions of the same entry — e.g. both operands of `E.a == E.a` —
+  /// share the one instance instead of each building its own.
+  final Map<String, FutureOr<ASTClassInstance<VMObject>>> _entryInstances = {};
+  List<ASTClassInstance<VMObject>>? _values;
+
+  /// Returns the cached `const` instance for the entry named [entryName], or
+  /// null if there is no such entry. Built once (lazily) and memoized.
+  FutureOr<ASTClassInstance<VMObject>?> getEntryInstance(
+    VMContext context,
+    String entryName,
+  ) {
+    var index = entries.indexWhere((e) => e.name == entryName);
+    if (index < 0) return null;
+    return _entryInstances.putIfAbsent(
+      entryName,
+      () => _buildEntryInstance(context, index),
+    );
+  }
+
+  /// All entry instances, in declaration order (Dart `EnumName.values`).
+  FutureOr<List<ASTClassInstance<VMObject>>> getValues(VMContext context) {
+    var values = _values;
+    if (values != null) return values;
+    return entries
+        .map((e) => getEntryInstance(context, e.name))
+        .toList()
+        .resolveAll()
+        .resolveMapped((list) {
+          var instances = list.whereType<ASTClassInstance<VMObject>>().toList();
+          _values = instances;
+          return instances;
+        });
+  }
+
+  Future<ASTClassInstance<VMObject>> _buildEntryInstance(
+    VMContext context,
+    int index,
+  ) async {
+    var entry = entries[index];
+    var classContext = createContext(context.typeResolver, context);
+    var runStatus = ASTRunStatus();
+
+    ASTClassInstance<VMObject> instance;
+    var arguments = entry.arguments;
+    if (arguments != null) {
+      // Rich/enhanced enum entry: run the `const` constructor with its args.
+      var constructor = getConstructor('', null, classContext);
+      if (constructor == null) {
+        throw StateError(
+          "Enum '$name' entry '${entry.name}' has constructor arguments but the "
+          "enum declares no constructor.",
+        );
+      }
+      var argValues = <ASTValue>[];
+      for (var a in arguments) {
+        argValues.add(await a.run(classContext, runStatus));
+      }
+      var result = await constructor.call(
+        classContext,
+        positionalParameters: argValues,
+      );
+      instance = result as ASTClassInstance<VMObject>;
+    } else {
+      // Simple enum entry: a bare instance (field initializers, if any, run).
+      instance = (await createInstance(classContext, runStatus))!;
+    }
+
+    // Seed the synthetic `index` (ordinal) and `name` fields.
+    instance.vmObject.setFieldValue('index', ASTValueInt(index));
+    instance.vmObject.setFieldValue('name', ASTValueString(entry.name));
+    return instance;
+  }
 
   @override
   String toString() => 'enum $name';

--- a/lib/src/languages/csharp/csharp_generator.dart
+++ b/lib/src/languages/csharp/csharp_generator.dart
@@ -126,13 +126,30 @@ class ApolloCodeGeneratorCSharp extends ApolloCodeGenerator {
     return out;
   }
 
+  /// Returns `true` if [clazz] is a rich/enhanced enum (entries with
+  /// constructor arguments, or declared fields/constructors/methods). A rich
+  /// enum can't map to a native C# `enum`, so it's emitted as a class with
+  /// static-readonly singleton instances.
+  bool _isRichEnum(ASTClassEnum clazz) =>
+      clazz.entries.any((e) => e.arguments != null) ||
+      clazz.fields.isNotEmpty ||
+      clazz.constructors.isNotEmpty ||
+      clazz.functions.isNotEmpty;
+
   /// Generates a C# `enum` declaration (with optional `= value` entries).
+  ///
+  /// A rich/enhanced enum is emitted as a class with a private constructor and
+  /// one `static readonly` singleton instance per entry (see [_isRichEnum]).
   StringBuffer generateASTClassEnum(
     ASTClassEnum clazz, {
     StringBuffer? out,
     String indent = '',
   }) {
     out ??= newOutput();
+
+    if (_isRichEnum(clazz)) {
+      return _generateRichEnumCSharp(clazz, out, indent);
+    }
 
     out.write(indent);
     out.write('enum ');
@@ -151,6 +168,114 @@ class ApolloCodeGeneratorCSharp extends ApolloCodeGenerator {
       if (i < entries.length - 1) out.write(',');
       out.write('\n');
     }
+
+    out.write('$indent}\n');
+
+    return out;
+  }
+
+  /// Emits a rich/enhanced enum as a C# class: declared fields, a `private`
+  /// constructor, the methods, one `public static readonly` singleton per
+  /// entry (constructed with its arguments) and a `Values` array.
+  StringBuffer _generateRichEnumCSharp(
+    ASTClassEnum clazz,
+    StringBuffer out,
+    String indent,
+  ) {
+    var i2 = '$indent  ';
+    var name = clazz.name;
+
+    out.write(indent);
+    out.write('class ');
+    out.write(name);
+    out.write(' {\n\n');
+
+    // Declared fields.
+    for (var field in clazz.fields) {
+      out.write(i2);
+      out.write('public ');
+      if (field.finalValue) out.write('readonly ');
+      out.write(generateASTType(field.type));
+      out.write(' ');
+      out.write(field.name);
+      if (field is ASTClassFieldWithInitialValue) {
+        out.write(' = ');
+        generateASTExpression(
+          field.initialValue,
+          out: out,
+          headIndented: false,
+        );
+      }
+      out.write(';\n');
+    }
+    if (clazz.fields.isNotEmpty) out.write('\n');
+
+    // Private constructor.
+    var ctor = clazz.constructors.isNotEmpty
+        ? clazz.constructors.first.firstFunction
+        : null;
+    if (ctor != null) {
+      var params = ctor.parameters.allParameters;
+      out.write(i2);
+      out.write('private ');
+      out.write(name);
+      out.write('(');
+      for (var i = 0; i < params.length; ++i) {
+        if (i > 0) out.write(', ');
+        out.write(generateASTType(params[i].type));
+        out.write(' ');
+        out.write(params[i].name);
+      }
+      out.write(') {\n');
+      for (var p in params) {
+        if (p.thisParameter) {
+          out.write('$i2  this.${p.name} = ${p.name};\n');
+        }
+      }
+      out.write(generateASTBlock(ctor, indent: i2, withBrackets: false));
+      out.write('$i2}\n\n');
+    }
+
+    // Methods.
+    for (var set in clazz.functions) {
+      for (var f in set.functions) {
+        if (f is! ASTClassFunctionDeclaration) continue;
+        out.write(i2);
+        out.write('public ');
+        if (f.modifiers.isStatic) out.write('static ');
+        out.write(generateASTType(f.returnType));
+        out.write(' ');
+        out.write(f.name);
+        out.write('(');
+        if (f.parametersSize > 0) {
+          generateASTParametersDeclaration(f.parameters, out: out);
+        }
+        out.write(') {\n');
+        out.write(generateASTBlock(f, indent: i2, withBrackets: false));
+        out.write('$i2}\n\n');
+      }
+    }
+
+    // Static singleton instances (one per entry).
+    for (var e in clazz.entries) {
+      out.write(i2);
+      out.write('public static readonly $name ${e.name} = new $name(');
+      var args = e.arguments;
+      if (args != null) {
+        for (var i = 0; i < args.length; ++i) {
+          if (i > 0) out.write(', ');
+          generateASTExpression(args[i], out: out, headIndented: false);
+        }
+      }
+      out.write(');\n');
+    }
+    if (clazz.entries.isNotEmpty) out.write('\n');
+
+    // Values array.
+    out.write(i2);
+    out.write('public static readonly $name[] Values = { ');
+    out.write(clazz.entries.map((e) => e.name).join(', '));
+    out.write(' };\n');
 
     out.write('$indent}\n');
 

--- a/lib/src/languages/csharp/csharp_grammar.dart
+++ b/lib/src/languages/csharp/csharp_grammar.dart
@@ -116,7 +116,7 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
             var name = v[0] as String;
             var valueOpt = v[1] as List?;
             var value = valueOpt != null ? valueOpt[1] as ASTExpression : null;
-            return ASTEnumEntry(name, value);
+            return ASTEnumEntry(name, value: value);
           });
 
   /// Type-parameter names of the class currently being parsed (e.g. `T` in

--- a/lib/src/languages/dart/dart_generator.dart
+++ b/lib/src/languages/dart/dart_generator.dart
@@ -122,13 +122,18 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
     return out;
   }
 
-  /// Generates a Dart `enum` declaration.
+  /// Generates a Dart `enum` declaration (simple or enhanced/rich).
   StringBuffer generateASTClassEnum(
     ASTClassEnum clazz, {
     StringBuffer? out,
     String indent = '',
   }) {
     out ??= newOutput();
+
+    var hasMembers =
+        clazz.fields.isNotEmpty ||
+        clazz.constructors.isNotEmpty ||
+        clazz.functions.isNotEmpty;
 
     out.write(indent);
     out.write('enum ');
@@ -138,14 +143,67 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
     var entries = clazz.entries;
     for (var i = 0; i < entries.length; ++i) {
       out.write('$indent  ');
-      out.write(entries[i].name);
+      _generateEnumEntry(entries[i], out);
       if (i < entries.length - 1) out.write(',');
       out.write('\n');
+    }
+
+    if (hasMembers) {
+      var indent2 = '$indent  ';
+      // Enhanced/rich enum: `;` then the class members (fields, the `const`
+      // constructor, methods) — reusing the class member generators.
+      out.write('$indent  ;\n');
+
+      for (var field in clazz.fields) {
+        generateASTClassField(field, out: out, indent: indent2);
+      }
+
+      for (var constructor in clazz.constructors) {
+        for (var c in constructor.functions) {
+          // Dart enum constructors must be `const`.
+          var cCode = generateASTClassConstructorDeclaration(
+            c,
+            indent: indent2,
+          ).toString();
+          out.write(indent2);
+          out.write('const ');
+          out.write(cCode.substring(indent2.length));
+        }
+      }
+
+      for (var set in clazz.functions) {
+        for (var f in set.functions) {
+          if (f is ASTClassFunctionDeclaration) {
+            generateASTClassFunctionDeclaration(f, out: out, indent: indent2);
+          }
+        }
+      }
     }
 
     out.write('$indent}\n');
 
     return out;
+  }
+
+  /// Generates a single enum entry: a bare name, an explicit value (`Red = 1`),
+  /// or rich constructor arguments (`earth(5.97, 6371)`).
+  void _generateEnumEntry(ASTEnumEntry entry, StringBuffer out) {
+    out.write(entry.name);
+
+    var value = entry.value;
+    var arguments = entry.arguments;
+
+    if (value != null) {
+      out.write(' = ');
+      generateASTExpression(value, out: out, headIndented: false);
+    } else if (arguments != null) {
+      out.write('(');
+      for (var i = 0; i < arguments.length; ++i) {
+        if (i > 0) out.write(', ');
+        generateASTExpression(arguments[i], out: out, headIndented: false);
+      }
+      out.write(')');
+    }
   }
 
   @override

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -220,6 +220,15 @@ class DartGrammarDefinition extends DartGrammarLexer {
               enumEntry() &
               (char(',').trimHidden() & enumEntry()).star() &
               char(',').trimHidden().optional() &
+              // Enhanced/rich enum body: `;` then class members (fields, a
+              // `const` constructor, methods) — reusing class-member parsing.
+              (char(';').trimHidden() &
+                      (ref0(classConstructorDefaultDeclaration) |
+                              ref0(classFunctionDeclaration) |
+                              ref0(classFieldDeclaration) |
+                              ref0(classFieldDeclarationWithValue))
+                          .star())
+                  .optional() &
               char('}').trimHidden())
           .map((v) {
             var name = v[1] as String;
@@ -227,22 +236,52 @@ class DartGrammarDefinition extends DartGrammarLexer {
             for (var e in (v[4] as List)) {
               entries.add(e[1] as ASTEnumEntry);
             }
-            return ASTClassEnum(
+            var enumClass = ASTClassEnum(
               name,
               ASTType<VMObject>(name),
               null,
               entries: entries,
             );
+            var membersOpt = v[6] as List?;
+            if (membersOpt != null) {
+              var members = membersOpt[1] as List;
+              enumClass.addAllFields(
+                members.whereType<ASTClassField>().toList(),
+              );
+              enumClass.addAllConstructors(
+                members.whereType<ASTClassConstructorDeclaration>().toList(),
+              );
+              enumClass.addAllFunctions(
+                members.whereType<ASTFunctionDeclaration>().toList(),
+              );
+            }
+            return enumClass;
           });
 
   Parser<ASTEnumEntry> enumEntry() =>
       (identifier().trimHidden() &
-              (char('=').trimHidden() & ref0(expression)).optional())
+              ((char('=').trimHidden() & ref0(expression)) |
+                      (char('(').trimHidden() &
+                          expressionSequence().optional() &
+                          char(')').trimHidden()))
+                  .optional())
           .map((v) {
             var name = v[0] as String;
-            var valueOpt = v[1] as List?;
-            var value = valueOpt != null ? valueOpt[1] as ASTExpression : null;
-            return ASTEnumEntry(name, value);
+            var suffix = v[1] as List?;
+            ASTExpression? value;
+            List<ASTExpression>? arguments;
+            if (suffix != null) {
+              if (suffix[0] == '=') {
+                // Explicit value: `Red = 1`.
+                value = suffix[1] as ASTExpression;
+              } else {
+                // Rich-enum constructor args: `earth(5.97, 6371)`.
+                arguments =
+                    (suffix[1] as List?)?.cast<ASTExpression>() ??
+                    <ASTExpression>[];
+              }
+            }
+            return ASTEnumEntry(name, value: value, arguments: arguments);
           });
 
   Parser<ASTBlock> classCodeBlock() =>
@@ -314,13 +353,14 @@ class DartGrammarDefinition extends DartGrammarLexer {
           });
 
   Parser<ASTClassConstructorDeclaration> classConstructorDefaultDeclaration() =>
-      (identifier() &
+      (constToken().trimHidden().optional() &
+              identifier() &
               constructorParametersDeclaration() &
               (char(';').trim() | codeBlock()))
           .map((v) {
-            var className = v[0];
-            var parameters = v[1] as ASTConstructorParametersDeclaration;
-            var optionalBlock = v[2];
+            var className = v[1];
+            var parameters = v[2] as ASTConstructorParametersDeclaration;
+            var optionalBlock = v[3];
             var block = optionalBlock is ASTBlock ? optionalBlock : null;
             return ASTClassConstructorDeclaration(
               ASTType(className),

--- a/lib/src/languages/java/java11/java11_generator.dart
+++ b/lib/src/languages/java/java11/java11_generator.dart
@@ -176,13 +176,18 @@ class ApolloCodeGeneratorJava11 extends ApolloCodeGenerator {
     return out;
   }
 
-  /// Generates a Java `enum` declaration.
+  /// Generates a Java `enum` declaration (simple or with members/constructor).
   StringBuffer generateASTClassEnum(
     ASTClassEnum clazz, {
     StringBuffer? out,
     String indent = '',
   }) {
     out ??= newOutput();
+
+    var hasMembers =
+        clazz.fields.isNotEmpty ||
+        clazz.constructors.isNotEmpty ||
+        clazz.functions.isNotEmpty;
 
     out.write(indent);
     out.write('enum ');
@@ -192,14 +197,57 @@ class ApolloCodeGeneratorJava11 extends ApolloCodeGenerator {
     var entries = clazz.entries;
     for (var i = 0; i < entries.length; ++i) {
       out.write('$indent  ');
-      out.write(entries[i].name);
-      if (i < entries.length - 1) out.write(',');
+      _generateEnumEntry(entries[i], out);
+      // Java requires a `;` after the constants when members follow.
+      if (i < entries.length - 1) {
+        out.write(',');
+      } else if (hasMembers) {
+        out.write(';');
+      }
       out.write('\n');
+    }
+
+    if (hasMembers) {
+      var indent2 = '$indent  ';
+
+      for (var field in clazz.fields) {
+        generateASTClassField(field, out: out, indent: indent2);
+      }
+
+      for (var constructor in clazz.constructors) {
+        for (var c in constructor.functions) {
+          generateASTClassConstructorDeclaration(c, out: out, indent: indent2);
+        }
+      }
+
+      for (var set in clazz.functions) {
+        for (var f in set.functions) {
+          if (f is ASTClassFunctionDeclaration) {
+            generateASTClassFunctionDeclaration(f, out: out, indent: indent2);
+          }
+        }
+      }
     }
 
     out.write('$indent}\n');
 
     return out;
+  }
+
+  /// Generates a single enum entry: a bare name or constructor arguments
+  /// (`EARTH(5.97, 6371)`).
+  void _generateEnumEntry(ASTEnumEntry entry, StringBuffer out) {
+    out.write(entry.name);
+
+    var arguments = entry.arguments;
+    if (arguments != null) {
+      out.write('(');
+      for (var i = 0; i < arguments.length; ++i) {
+        if (i > 0) out.write(', ');
+        generateASTExpression(arguments[i], out: out, headIndented: false);
+      }
+      out.write(')');
+    }
   }
 
   @override

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -63,6 +63,9 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
 
   Parser topLevelDefinition() => (enumDeclaration() | classDeclaration());
 
+  /// Java enum: `enum Name { A[(args)], B; members }`. After the constants an
+  /// optional `;` introduces class members (fields, a constructor, methods),
+  /// reusing the class-member parsing (rich/enhanced enum).
   Parser<ASTClassEnum> enumDeclaration() =>
       (string('enum') &
               ref0(identifierPartLexicalToken).not() &
@@ -71,6 +74,13 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
               enumEntry() &
               (char(',').trimHidden() & enumEntry()).star() &
               char(',').trimHidden().optional() &
+              (char(';').trimHidden() &
+                      (ref0(classConstructorDefaultDeclaration) |
+                              ref0(classFunctionDeclaration) |
+                              ref0(classFieldDeclaration) |
+                              ref0(classFieldDeclarationWithValue))
+                          .star())
+                  .optional() &
               char('}').trimHidden())
           .map((v) {
             var name = v[2] as String;
@@ -78,16 +88,50 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
             for (var e in (v[5] as List)) {
               entries.add(e[1] as ASTEnumEntry);
             }
-            return ASTClassEnum(
+
+            var enumClass = ASTClassEnum(
               name,
               ASTType<VMObject>(name),
               null,
               entries: entries,
             );
+
+            var membersOpt = v[7] as List?;
+            if (membersOpt != null) {
+              var members = membersOpt[1] as List;
+              enumClass.addAllFields(
+                members.whereType<ASTClassField>().toList(),
+              );
+              enumClass.addAllConstructors(
+                members.whereType<ASTClassConstructorDeclaration>().toList(),
+              );
+              enumClass.addAllFunctions(
+                members.whereType<ASTFunctionDeclaration>().toList(),
+              );
+            }
+
+            return enumClass;
           });
 
+  /// A Java enum entry: a bare name or with constructor arguments
+  /// (`EARTH(5.97, 6371)`).
   Parser<ASTEnumEntry> enumEntry() =>
-      identifier().trimHidden().map((v) => ASTEnumEntry(v));
+      (identifier().trimHidden() &
+              (char('(').trimHidden() &
+                      expressionSequence().optional() &
+                      char(')').trimHidden())
+                  .optional())
+          .map((v) {
+            var name = v[0] as String;
+            var argsOpt = v[1] as List?;
+            List<ASTExpression>? arguments;
+            if (argsOpt != null) {
+              arguments =
+                  (argsOpt[1] as List?)?.cast<ASTExpression>() ??
+                  <ASTExpression>[];
+            }
+            return ASTEnumEntry(name, arguments: arguments);
+          });
 
   /// Type-parameter names of the class currently being parsed (e.g. `T` in
   /// `class Wrapper<T>`). Used by [simpleType] to erase them to `dynamic`.

--- a/lib/src/languages/kotlin/kotlin_generator.dart
+++ b/lib/src/languages/kotlin/kotlin_generator.dart
@@ -174,7 +174,11 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
     return out;
   }
 
-  /// Generates a Kotlin `enum class` declaration.
+  /// Generates a Kotlin `enum class` declaration (simple or rich).
+  ///
+  /// Kotlin places the constructor parameters in the class header
+  /// (`enum class Planet(val mass: Double, ...)`); the enum constants then
+  /// pass their arguments, and any methods follow after a `;`.
   StringBuffer generateASTClassEnum(
     ASTClassEnum clazz, {
     StringBuffer? out,
@@ -182,22 +186,91 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
   }) {
     out ??= newOutput();
 
+    var fields = clazz.fields;
+    var constructors = clazz.constructors;
+    var functions = clazz.functions;
+
+    // Primary-constructor parameters (go in the enum class header).
+    var ctorParams = <ASTConstructorParameterDeclaration>[];
+    if (constructors.isNotEmpty) {
+      var c = constructors.first.functions.first;
+      ctorParams = c.parameters.positionalParameters ?? [];
+    }
+    var ctorParamNames = ctorParams.map((p) => p.name).toSet();
+
     out.write(indent);
     out.write('enum class ');
     out.write(clazz.name);
+
+    if (ctorParams.isNotEmpty) {
+      out.write('(');
+      for (var i = 0; i < ctorParams.length; ++i) {
+        var p = ctorParams[i];
+        if (i > 0) out.write(', ');
+        out.write('val ');
+        out.write(p.name);
+        out.write(': ');
+        generateASTType(p.type, out: out);
+      }
+      out.write(')');
+    }
+
     out.write(' {\n');
+
+    var indent2 = '$indent  ';
+
+    // Fields already declared as constructor params live in the header; any
+    // remaining fields stay as body properties.
+    var bodyFields = fields
+        .where((f) => !ctorParamNames.contains(f.name))
+        .toList();
+    var hasMembers = bodyFields.isNotEmpty || functions.isNotEmpty;
 
     var entries = clazz.entries;
     for (var i = 0; i < entries.length; ++i) {
       out.write('$indent  ');
-      out.write(entries[i].name);
-      if (i < entries.length - 1) out.write(',');
+      _generateEnumEntry(entries[i], out);
+      if (i < entries.length - 1) {
+        out.write(',');
+      } else if (hasMembers) {
+        out.write(';');
+      }
       out.write('\n');
+    }
+
+    if (hasMembers) {
+      for (var field in bodyFields) {
+        generateASTClassField(field, out: out, indent: indent2);
+      }
+
+      for (var set in functions) {
+        for (var f in set.functions) {
+          if (f is ASTClassFunctionDeclaration) {
+            generateASTClassFunctionDeclaration(f, out: out, indent: indent2);
+          }
+        }
+      }
     }
 
     out.write('$indent}\n');
 
     return out;
+  }
+
+  /// Generates a single enum entry: a bare name or constructor arguments
+  /// (`EARTH(5.97, 6371)`).
+  void _generateEnumEntry(ASTEnumEntry entry, StringBuffer out) {
+    out.write(entry.name);
+
+    var arguments = entry.arguments;
+    if (arguments != null) {
+      out.write('(');
+      for (var i = 0; i < arguments.length; ++i) {
+        if (i > 0) out.write(', ');
+        generateASTExpression(arguments[i], out: out, headIndented: false);
+      }
+      out.write(')');
+    }
   }
 
   @override

--- a/lib/src/languages/kotlin/kotlin_grammar.dart
+++ b/lib/src/languages/kotlin/kotlin_grammar.dart
@@ -108,33 +108,142 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
               statementVariableDeclaration())
           .plus();
 
-  /// Kotlin `enum class Name { A, B, C }`.
+  /// Kotlin enum class:
+  /// `enum class Name[(val p: T, ...)] { A[(args)], B; members }`.
+  ///
+  /// The optional header parameters declare both the enum's fields and a
+  /// `this.`-binding constructor (auto-assigning the fields); the optional
+  /// `;` + members section adds extra fields/methods (rich/enhanced enum).
   Parser<ASTClassEnum> enumDeclaration() =>
       (string('enum') &
               ref0(identifierPartLexicalToken).not() &
               classToken().trimHidden() &
               identifier().trimHidden() &
+              enumHeaderParameters().optional() &
               char('{').trimHidden() &
               enumEntry() &
               (char(',').trimHidden() & enumEntry()).star() &
               char(',').trimHidden().optional() &
+              (char(';').trimHidden() &
+                      (ref0(classFunctionDeclaration) |
+                              ref0(classFieldDeclaration))
+                          .star())
+                  .optional() &
               char('}').trimHidden())
           .map((v) {
             var name = v[3] as String;
-            var entries = <ASTEnumEntry>[v[5] as ASTEnumEntry];
-            for (var e in (v[6] as List)) {
+            var headerParams =
+                (v[4]
+                    as List<({String name, ASTType type, bool finalValue})>?) ??
+                const <({String name, ASTType type, bool finalValue})>[];
+
+            var entries = <ASTEnumEntry>[v[6] as ASTEnumEntry];
+            for (var e in (v[7] as List)) {
               entries.add(e[1] as ASTEnumEntry);
             }
-            return ASTClassEnum(
+
+            var enumClass = ASTClassEnum(
               name,
               ASTType<VMObject>(name),
               null,
               entries: entries,
             );
+
+            if (headerParams.isNotEmpty) {
+              enumClass.addAllFields(
+                headerParams.map(
+                  (p) => ASTClassField(p.type, p.name, p.finalValue),
+                ),
+              );
+              var ctorParams = <ASTConstructorParameterDeclaration>[
+                for (var p in headerParams)
+                  ASTConstructorParameterDeclaration(
+                    p.type,
+                    p.name,
+                    -1,
+                    false,
+                    thisParameter: true,
+                  ),
+              ];
+              enumClass.addConstructor(
+                ASTClassConstructorDeclaration(
+                  ASTType<VMObject>(name),
+                  '',
+                  ASTConstructorParametersDeclaration(ctorParams, null, null),
+                ),
+              );
+            }
+
+            var membersOpt = v[9] as List?;
+            if (membersOpt != null) {
+              var members = membersOpt[1] as List;
+              enumClass.addAllFields(
+                members.whereType<ASTClassField>().toList(),
+              );
+              enumClass.addAllConstructors(
+                members.whereType<ASTClassConstructorDeclaration>().toList(),
+              );
+              enumClass.addAllFunctions(
+                members.whereType<ASTFunctionDeclaration>().toList(),
+              );
+            }
+
+            return enumClass;
           });
 
+  /// Kotlin enum class header parameters: `(val mass: Double, val radius: ...)`.
+  Parser<List<({String name, ASTType type, bool finalValue})>>
+  enumHeaderParameters() =>
+      (char('(').trimHidden() &
+              enumHeaderParameter() &
+              (char(',').trimHidden() & enumHeaderParameter()).star() &
+              char(',').trimHidden().optional() &
+              char(')').trimHidden())
+          .map((v) {
+            var list = <({String name, ASTType type, bool finalValue})>[
+              v[1] as ({String name, ASTType type, bool finalValue}),
+            ];
+            for (var e in (v[2] as List)) {
+              list.add(
+                (e as List)[1]
+                    as ({String name, ASTType type, bool finalValue}),
+              );
+            }
+            return list;
+          });
+
+  Parser<({String name, ASTType type, bool finalValue})>
+  enumHeaderParameter() =>
+      ((valToken() | varToken()).trimHidden() &
+              identifier().trimHidden() &
+              char(':').trimHidden() &
+              type())
+          .map((v) {
+            var finalValue = (v[0] as Token).value == 'val';
+            var name = v[1] as String;
+            var type = v[3] as ASTType;
+            return (name: name, type: type, finalValue: finalValue);
+          });
+
+  /// A Kotlin enum entry: a bare name or with constructor arguments
+  /// (`EARTH(5.97, 6371)`).
   Parser<ASTEnumEntry> enumEntry() =>
-      identifier().trimHidden().map((v) => ASTEnumEntry(v));
+      (identifier().trimHidden() &
+              (char('(').trimHidden() &
+                      expressionSequence().optional() &
+                      char(')').trimHidden())
+                  .optional())
+          .map((v) {
+            var name = v[0] as String;
+            var argsOpt = v[1] as List?;
+            List<ASTExpression>? arguments;
+            if (argsOpt != null) {
+              arguments =
+                  (argsOpt[1] as List?)?.cast<ASTExpression>() ??
+                  <ASTExpression>[];
+            }
+            return ASTEnumEntry(name, arguments: arguments);
+          });
 
   Parser<ASTFunctionDeclaration> functionDeclaration() =>
       (funToken().trimHidden() &

--- a/lib/src/languages/python/python_generator.dart
+++ b/lib/src/languages/python/python_generator.dart
@@ -346,14 +346,32 @@ class ApolloCodeGeneratorPython extends ApolloCodeGenerator {
     return out;
   }
 
+  /// Returns `true` if [clazz] is a rich/enhanced enum (entries with
+  /// constructor arguments, or declared fields/constructors/methods). A rich
+  /// enum can't map to a `Enum` subclass with plain members, so it's emitted as
+  /// a plain class with class-level singleton instances.
+  bool _isRichEnum(ASTClassEnum clazz) =>
+      clazz.entries.any((e) => e.arguments != null) ||
+      clazz.fields.isNotEmpty ||
+      clazz.constructors.isNotEmpty ||
+      clazz.functions.isNotEmpty;
+
   /// Generates a Python enum: `class Name(Enum):` with `NAME = value` members.
   /// Members without an explicit value get their ordinal index.
+  ///
+  /// A rich/enhanced enum is emitted as a plain class with an `__init__` and
+  /// class-level singleton instances assigned after the class (see
+  /// [_isRichEnum]).
   StringBuffer generateASTClassEnum(
     ASTClassEnum clazz, {
     StringBuffer? out,
     String indent = '',
   }) {
     out ??= newOutput();
+
+    if (_isRichEnum(clazz)) {
+      return _generateRichEnumPython(clazz, out, indent);
+    }
 
     out.write(indent);
     out.write('class ');
@@ -378,6 +396,91 @@ class ApolloCodeGeneratorPython extends ApolloCodeGenerator {
       }
       out.write('\n');
     }
+    out.write('\n');
+
+    return out;
+  }
+
+  /// Emits a rich/enhanced enum as a plain Python class: an `__init__` that
+  /// assigns the declared fields, the methods, and class-level singleton
+  /// instances assigned after the class body (so the type already exists),
+  /// plus a `values` list.
+  StringBuffer _generateRichEnumPython(
+    ASTClassEnum clazz,
+    StringBuffer out,
+    String indent,
+  ) {
+    var bodyIndent = '$indent$_tab';
+    var name = clazz.name;
+
+    out.write(indent);
+    out.write('class ');
+    out.write(name);
+    out.write(':\n');
+
+    var before = out.length;
+
+    // __init__ from the enum constructor (assigns the declared fields).
+    var ctor = clazz.constructors.isNotEmpty
+        ? clazz.constructors.first.firstFunction
+        : null;
+    if (ctor != null) {
+      var params = ctor.parameters.allParameters;
+      out.write(bodyIndent);
+      out.write('def __init__(self');
+      for (var p in params) {
+        out.write(', ');
+        out.write(p.name);
+      }
+      out.write('):\n');
+      var assigned = false;
+      for (var p in params) {
+        if (p.thisParameter) {
+          out.write('$bodyIndent${_tab}self.${p.name} = ${p.name}\n');
+          assigned = true;
+        }
+      }
+      if (!assigned) {
+        out.write('$bodyIndent${_tab}pass\n');
+      }
+      out.write('\n');
+    }
+
+    // Methods.
+    for (var set in clazz.functions) {
+      for (var f in set.functions) {
+        _generateFunction(f, out: out, indent: bodyIndent, isMethod: true);
+      }
+    }
+
+    if (out.length == before) {
+      out.write(bodyIndent);
+      out.write('pass\n');
+    }
+
+    out.write('\n');
+
+    // Class-level singleton instances, assigned after the class so the type
+    // already exists when constructing them.
+    for (var e in clazz.entries) {
+      out.write(indent);
+      out.write('$name.${e.name} = $name(');
+      var args = e.arguments;
+      if (args != null) {
+        for (var i = 0; i < args.length; ++i) {
+          if (i > 0) out.write(', ');
+          generateASTExpression(args[i], out: out, headIndented: false);
+        }
+      }
+      out.write(')\n');
+    }
+
+    // Values list.
+    out.write(indent);
+    out.write('$name.values = [');
+    out.write(clazz.entries.map((e) => '$name.${e.name}').join(', '));
+    out.write(']\n');
+
     out.write('\n');
 
     return out;

--- a/lib/src/languages/python/python_grammar.dart
+++ b/lib/src/languages/python/python_grammar.dart
@@ -127,7 +127,9 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
               char('=').trimHidden() &
               ref0(expression) &
               newlineToken())
-          .map((v) => ASTEnumEntry(v[0] as String, value: v[2] as ASTExpression));
+          .map(
+            (v) => ASTEnumEntry(v[0] as String, value: v[2] as ASTExpression),
+          );
 
   // ---------------------------------------------------------------------------
   // Imports: `import x [as y]` and `from x import y`.

--- a/lib/src/languages/python/python_grammar.dart
+++ b/lib/src/languages/python/python_grammar.dart
@@ -127,7 +127,7 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
               char('=').trimHidden() &
               ref0(expression) &
               newlineToken())
-          .map((v) => ASTEnumEntry(v[0] as String, v[2] as ASTExpression));
+          .map((v) => ASTEnumEntry(v[0] as String, value: v[2] as ASTExpression));
 
   // ---------------------------------------------------------------------------
   // Imports: `import x [as y]` and `from x import y`.

--- a/lib/src/languages/typescript/ts/typescript_generator.dart
+++ b/lib/src/languages/typescript/ts/typescript_generator.dart
@@ -160,13 +160,30 @@ class ApolloCodeGeneratorTypeScript extends ApolloCodeGenerator {
     return out;
   }
 
+  /// Returns `true` if [clazz] is a rich/enhanced enum (entries with
+  /// constructor arguments, or declared fields/constructors/methods). A rich
+  /// enum can't map to a native TypeScript `enum`, so it's emitted as a class
+  /// with static-readonly singleton instances.
+  bool _isRichEnum(ASTClassEnum clazz) =>
+      clazz.entries.any((e) => e.arguments != null) ||
+      clazz.fields.isNotEmpty ||
+      clazz.constructors.isNotEmpty ||
+      clazz.functions.isNotEmpty;
+
   /// Generates a TypeScript `enum` declaration.
+  ///
+  /// A rich/enhanced enum is emitted as a class with a constructor and one
+  /// `static readonly` singleton instance per entry (see [_isRichEnum]).
   StringBuffer generateASTClassEnum(
     ASTClassEnum clazz, {
     StringBuffer? out,
     String indent = '',
   }) {
     out ??= newOutput();
+
+    if (_isRichEnum(clazz)) {
+      return _generateRichEnumTypeScript(clazz, out, indent);
+    }
 
     out.write(indent);
     out.write('enum ');
@@ -185,6 +202,105 @@ class ApolloCodeGeneratorTypeScript extends ApolloCodeGenerator {
       if (i < entries.length - 1) out.write(',');
       out.write('\n');
     }
+
+    out.write('$indent}\n');
+
+    return out;
+  }
+
+  /// Emits a rich/enhanced enum as a TypeScript class: a constructor using
+  /// parameter properties for the declared fields, the methods, one
+  /// `static readonly` singleton per entry (constructed with its arguments)
+  /// and a `values` array.
+  StringBuffer _generateRichEnumTypeScript(
+    ASTClassEnum clazz,
+    StringBuffer out,
+    String indent,
+  ) {
+    var i2 = '$indent  ';
+    var name = clazz.name;
+
+    out.write(indent);
+    out.write('class ');
+    out.write(name);
+    out.write(' {\n');
+
+    // Constructor — parameter properties declare and assign the fields.
+    var ctor = clazz.constructors.isNotEmpty
+        ? clazz.constructors.first.firstFunction
+        : null;
+
+    // Names of the fields covered by the constructor's `this.` parameters.
+    var ctorFieldNames = <String>{};
+
+    if (ctor != null) {
+      var params = ctor.parameters.allParameters;
+      out.write(i2);
+      out.write('constructor(');
+      for (var i = 0; i < params.length; ++i) {
+        var p = params[i];
+        if (i > 0) out.write(', ');
+        if (p.thisParameter) {
+          ctorFieldNames.add(p.name);
+          var field = clazz.getField(p.name);
+          out.write(
+            (field != null && field.finalValue)
+                ? 'public readonly '
+                : 'public ',
+          );
+        }
+        out.write(p.name);
+        _writeTypeAnnotation(p.type, out);
+      }
+      out.write(') {}\n\n');
+    }
+
+    // Fields not declared via constructor parameter properties.
+    for (var field in clazz.fields) {
+      if (ctorFieldNames.contains(field.name)) continue;
+      out.write(i2);
+      if (field.modifiers.isStatic) out.write('static ');
+      if (field.finalValue) out.write('readonly ');
+      out.write(field.name);
+      _writeTypeAnnotation(field.type, out);
+      if (field is ASTClassFieldWithInitialValue) {
+        out.write(' = ');
+        generateASTExpression(
+          field.initialValue,
+          out: out,
+          headIndented: false,
+        );
+      }
+      out.write(';\n');
+    }
+
+    // Methods.
+    for (var set in clazz.functions) {
+      for (var f in set.functions) {
+        if (f is! ASTClassFunctionDeclaration) continue;
+        generateASTClassFunctionDeclaration(f, out: out, indent: i2);
+      }
+    }
+
+    // Static singleton instances (one per entry).
+    for (var e in clazz.entries) {
+      out.write(i2);
+      out.write('static readonly ${e.name} = new $name(');
+      var args = e.arguments;
+      if (args != null) {
+        for (var i = 0; i < args.length; ++i) {
+          if (i > 0) out.write(', ');
+          generateASTExpression(args[i], out: out, headIndented: false);
+        }
+      }
+      out.write(');\n');
+    }
+
+    // Values array.
+    out.write(i2);
+    out.write('static readonly values = [');
+    out.write(clazz.entries.map((e) => '$name.${e.name}').join(', '));
+    out.write('];\n');
 
     out.write('$indent}\n');
 

--- a/lib/src/languages/typescript/ts/typescript_grammar.dart
+++ b/lib/src/languages/typescript/ts/typescript_grammar.dart
@@ -340,7 +340,7 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
             var name = v[0] as String;
             var valueOpt = v[1] as List?;
             var value = valueOpt != null ? valueOpt[1] as ASTExpression : null;
-            return ASTEnumEntry(name, value);
+            return ASTEnumEntry(name, value: value);
           });
 
   Parser<ASTBlock> classCodeBlock() =>

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -172,6 +172,22 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       types[field.name] = field.type;
       offset += _elemSize(field.type);
     }
+    // An enum entry is a `const` instance carrying two synthetic fields seeded
+    // at build time: `index` (the ordinal, an `int` -> i64/8B) and `name` (a
+    // `String` -> i32 ptr/4B). Append them after the declared fields so an entry
+    // instance has slots for them (loaded through the regular field-load path).
+    if (clazz is ASTClassEnum) {
+      if (!offsets.containsKey('index')) {
+        offsets['index'] = offset;
+        types['index'] = _astTypeInt64;
+        offset += _elemSize(_astTypeInt64);
+      }
+      if (!offsets.containsKey('name')) {
+        offsets['name'] = offset;
+        types['name'] = _astTypeString;
+        offset += _elemSize(_astTypeString);
+      }
+    }
     return WasmClassLayout(clazz.name, offsets, types, offset);
   }
 
@@ -954,26 +970,52 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   }) {
     out ??= newOutput();
 
-    // One mutable i32 global: the heap pointer `$hp`, initialized to heapStart.
-    var entry = BytesOutput(
-      data: [
+    // Global 0 (mutable i32): the heap pointer `$hp`, initialized to heapStart.
+    var entries = <BytesOutput>[
+      BytesOutput(
+        data: [
+          BytesOutput(
+            data: WasmType.i32Type.value,
+            description: "Global type(i32)",
+          ),
+          BytesOutput(data: Wasm.globalMutable, description: "Mutable"),
+          BytesOutput(
+            data: [...Wasm32.i32Const(module.heapStart), Wasm.end],
+            description: "Init (i32.const ${module.heapStart})",
+          ),
+        ],
+        description: "Global \$hp",
+      ),
+    ];
+
+    // Globals 1..N (mutable i32, init 0): one per enum entry, caching its
+    // lazily-built `const` instance pointer (0 = not yet built).
+    for (var i = 0; i < module.enumEntryGlobalCount; ++i) {
+      entries.add(
         BytesOutput(
-          data: WasmType.i32Type.value,
-          description: "Global type(i32)",
+          data: [
+            BytesOutput(
+              data: WasmType.i32Type.value,
+              description: "Global type(i32)",
+            ),
+            BytesOutput(data: Wasm.globalMutable, description: "Mutable"),
+            BytesOutput(
+              data: [...Wasm32.i32Const(0), Wasm.end],
+              description: "Init (i32.const 0)",
+            ),
+          ],
+          description: "Enum entry cache global #${i + 1}",
         ),
-        BytesOutput(data: Wasm.globalMutable, description: "Mutable"),
-        BytesOutput(
-          data: [...Wasm32.i32Const(module.heapStart), Wasm.end],
-          description: "Init (i32.const ${module.heapStart})",
-        ),
-      ],
-      description: "Global \$hp",
-    );
+      );
+    }
 
     out.writeByte(Wasm.sectionGlobal, description: "Section Global ID");
     out.writeBytesLeb128Block([
-      BytesOutput(data: Leb128.encodeUnsigned(1), description: "Globals count"),
-      entry,
+      BytesOutput(
+        data: Leb128.encodeUnsigned(entries.length),
+        description: "Globals count",
+      ),
+      ...entries,
     ], description: "Globals");
 
     return out;
@@ -4133,6 +4175,21 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     var name = expression.name;
     var varName = expression.variable.name;
+
+    // `EnumName.entry`: the receiver names an enum class (not a local variable),
+    // so resolve it to the entry's cached `const` instance pointer (built and
+    // cached lazily on first access). The subsequent `.index`/`.name`/declared
+    // field load and method dispatch then flow through the normal instance
+    // machinery, since the result has the enum's class layout.
+    var enumPtr = _tryGenerateEnumEntryAccess(
+      expression,
+      varName,
+      name,
+      out: out,
+      context: context,
+    );
+    if (enumPtr != null) return enumPtr;
+
     var localVar = _getLocalVariable(context, varName);
 
     var listType = localVar.type;
@@ -4220,6 +4277,191 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     throw UnimplementedError(
       "Wasm getter `.$name` on ${localVar.type} is not supported yet.",
     );
+  }
+
+  /// If the receiver [varName] of `EnumName.member` names an `ASTClassEnum`,
+  /// emits the value of that static access and returns [out]; otherwise returns
+  /// `null` (the caller falls back to the local-variable getter path).
+  ///
+  /// - `EnumName.entry` -> the entry's cached `const` instance pointer (i32),
+  ///   built lazily by a synthesized per-entry init function.
+  /// - `EnumName.values` -> a freshly materialized list of all entry pointers.
+  BytesOutput? _tryGenerateEnumEntryAccess(
+    ASTExpressionObjectGetterAccess expression,
+    String varName,
+    String name, {
+    required BytesOutput out,
+    required WasmContext context,
+  }) {
+    var node = expression.getNodeIdentifier(varName);
+    if (node is! ASTClassEnum) return null;
+    var enumClass = node;
+    var module = context.module;
+    if (module == null) return null;
+
+    if (name == 'values') {
+      return _generateEnumValues(enumClass, out: out, context: context);
+    }
+
+    var entryIndex = enumClass.entries.indexWhere((e) => e.name == name);
+    if (entryIndex < 0) return null; // a static member, not an enum entry
+
+    var initIndex = _ensureEnumEntryInitFunction(enumClass, entryIndex, module);
+    out.write(
+      Wasm.call(initIndex),
+      description: "[OP] enum `${enumClass.name}.$name` instance",
+    );
+    context.stackPush(enumClass.type, "enum `${enumClass.name}.$name`");
+    return out;
+  }
+
+  /// Emits `EnumName.values`: a fresh list (the regular list layout
+  /// `[len][cap][dataPtr]`) of the i32 entry-instance pointers, so
+  /// `for (var e in EnumName.values)` works through the normal list for-each.
+  BytesOutput _generateEnumValues(
+    ASTClassEnum enumClass, {
+    required BytesOutput out,
+    required WasmContext context,
+  }) {
+    var module = context.module!;
+    module.requiresMemory = true;
+    module.requiresHeapGlobal = true;
+    module.ensureAllocFunction();
+
+    var n = enumClass.entries.length;
+    const elemSize = 4; // each element is an i32 instance pointer
+
+    var hdrLocal = context.scratchLocal(_astTypeString, 30);
+    var dataLocal = context.scratchLocal(_astTypeString, 31);
+
+    // header = alloc(12) ; data = alloc(n*4)
+    out.write(Wasm32.i32Const(12));
+    _emitInlineAlloc(out, context);
+    out.write(Wasm.localSet(hdrLocal));
+    out.write(Wasm32.i32Const(n * elemSize));
+    _emitInlineAlloc(out, context);
+    out.write(Wasm.localSet(dataLocal));
+
+    // header[0]=length ; header[4]=capacity ; header[8]=dataPtr
+    out.write(Wasm.localGet(hdrLocal));
+    out.write(Wasm32.i32Const(n));
+    out.write(Wasm32.i32Store(2, 0));
+    out.write(Wasm.localGet(hdrLocal));
+    out.write(Wasm32.i32Const(n));
+    out.write(Wasm32.i32Store(2, 4));
+    out.write(Wasm.localGet(hdrLocal));
+    out.write(Wasm.localGet(dataLocal));
+    out.write(Wasm32.i32Store(2, 8));
+
+    // data[i] = <entry i instance pointer>
+    for (var i = 0; i < n; ++i) {
+      var initIndex = _ensureEnumEntryInitFunction(enumClass, i, module);
+      out.write(Wasm.localGet(dataLocal));
+      out.write(Wasm.call(initIndex));
+      out.write(Wasm32.i32Store(2, i * elemSize));
+    }
+
+    out.write(Wasm.localGet(hdrLocal));
+    context.stackPush(
+      ASTTypeArray(enumClass.type),
+      "enum `${enumClass.name}.values`",
+    );
+    return out;
+  }
+
+  /// Registers (once) a synthesized `() -> i32` function that lazily builds and
+  /// caches the `const` instance for enum [enumClass]'s entry at [entryIndex],
+  /// returning the Wasm function index to `call`.
+  ///
+  /// The instance is built by invoking the enum's constructor (the rich entry's
+  /// arguments, or the implicit zero-arg constructor for a simple entry), then
+  /// seeding the synthetic `index` (ordinal i64) and `name` (interned String
+  /// ptr) slots, and caching the pointer in a per-entry i32 global so repeated
+  /// access (and `==` identity) sees the one singleton.
+  int _ensureEnumEntryInitFunction(
+    ASTClassEnum enumClass,
+    int entryIndex,
+    WasmModuleContext module,
+  ) {
+    var entry = enumClass.entries[entryIndex];
+    var synthName = '__enum_${enumClass.name}_${entry.name}';
+    var existing = module.synthFunctionIndex(synthName);
+    if (existing != null) return existing;
+
+    module.requiresMemory = true;
+    module.requiresHeapGlobal = true;
+    module.ensureAllocFunction();
+
+    var layout = module.classLayouts[enumClass.name]!;
+    var globalIndex = module.enumEntryGlobalIndex(synthName);
+    var namePtr = module.internStringLiteral(entry.name);
+
+    // Build the body with a fresh context so the constructor invocation reuses
+    // the full argument-evaluation / type-conversion machinery.
+    var context = WasmContext(module: module);
+    var instLocal = context.scratchLocal(_astTypeString, 0); // i32 ptr
+
+    var body = newOutput();
+
+    // if (global == 0) { build + cache }
+    body.write(Wasm.globalGet(globalIndex));
+    body.writeByte(Wasm32.i32EqualsToZero);
+    body.write(Wasm.ifInstruction(WasmType.voidType));
+
+    // instance = EnumName(<entry args>)  (the constructor allocates + inits).
+    var args = entry.arguments ?? const <ASTExpression>[];
+    var invocation = ASTExpressionLocalFunctionInvocation(
+      enumClass.name,
+      args.toList(),
+    );
+    generateASTExpressionLocalFunctionInvocation(
+      invocation,
+      out: body,
+      context: context,
+    );
+    context.stackDrop(); // consumed by the local.set below
+    body.write(Wasm.localSet(instLocal));
+
+    // instance.index = ordinal (i64)
+    body.write(Wasm.localGet(instLocal));
+    body.write(Wasm64.i64Const(entryIndex));
+    _emitElemStore(body, _astTypeInt64, layout.offsets['index']!);
+
+    // instance.name = interned String ptr (i32)
+    body.write(Wasm.localGet(instLocal));
+    body.write(Wasm32.i32Const(namePtr));
+    _emitElemStore(body, _astTypeString, layout.offsets['name']!);
+
+    // global = instance
+    body.write(Wasm.localGet(instLocal));
+    body.write(Wasm.globalSet(globalIndex));
+    body.writeByte(Wasm.end); // if
+
+    // return global
+    body.write(Wasm.globalGet(globalIndex));
+
+    // Function body: local declarations (scratch locals) + ops + end.
+    var outBody = newOutput();
+    var scratchTypes = context.scratchLocalTypes;
+    outBody.write(
+      Leb128.encodeUnsigned(scratchTypes.length),
+      description: "Local groups (enum init `$synthName`)",
+    );
+    for (var astType in scratchTypes) {
+      outBody.write(Leb128.encodeUnsigned(1), description: "Scratch var count");
+      outBody.writeByte(
+        astType.wasmCode,
+        description: "Scratch (${astType.wasmType.name})",
+      );
+    }
+    outBody.writeBytes(body);
+    outBody.writeByte(Wasm.end, description: "Enum init body end");
+
+    module.addSynthFunction(
+      WasmSynthFunction(synthName, const [], const [WasmType.i32Type], outBody),
+    );
+
+    return module.synthFunctionIndex(synthName)!;
   }
 
   /// Allocates a heap cell ("box") for each captured variable of [f] so it can
@@ -8846,6 +9088,35 @@ class WasmModuleContext {
 
   final List<WasmSynthFunction> synthFunctions = [];
   final Set<String> _synthNames = {};
+
+  /// Registers a pre-built synthesized function (e.g. an enum entry initializer).
+  void addSynthFunction(WasmSynthFunction f) {
+    if (_synthNames.contains(f.name)) return;
+    synthFunctions.add(f);
+    _synthNames.add(f.name);
+  }
+
+  // --- Enum entry caches (one mutable i32 global per enum entry) ---
+
+  /// Per-entry global keys (in registration order). Each holds the i32 pointer
+  /// of a cached enum entry `const` instance (0 = not yet built). Placed after
+  /// the heap-pointer global `$hp` (index 0), so a key's global index is
+  /// `1 + its position` here.
+  final List<String> _enumEntryGlobals = [];
+
+  /// Number of enum-entry cache globals (emitted after `$hp`).
+  int get enumEntryGlobalCount => _enumEntryGlobals.length;
+
+  /// Registers (or reuses) the cache global for enum-entry [key], returning its
+  /// Wasm global index.
+  int enumEntryGlobalIndex(String key) {
+    var i = _enumEntryGlobals.indexOf(key);
+    if (i >= 0) return 1 + i;
+    _enumEntryGlobals.add(key);
+    requiresMemory = true;
+    requiresHeapGlobal = true; // ensures the Global section is emitted
+    return _enumEntryGlobals.length; // 1 + (length-1)
+  }
 
   /// Ensures the exported `__alloc(i32 size) -> i32 ptr` bump-allocator function
   /// exists. Exported so the host can allocate strings in module memory.

--- a/test/apollovm_enum_test.dart
+++ b/test/apollovm_enum_test.dart
@@ -1,0 +1,134 @@
+@Tags(['dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Runs the top-level `run()` of [src] and returns its value.
+Future<Object?> _run(String src) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', src, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source");
+  var res = await vm.createRunner('dart')!.executeFunction('', 'run');
+  return res.getValueNoContext();
+}
+
+void main() {
+  group('Simple enum (entries are const instances)', () {
+    const head = 'enum Color { red, green, blue }\n';
+
+    test('.index is the ordinal', () async {
+      expect(
+        await _run('${head}int run() { var c = Color.blue; return c.index; }'),
+        equals(2),
+      );
+    });
+
+    test('.name is the entry name', () async {
+      expect(
+        await _run(
+          '${head}String run() { var c = Color.green; return c.name; }',
+        ),
+        equals('green'),
+      );
+    });
+
+    test('entries are identity-equal singletons', () async {
+      expect(
+        await _run('${head}bool run() { return Color.red == Color.red; }'),
+        isTrue,
+      );
+      expect(
+        await _run('${head}bool run() { return Color.red == Color.blue; }'),
+        isFalse,
+      );
+    });
+
+    test('.values lists all entries in order', () async {
+      expect(
+        await _run(
+          '${head}String run() { var s = ""; '
+          'for (var c in Color.values) { s = s + c.name; } return s; }',
+        ),
+        equals('redgreenblue'),
+      );
+    });
+  });
+
+  group('Rich/enhanced enum (constructor, fields, methods)', () {
+    const planet = '''
+enum Planet {
+  earth(5.97, 6371), mars(0.642, 3389);
+  final double mass;
+  final double radius;
+  const Planet(this.mass, this.radius);
+  double gravity() { return mass / (radius * radius); }
+}
+''';
+
+    test('entry constructor arg becomes a field', () async {
+      expect(
+        await _run(
+          '${planet}double run() { var e = Planet.earth; return e.mass; }',
+        ),
+        closeTo(5.97, 1e-9),
+      );
+      expect(
+        await _run(
+          '${planet}double run() { var m = Planet.mars; return m.radius; }',
+        ),
+        closeTo(3389, 1e-9),
+      );
+    });
+
+    test('method call on an entry (direct chain)', () async {
+      var g = await _run(
+        '${planet}double run() { return Planet.earth.gravity(); }',
+      );
+      expect(g as double, closeTo(5.97 / (6371 * 6371), 1e-15));
+    });
+
+    test('.index / .name on a rich entry', () async {
+      expect(
+        await _run(
+          '${planet}int run() { var m = Planet.mars; return m.index; }',
+        ),
+        equals(1),
+      );
+      expect(
+        await _run(
+          '${planet}String run() { var e = Planet.earth; return e.name; }',
+        ),
+        equals('earth'),
+      );
+    });
+
+    test('rich entries are identity-equal', () async {
+      expect(
+        await _run(
+          '${planet}bool run() { return Planet.earth == Planet.earth; }',
+        ),
+        isTrue,
+      );
+    });
+  });
+
+  group('Explicit-value enum (`= N`)', () {
+    const head = 'enum Level { Low = 1, Medium = 5, High = 10 }\n';
+
+    test('.value exposes the explicit value; .index is the ordinal', () async {
+      expect(
+        await _run(
+          '${head}int run() { var m = Level.Medium; return m.value; }',
+        ),
+        equals(5),
+      );
+      expect(
+        await _run(
+          '${head}int run() { var m = Level.Medium; return m.index; }',
+        ),
+        equals(1),
+      );
+    });
+  });
+}

--- a/test/apollovm_wasm_enum_test.dart
+++ b/test/apollovm_wasm_enum_test.dart
@@ -1,0 +1,103 @@
+@Tags(['wasm', 'dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Compiles [src] (Dart) to Wasm and runs `Main.run` on BOTH the AST
+/// interpreter and the compiled Wasm module, asserting both produce
+/// [expected]. Enum entries are `const` instances, so this exercises enum
+/// instances (entry access, `.index`/`.name`, fields, methods) under Wasm.
+Future<void> _bothEqual(String src, Object? expected) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', src, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source");
+
+  var astRes = await vm
+      .createRunner('dart')!
+      .executeClassMethod('', 'Main', 'run');
+  expect(astRes.getValueNoContext(), expected, reason: 'interpreter');
+
+  var storage = vm.generateAllIn<BytesOutput>('wasm');
+  var modules = await storage.allEntries();
+  BytesOutput? compiled;
+  for (var ns in modules.entries) {
+    for (var m in ns.value.entries) {
+      compiled ??= m.value;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var vmWasm = ApolloVM();
+  await vmWasm.loadCodeUnit(
+    BinaryCodeUnit('wasm', compiled!.output(), id: 'test.wasm', namespace: ''),
+  );
+  var wasmRes = await vmWasm
+      .createRunner('wasm')!
+      .executeFunction('', 'Main.run');
+  expect(wasmRes.getValueNoContext(), expected, reason: 'Wasm');
+}
+
+void main() {
+  group('Wasm: enum entries as const instances', () {
+    const color = 'enum Color { red, green, blue }\n';
+
+    test('entry .index (ordinal)', () async {
+      await _bothEqual(
+        '${color}class Main { static int run() { var c = Color.blue; return c.index; } }',
+        2,
+      );
+    });
+
+    test('entry .name', () async {
+      await _bothEqual(
+        '${color}class Main { static String run() { var c = Color.green; return c.name; } }',
+        'green',
+      );
+    });
+
+    test('Color.values length (for-in)', () async {
+      await _bothEqual(
+        '${color}class Main { static int run() { var n = 0; '
+        'for (var c in Color.values) { n = n + 1; } return n; } }',
+        3,
+      );
+    });
+  });
+
+  group('Wasm: rich enum (constructor args, fields, methods)', () {
+    const planet = '''
+enum Planet {
+  earth(5.97, 6371), mars(0.642, 3389);
+  final double mass;
+  final double radius;
+  const Planet(this.mass, this.radius);
+  double gravity() { return mass / (radius * radius); }
+}
+''';
+
+    test('entry field from a constructor arg', () async {
+      await _bothEqual(
+        '${planet}class Main { static double run() { var e = Planet.earth; return e.mass; } }',
+        5.97,
+      );
+    });
+
+    test('method call on an entry', () async {
+      // Note: the Wasm backend resolves an enum-entry access but does not yet
+      // chain a method call directly on it (`Planet.earth.gravity()`); bind the
+      // entry to a variable first. The interpreter handles either form.
+      await _bothEqual(
+        '${planet}class Main { static double run() { var e = Planet.earth; return e.gravity(); } }',
+        5.97 / (6371 * 6371),
+      );
+    });
+
+    test('rich entry .index', () async {
+      await _bothEqual(
+        '${planet}class Main { static int run() { var m = Planet.mars; return m.index; } }',
+        1,
+      );
+    });
+  });
+}

--- a/test/tests_definitions/csharp_enum_value_access.test.xml
+++ b/test/tests_definitions/csharp_enum_value_access.test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<test title="C# enum value access (explicit values)">
+<test title="C# enum value access (explicit values via .value)">
     <source language="csharp">
         <![CDATA[
 enum Level {
@@ -10,8 +10,9 @@ enum Level {
 
 class C {
   static int run(){
-    int x = Level.Medium;
-    return x + Level.High;
+    Level m = Level.Medium;
+    Level h = Level.High;
+    return m.value + h.value;
   }
 }
         ]]>
@@ -33,8 +34,9 @@ enum Level {
 class C {
 
   static int run() {
-    int x = Level.Medium;
-    return x + Level.High;
+    Level m = Level.Medium;
+    Level h = Level.High;
+    return m.value + h.value;
   }
 
 }

--- a/test/tests_definitions/dart_enum_value_access.test.xml
+++ b/test/tests_definitions/dart_enum_value_access.test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<test title="Dart enum value access (ordinal)">
+<test title="Dart enum value access (ordinal via .index)">
     <source language="dart">
         <![CDATA[
 enum Color {
@@ -9,11 +9,11 @@ enum Color {
 }
 
 int run() {
-  int a = Color.red;
-  int b = Color.green;
-  int c = Color.blue;
-  int total = a + b + c;
-  if (Color.green == 1) {
+  var a = Color.red;
+  var b = Color.green;
+  var c = Color.blue;
+  int total = a.index + b.index + c.index;
+  if (b.index == 1) {
     total = total + 100;
   }
   return total;
@@ -30,11 +30,11 @@ int run() {
 <<<< NAMESPACE="" >>>>
 <<<< CODE_UNIT_START="/test" >>>>
   int run() {
-    int a = Color.red;
-    int b = Color.green;
-    int c = Color.blue;
-    int total = (a + b) + c;
-    if (Color.green == 1) {
+    var a = Color.red;
+    var b = Color.green;
+    var c = Color.blue;
+    int total = (a.index + b.index) + c.index;
+    if (b.index == 1) {
         total = total + 100;
     }
 

--- a/test/tests_definitions/java_enum_value_access.test.xml
+++ b/test/tests_definitions/java_enum_value_access.test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<test title="Java enum value access (ordinal)">
+<test title="Java enum value access (ordinal via .index)">
     <source language="java11">
         <![CDATA[
 enum Day {
@@ -10,8 +10,8 @@ enum Day {
 
 class C {
   static int run(){
-    int d = Day.Wed;
-    return d;
+    Day d = Day.Wed;
+    return d.index;
   }
 }
         ]]>
@@ -33,8 +33,8 @@ enum Day {
 class C {
 
   static int run() {
-    int d = Day.Wed;
-    return d;
+    Day d = Day.Wed;
+    return d.index;
   }
 
 }


### PR DESCRIPTION
## Summary

Redesigns enums from **"entry = int ordinal"** to **"enum = a class; each entry = a cached `const` instance"**, enabling Dart **enhanced/rich enums** (entries with constructor args, fields, and methods) — across the interpreter, all source languages, and Wasm.

```dart
enum Planet {
  earth(5.97, 6371), mars(0.642, 3389);
  final double mass; final double radius;
  const Planet(this.mass, this.radius);
  double gravity() => mass / (radius * radius);
}
// Planet.earth.mass == 5.97 ; Planet.earth.gravity() ; Planet.earth.index == 0 ;
// Planet.earth.name == 'earth' ; Planet.values == [earth, mars] ; identity ==
```

## ⚠️ Breaking change
An enum entry is **no longer an `int`**. Use `Color.blue.index` for the ordinal (and `.value` for explicit `= N` entries) instead of `int x = Color.blue`. The 3 int-based enum tests were migrated accordingly.

## What changed
- **AST/interpreter**: `ASTEnumEntry.arguments`; `ASTClassEnum` materializes each entry as a memoized `ASTClassInstance` via the `const` constructor (or `createInstance` for simple enums), seeding synthetic `index`/`name` (and `value` for explicit-value entries). Entries are singletons ⇒ identity `==`. `EnumName.entry` → instance; `EnumName.values` → list.
- **Dart parser**: enhanced-enum syntax — entry `(args)`, optional `;` + members (fields, `const` constructor, methods).
- **Other parsers**: Java & Kotlin parse rich-enum entry args + members.
- **Generators**: Dart/Java/Kotlin emit native rich enums; C#/TS/Python emit a class + `static`-const-instances idiom; simple enums unchanged.
- **Wasm**: each entry compiles to a heap instance (lazily built, cached in a per-entry global); enum layout gains synthetic `index`/`name` slots; `.index`/`.name`/fields/methods reuse the existing instance machinery; `EnumName.values` materializes a list.
- **Docs**: README documents rich enums + the breaking change (footnotes compacted).

## Testing
- New `test/apollovm_enum_test.dart` (interpreter) and `test/apollovm_wasm_enum_test.dart` (interpreter == compiled module).
- Migrated `{dart,java,csharp}_enum_value_access` definition tests to `.index`/`.value`.
- **Full suite green**: 622 non-Wasm + 314 Wasm tests pass; `dart analyze` clean; example runs.

## Known limitations (documented)
- Direct `.field` chaining after a class/enum member (`Planet.earth.mass`, `Color.values.length`) needs a variable — a pre-existing grammar limit affecting all `expr.field.field`; method chains like `.gravity()` work in the interpreter.
- The Wasm backend resolves an enum-entry access but doesn't yet chain a method call *directly* on it (`Planet.earth.gravity()`) — bind to a variable first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)