### PR TITLE
fix(wasm): correct enum-entry initializer call index when host imports shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 0.1.44
+
+### Wasm backend: rich-enum field/method reads in a `print` context
+
+- Fixed garbage values when a rich-enum instance field or method result was
+  passed through `print(...)` / string interpolation (e.g. `print(p.gravity)`
+  or `print('${p.mult(2)}')`). The lazily-generated enum-entry initializer
+  baked its constructor `call` index during an early discovery pass, before the
+  `print`/`double_to_str` host imports were registered; those imports then
+  shifted every function index, so the cached call landed on a host import
+  instead of the enum constructor. Enum-entry initializer bodies are now
+  generated lazily (after the import count is final), so the call indices are
+  correct. Reading the same field/method outside a `print` (e.g. `return
+  p.gravity`) was already correct.
+
 ## 0.1.43
 
 ### Wasm backend: close several Dart → WebAssembly gaps

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -53,7 +53,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.43';
+  static final String VERSION = '0.1.44';
 
   static int _idCount = 0;
 

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -1080,11 +1080,14 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         .toList();
 
     // Synth functions (e.g. `__alloc`) registered during user-body codegen.
-    // Each body is length-prefixed (like user-function bodies).
+    // Each body is length-prefixed (like user-function bodies). Bodies are
+    // materialized here — after the import-discovery pass above has finalized
+    // `importCount` — so a deferred body (e.g. an enum-entry init that calls the
+    // enum constructor) bakes in correct function-call indices.
     for (var s in module.synthFunctions) {
       var bodyEntry = newOutput();
       bodyEntry.writeBytesLeb128Block([
-        s.body,
+        s.materializeBody(),
       ], description: "Synth body `${s.name}`");
       entries.add(bodyEntry);
     }
@@ -4600,89 +4603,108 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     var globalIndex = module.enumEntryGlobalIndex(synthName);
     var namePtr = module.internStringLiteral(entry.name);
 
-    // Build the body with a fresh context so the constructor invocation reuses
-    // the full argument-evaluation / type-conversion machinery.
-    var context = WasmContext(module: module);
-    var instLocal = context.scratchLocal(_astTypeString, 0); // i32 ptr
+    // The body calls the enum's constructor, whose call index is
+    // `importCount + position`. Host imports are registered lazily as bodies are
+    // generated, so the body must be materialized only AFTER the import-
+    // discovery pass has finalized `importCount` — otherwise a `print`/string
+    // coercion elsewhere could register imports later and shift the baked call
+    // index onto a host import. Defer body generation via `bodyBuilder`; only
+    // the synth function's *index* is reserved eagerly here.
+    BytesOutput buildBody() {
+      // Build the body with a fresh context so the constructor invocation reuses
+      // the full argument-evaluation / type-conversion machinery.
+      var context = WasmContext(module: module);
+      var instLocal = context.scratchLocal(_astTypeString, 0); // i32 ptr
 
-    var body = newOutput();
+      var body = newOutput();
 
-    // if (global == 0) { build + cache }
-    body.write(Wasm.globalGet(globalIndex));
-    body.writeByte(Wasm32.i32EqualsToZero);
-    body.write(Wasm.ifInstruction(WasmType.voidType));
+      // if (global == 0) { build + cache }
+      body.write(Wasm.globalGet(globalIndex));
+      body.writeByte(Wasm32.i32EqualsToZero);
+      body.write(Wasm.ifInstruction(WasmType.voidType));
 
-    // instance = EnumName(<entry args>)  (the constructor allocates + inits).
-    var args = entry.arguments ?? const <ASTExpression>[];
-    var invocation = ASTExpressionLocalFunctionInvocation(
-      enumClass.name,
-      args.toList(),
-    );
-    generateASTExpressionLocalFunctionInvocation(
-      invocation,
-      out: body,
-      context: context,
-    );
-    context.stackDrop(); // consumed by the local.set below
-    body.write(Wasm.localSet(instLocal));
-
-    // instance.index = ordinal (i64)
-    body.write(Wasm.localGet(instLocal));
-    body.write(Wasm64.i64Const(entryIndex));
-    _emitElemStore(body, _astTypeInt64, layout.offsets['index']!);
-
-    // instance.name = interned String ptr (i32)
-    body.write(Wasm.localGet(instLocal));
-    body.write(Wasm32.i32Const(namePtr));
-    _emitElemStore(body, _astTypeString, layout.offsets['name']!);
-
-    // instance.value = explicit declared value (i64), for explicit-value enums.
-    var valueOffset = layout.offsets['value'];
-    if (valueOffset != null) {
-      body.write(Wasm.localGet(instLocal));
-      var entryValue = entry.value;
-      if (entryValue != null) {
-        generateASTExpression(entryValue, out: body, context: context);
-        _autoConvertStackTypes(
-          context.stackGet(0)!.type,
-          _astTypeInt64,
-          out: body,
-          context: context,
-        );
-        context.stackDrop(); // consumed by the store below
-      } else {
-        body.write(Wasm64.i64Const(0));
-      }
-      _emitElemStore(body, _astTypeInt64, valueOffset);
-    }
-
-    // global = instance
-    body.write(Wasm.localGet(instLocal));
-    body.write(Wasm.globalSet(globalIndex));
-    body.writeByte(Wasm.end); // if
-
-    // return global
-    body.write(Wasm.globalGet(globalIndex));
-
-    // Function body: local declarations (scratch locals) + ops + end.
-    var outBody = newOutput();
-    var scratchTypes = context.scratchLocalTypes;
-    outBody.write(
-      Leb128.encodeUnsigned(scratchTypes.length),
-      description: "Local groups (enum init `$synthName`)",
-    );
-    for (var astType in scratchTypes) {
-      outBody.write(Leb128.encodeUnsigned(1), description: "Scratch var count");
-      outBody.writeByte(
-        astType.wasmCode,
-        description: "Scratch (${astType.wasmType.name})",
+      // instance = EnumName(<entry args>)  (the constructor allocates + inits).
+      var args = entry.arguments ?? const <ASTExpression>[];
+      var invocation = ASTExpressionLocalFunctionInvocation(
+        enumClass.name,
+        args.toList(),
       );
+      generateASTExpressionLocalFunctionInvocation(
+        invocation,
+        out: body,
+        context: context,
+      );
+      context.stackDrop(); // consumed by the local.set below
+      body.write(Wasm.localSet(instLocal));
+
+      // instance.index = ordinal (i64)
+      body.write(Wasm.localGet(instLocal));
+      body.write(Wasm64.i64Const(entryIndex));
+      _emitElemStore(body, _astTypeInt64, layout.offsets['index']!);
+
+      // instance.name = interned String ptr (i32)
+      body.write(Wasm.localGet(instLocal));
+      body.write(Wasm32.i32Const(namePtr));
+      _emitElemStore(body, _astTypeString, layout.offsets['name']!);
+
+      // instance.value = explicit declared value (i64), for explicit-value enums.
+      var valueOffset = layout.offsets['value'];
+      if (valueOffset != null) {
+        body.write(Wasm.localGet(instLocal));
+        var entryValue = entry.value;
+        if (entryValue != null) {
+          generateASTExpression(entryValue, out: body, context: context);
+          _autoConvertStackTypes(
+            context.stackGet(0)!.type,
+            _astTypeInt64,
+            out: body,
+            context: context,
+          );
+          context.stackDrop(); // consumed by the store below
+        } else {
+          body.write(Wasm64.i64Const(0));
+        }
+        _emitElemStore(body, _astTypeInt64, valueOffset);
+      }
+
+      // global = instance
+      body.write(Wasm.localGet(instLocal));
+      body.write(Wasm.globalSet(globalIndex));
+      body.writeByte(Wasm.end); // if
+
+      // return global
+      body.write(Wasm.globalGet(globalIndex));
+
+      // Function body: local declarations (scratch locals) + ops + end.
+      var outBody = newOutput();
+      var scratchTypes = context.scratchLocalTypes;
+      outBody.write(
+        Leb128.encodeUnsigned(scratchTypes.length),
+        description: "Local groups (enum init `$synthName`)",
+      );
+      for (var astType in scratchTypes) {
+        outBody.write(
+          Leb128.encodeUnsigned(1),
+          description: "Scratch var count",
+        );
+        outBody.writeByte(
+          astType.wasmCode,
+          description: "Scratch (${astType.wasmType.name})",
+        );
+      }
+      outBody.writeBytes(body);
+      outBody.writeByte(Wasm.end, description: "Enum init body end");
+      return outBody;
     }
-    outBody.writeBytes(body);
-    outBody.writeByte(Wasm.end, description: "Enum init body end");
 
     module.addSynthFunction(
-      WasmSynthFunction(synthName, const [], const [WasmType.i32Type], outBody),
+      WasmSynthFunction(
+        synthName,
+        const [],
+        const [WasmType.i32Type],
+        null,
+        bodyBuilder: buildBody,
+      ),
     );
 
     return module.synthFunctionIndex(synthName)!;
@@ -9101,8 +9123,17 @@ class WasmSynthFunction {
   final List<WasmType> params;
   final List<WasmType> results;
 
-  /// The complete code body: locals vector + instructions + `end`.
-  final BytesOutput body;
+  /// The complete code body (locals vector + instructions + `end`), or null
+  /// when [bodyBuilder] defers body generation.
+  final BytesOutput? body;
+
+  /// Deferred body generator. Used when the body bakes in function-call indices
+  /// that depend on the final `importCount` (e.g. an enum-entry init that calls
+  /// the enum constructor): the synth function's *index* is registered eagerly
+  /// (during the import-discovery pass), but its *body* is materialized only
+  /// once all host imports have been registered, so call indices are correct.
+  final BytesOutput Function()? bodyBuilder;
+
   final bool exported;
 
   WasmSynthFunction(
@@ -9110,8 +9141,12 @@ class WasmSynthFunction {
     this.params,
     this.results,
     this.body, {
+    this.bodyBuilder,
     this.exported = false,
   });
+
+  /// The body bytes, generating them on demand via [bodyBuilder] if deferred.
+  BytesOutput materializeBody() => body ?? bodyBuilder!();
 }
 
 /// Memory layout of a class instance: field byte [offsets] (declaration order),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, C#, JavaScript, TypeScript, Lua and Python with on-the-fly Wasm compilation.
-version: 0.1.43
+version: 0.1.44
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/wasm/apollovm_wasm_enum_test.dart
+++ b/test/wasm/apollovm_wasm_enum_test.dart
@@ -78,6 +78,48 @@ Future<void> _bothEqual(String src, Object? expected) async {
   expect(wasmRes.getValueNoContext(), expected, reason: 'Wasm');
 }
 
+/// Compiles [src] (Dart) and runs the static `Main.run` (no return value) on
+/// BOTH the AST interpreter and the compiled Wasm module, asserting both emit
+/// [expectedPrints].
+///
+/// Exercises enum access in a function that ALSO calls `print` / string
+/// interpolation: `print` and `int_to_str`/`double_to_str` are registered as
+/// host imports, which shifts module function indices. A lazily-generated
+/// enum-entry init synth function must bake its constructor call index using the
+/// FINAL import count, or it ends up calling a host import instead of the
+/// constructor (reading back garbage fields).
+Future<void> _bothPrints(String src, List<String> expectedPrints) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', src, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source");
+
+  var astRunner = vm.createRunner('dart')!;
+  var astOut = <String>[];
+  astRunner.externalPrintFunction = (o) => astOut.add('$o');
+  await astRunner.executeClassMethod('', 'Main', 'run');
+  expect(astOut, equals(expectedPrints), reason: 'interpreter print output');
+
+  var storage = vm.generateAllIn<BytesOutput>('wasm');
+  var modules = await storage.allEntries();
+  BytesOutput? compiled;
+  for (var ns in modules.entries) {
+    for (var m in ns.value.entries) {
+      compiled ??= m.value;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var vmWasm = ApolloVM();
+  await vmWasm.loadCodeUnit(
+    BinaryCodeUnit('wasm', compiled!.output(), id: 'test.wasm', namespace: ''),
+  );
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  var wasmOut = <String>[];
+  wasmRunner.externalPrintFunction = (o) => wasmOut.add('$o');
+  await wasmRunner.executeFunction('', 'Main.run');
+  expect(wasmOut, equals(expectedPrints), reason: 'Wasm print output');
+}
+
 void main() {
   group('Wasm: enum entries as const instances', () {
     const color = 'enum Color { red, green, blue }\n';
@@ -176,6 +218,92 @@ enum Planet {
         }
         ''', 9.8 / 3.7);
     });
+  });
+
+  group('Wasm: rich enum fields/methods printed (host-import index)', () {
+    // Regression: an enum's fields/methods accessed in a function that ALSO
+    // calls `print` (registering `print`/`*_to_str` host imports) used to read
+    // garbage, because the enum-entry init synth baked a stale constructor call
+    // index that the later-registered imports shifted onto a host import.
+    const planet = '''
+enum Planet {
+  earth(9.8), mars(3.7);
+  final double gravity;
+  const Planet(this.gravity);
+  double mult(double m) => gravity * m;
+  double ratio(Planet p) => gravity / p.gravity;
+}
+''';
+
+    // The exact motivating program. Restricted to the VM: the irrational
+    // `9.8 / 3.7` ratio renders slightly differently under dart2js's
+    // `double_to_str` than the interpreter (an orthogonal double-formatting
+    // concern), so the cross-platform cases below use round values.
+    test('the motivating program', () async {
+      await _bothPrints(
+        '${planet}class Main { static void run() {\n'
+        '  var earth = Planet.earth;\n'
+        '  var mars = Planet.mars;\n'
+        "  print('earth.gravity: \${earth.gravity}');\n"
+        "  print('mars.index: \${mars.index} ; mars.name: \${mars.name}');\n"
+        "  print('earth.mult(2): \${earth.mult(2)}');\n"
+        "  print('earth / mars: \${earth.ratio(mars)}');\n"
+        '} }',
+        [
+          'earth.gravity: 9.8',
+          'mars.index: 1 ; mars.name: mars',
+          'earth.mult(2): 19.6',
+          'earth / mars: ${9.8 / 3.7}',
+        ],
+      );
+    }, testOn: 'vm');
+
+    test('print an enum double field directly', () async {
+      await _bothPrints(
+        '${planet}class Main { static void run() {\n'
+        '  var e = Planet.earth;\n'
+        '  print(e.gravity);\n'
+        '} }',
+        ['9.8'],
+      );
+    });
+
+    test('print an enum method result', () async {
+      // 9.8 * 2 = 19.6 — a non-whole double that renders identically on the VM
+      // and dart2js (whole doubles like `37.0` print as `37` under dart2js).
+      await _bothPrints(
+        '${planet}class Main { static void run() {\n'
+        '  var e = Planet.earth;\n'
+        '  print(e.mult(2.0));\n'
+        '} }',
+        ['19.6'],
+      );
+    });
+
+    test('print enum .index and .name together', () async {
+      await _bothPrints(
+        '${planet}class Main { static void run() {\n'
+        '  var e = Planet.mars;\n'
+        "  print('\${e.index}/\${e.name}');\n"
+        '} }',
+        ['1/mars'],
+      );
+    });
+
+    // VM-only: `ratio` returns a whole/irrational double whose string form
+    // differs under dart2js (an orthogonal double-formatting concern). The
+    // enum-typed-parameter path is also covered cross-platform by the
+    // value-comparing `enum method taking an enum-typed parameter` test above.
+    test('print enum-typed-parameter method result', () async {
+      await _bothPrints(
+        '${planet}class Main { static void run() {\n'
+        '  var e = Planet.earth;\n'
+        '  var m = Planet.mars;\n'
+        '  print(e.ratio(m));\n'
+        '} }',
+        ['${9.8 / 3.7}'],
+      );
+    }, testOn: 'vm');
   });
 
   group('Wasm: switch on an enum', () {


### PR DESCRIPTION
## Summary

Fixes garbage values when a **rich-enum instance field or method result is passed through `print(...)` / string interpolation** on the Wasm backend, e.g.:

```dart
enum Planet {
  earth(9.8), mars(3.7);
  final double gravity;
  const Planet(this.gravity);
  double mult(double m) => gravity * m;
  double ratio(Planet p) => gravity / p.gravity;
}

class Foo {
  static void main() {
    var earth = Planet.earth;
    var mars = Planet.mars;
    print(earth.gravity);      // was garbage, now 9.8
    print('${mars.index}/${mars.name}'); // 1/mars
    print(earth.mult(2));      // 19.6
    print(earth.ratio(mars));  // 9.8 / 3.7
  }
}
```

## Root cause

The lazily-generated enum-entry initializer baked its constructor `call` index during the **discovery pass**, before the `print`/`double_to_str` host imports were registered. Those host imports occupy low function indices, so registering them shifted every regular function index — the cached `call` then landed on a host import (e.g. `double_to_str`) instead of the enum constructor, producing a garbage instance. Reading the same field/method outside a `print` (e.g. `return p.gravity`) was already correct because no host import was pulled in.

## Fix

Generate enum-entry initializer **bodies lazily** (after `importCount` is final) via a new `WasmSynthFunction.bodyBuilder` deferral, materialized at emit time. Call indices are then resolved against the finalized import count.

## Tests

Adds dual-run (AST interpreter + Wasm) regression tests in `apollovm_wasm_enum_test.dart` covering the motivating program and field/method/`.index`/`.name`/enum-typed-parameter reads in a `print` context. Validated on:
- the native `wasm_run` runtime — full wasm suite green (`+364`),
- **Chrome / WasmGC** (`--platform chrome`) — green.

Cross-platform tests use double values that render identically under the VM and dart2js; the exact irrational-ratio motivating program is asserted VM-only (an orthogonal `double_to_str` vs dart2js formatting difference).

`dart format` clean, `dart analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)