### PR TITLE
Wasm backend: close several Dart → WebAssembly gaps + String switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 0.1.43
+
+### Wasm backend: close several Dart → WebAssembly gaps
+
+- **Unqualified sibling class-method calls** now resolve: a method can call a
+  sibling `static` method by bare name (`dbl(x)` instead of `Foo.dbl(x)`),
+  including with named arguments and omitted default parameters.
+- **`String + <number>`** concatenation (from Java/Kotlin/C#/JS/TS, e.g.
+  `"n=" + n`) compiles, coercing the numeric operand to a String.
+- **`switch` on a `String`** scrutinee (content equality). `switch` on `int`
+  already worked; the Dart interpreter already handled `String`/`enum` switch.
+- **Rich-enum methods that take an enum-typed parameter** (`double ratio(Planet
+  p)`) compile; **C#/TypeScript explicit-value enums** expose `.value`.
+- **Typed catch-all clauses** (`on Exception catch (e)` / `catch (Exception
+  e)`) compile instead of failing on the declared exception type.
+- Known remaining gaps (documented, with skipped reproduction tests): `Map`/
+  `List` → String coercion, generic (`Box<T>`) primitive fields, lambdas, and
+  `switch` on `enum`/`dynamic` scrutinees.
+
 ## 0.1.42
 
 ### Named / keyword arguments

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,18 @@
   including with named arguments and omitted default parameters.
 - **`String + <number>`** concatenation (from Java/Kotlin/C#/JS/TS, e.g.
   `"n=" + n`) compiles, coercing the numeric operand to a String.
-- **`switch` on a `String`** scrutinee (content equality). `switch` on `int`
-  already worked; the Dart interpreter already handled `String`/`enum` switch.
+- **`switch` on a `String`** scrutinee (content equality) and **`switch` on an
+  `enum`** scrutinee (compared by ordinal). `switch` on `int` already worked.
+  Also fixes a function-end edge case where a `switch` that returns on all paths
+  as the last statement (e.g. after a `var` declaration) compiled to a function
+  that fell off its end without a return value.
 - **Rich-enum methods that take an enum-typed parameter** (`double ratio(Planet
   p)`) compile; **C#/TypeScript explicit-value enums** expose `.value`.
 - **Typed catch-all clauses** (`on Exception catch (e)` / `catch (Exception
   e)`) compile instead of failing on the declared exception type.
 - Known remaining gaps (documented, with skipped reproduction tests): `Map`/
   `List` → String coercion, generic (`Box<T>`) primitive fields, lambdas, and
-  `switch` on `enum`/`dynamic` scrutinees.
+  `switch` on a boxed `dynamic`/`Object` scrutinee.
 
 ## 0.1.42
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@
   `"n=" + n`) compiles, coercing the numeric operand to a String.
 - **`switch` on a `String`** scrutinee (content equality) and **`switch` on an
   `enum`** scrutinee (compared by ordinal). `switch` on `int` already worked.
-  Also fixes a function-end edge case where a `switch` that returns on all paths
-  as the last statement (e.g. after a `var` declaration) compiled to a function
-  that fell off its end without a return value.
+  Also fixes a general function-end edge case: a control construct
+  (`switch`/`if`/`while`) that returns on all paths as the last statement (e.g.
+  after a `var` declaration) compiled to a function that fell off its end
+  without a return value.
 - **Rich-enum methods that take an enum-typed parameter** (`double ratio(Planet
   p)`) compile; **C#/TypeScript explicit-value enums** expose `.value`.
 - **Typed catch-all clauses** (`on Exception catch (e)` / `catch (Exception

--- a/WASM_BACKEND_PLAN.md
+++ b/WASM_BACKEND_PLAN.md
@@ -1,0 +1,443 @@
+# Plan: extend the ApolloVM Wasm backend (Dart → WebAssembly)
+
+> For another Claude. This is a work plan to close concrete gaps in the
+> on-the-fly Wasm compiler. Every gap below was reproduced against **0.1.42**
+> with the native `wasm_run` runtime and includes a **ready-to-paste test** in
+> the repo's existing harness style. Fix one gap, make its test green, repeat.
+
+The Wasm backend lives almost entirely in:
+- `lib/src/languages/wasm/wasm_generator.dart` — AST → Wasm codegen (most gaps).
+- `lib/src/languages/wasm/wasm_parser.dart` — Wasm binary/type parsing.
+- `lib/src/languages/wasm/wasm_runner.dart` — load + execute a compiled module.
+
+## How to run / verify
+
+```bash
+dart run wasm_run:setup            # one-time: install the native wasm_run lib
+dart test -t wasm -x wasm-gc -x wasm-chrome    # all Wasm backend tests, native runtime
+dart test test/wasm/apollovm_wasm_named_parameters_test.dart -x wasm-gc   # one file
+```
+
+- `wasm-gc` / `wasm-chrome` tags need a browser (WasmGC engine); the native
+  `wasm_run` runtime (wasmtime/wasmi) has **no GC**, so exclude those tags when
+  iterating locally. None of the gaps below need GC — they reproduce on the
+  native runtime.
+- All **59** existing Wasm tests pass today; don't regress them.
+
+## The test harness (`_testWasm`)
+
+Each `test/wasm/apollovm_wasm_*_test.dart` defines a local helper:
+
+```dart
+Future<void> _testWasm({
+  required String language,            // 'dart' | 'kotlin' | 'java11' | ...
+  required String code,
+  required String functionName,        // export to call: 'run' or 'Foo.run'
+  required Map<List, Object?> executions,   // { argsList : expectedReturn }
+  Map<String, dynamic>? expecteWasm,
+}) async { ... }
+```
+
+It compiles `code` to Wasm, loads it, calls `functionName`, and asserts the
+return value equals the expected one (works for `int`, `double`, `String`,
+`bool`). Design each new test to **return** the value to assert (not `print`).
+
+---
+
+## What already works (do NOT "fix" these — keep them green)
+
+- Top-level `int`/`double`/`String`/`bool` functions: arithmetic, `while`/`for`,
+  `if`/`else`, ternary, `switch` on **`int`**, `do`/`while`, bitwise, `int`
+  string-interpolation (`'$n'`), `String + String`.
+- **Top-level** function-to-function calls, including **named arguments** and
+  **default parameter values** (see `apollovm_wasm_named_parameters_test.dart`,
+  `apollovm_wasm_default_parameters_test.dart`).
+- Classes driven from a top-level entry: constructors, `this.` params, field
+  initializers, **external field read/write**, **`double` fields**, instance
+  methods called **via a receiver** (`p.sum()`), `toString()`.
+- Static method as the **entry point**; `static main(List<Object> args)`.
+- Simple `enum`: entry `.index` / `.name`.
+- Dart untyped `try`/`catch`/`finally` + `throw`.
+
+The gaps below are the cases *outside* that envelope.
+
+---
+
+## GAP 1 — unqualified calls to sibling class methods (HIGHEST IMPACT)
+
+**This single gap also causes named-args and default-params to fail when the
+callee is a class method** (they already work at top level). Fixing it unblocks
+three playground examples at once.
+
+- **Error** (`wasm_generator.dart:2123`):
+  `Bad state: Can't resolve local function \`dbl\` with 1 argument(s) in the Wasm function index table.`
+- **Trigger**: a method calls a *sibling* method of the same class by bare name
+  (no receiver): `dbl(x)` instead of `this.dbl(x)` / `Foo.dbl(x)`. Top-level
+  function-to-function calls resolve fine; the function index table just doesn't
+  register/resolve class methods for unqualified call sites.
+- **Root cause to investigate**: how the function index table is populated
+  around `wasm_generator.dart:2123`. Top-level functions are registered by name;
+  class methods (static and instance) need to be resolvable for an unqualified
+  sibling call, with the named/default-argument normalization applied the same
+  way it already is for top-level calls.
+
+**Test — add to `test/wasm/apollovm_wasm_static_method_test.dart`:**
+
+```dart
+test('unqualified sibling static call resolves', () => _testWasm(
+  language: 'dart',
+  code: r'''
+    class Foo {
+      static int dbl(int n) { return n * 2; }
+      static int run(int x) { return dbl(x); }   // bare-name sibling call
+    }
+  ''',
+  functionName: 'Foo.run',
+  executions: {[5]: 10},
+));
+```
+
+**Test — add to `test/wasm/apollovm_wasm_named_parameters_test.dart`** (named
+args on a class method):
+
+```dart
+test('named args on a static class method', () => _testWasm(
+  language: 'dart',
+  code: r'''
+    class Foo {
+      static int area(int w, int h) { return w * h; }
+      static int run() { return area(h: 3, w: 4); }
+    }
+  ''',
+  functionName: 'Foo.run',
+  executions: {[]: 12},
+));
+```
+
+**Test — add to `test/wasm/apollovm_wasm_default_parameters_test.dart`**
+(omitted default on a class method):
+
+```dart
+test('default param omitted on a class method', () => _testWasm(
+  language: 'dart',
+  code: r'''
+    class Foo {
+      static int area(int w, [int h = 3]) { return w * h; }
+      static int run() { return area(5); }   // h defaults to 3
+    }
+  ''',
+  functionName: 'Foo.run',
+  executions: {[]: 15},
+));
+```
+
+---
+
+## GAP 2 — `String + <number>` concatenation (number → string)
+
+- **Error** (`wasm_generator.dart:3097`):
+  `UnimplementedError: Wasm string \`+\` with a non-String operand (number-to-string) is not supported yet (String + int).`
+  (also `String + double`, `String + num`, `String + dynamic`, `String + int(64)`)
+- **Trigger**: the `+` operator with a `String` LHS and a numeric RHS. Dart
+  forbids this syntactically, so it arrives from **Java/Kotlin/C#/JS/TS** sources
+  (e.g. `"n = " + n`). Note `int` interpolation (`'$n'`) and `String + String`
+  already work — the missing piece is an `int`/`double` → `String` conversion in
+  the `+` codegen path.
+- **Fix direction**: reuse whatever number→string conversion the interpolation
+  path already uses, in the binary-`+` string branch at `wasm_generator.dart:3097`.
+
+**Test — new file `test/wasm/apollovm_wasm_string_concat_test.dart`** (mirror the
+`_testWasm` helper from a sibling file):
+
+```dart
+test('String + int (Kotlin)', () => _testWasm(
+  language: 'kotlin',
+  code: r'''
+    fun run(n: Int): String {
+      return "n=" + n
+    }
+  ''',
+  functionName: 'run',
+  executions: {[5]: 'n=5'},
+));
+
+test('String + double (Kotlin)', () => _testWasm(
+  language: 'kotlin',
+  code: r'''
+    fun run(): String {
+      return "g=" + 9.8
+    }
+  ''',
+  functionName: 'run',
+  executions: {[]: 'g=9.8'},
+));
+```
+
+---
+
+## GAP 3 — `Map` (collection) → String coercion
+
+- **Error** (`wasm_generator.dart:8517`):
+  `UnimplementedError: Wasm string coercion of type Map<String,int> is not supported yet.`
+- **Trigger**: interpolating/coercing a whole `Map` (or `List`) to a `String`.
+- **Fix direction**: implement a runtime string-coercion for collection values
+  at `wasm_generator.dart:8517` (emit `{k: v, ...}` like Dart's `Map.toString`).
+
+**Test — add to `test/wasm/apollovm_wasm_maps_test.dart`:**
+
+```dart
+test('Map interpolated into a String', () => _testWasm(
+  language: 'dart',
+  code: r'''
+    String run() {
+      var m = <String, int>{'a': 1, 'b': 2};
+      return 'Map: $m';
+    }
+  ''',
+  functionName: 'run',
+  executions: {[]: 'Map: {a: 1, b: 2}'},
+));
+```
+
+---
+
+## GAP 4 — generic class `Box<T>` produces invalid Wasm
+
+- **Error** (at execution, after compile): the module fails validation —
+  `FrbAnyhowException(WebAssembly translation error … type mismatch: expected i64, found i32)`.
+- **Trigger**: a generic class with a type-parameter field, e.g. `Box<T>{ T value; }`,
+  instantiated as `Box<int>` and read back. Non-generic classes with the same
+  shape already work (`apollovm_wasm_object_field_test.dart`), so this is specific
+  to type-parameter fields: the field's storage/width is emitted as `i32` where
+  the `int` value needs `i64` (an int-width mismatch in object-field codegen).
+- **Fix direction**: when a type parameter resolves to `int`, the field
+  load/store must use the i64 representation. Look at object-field codegen and
+  generic type resolution in `wasm_generator.dart`.
+
+**Test — add to `test/wasm/apollovm_wasm_object_field_test.dart`:**
+
+```dart
+test('generic Box<int> field round-trips', () => _testWasm(
+  language: 'dart',
+  code: r'''
+    class Box<T> {
+      T value;
+      Box(this.value);
+    }
+    int run(int x) {
+      var b = Box<int>(x);
+      return b.value;
+    }
+  ''',
+  functionName: 'run',
+  executions: {[7]: 7},
+));
+```
+
+---
+
+## GAP 5 — `switch` on a non-`int` scrutinee
+
+- **Error** (`wasm_generator.dart:7424`):
+  `UnimplementedError: Wasm switch on dynamic is not supported (int only).`
+  (also `Wasm switch on num is not supported (int only)`)
+- **Trigger**: `switch` where the scrutinee is `dynamic` (untyped JS/Python) or
+  `num` (TS). `switch` on a statically-`int` value works.
+- **Fix direction**: coerce/narrow the scrutinee to `int` (or `i64`) before the
+  branch table at `wasm_generator.dart:7424`, or support a fallback compare chain.
+
+**Test — add to `test/wasm/apollovm_wasm_ops_test.dart`:**
+
+```dart
+test('switch on a num scrutinee (TypeScript)', () => _testWasm(
+  language: 'typescript',
+  code: r'''
+    function run(n: number): number {
+      switch (n) {
+        case 1: return 10;
+        case 2: return 20;
+        default: return 99;
+      }
+    }
+  ''',
+  functionName: 'run',
+  executions: {[1]: 10, [2]: 20, [5]: 99},
+));
+```
+
+---
+
+## GAP 6 — anonymous functions / lambdas
+
+- **Error** (`wasm_generator.dart:841`):
+  `Unsupported operation: Wasm: can't infer the return type of an anonymous function …`
+  and, for JS/TS, `UnimplementedError: generateASTStatementFunctionDeclaration`.
+- **Trigger**: assigning a lambda to a local and invoking it.
+- **Fix direction**: infer the closure's return type from its body / the
+  expected type at the use site; implement nested function-declaration codegen
+  for JS/TS.
+
+**Test — new file `test/wasm/apollovm_wasm_lambda_test.dart`:**
+
+```dart
+test('local lambda invoked', () => _testWasm(
+  language: 'dart',
+  code: r'''
+    int run(int x) {
+      var twice = (int n) => n * 2;
+      return twice(x);
+    }
+  ''',
+  functionName: 'run',
+  executions: {[5]: 10},
+));
+```
+
+---
+
+## GAP 7 — rich-enum methods & enum-typed parameters
+
+Simple enums (`.index`/`.name`) already compile and run. The gaps appear with
+**enhanced enums that declare methods** and with **enum-typed parameters**.
+
+- **Error**: `Bad state: Can't handle type: Planet` (`wasm_parser.dart:176` /
+  `wasm_generator.dart:10081`) when an enum type is used as a parameter type;
+  enum entries with method bodies also need codegen.
+- **Trigger** (the playground's `Dart — Rich enum (fields & methods)`):
+
+```dart
+enum Planet {
+  earth(9.8),
+  mars(3.7);
+
+  final double gravity;
+
+  const Planet(this.gravity);
+
+  double mult(double m) => gravity * m;
+
+  double ratio(Planet p) => gravity / p.gravity;   // enum-typed param `p`
+}
+```
+
+**Test — add to `test/wasm/apollovm_wasm_enum_test.dart`:**
+
+```dart
+test('enum method using a field', () => _testWasm(
+  language: 'dart',
+  code: r'''
+    enum Planet {
+      earth(9.8), mars(3.7);
+      final double gravity;
+      const Planet(this.gravity);
+      double mult(double m) { return gravity * m; }
+    }
+    double run() {
+      var e = Planet.earth;
+      return e.mult(2.0);   // expect 19.6
+    }
+  ''',
+  functionName: 'run',
+  executions: {[]: 19.6},
+));
+
+test('enum method taking an enum-typed parameter', () => _testWasm(
+  language: 'dart',
+  code: r'''
+    enum Planet {
+      earth(9.8), mars(3.7);
+      final double gravity;
+      const Planet(this.gravity);
+      double ratio(Planet p) { return gravity / p.gravity; }
+    }
+    double run() {
+      var e = Planet.earth;
+      var m = Planet.mars;
+      return e.ratio(m);    // 9.8 / 3.7
+    }
+  ''',
+  functionName: 'run',
+  executions: {[]: 9.8 / 3.7},
+));
+```
+
+---
+
+## GAP 8 — typed exception catch (`catch (Exception e)`)
+
+- **Error**: `Bad state: Can't handle type: Exception`.
+- **Trigger**: a `catch` clause with a declared exception **type** (Java/Kotlin/C#).
+  Dart's untyped `catch (e)` + `try`/`finally` already work
+  (`apollovm_wasm_exception_test.dart`).
+- **Fix direction**: treat a typed catch like the untyped one (the Wasm model
+  has a single thrown value); ignore/normalize the declared type.
+
+**Test — add to `test/wasm/apollovm_wasm_exception_test.dart`:**
+
+```dart
+test('typed catch (Java)', () => _testWasm(
+  language: 'java11',
+  code: r'''
+    class Foo {
+      static int run(int b) {
+        try {
+          if (b == 0) { throw "zero"; }
+          return b;
+        } catch (Exception e) {
+          return -1;
+        }
+      }
+    }
+  ''',
+  functionName: 'Foo.run',
+  executions: {[0]: -1, [5]: 5},
+));
+```
+
+---
+
+## GAP 9 — C# enum `.value` getter
+
+- **Error** (`wasm_generator.dart:4449`):
+  `UnimplementedError: Wasm getter \`.value\` on Level is not supported yet.`
+- **Trigger**: reading an explicit-value (C#) enum entry's `.value`.
+
+**Test — add to `test/wasm/apollovm_wasm_enum_test.dart`:**
+
+```dart
+test('C# enum .value', () => _testWasm(
+  language: 'csharp',
+  code: r'''
+    enum Level { Low = 1, Medium = 5, High = 10 }
+    class Foo {
+      public static int run() {
+        var m = Level.Medium;
+        return m.value;
+      }
+    }
+  ''',
+  functionName: 'Foo.run',
+  executions: {[]: 5},
+));
+```
+
+---
+
+## Suggested order
+
+1. **GAP 1** (class-method call resolution) — one subsystem, unblocks named
+   args + defaults + sibling/async calls on class methods.
+2. **GAP 2** (`String + number`) — unblocks most non-Dart examples broadly.
+3. **GAP 4** (generic field i64/i32) — object-field codegen correctness.
+4. **GAP 3** (Map coercion), **GAP 5** (non-int switch), **GAP 6** (lambdas),
+   **GAP 7** (rich-enum methods / enum params), **GAP 8** (typed catch),
+   **GAP 9** (C# `.value`) — independent, feature-by-feature.
+
+After each fix: `dart test -t wasm -x wasm-gc -x wasm-chrome` must stay green
+(all existing tests + the new one for that gap).
+
+### Source of these findings
+
+Reproduced by compiling the ApolloVM web playground examples
+(`apollovm_web_example`) through the full Wasm pipeline; the playground itself is
+a good end-to-end smoke test once these land.

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -53,7 +53,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.42';
+  static final String VERSION = '0.1.43';
 
   static int _idCount = 0;
 

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -10162,6 +10162,11 @@ extension _ASTTypeExtension on ASTType {
     } else if (this is ASTType<VMObject>) {
       // A class instance is an i32 pointer into linear memory.
       return WasmType.i32Type;
+    } else if (name.isNotEmpty) {
+      // Any other named reference type — a user class or an enum used by name
+      // (e.g. an enum-typed parameter `Planet p`) — is a heap instance,
+      // represented as an i32 pointer like other object instances.
+      return WasmType.i32Type;
     }
 
     throw StateError("Can't handle type: $this");

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -7474,15 +7474,39 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     out ??= newOutput();
     context ??= WasmContext();
 
-    // Evaluate the switch value once into a scratch local (int only).
+    // Evaluate the switch value once into a scratch local. Supported scrutinee
+    // kinds:
+    //  - `int`    : i64 equality (branch table).
+    //  - `String` : content equality via the `__streq` host/synth helper.
+    //  - a reference instance (e.g. an `enum` entry): i32 pointer identity —
+    //    enum entries are cached `const` singletons, so `==` is identity.
+    // A boxed `dynamic`/`Object` scrutinee is not supported (see GAP 5).
     generateASTExpression(statement.expression, out: out, context: context);
     var valueType = context.stackGet(0)!.type;
-    if (valueType != _astTypeInt64 && valueType != _astTypeInt) {
+
+    final switchOnInt =
+        valueType == _astTypeInt64 || valueType == _astTypeInt;
+    final switchOnString = valueType is ASTTypeString;
+
+    if (!switchOnInt && !switchOnString) {
       throw UnimplementedError(
-        "Wasm switch on $valueType is not supported (int only).",
+        "Wasm switch on $valueType is not supported (int or String only).",
       );
     }
-    var valueLocal = context.scratchLocal(_astTypeInt64, 17);
+
+    int? strEqIndex;
+    if (switchOnString) {
+      var module = context.module!;
+      module.requiresMemory = true;
+      module.ensureStrEqFunction();
+      strEqIndex = module.synthFunctionIndex('__streq')!;
+    }
+
+    // The scrutinee is held as i64 (int) or i32 (String handle).
+    final ASTType scrutineeLocalType = switchOnInt
+        ? _astTypeInt64
+        : _astTypeString;
+    var valueLocal = context.scratchLocal(scrutineeLocalType, 17);
     out.write(Wasm.localSet(valueLocal));
     context.stackDrop();
 
@@ -7530,10 +7554,21 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         continue;
       }
       out.write(Wasm.localGet(valueLocal));
-      context.stackPush(_astTypeInt64, "switch value");
+      context.stackPush(scrutineeLocalType, "switch value");
       generateASTExpression(c.value!, out: out, context: context);
-      out.writeByte(Wasm64.i64Equals, description: "[OP] switch case == ");
-      context.stackOperationBinary(_astTypeInt32, "i64.eq (switch)");
+      if (switchOnString) {
+        // __streq(scrutinee, caseValue) -> i32 (0/1) content equality.
+        out.write(
+          Wasm.call(strEqIndex!),
+          description: "[OP] switch case __streq",
+        );
+      } else {
+        out.writeByte(
+          Wasm64.i64Equals,
+          description: "[OP] switch case == (i64)",
+        );
+      }
+      context.stackOperationBinary(_astTypeInt32, "switch case ==");
       out.write(
         Wasm.brIf(context.controlDepth - entryLevel(i)),
         description: "[OP] switch br_if case $i",

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -246,17 +246,10 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         if (fn.modifiers.isStatic) {
           // Static method: no `this`. Synthesized as an exported module function
           // under the qualified `Class.method` name, generated like a top-level
-          // function (see [_WasmStaticMethodFunction]).
-          var staticParams = fn.parameters.allParameters
-              .map(
-                (p) => ASTFunctionParameterDeclaration(
-                  p.type,
-                  p.name,
-                  p.index,
-                  p.optional,
-                ),
-              )
-              .toList();
+          // function (see [_WasmStaticMethodFunction]). The declared parameters
+          // are reused directly (as the instance-method path does) so their
+          // default values are preserved for default-argument resolution.
+          var staticParams = fn.parameters.allParameters.toList();
           result.add(
             _WasmStaticMethodFunction(
               clazz,
@@ -1112,10 +1105,14 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       return _generateClassConstructorFunction(f, module: module);
     } else if (f is _WasmMethodFunction) {
       return _generateClassMethodFunction(f, module: module);
+    } else if (f is _WasmStaticMethodFunction) {
+      // A static method has no `this` (params remain locals 0..n-1), but it
+      // still belongs to a class: set `classLayout` so an unqualified sibling
+      // call can resolve against the enclosing class's static methods.
+      var context = WasmContext(module: module);
+      context.classLayout = module.classLayouts[f.clazz.name];
+      return generateASTFunctionDeclaration(f, context: context, module: module);
     }
-    // A `_WasmStaticMethodFunction` has no `this`; it is generated with a fresh
-    // context (no `thisLocalIndex`/`classLayout`), exactly like a top-level
-    // function — params become locals 0..n-1.
     return generateASTFunctionDeclaration(f, module: module);
   }
 
@@ -2106,23 +2103,37 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         );
       }
 
-      // Only static methods are callable without a receiver. A receiver-less
-      // call that matches a non-static method (e.g. a `static` method calling an
-      // instance sibling, where no `this` is in scope) needs an instance.
-      var instanceMethod = context.module?.instanceMethodQualifiedName(
-        name,
-        argsCount,
-      );
-      if (instanceMethod != null) {
-        throw UnsupportedError(
-          "Can't call non-static method '$instanceMethod' without an instance.",
+      // A bare-name call to a sibling STATIC method of the enclosing class.
+      // Static methods are registered under their qualified `Class.method`
+      // name, so they miss the top-level bare-name lookup above; resolve them
+      // here and fall through to the normal call emission below (no receiver).
+      if (layout != null) {
+        calleeIndex = context.module?.staticMethodIndexForCall(
+          layout.className,
+          name,
+          argsCount,
         );
       }
 
-      throw StateError(
-        "Can't resolve local function `$name` with $argsCount argument(s) "
-        "in the Wasm function index table.",
-      );
+      if (calleeIndex == null) {
+        // Only static methods are callable without a receiver. A receiver-less
+        // call that matches a non-static method (e.g. a `static` method calling
+        // an instance sibling, where no `this` is in scope) needs an instance.
+        var instanceMethod = context.module?.instanceMethodQualifiedName(
+          name,
+          argsCount,
+        );
+        if (instanceMethod != null) {
+          throw UnsupportedError(
+            "Can't call non-static method '$instanceMethod' without an instance.",
+          );
+        }
+
+        throw StateError(
+          "Can't resolve local function `$name` with $argsCount argument(s) "
+          "in the Wasm function index table.",
+        );
+      }
     }
 
     var callee = context.functionByIndex(calleeIndex)!;
@@ -3089,17 +3100,27 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     var stackType1 = stack1.type;
     var stackType2 = stack2.type;
 
-    // String `+` -> concatenation (both operands must already be String).
+    // String `+` -> concatenation. Each operand is coerced to a String handle
+    // (a String is already a handle; int/double/bool route through the same
+    // host converters used by string interpolation), so `String + number`
+    // (from Java/Kotlin/C#/JS/TS, e.g. `"n=" + n`) works.
     if (expression.operator == ASTExpressionOperator.add &&
         (stackType1 is ASTTypeString || stackType2 is ASTTypeString)) {
-      if (stackType1 is! ASTTypeString || stackType2 is! ASTTypeString) {
-        throw UnimplementedError(
-          "Wasm string `+` with a non-String operand (number-to-string) is "
-          "not supported yet ($stackType1 + $stackType2).",
-        );
-      }
+      // The operands were tracked on the virtual stack during generation above;
+      // drop them and re-track as each is emitted then coerced, so the coercion
+      // helpers see the correct top-of-stack value (the conversion bytes must be
+      // interleaved between the two operand buffers).
+      context.stackDrop(); // operand 2 (stack2)
+      context.stackDrop(); // operand 1 (stack1)
+
       out.writeBytes(exp1Out);
+      context.stackPush(stackType1, "string `+` operand 1");
+      _emitToStringHandle(out, context, stackType1);
+
       out.writeBytes(exp2Out);
+      context.stackPush(stackType2, "string `+` operand 2");
+      _emitToStringHandle(out, context, stackType2);
+
       context.assertStackLength(stackLng2, "After push string operands");
       _emitStringConcat2(out, context);
       context.assertStackLength(stackLng0 + 1, "After string concat");
@@ -5844,6 +5865,15 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       final clauseVarTypes = <ASTType?>[];
       for (final c in s.catches) {
         var varType = c.exceptionType;
+        // A declared catch-all type (`Exception`/`Throwable`/`Error`/`Object`/
+        // `dynamic`, from Java/Kotlin/C# `catch (Exception e)` or Dart
+        // `on Exception catch (e)`) is not a representable Wasm value type and
+        // binds whatever was thrown. Resolve its bound variable like an untyped
+        // `catch (e)` (infer from the thrown value); the clause still matches
+        // every tag via [_catchClauseAcceptedTags].
+        if (varType != null && _excCatchAllTypeNames.contains(varType.name)) {
+          varType = null;
+        }
         if (varType == null && c.variableName != null) {
           final inferred = _inferTryThrownType(s.tryBlock);
           if (inferred != null) {
@@ -9243,6 +9273,34 @@ class WasmModuleContext {
     for (var i = 0; i < functions.length; ++i) {
       var f = functions[i];
       if (f is! _WasmMethodFunction ||
+          f.clazz.name != className ||
+          f.method.name != methodName) {
+        continue;
+      }
+      var size = f.method.parameters.size;
+      if (size < suppliedCount) continue;
+      if (bestSize == null || size < bestSize) {
+        bestSize = size;
+        bestIndex = importCount + i;
+      }
+    }
+    return bestIndex;
+  }
+
+  /// Like [methodIndexForCall] but for **static** methods (no receiver):
+  /// resolves a bare-name call to a sibling `static` method of [className].
+  /// Returns the smallest declared arity `>= suppliedCount` (so omitted
+  /// default-valued trailing parameters still resolve).
+  int? staticMethodIndexForCall(
+    String className,
+    String methodName,
+    int suppliedCount,
+  ) {
+    int? bestIndex;
+    int? bestSize;
+    for (var i = 0; i < functions.length; ++i) {
+      var f = functions[i];
+      if (f is! _WasmStaticMethodFunction ||
           f.clazz.name != className ||
           f.method.name != methodName) {
         continue;

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -1119,7 +1119,11 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       // call can resolve against the enclosing class's static methods.
       var context = WasmContext(module: module);
       context.classLayout = module.classLayouts[f.clazz.name];
-      return generateASTFunctionDeclaration(f, context: context, module: module);
+      return generateASTFunctionDeclaration(
+        f,
+        context: context,
+        module: module,
+      );
     }
     return generateASTFunctionDeclaration(f, module: module);
   }
@@ -4850,7 +4854,18 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     var returnType = effectiveReturnType;
 
-    if (!returnType.isVoid && context.stackLength == 0) {
+    // A non-void function needs a trailing `unreachable` + default when the
+    // validator considers the body end reachable but no value is produced. This
+    // is detected by `stackLength == 0` (the body left nothing). It also applies
+    // when the last statement is a `switch` that returns on all paths: such a
+    // switch ends with a `block`'s `end` (reachable to the validator) yet the
+    // scrutinee evaluation can leave a residual virtual-stack entry (e.g. when
+    // preceded by a `var` declaration), so the `stackLength == 0` check alone
+    // would miss it.
+    var lastStatement = f.statements.isEmpty ? null : f.statements.last;
+
+    if (!returnType.isVoid &&
+        (context.stackLength == 0 || lastStatement is ASTStatementSwitch)) {
       // Notify that the function can't reach the end.
       bodyCode.writeByte(
         Wasm.unreachable,
@@ -7484,13 +7499,23 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     generateASTExpression(statement.expression, out: out, context: context);
     var valueType = context.stackGet(0)!.type;
 
-    final switchOnInt =
-        valueType == _astTypeInt64 || valueType == _astTypeInt;
+    final switchOnInt = valueType == _astTypeInt64 || valueType == _astTypeInt;
     final switchOnString = valueType is ASTTypeString;
 
-    if (!switchOnInt && !switchOnString) {
+    // An `enum` scrutinee is compared by ordinal: reduce both the scrutinee and
+    // each case entry to their `.index` (i64).
+    final enumLayout =
+        (!switchOnInt && !switchOnString && valueType.name.isNotEmpty)
+        ? context.module?.classLayouts[valueType.name]
+        : null;
+    final switchOnEnum =
+        enumLayout != null && enumLayout.offsets.containsKey('index');
+    final enumIndexOffset = switchOnEnum ? enumLayout.offsets['index']! : 0;
+
+    if (!switchOnInt && !switchOnString && !switchOnEnum) {
       throw UnimplementedError(
-        "Wasm switch on $valueType is not supported (int or String only).",
+        "Wasm switch on $valueType is not supported "
+        "(int, String or enum only).",
       );
     }
 
@@ -7502,8 +7527,17 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       strEqIndex = module.synthFunctionIndex('__streq')!;
     }
 
-    // The scrutinee is held as i64 (int) or i32 (String handle).
-    final ASTType scrutineeLocalType = switchOnInt
+    if (switchOnEnum) {
+      context.module?.requiresMemory = true;
+      out.write(
+        Wasm64.i64Load(3, enumIndexOffset),
+        description: "[OP] switch enum scrutinee .index",
+      );
+      context.stackReplace(_astTypeInt64, "enum scrutinee .index");
+    }
+
+    // The scrutinee is held as i64 (int / enum ordinal) or i32 (String handle).
+    final ASTType scrutineeLocalType = (switchOnInt || switchOnEnum)
         ? _astTypeInt64
         : _astTypeString;
     var valueLocal = context.scratchLocal(scrutineeLocalType, 17);
@@ -7556,6 +7590,15 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       out.write(Wasm.localGet(valueLocal));
       context.stackPush(scrutineeLocalType, "switch value");
       generateASTExpression(c.value!, out: out, context: context);
+      if (switchOnEnum) {
+        // Reduce the case enum entry to its `.index` (i64), then compare ints.
+        context.module?.requiresMemory = true;
+        out.write(
+          Wasm64.i64Load(3, enumIndexOffset),
+          description: "[OP] switch enum case .index",
+        );
+        context.stackReplace(_astTypeInt64, "enum case .index");
+      }
       if (switchOnString) {
         // __streq(scrutinee, caseValue) -> i32 (0/1) content equality.
         out.write(

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -4854,18 +4854,18 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     var returnType = effectiveReturnType;
 
-    // A non-void function needs a trailing `unreachable` + default when the
-    // validator considers the body end reachable but no value is produced. This
-    // is detected by `stackLength == 0` (the body left nothing). It also applies
-    // when the last statement is a `switch` that returns on all paths: such a
-    // switch ends with a `block`'s `end` (reachable to the validator) yet the
-    // scrutinee evaluation can leave a residual virtual-stack entry (e.g. when
-    // preceded by a `var` declaration), so the `stackLength == 0` check alone
-    // would miss it.
+    // A non-void function needs a trailing `unreachable` + default unless its
+    // body already ends with an explicit `return` instruction. When the last
+    // top-level statement is NOT a `return` (e.g. a `switch`/`if`/`while` that
+    // returns on all paths), the body ends with a `block`'s `end`, which the
+    // validator treats as reachable — so the terminator is required even when a
+    // residual virtual-stack entry (e.g. from a preceding `var` declaration)
+    // makes `context.stackLength != 0`. The `stackLength == 0` case keeps the
+    // (redundant but pre-existing) terminator for plain `return`-ended bodies.
     var lastStatement = f.statements.isEmpty ? null : f.statements.last;
 
     if (!returnType.isVoid &&
-        (context.stackLength == 0 || lastStatement is ASTStatementSwitch)) {
+        (context.stackLength == 0 || lastStatement is! ASTStatementReturn)) {
       // Notify that the function can't reach the end.
       bodyCode.writeByte(
         Wasm.unreachable,

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -187,6 +187,14 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         types['name'] = _astTypeString;
         offset += _elemSize(_astTypeString);
       }
+      // An explicit-value enum (C#/TypeScript `Medium = 5`) exposes the declared
+      // integer via `.value`; give it an i64 slot seeded at build time.
+      if (clazz.entries.any((e) => e.value != null) &&
+          !offsets.containsKey('value')) {
+        offsets['value'] = offset;
+        types['value'] = _astTypeInt64;
+        offset += _elemSize(_astTypeInt64);
+      }
     }
     return WasmClassLayout(clazz.name, offsets, types, offset);
   }
@@ -4623,6 +4631,26 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     body.write(Wasm.localGet(instLocal));
     body.write(Wasm32.i32Const(namePtr));
     _emitElemStore(body, _astTypeString, layout.offsets['name']!);
+
+    // instance.value = explicit declared value (i64), for explicit-value enums.
+    var valueOffset = layout.offsets['value'];
+    if (valueOffset != null) {
+      body.write(Wasm.localGet(instLocal));
+      var entryValue = entry.value;
+      if (entryValue != null) {
+        generateASTExpression(entryValue, out: body, context: context);
+        _autoConvertStackTypes(
+          context.stackGet(0)!.type,
+          _astTypeInt64,
+          out: body,
+          context: context,
+        );
+        context.stackDrop(); // consumed by the store below
+      } else {
+        body.write(Wasm64.i64Const(0));
+      }
+      _emitElemStore(body, _astTypeInt64, valueOffset);
+    }
 
     // global = instance
     body.write(Wasm.localGet(instLocal));

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, C#, JavaScript, TypeScript, Lua and Python with on-the-fly Wasm compilation.
-version: 0.1.42
+version: 0.1.43
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/wasm/apollovm_wasm_enum_test.dart
+++ b/test/wasm/apollovm_wasm_enum_test.dart
@@ -1,8 +1,50 @@
-@Tags(['wasm', 'dart'])
+@Tags(['wasm', 'dart', 'csharp'])
 library;
 
 import 'package:apollovm/apollovm.dart';
 import 'package:test/test.dart';
+
+/// Compiles [src] in [language] to Wasm and runs the static [entry] (e.g.
+/// `Foo.run`) on BOTH the AST interpreter and the compiled Wasm module,
+/// asserting both produce [expected].
+Future<void> _bothEqualLang(
+  String language,
+  String src,
+  String entry,
+  Object? expected,
+) async {
+  var dot = entry.indexOf('.');
+  var className = entry.substring(0, dot);
+  var method = entry.substring(dot + 1);
+
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit(language, src, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load `$language` source");
+
+  var astRes = await vm
+      .createRunner(language)!
+      .executeClassMethod('', className, method);
+  expect(astRes.getValueNoContext(), expected, reason: 'interpreter');
+
+  var storage = vm.generateAllIn<BytesOutput>('wasm');
+  var modules = await storage.allEntries();
+  BytesOutput? compiled;
+  for (var ns in modules.entries) {
+    for (var m in ns.value.entries) {
+      compiled ??= m.value;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var vmWasm = ApolloVM();
+  await vmWasm.loadCodeUnit(
+    BinaryCodeUnit('wasm', compiled!.output(), id: 'test.wasm', namespace: ''),
+  );
+  var wasmRes = await vmWasm
+      .createRunner('wasm')!
+      .executeFunction('', entry);
+  expect(wasmRes.getValueNoContext(), expected, reason: 'Wasm');
+}
 
 /// Compiles [src] (Dart) to Wasm and runs `Main.run` on BOTH the AST
 /// interpreter and the compiled Wasm module, asserting both produce
@@ -97,6 +139,27 @@ enum Planet {
       await _bothEqual(
         '${planet}class Main { static int run() { var m = Planet.mars; return m.index; } }',
         1,
+      );
+    });
+  });
+
+  group('Wasm: C# enum .value (explicit values)', () {
+    // GAP 9: an explicit-value (C#) enum entry exposes its declared integer via
+    // `.value`.
+    test('C# enum .value', () async {
+      await _bothEqualLang(
+        'csharp',
+        r'''
+        enum Level { Low = 1, Medium = 5, High = 10 }
+        class Foo {
+          public static int run() {
+            var m = Level.Medium;
+            return m.value;
+          }
+        }
+        ''',
+        'Foo.run',
+        5,
       );
     });
   });

--- a/test/wasm/apollovm_wasm_enum_test.dart
+++ b/test/wasm/apollovm_wasm_enum_test.dart
@@ -196,6 +196,75 @@ enum Planet {
         }
         ''', 2);
     });
+
+    test('enum switch matches the last entry explicitly', () async {
+      await _bothEqual(r'''
+        enum Color { red, green, blue }
+        class Main {
+          static int run() {
+            var c = Color.blue;
+            switch (c) {
+              case Color.red: return 1;
+              case Color.green: return 2;
+              case Color.blue: return 3;
+              default: return 9;
+            }
+          }
+        }
+        ''', 3);
+    });
+
+    test('enum switch falls to default', () async {
+      await _bothEqual(r'''
+        enum Color { red, green, blue }
+        class Main {
+          static int run() {
+            var c = Color.blue;
+            switch (c) {
+              case Color.red: return 1;
+              case Color.green: return 2;
+              default: return 99;
+            }
+          }
+        }
+        ''', 99);
+    });
+
+    test('enum switch returns a String', () async {
+      await _bothEqual(r'''
+        enum Color { red, green, blue }
+        class Main {
+          static String run() {
+            var c = Color.green;
+            switch (c) {
+              case Color.red: return 'R';
+              case Color.green: return 'G';
+              default: return '?';
+            }
+          }
+        }
+        ''', 'G');
+    });
+
+    test('enum switch over a rich enum entry', () async {
+      await _bothEqual(r'''
+        enum Planet {
+          earth(9.8), mars(3.7);
+          final double gravity;
+          const Planet(this.gravity);
+        }
+        class Main {
+          static double run() {
+            var p = Planet.mars;
+            switch (p) {
+              case Planet.earth: return 1.0;
+              case Planet.mars: return 2.0;
+              default: return 0.0;
+            }
+          }
+        }
+        ''', 2.0);
+    });
   });
 
   group('Wasm: C# enum .value (explicit values)', () {

--- a/test/wasm/apollovm_wasm_enum_test.dart
+++ b/test/wasm/apollovm_wasm_enum_test.dart
@@ -141,6 +141,49 @@ enum Planet {
         1,
       );
     });
+
+    // GAP 7: an enum method that uses a field.
+    test('enum method using a field', () async {
+      await _bothEqual(
+        r'''
+        enum Planet {
+          earth(9.8), mars(3.7);
+          final double gravity;
+          const Planet(this.gravity);
+          double mult(double m) { return gravity * m; }
+        }
+        class Main {
+          static double run() {
+            var e = Planet.earth;
+            return e.mult(2.0);
+          }
+        }
+        ''',
+        19.6,
+      );
+    });
+
+    // GAP 7: an enum method taking an enum-TYPED parameter (`Planet p`).
+    test('enum method taking an enum-typed parameter', () async {
+      await _bothEqual(
+        r'''
+        enum Planet {
+          earth(9.8), mars(3.7);
+          final double gravity;
+          const Planet(this.gravity);
+          double ratio(Planet p) { return gravity / p.gravity; }
+        }
+        class Main {
+          static double run() {
+            var e = Planet.earth;
+            var m = Planet.mars;
+            return e.ratio(m);
+          }
+        }
+        ''',
+        9.8 / 3.7,
+      );
+    });
   });
 
   group('Wasm: C# enum .value (explicit values)', () {

--- a/test/wasm/apollovm_wasm_enum_test.dart
+++ b/test/wasm/apollovm_wasm_enum_test.dart
@@ -186,6 +186,31 @@ enum Planet {
     });
   });
 
+  group('Wasm: switch on an enum', () {
+    // The Dart interpreter handles `switch` on an enum; the Wasm compiler does
+    // not yet (the scrutinee's enum value reduction leaves the stack
+    // unbalanced). `switch` on `int` and `String` work.
+    test('switch on an enum scrutinee', () async {
+      await _bothEqual(
+        r'''
+        enum Color { red, green, blue }
+        class Main {
+          static int run() {
+            var c = Color.green;
+            switch (c) {
+              case Color.red: return 1;
+              case Color.green: return 2;
+              default: return 9;
+            }
+          }
+        }
+        ''',
+        2,
+      );
+    }, skip: 'BUG: Wasm `switch` on an enum scrutinee is not yet supported '
+        '(int and String switch work).');
+  });
+
   group('Wasm: C# enum .value (explicit values)', () {
     // GAP 9: an explicit-value (C#) enum entry exposes its declared integer via
     // `.value`.

--- a/test/wasm/apollovm_wasm_enum_test.dart
+++ b/test/wasm/apollovm_wasm_enum_test.dart
@@ -40,9 +40,7 @@ Future<void> _bothEqualLang(
   await vmWasm.loadCodeUnit(
     BinaryCodeUnit('wasm', compiled!.output(), id: 'test.wasm', namespace: ''),
   );
-  var wasmRes = await vmWasm
-      .createRunner('wasm')!
-      .executeFunction('', entry);
+  var wasmRes = await vmWasm.createRunner('wasm')!.executeFunction('', entry);
   expect(wasmRes.getValueNoContext(), expected, reason: 'Wasm');
 }
 
@@ -144,8 +142,7 @@ enum Planet {
 
     // GAP 7: an enum method that uses a field.
     test('enum method using a field', () async {
-      await _bothEqual(
-        r'''
+      await _bothEqual(r'''
         enum Planet {
           earth(9.8), mars(3.7);
           final double gravity;
@@ -158,15 +155,12 @@ enum Planet {
             return e.mult(2.0);
           }
         }
-        ''',
-        19.6,
-      );
+        ''', 19.6);
     });
 
     // GAP 7: an enum method taking an enum-TYPED parameter (`Planet p`).
     test('enum method taking an enum-typed parameter', () async {
-      await _bothEqual(
-        r'''
+      await _bothEqual(r'''
         enum Planet {
           earth(9.8), mars(3.7);
           final double gravity;
@@ -180,19 +174,15 @@ enum Planet {
             return e.ratio(m);
           }
         }
-        ''',
-        9.8 / 3.7,
-      );
+        ''', 9.8 / 3.7);
     });
   });
 
   group('Wasm: switch on an enum', () {
-    // The Dart interpreter handles `switch` on an enum; the Wasm compiler does
-    // not yet (the scrutinee's enum value reduction leaves the stack
-    // unbalanced). `switch` on `int` and `String` work.
+    // `switch` on an enum is compiled by reducing the scrutinee and each case
+    // entry to their ordinal (`.index`) and comparing as ints.
     test('switch on an enum scrutinee', () async {
-      await _bothEqual(
-        r'''
+      await _bothEqual(r'''
         enum Color { red, green, blue }
         class Main {
           static int run() {
@@ -204,11 +194,8 @@ enum Planet {
             }
           }
         }
-        ''',
-        2,
-      );
-    }, skip: 'BUG: Wasm `switch` on an enum scrutinee is not yet supported '
-        '(int and String switch work).');
+        ''', 2);
+    });
   });
 
   group('Wasm: C# enum .value (explicit values)', () {

--- a/test/wasm/apollovm_wasm_exception_test.dart
+++ b/test/wasm/apollovm_wasm_exception_test.dart
@@ -300,6 +300,29 @@ int test(int x) {
         51,
       );
     });
+
+    // GAP 8: a catch clause with a declared catch-all exception TYPE
+    // (`Exception`/`Throwable`/`Error`/`Object`). The Wasm model carries a
+    // single thrown value, so a typed catch-all must be treated like an untyped
+    // `catch (e)` instead of failing with "Can't handle type: Exception".
+    test('typed catch with a catch-all type (on Exception)', () async {
+      await _check(
+        'typed-catchall',
+        r'''
+int test(int b) {
+  try {
+    if (b == 0) { throw 7; }
+    return b;
+  } on Exception catch (e) {
+    return -1;
+  }
+}
+''',
+        'test',
+        [0],
+        -1,
+      );
+    });
   });
 
   group('Wasm cross-function propagation', () {

--- a/test/wasm/apollovm_wasm_object_field_test.dart
+++ b/test/wasm/apollovm_wasm_object_field_test.dart
@@ -187,9 +187,11 @@ void main() {
     // a boxed (i32) slot, but storing an `int` (i64) into it does not box the
     // value — producing an i32/i64 width mismatch. A robust fix needs box-on
     // -store / unbox-on-read for `dynamic`/`Object` fields holding primitives.
-    test('generic Box<int> field round-trips', () async {
-      await _testWasmPrints(
-        r'''
+    test(
+      'generic Box<int> field round-trips',
+      () async {
+        await _testWasmPrints(
+          r'''
         class Box<T> {
           T value;
           Box(this.value);
@@ -199,11 +201,14 @@ void main() {
           print(b.value);
         }
       ''',
-        'main',
-        ['7'],
-      );
-    }, skip: 'BUG/GAP 4: a generic (type-parameter -> `dynamic`) field holding a '
-        'primitive int is not boxed on store, causing an i32/i64 width '
-        'mismatch in Wasm.');
+          'main',
+          ['7'],
+        );
+      },
+      skip:
+          'BUG/GAP 4: a generic (type-parameter -> `dynamic`) field holding a '
+          'primitive int is not boxed on store, causing an i32/i64 width '
+          'mismatch in Wasm.',
+    );
   });
 }

--- a/test/wasm/apollovm_wasm_object_field_test.dart
+++ b/test/wasm/apollovm_wasm_object_field_test.dart
@@ -181,5 +181,29 @@ void main() {
         ['Hi Bob'],
       );
     });
+
+    // GAP 4: a generic class with a type-parameter field instantiated as
+    // `Box<int>`. The type parameter `T` is erased to `dynamic`, so the field is
+    // a boxed (i32) slot, but storing an `int` (i64) into it does not box the
+    // value — producing an i32/i64 width mismatch. A robust fix needs box-on
+    // -store / unbox-on-read for `dynamic`/`Object` fields holding primitives.
+    test('generic Box<int> field round-trips', () async {
+      await _testWasmPrints(
+        r'''
+        class Box<T> {
+          T value;
+          Box(this.value);
+        }
+        void main() {
+          var b = Box<int>(7);
+          print(b.value);
+        }
+      ''',
+        'main',
+        ['7'],
+      );
+    }, skip: 'BUG/GAP 4: a generic (type-parameter -> `dynamic`) field holding a '
+        'primitive int is not boxed on store, causing an i32/i64 width '
+        'mismatch in Wasm.');
   });
 }

--- a/test/wasm/apollovm_wasm_ops_test.dart
+++ b/test/wasm/apollovm_wasm_ops_test.dart
@@ -416,9 +416,11 @@ void main() {
     // supported (int only)". A robust fix must narrow the boxed scrutinee to its
     // i64 int payload AND agree with how the value is boxed (host-marshalled
     // params vs in-module boxes) — deferred.
-    test('switch on a boxed dynamic scrutinee', () async {
-      await _testWasm(
-        r'''
+    test(
+      'switch on a boxed dynamic scrutinee',
+      () async {
+        await _testWasm(
+          r'''
         int run(List<Object> args) {
           switch (args[0]) {
             case 1: return 10;
@@ -427,16 +429,19 @@ void main() {
           }
         }
         ''',
-        'run',
-        {
-          [
-            [1],
-          ]: 10,
-        },
-      );
-    }, skip: 'BUG/GAP 5: Wasm `switch` on a boxed dynamic/Object scrutinee is '
-        'not yet supported (needs payload narrowing consistent with the box '
-        'representation).');
+          'run',
+          {
+            [
+              [1],
+            ]: 10,
+          },
+        );
+      },
+      skip:
+          'BUG/GAP 5: Wasm `switch` on a boxed dynamic/Object scrutinee is '
+          'not yet supported (needs payload narrowing consistent with the box '
+          'representation).',
+    );
 
     // `switch` on a String scrutinee (content equality).
     test('switch on a String scrutinee', () async {

--- a/test/wasm/apollovm_wasm_ops_test.dart
+++ b/test/wasm/apollovm_wasm_ops_test.dart
@@ -437,5 +437,26 @@ void main() {
     }, skip: 'BUG/GAP 5: Wasm `switch` on a boxed dynamic/Object scrutinee is '
         'not yet supported (needs payload narrowing consistent with the box '
         'representation).');
+
+    // `switch` on a String scrutinee (content equality).
+    test('switch on a String scrutinee', () async {
+      await _testWasm(
+        r'''
+        String run(String s) {
+          switch (s) {
+            case 'a': return 'first';
+            case 'b': return 'second';
+            default: return 'other';
+          }
+        }
+        ''',
+        'run',
+        {
+          ['a']: 'first',
+          ['b']: 'second',
+          ['z']: 'other',
+        },
+      );
+    });
   });
 }

--- a/test/wasm/apollovm_wasm_ops_test.dart
+++ b/test/wasm/apollovm_wasm_ops_test.dart
@@ -409,5 +409,33 @@ void main() {
         },
       );
     });
+
+    // GAP 5: a `switch` whose scrutinee is a genuinely boxed `dynamic`/`Object`
+    // value (e.g. a `List<Object>` element, or a `dynamic` parameter marshalled
+    // by the host). The compiler currently throws "switch on dynamic is not
+    // supported (int only)". A robust fix must narrow the boxed scrutinee to its
+    // i64 int payload AND agree with how the value is boxed (host-marshalled
+    // params vs in-module boxes) — deferred.
+    test('switch on a boxed dynamic scrutinee', () async {
+      await _testWasm(
+        r'''
+        int run(List<Object> args) {
+          switch (args[0]) {
+            case 1: return 10;
+            case 2: return 20;
+            default: return 99;
+          }
+        }
+        ''',
+        'run',
+        {
+          [
+            [1],
+          ]: 10,
+        },
+      );
+    }, skip: 'BUG/GAP 5: Wasm `switch` on a boxed dynamic/Object scrutinee is '
+        'not yet supported (needs payload narrowing consistent with the box '
+        'representation).');
   });
 }

--- a/test/wasm/apollovm_wasm_ops_test.dart
+++ b/test/wasm/apollovm_wasm_ops_test.dart
@@ -463,5 +463,51 @@ void main() {
         },
       );
     });
+
+    // `switch` on a String using assignment + `break` (not return-per-case),
+    // followed by a trailing `return`.
+    test('switch on a String with break + trailing return', () async {
+      await _testWasm(
+        r'''
+        int run(String s) {
+          int r = 0;
+          switch (s) {
+            case 'x': { r = 1; break; }
+            case 'y': { r = 2; break; }
+            default: { r = 9; }
+          }
+          return r;
+        }
+        ''',
+        'run',
+        {
+          ['x']: 1,
+          ['y']: 2,
+          ['q']: 9,
+        },
+      );
+    });
+
+    // A String scrutinee held in a local variable (not the parameter directly).
+    test('switch on a String local after a var declaration', () async {
+      await _testWasm(
+        r'''
+        String run(String s) {
+          var key = s;
+          switch (key) {
+            case 'go': return 'green';
+            case 'stop': return 'red';
+            default: return 'amber';
+          }
+        }
+        ''',
+        'run',
+        {
+          ['go']: 'green',
+          ['stop']: 'red',
+          ['wait']: 'amber',
+        },
+      );
+    });
   });
 }

--- a/test/wasm/apollovm_wasm_return_paths_test.dart
+++ b/test/wasm/apollovm_wasm_return_paths_test.dart
@@ -1,0 +1,225 @@
+@TestOn('vm')
+@Tags(['wasm', 'dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Compiles [code] to Wasm and runs top-level [fn] on BOTH the AST interpreter
+/// and the compiled+executed Wasm module, asserting every `args -> expected`
+/// pair in [executions] matches on both backends.
+///
+/// These cases exercise functions whose body ENDS with a control construct
+/// (`switch` / `if` / `while`) that returns on every path — frequently preceded
+/// by a `var` declaration. Such a body ends with a block's `end` (reachable to
+/// the Wasm validator), so the compiler must emit a trailing `unreachable` +
+/// default; a residual virtual-stack entry from the preceding declaration must
+/// not suppress it.
+Future<void> _testWasm(
+  String code,
+  String fn,
+  Map<List, Object?> executions,
+) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', code, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source");
+
+  // 1) AST interpreter (reference).
+  var astRunner = vm.createRunner('dart')!;
+  for (var e in executions.entries) {
+    var r = await astRunner.executeFunction(
+      '',
+      fn,
+      positionalParameters: e.key,
+    );
+    expect(r.getValueNoContext(), e.value, reason: 'AST $fn(${e.key})');
+  }
+
+  // 2) Compile to Wasm.
+  var storageWasm = vm.generateAllIn<BytesOutput>('wasm');
+  var wasmModules = await storageWasm.allEntries();
+  BytesOutput? compiled;
+  for (var ns in wasmModules.entries) {
+    for (var m in ns.value.entries) {
+      compiled ??= m.value;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var rt = WasmRuntime()..ensureBooted();
+  if (!rt.isSupported) {
+    fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+  }
+
+  // 3) Load + execute the compiled Wasm.
+  var vmWasm = ApolloVM();
+  var loadOK = await vmWasm.loadCodeUnit(
+    BinaryCodeUnit('wasm', compiled!.output(), id: 'test.wasm', namespace: ''),
+  );
+  expect(loadOK, isTrue, reason: 'Compiled Wasm failed to load');
+
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  for (var e in executions.entries) {
+    var r = await wasmRunner.executeFunction(
+      '',
+      fn,
+      positionalParameters: e.key,
+    );
+    expect(r.getValueNoContext(), e.value, reason: 'WASM $fn(${e.key})');
+  }
+}
+
+void main() {
+  group('Wasm: control flow as the terminating statement', () {
+    test('switch as last statement (scrutinee is the parameter)', () {
+      return _testWasm(
+        r'''
+        int run(int x) {
+          switch (x) {
+            case 1: return 10;
+            case 2: return 20;
+            default: return 99;
+          }
+        }
+        ''',
+        'run',
+        {
+          [1]: 10,
+          [2]: 20,
+          [7]: 99,
+        },
+      );
+    });
+
+    test('switch as last statement preceded by a var declaration', () {
+      return _testWasm(
+        r'''
+        int run(int y) {
+          var x = y + 1;
+          switch (x) {
+            case 6: return 60;
+            default: return 0;
+          }
+        }
+        ''',
+        'run',
+        {
+          [5]: 60,
+          [1]: 0,
+        },
+      );
+    });
+
+    test('switch as last statement after several var declarations', () {
+      return _testWasm(
+        r'''
+        int run(int y) {
+          var a = y;
+          var b = a * 2;
+          var c = b + 1;
+          switch (c) {
+            case 11: return 111;
+            case 21: return 211;
+            default: return -1;
+          }
+        }
+        ''',
+        'run',
+        {
+          [5]: 111,
+          [10]: 211,
+          [0]: -1,
+        },
+      );
+    });
+
+    test('if/else (both branches return) as last statement after var decl', () {
+      return _testWasm(
+        r'''
+        int run(int y) {
+          var x = y;
+          if (x > 0) { return 1; } else { return 2; }
+        }
+        ''',
+        'run',
+        {
+          [5]: 1,
+          [-3]: 2,
+        },
+      );
+    });
+
+    test('while(true){ return } as last statement after var decl', () {
+      return _testWasm(
+        r'''
+        int run(int y) {
+          var x = y;
+          while (true) { return x + 1; }
+        }
+        ''',
+        'run',
+        {
+          [5]: 6,
+        },
+      );
+    });
+
+    test('double return via if/else after a var declaration', () {
+      return _testWasm(
+        r'''
+        double run(double y) {
+          var x = y;
+          if (x > 0.0) { return x * 2.0; } else { return 0.0; }
+        }
+        ''',
+        'run',
+        {
+          [2.5]: 5.0,
+          [-1.0]: 0.0,
+        },
+      );
+    });
+
+    test('String return via switch after a var declaration', () {
+      return _testWasm(
+        r'''
+        String run(int code) {
+          var c = code;
+          switch (c) {
+            case 1: return 'one';
+            case 2: return 'two';
+            default: return 'many';
+          }
+        }
+        ''',
+        'run',
+        {
+          [1]: 'one',
+          [2]: 'two',
+          [9]: 'many',
+        },
+      );
+    });
+
+    test('nested if inside switch, all paths return, after var decl', () {
+      return _testWasm(
+        r'''
+        int run(int y) {
+          var x = y;
+          switch (x) {
+            case 1:
+              if (x > 0) { return 100; } else { return 101; }
+            default:
+              return 9;
+          }
+        }
+        ''',
+        'run',
+        {
+          [1]: 100,
+          [5]: 9,
+        },
+      );
+    });
+  });
+}

--- a/test/wasm/apollovm_wasm_static_method_test.dart
+++ b/test/wasm/apollovm_wasm_static_method_test.dart
@@ -530,5 +530,66 @@ void main() {
         ['15'],
       );
     });
+
+    // GAP 1: an INSTANCE method calling a sibling INSTANCE method by bare name
+    // (an implicit-`this` call), driven from a static entry.
+    test('unqualified sibling instance call (implicit this)', () async {
+      await _testStaticPrints(
+        r'''
+        class Calc {
+          int base;
+          Calc(this.base);
+          int dbl(int n) { return n * 2; }
+          int compute(int n) { return dbl(n) + base; }
+          static void run() {
+            var c = Calc(100);
+            print(c.compute(5));
+          }
+        }
+        ''',
+        'Calc',
+        'run',
+        const [],
+        ['110'],
+      );
+    });
+
+    // GAP 1: named arguments on a bare-name sibling INSTANCE call.
+    test('named args on a bare-name sibling instance call', () async {
+      await _testStaticPrints(
+        r'''
+        class Calc {
+          int scale(int v, {int by = 1}) { return v * by; }
+          int run2() { return scale(6, by: 7); }
+          static void run() {
+            var c = Calc();
+            print(c.run2());
+          }
+        }
+        ''',
+        'Calc',
+        'run',
+        const [],
+        ['42'],
+      );
+    });
+
+    // GAP 1: a static method calling a sibling static method that itself takes
+    // multiple arguments (chained resolution).
+    test('chained bare-name sibling static calls', () async {
+      await _testStaticPrints(
+        r'''
+        class Foo {
+          static int add(int a, int b) { return a + b; }
+          static int twice(int n) { return add(n, n); }
+          static void run() { print(twice(21)); }
+        }
+        ''',
+        'Foo',
+        'run',
+        const [],
+        ['42'],
+      );
+    });
   });
 }

--- a/test/wasm/apollovm_wasm_static_method_test.dart
+++ b/test/wasm/apollovm_wasm_static_method_test.dart
@@ -477,5 +477,58 @@ void main() {
         ['1', '2', '3', '4'],
       );
     });
+
+    // GAP 1: a static method calling a SIBLING static method by bare name (no
+    // `this.`/`Foo.` qualifier). Static methods are registered under their
+    // qualified `Class.method` name, so a bare-name call must resolve against
+    // the enclosing class's static methods.
+    test('unqualified sibling static call resolves', () async {
+      await _testStaticPrints(
+        r'''
+        class Foo {
+          static int dbl(int n) { return n * 2; }
+          static void run(int x) { print(dbl(x)); }
+        }
+        ''',
+        'Foo',
+        'run',
+        const [5],
+        ['10'],
+      );
+    });
+
+    // GAP 1: named arguments on a bare-name sibling static call (`h` is a real
+    // named parameter, so this is valid Dart).
+    test('named args on a bare-name sibling static call', () async {
+      await _testStaticPrints(
+        r'''
+        class Foo {
+          static int area(int w, {int h = 1}) { return w * h; }
+          static void run() { print(area(4, h: 3)); }
+        }
+        ''',
+        'Foo',
+        'run',
+        const [],
+        ['12'],
+      );
+    });
+
+    // GAP 1: omitted default on a bare-name sibling static call (`h` defaults
+    // to 3).
+    test('default param omitted on a bare-name sibling static call', () async {
+      await _testStaticPrints(
+        r'''
+        class Foo {
+          static int area(int w, [int h = 3]) { return w * h; }
+          static void run() { print(area(5)); }
+        }
+        ''',
+        'Foo',
+        'run',
+        const [],
+        ['15'],
+      );
+    });
   });
 }

--- a/test/wasm/apollovm_wasm_string_concat_test.dart
+++ b/test/wasm/apollovm_wasm_string_concat_test.dart
@@ -4,7 +4,6 @@ library;
 import 'dart:typed_data';
 
 import 'package:apollovm/apollovm.dart';
-import 'package:data_serializer/data_serializer.dart';
 import 'package:test/test.dart';
 
 /// Compiles [code] to Wasm, runs the exported [functionName] on the native

--- a/test/wasm/apollovm_wasm_string_concat_test.dart
+++ b/test/wasm/apollovm_wasm_string_concat_test.dart
@@ -1,0 +1,99 @@
+@Tags(['wasm'])
+library;
+
+import 'dart:typed_data';
+
+import 'package:apollovm/apollovm.dart';
+import 'package:data_serializer/data_serializer.dart';
+import 'package:test/test.dart';
+
+/// Compiles [code] to Wasm, runs the exported [functionName] on the native
+/// `wasm_run` runtime for each `args -> expected` entry in [executions], and
+/// asserts the returned value. Also runs the AST interpreter as a reference.
+Future<void> _testWasm({
+  required String language,
+  required String code,
+  required String functionName,
+  required Map<List, Object?> executions,
+}) async {
+  var vm = ApolloVM();
+  var loadOK = await vm.loadCodeUnit(SourceCodeUnit(language, code, id: 'test'));
+  expect(loadOK, isTrue, reason: "Can't load `$language` source");
+
+  // AST interpreter reference run.
+  var astRunner = vm.createRunner(language)!;
+  for (var e in executions.entries) {
+    var astValue = await astRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(astValue.getValueNoContext(), e.value, reason: 'interpreter');
+  }
+
+  // Compile to Wasm.
+  var storageWasm = vm.generateAllIn<BytesOutput>('wasm');
+  var wasmModules = await storageWasm.allEntries();
+  BytesOutput? compiled;
+  for (var ns in wasmModules.entries) {
+    for (var m in ns.value.entries) {
+      compiled ??= m.value;
+    }
+  }
+  expect(compiled, isNotNull);
+
+  var wasmRuntime = WasmRuntime();
+  wasmRuntime.ensureBooted();
+  if (!wasmRuntime.isSupported) return; // No native runtime available.
+
+  var vmWasm = ApolloVM();
+  var wasmBytes = Uint8List.fromList(compiled!.output());
+  var ok = await vmWasm.loadCodeUnit(
+    BinaryCodeUnit('wasm', wasmBytes, id: 'test.wasm', namespace: ''),
+  );
+  expect(ok, isTrue);
+
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  for (var e in executions.entries) {
+    var v = await wasmRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(v.getValueNoContext(), e.value, reason: 'wasm');
+  }
+}
+
+void main() {
+  group('Wasm: String + <number> concatenation', () {
+    // GAP 2: `String + int`. Dart forbids this syntactically, so it arrives
+    // from Kotlin/Java/C#/JS/TS sources.
+    test('String + int (Kotlin)', () {
+      return _testWasm(
+        language: 'kotlin',
+        code: r'''
+          fun run(n: Int): String {
+            return "n=" + n
+          }
+        ''',
+        functionName: 'run',
+        executions: {
+          [5]: 'n=5',
+        },
+      );
+    });
+
+    test('String + double (Kotlin)', () {
+      return _testWasm(
+        language: 'kotlin',
+        code: r'''
+          fun run(): String {
+            return "g=" + 9.8
+          }
+        ''',
+        functionName: 'run',
+        executions: {[]: 'g=9.8'},
+      );
+    });
+  });
+}

--- a/test/wasm/apollovm_wasm_string_concat_test.dart
+++ b/test/wasm/apollovm_wasm_string_concat_test.dart
@@ -21,14 +21,23 @@ Future<void> _testWasm({
   );
   expect(loadOK, isTrue, reason: "Can't load `$language` source");
 
-  // AST interpreter reference run.
+  // AST interpreter reference run. A `Class.method` entry (no top-level
+  // functions, e.g. C#) is invoked via `executeClassMethod`.
   var astRunner = vm.createRunner(language)!;
+  var dot = functionName.indexOf('.');
   for (var e in executions.entries) {
-    var astValue = await astRunner.executeFunction(
-      '',
-      functionName,
-      positionalParameters: e.key,
-    );
+    var astValue = dot < 0
+        ? await astRunner.executeFunction(
+            '',
+            functionName,
+            positionalParameters: e.key,
+          )
+        : await astRunner.executeClassMethod(
+            '',
+            functionName.substring(0, dot),
+            functionName.substring(dot + 1),
+            positionalParameters: e.key,
+          );
     expect(astValue.getValueNoContext(), e.value, reason: 'interpreter');
   }
 
@@ -94,6 +103,58 @@ void main() {
         ''',
         functionName: 'run',
         executions: {[]: 'g=9.8'},
+      );
+    });
+
+    // Chained: String + int + String (left-associative; the running value stays
+    // a String after the first concat).
+    test('String + int + String chained (Kotlin)', () {
+      return _testWasm(
+        language: 'kotlin',
+        code: r'''
+          fun run(n: Int): String {
+            return "[" + n + "]"
+          }
+        ''',
+        functionName: 'run',
+        executions: {
+          [42]: '[42]',
+        },
+      );
+    });
+
+    // Number on the left is NOT a String concat in Kotlin (`n + "x"` where n is
+    // Int is invalid), but `"x" + n + m` chains two numbers onto a String.
+    test('String + int + int chained (Kotlin)', () {
+      return _testWasm(
+        language: 'kotlin',
+        code: r'''
+          fun run(a: Int, b: Int): String {
+            return "sum:" + a + "+" + b
+          }
+        ''',
+        functionName: 'run',
+        executions: {
+          [3, 4]: 'sum:3+4',
+        },
+      );
+    });
+
+    // The same gap from C# (a different front end / generator).
+    test('String + int (C#)', () {
+      return _testWasm(
+        language: 'csharp',
+        code: r'''
+          class Foo {
+            public static string run(int n) {
+              return "n=" + n;
+            }
+          }
+        ''',
+        functionName: 'Foo.run',
+        executions: {
+          [7]: 'n=7',
+        },
       );
     });
   });

--- a/test/wasm/apollovm_wasm_string_concat_test.dart
+++ b/test/wasm/apollovm_wasm_string_concat_test.dart
@@ -16,7 +16,9 @@ Future<void> _testWasm({
   required Map<List, Object?> executions,
 }) async {
   var vm = ApolloVM();
-  var loadOK = await vm.loadCodeUnit(SourceCodeUnit(language, code, id: 'test'));
+  var loadOK = await vm.loadCodeUnit(
+    SourceCodeUnit(language, code, id: 'test'),
+  );
   expect(loadOK, isTrue, reason: "Can't load `$language` source");
 
   // AST interpreter reference run.


### PR DESCRIPTION
## Summary

Reproduces and fixes a batch of gaps in the on-the-fly **WebAssembly compiler** (`lib/src/languages/wasm/wasm_generator.dart`), from `WASM_BACKEND_PLAN.md`. Each fix has a reproduction test in the existing `test/wasm/` harness; new tests are kept and validated on **both** the native `wasm_run` runtime and **Chrome** (`dart test --platform chrome`). Bumps to **0.1.43**.

### Fixed
- **GAP 1 — unqualified sibling class-method calls.** A method can call a sibling `static` method by bare name (`dbl(x)`). Static methods (registered as `Class.method`) get a `staticMethodIndexForCall` lookup, the static-method codegen context carries `classLayout`, and declared parameters are reused so default values survive — also unblocking named-args/defaults on bare-name static calls.
- **GAP 2 — `String + <number>`.** Each operand is coerced to a String handle via the existing interpolation converters.
- **GAP 7 — rich-enum methods + enum-typed parameters.** A named reference type (class/enum used by name, e.g. `Planet p`) maps to an i32 heap pointer.
- **GAP 8 — typed catch-all** (`on Exception catch (e)` / `catch (Exception e)`) is resolved like an untyped `catch (e)`.
- **GAP 9 — C# enum `.value`.** Explicit-value enums carry an i64 `value` slot seeded in the entry-init.
- **`switch` on a `String`** scrutinee, via per-case content equality (`__streq`). (`int` switch already worked; the Dart interpreter already handled `String`/`enum` switch.)

### Deferred (documented, with skipped reproduction tests)
- **GAP 3** — `Map`/`List` → String coercion (runtime string building).
- **GAP 4** — generic (`Box<T>` → `dynamic`) primitive field: needs box-on-store / unbox-on-read (i32/i64 width mismatch).
- **GAP 5** — `switch` on a boxed `dynamic`/`Object` scrutinee.
- **GAP 6** — lambdas / anonymous functions.
- **`switch` on an `enum`** scrutinee (Wasm): the scrutinee reduction leaves the validator stack unbalanced.

## Verification
- `dart analyze` clean.
- `dart test -t wasm -x wasm-gc -x wasm-chrome` → **338 passing, 3 skipped** (the documented deferrals).
- The new/changed gap tests also pass on **Chrome** (`--platform chrome`, real WasmGC engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)