### PR TITLE
fix(wasm): num, boxed switch, scalar dynamic params, generics & lambdas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,18 @@
   arguments seen as `0`. (The `apollovm_sig` section is now emitted whenever a
   public function has an `Object`/`dynamic` parameter, and a plain `num` is
   tagged as `int` so it is passed as a raw i64 rather than boxed.)
+- **Anonymous functions with an untyped parameter** (`n => n * 2` from
+  C#/Lua/Python) now compile: the parameter type is inferred from its body. A
+  nested closure's `return` no longer makes the enclosing (void) function
+  non-void.
+- **Named nested function declarations** (`let twice = (n) => …`, which
+  JavaScript/TypeScript parse as a function declaration rather than a `var`) are
+  hoisted and lowered to a direct `call`.
+- **A boxed value flows into and out of an `Object`/`dynamic` slot.** A concrete
+  value passed to a generic `T` field/parameter (represented as a boxed
+  `Object`) is boxed; a boxed value used in arithmetic or passed to a typed
+  numeric parameter is unboxed. This makes generic `Box<T>` (Dart, Java, Kotlin,
+  C#, TypeScript) work.
 
 ## 0.1.45
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 0.1.46
+
+### Wasm backend: `num` (TypeScript/JS `number`) + switch on a boxed scrutinee
+
+- **`num` (a TypeScript/JavaScript `number`) is now supported** in the Wasm
+  backend. A plain `num` has no fixed width; the VM treats integer-valued
+  numbers as `int`, so `num` is represented as i64. This fixes string
+  interpolation/concatenation of a `num` (e.g. `"sum=" + (a + b)`), `switch` on
+  a `num` scrutinee, and `num` arithmetic — unblocking the TypeScript Class,
+  Conditional, Exceptions and Switch examples.
+- **`switch` on a boxed `dynamic`/`Object` scrutinee** (e.g. a `List<Object>`
+  element) now compiles: the scrutinee is unboxed to a concrete i64 to drive
+  the integer branch table.
+
 ## 0.1.45
 
 ### Wasm backend: collection-to-String + dynamic arithmetic on boxed values

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@
 - **`switch` on a boxed `dynamic`/`Object` scrutinee** (e.g. a `List<Object>`
   element) now compiles: the scrutinee is unboxed to a concrete i64 to drive
   the integer branch table.
+- **Scalar `Object`/`dynamic` entry-point parameters are now marshalled.** An
+  untyped parameter (e.g. a JavaScript/Python `main(a, b)`, or an explicit Dart
+  `dynamic` parameter) is passed as a host-allocated box instead of a raw scalar
+  the module would read as a garbage pointer — fixing the JavaScript, Lua and
+  Python Class/Conditional/Switch examples, which previously ran with all
+  arguments seen as `0`. (The `apollovm_sig` section is now emitted whenever a
+  public function has an `Object`/`dynamic` parameter, and a plain `num` is
+  tagged as `int` so it is passed as a raw i64 rather than boxed.)
 
 ## 0.1.45
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,11 @@
   `Object`) is boxed; a boxed value used in arithmetic or passed to a typed
   numeric parameter is unboxed. This makes generic `Box<T>` (Dart, Java, Kotlin,
   C#, TypeScript) work.
+- **More boxed-operand operations.** A `var` whose initializer is a boxed-operand
+  expression (e.g. `var s = a + b` where `a`/`b` are `Object[]`/`List<Object>`
+  elements) is refined to the result's concrete type, and the `== 0` fast path
+  (`i64.eqz`) unboxes a boxed operand first. Fixes the Java Class example and the
+  JavaScript try/catch example.
 
 ## 0.1.45
 

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -53,7 +53,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.45';
+  static final String VERSION = '0.1.46';
 
   static int _idCount = 0;
 

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -3144,6 +3144,12 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       "After operation expression (left)",
     );
 
+    // A boxed `Object`/`dynamic` operand (e.g. a dynamic `b` in `b == 0`) is
+    // unboxed to i64 before the `i64.eqz`.
+    if (_isObjectType(context.stackGet(0)!.type)) {
+      _emitUnboxNumberInto(out, context, _astTypeInt64);
+    }
+
     out.writeByte(
       Wasm64.i64EqualsToZero,
       description: "[OP] operator: equals to zero",
@@ -8562,7 +8568,12 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     // concrete function type (signature generics) so a later `twice(x)` call
     // dispatches via `call_indirect` with the matching type.
     var initType = context.stackGet(0)!.type;
-    if (localVar.type is ASTTypeDynamic) {
+    if (_isObjectType(localVar.type) && !_isObjectType(initType)) {
+      // A `var`/`Object`/`dynamic` local whose initializer has a concrete type:
+      // refine to it so method/field access and the local's Wasm width are
+      // correct — `var p = Point()` (i32 instance) or `var s = a + b` where
+      // `a`/`b` are boxed `Object`s and the sum is an i64. A genuinely boxed
+      // initializer (e.g. `var a = args[0]`) stays `Object`.
       context.updateLocalVariableType(name, initType);
     } else if (initType is ASTTypeFunction &&
         (initType.generics?.isNotEmpty ?? false)) {

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -303,6 +303,9 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     if (t is ASTTypeString) return 4;
     if (t is ASTTypeArray) return 6;
     if (t is ASTTypeMap) return 7;
+    // A plain `num` (TS/JS `number`) is represented as i64 (int), so tag it as
+    // int — NOT as `Object` (5), so the host passes a raw i64, not a box.
+    if (t is ASTTypeNum) return 1;
     return 5;
   }
 
@@ -331,17 +334,15 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         t is ASTTypeString ||
         t is ASTTypeBool ||
         t is ASTTypeArray ||
-        t is ASTTypeMap;
+        t is ASTTypeMap ||
+        _isObjectType(t);
     for (var f in module.functions) {
       if (f.modifiers.isPrivate) continue;
       if (needs(f.effectiveReturnType)) return true;
       for (var p in f.parameters.allParameters) {
-        if (p.type is ASTTypeString ||
-            p.type is ASTTypeBool ||
-            p.type is ASTTypeArray ||
-            p.type is ASTTypeMap) {
-          return true;
-        }
+        // An `Object`/`dynamic` param must be in the section so the runner
+        // knows to pass a host-allocated box (not a raw scalar).
+        if (needs(p.type)) return true;
       }
     }
     return false;
@@ -355,7 +356,9 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       for (var p in f.parameters.allParameters) {
         if (p.type is ASTTypeString ||
             p.type is ASTTypeArray ||
-            p.type is ASTTypeMap) {
+            p.type is ASTTypeMap ||
+            _isObjectType(p.type)) {
+          // A scalar `Object`/`dynamic` param is passed as a host-allocated box.
           return true;
         }
       }

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -7857,7 +7857,20 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     generateASTExpression(statement.expression, out: out, context: context);
     var valueType = context.stackGet(0)!.type;
 
-    final switchOnInt = valueType == _astTypeInt64 || valueType == _astTypeInt;
+    // A boxed `dynamic`/`Object` scrutinee (e.g. a JavaScript/Python untyped
+    // parameter) is unboxed to a concrete i64 so it can drive the int branch
+    // table (case labels are integer literals).
+    if (_isObjectType(valueType)) {
+      _emitUnboxNumberInto(out, context, _astTypeInt64);
+      context.stackReplace(_astTypeInt64, "unboxed dynamic switch scrutinee");
+      valueType = _astTypeInt64;
+    }
+
+    // A plain `num` (TS/JS `number`) is represented as i64; switch on it as int.
+    final switchOnInt =
+        valueType == _astTypeInt64 ||
+        valueType == _astTypeInt ||
+        (valueType is ASTTypeNum && valueType is! ASTTypeDouble);
     final switchOnString = valueType is ASTTypeString;
 
     // An `enum` scrutinee is compared by ordinal: reduce both the scrutinee and
@@ -9023,6 +9036,9 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       _emitBoolToString(out, context);
     } else if (type is ASTTypeInt || type is ASTTypeDouble) {
       _emitNumberToString(out, context, type);
+    } else if (type is ASTTypeNum) {
+      // A plain `num` (TS/JS `number`) is represented as i64 (int) in Wasm.
+      _emitNumberToString(out, context, _astTypeInt);
     } else if (_isObjectType(type)) {
       _emitBoxToString(out, context);
     } else if (type is ASTTypeMap) {
@@ -10908,6 +10924,10 @@ extension _ASTTypeExtension on ASTType {
       return WasmType.i64Type;
     } else if (this is ASTTypeDouble) {
       return WasmType.f64Type;
+    } else if (this is ASTTypeNum) {
+      // A plain `num` (e.g. TypeScript/JS `number`) has no fixed width; ApolloVM
+      // treats integer-valued numbers as `int`, so represent it as i64.
+      return WasmType.i64Type;
     } else if (this is ASTTypeBool) {
       return WasmType.i32Type;
     } else if (this is ASTTypeString) {

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -732,14 +732,26 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   _collectAnonymousClosures(List<ASTFunctionDeclaration> baseFunctions) {
     var moduleFnNames = baseFunctions.map((f) => f.name).toSet();
 
+    // The closure function carried by a node: an anonymous-function literal
+    // (`(n) => …`) or a named nested function declaration (JS/TS parse
+    // `let twice = (n) => …` as a named nested function, not a `var`).
+    ASTFunctionDeclaration? closureFnOf(ASTNode node) {
+      if (node is ASTExpressionLiteralFunction) return node.function;
+      if (node is ASTStatementFunctionDeclaration) {
+        return node.functionDeclaration;
+      }
+      return null;
+    }
+
     // Map each closure to the function type it is passed as, and to the
     // function that lexically encloses it (for resolving captured-var types).
     var expected = <ASTFunctionDeclaration, ASTTypeFunction>{};
     var enclosingOf = <ASTFunctionDeclaration, ASTFunctionDeclaration>{};
     for (var encl in baseFunctions) {
       for (var node in encl.descendantChildren) {
-        if (node is ASTExpressionLiteralFunction) {
-          enclosingOf.putIfAbsent(node.function, () => encl);
+        var cfn = closureFnOf(node);
+        if (cfn != null) {
+          enclosingOf.putIfAbsent(cfn, () => encl);
         }
         if (node is ASTExpressionLocalFunctionInvocation) {
           var callee = _findModuleFunction(
@@ -775,8 +787,8 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     var seen = <ASTFunctionDeclaration>{};
     for (var encl in baseFunctions) {
       for (var node in encl.descendantChildren) {
-        if (node is ASTExpressionLiteralFunction) {
-          var fn = node.function;
+        var fn = closureFnOf(node);
+        if (fn != null) {
           if (!seen.add(fn)) continue;
 
           var funcType = expected[fn];
@@ -831,12 +843,21 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     };
     for (var encl in baseFunctions) {
       for (var node in encl.descendantChildren) {
-        if (node is! ASTStatementVariableDeclaration) continue;
-        var init = node.value;
-        if (init is! ASTExpressionLiteralFunction) continue;
-        if (!captureFree.contains(init.function)) continue;
-        if (!_isClosureVarCallOnly(encl, node.name)) continue;
-        (directClosureVars[encl] ??= {})[node.name] = init.function;
+        // `var f = (n) => …`: a closure literal bound to a call-only variable.
+        if (node is ASTStatementVariableDeclaration) {
+          var init = node.value;
+          if (init is! ASTExpressionLiteralFunction) continue;
+          if (!captureFree.contains(init.function)) continue;
+          if (!_isClosureVarCallOnly(encl, node.name)) continue;
+          (directClosureVars[encl] ??= {})[node.name] = init.function;
+        } else if (node is ASTStatementFunctionDeclaration) {
+          // `let twice = (n) => …` (JS/TS): a named nested function, called by
+          // name. Lowered to a direct `call` just like a call-only closure var.
+          var fn = node.functionDeclaration;
+          if (!captureFree.contains(fn)) continue;
+          if (!_isClosureVarCallOnly(encl, fn.name)) continue;
+          (directClosureVars[encl] ??= {})[fn.name] = fn;
+        }
       }
     }
 
@@ -930,6 +951,27 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     return null;
   }
 
+  /// Best-effort static inference of an untyped closure parameter [paramName]
+  /// from its use in the body: a parameter that participates in a binary
+  /// operation is numeric, taking `double` when the other operand is `double`,
+  /// else `int`. Returns `null` when it can't be inferred.
+  ASTType? _inferParamTypeFromBody(
+    ASTFunctionDeclaration fn,
+    String paramName,
+  ) {
+    bool isParam(ASTExpression e) =>
+        e is ASTExpressionVariableAccess && e.variable.name == paramName;
+    for (var node in fn.descendantChildren) {
+      if (node is! ASTExpressionOperation) continue;
+      var e1 = node.expression1, e2 = node.expression2;
+      if (!isParam(e1) && !isParam(e2)) continue;
+      var other = isParam(e1) ? e2 : e1;
+      var t = _inferStaticExpressionType(other, const {});
+      return t is ASTTypeDouble ? _astTypeDouble : _astTypeInt;
+    }
+    return null;
+  }
+
   /// Best-effort static type of [expr] given a [scope] of variable-name -> type
   /// (e.g. a closure's parameters). Handles literals, variable reads and binary
   /// operations — enough for simple arrow bodies (`n * 2`, `n + 1`, `n > 0`).
@@ -998,6 +1040,14 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
           result.add(t);
           continue;
         }
+      }
+      // No typed context (e.g. `var f = (n) => n * 2` from C#/Lua/Python where
+      // the parameter is untyped): infer the parameter type from how it is used
+      // in the body.
+      var inferred = _inferParamTypeFromBody(fn, params[i].name);
+      if (inferred != null) {
+        result.add(inferred);
+        continue;
       }
       throw UnsupportedError(
         "Wasm: can't infer the type of parameter `${params[i].name}` of an "
@@ -2211,6 +2261,23 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       return _generatePrintInvocation(expression, out: out, context: context);
     }
 
+    // A capture-free, call-only closure — a `var f = (n) => …` or a named
+    // nested function (`let f = (n) => …` parsed as a function declaration) — is
+    // lowered directly to a `call` of the closure function (its env parameter is
+    // unused, so a null env is passed), skipping the env allocation and
+    // `call_indirect`. Checked before the module-function table because a named
+    // nested closure is *also* a module function, but its true signature takes
+    // the hidden env parameter.
+    var directFn = context.directClosureVars[name];
+    if (directFn != null) {
+      return _emitDirectClosureCall(
+        expression,
+        directFn,
+        out: out,
+        context: context,
+      );
+    }
+
     // Resolve at the callee's DECLARED arity: a call may omit trailing
     // parameters that have default values, so the supplied [argsCount] can be
     // less than the registered (declared) arity.
@@ -2234,19 +2301,6 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
           methodName: name,
           arguments: positionalArgs,
           namedArguments: namedArgs,
-          out: out,
-          context: context,
-        );
-      }
-
-      // A capture-free, call-only closure assigned to a `var`: lower directly
-      // to a `call` of the closure function (its env parameter is unused, so a
-      // null env is passed), skipping the env allocation and `call_indirect`.
-      var directFn = context.directClosureVars[name];
-      if (directFn != null) {
-        return _emitDirectClosureCall(
-          expression,
-          directFn,
           out: out,
           context: context,
         );
@@ -3016,8 +3070,10 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     BytesOutput out,
     WasmContext context,
   ) {
-    assert(stackType1 == _astTypeInt, stackType1);
-    assert(stackType2 == _astTypeInt, stackType2);
+    // `int` operands, or a plain `num` (TS/JS `number`) which is represented as
+    // i64 like `int`.
+    assert(stackType1 is ASTTypeNum, stackType1);
+    assert(stackType2 is ASTTypeNum, stackType2);
 
     if (stackType1.equalsStrict(stackType2)) {
       out.writeBytes(opsOut1);
@@ -8328,6 +8384,26 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     if (stackType == targetType) return out;
 
+    // A boxed `Object`/`dynamic` value flowing into a concrete numeric target
+    // (e.g. a dynamic argument passed to a typed `int` closure/function
+    // parameter) is unboxed via the runtime box tag.
+    if (_isObjectType(stackType) && targetType is ASTTypeNum) {
+      _emitUnboxNumberInto(
+        out,
+        context,
+        targetType is ASTTypeDouble ? _astTypeDouble64 : _astTypeInt64,
+      );
+      return out;
+    }
+
+    // A concrete value flowing into an `Object`/`dynamic` target (e.g. an `int`
+    // argument passed to a generic `T` field/parameter, which is represented as
+    // a boxed `Object`) is boxed.
+    if (_isObjectType(targetType) && !_isObjectType(stackType)) {
+      _emitBoxValue(out, context);
+      return out;
+    }
+
     if (stackType is ASTTypeNum) {
       final stackType32 = stackType.isBits32;
       final stackType64 = stackType.isBits64;
@@ -8516,7 +8592,12 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     ASTStatementFunctionDeclaration statement, {
     BytesOutput? out,
   }) {
-    throw UnimplementedError("generateASTStatementFunctionDeclaration");
+    // A named nested function (e.g. JS/TS `let twice = (n) => …`) is collected
+    // and generated as a module function by [_collectAnonymousClosures]; the
+    // declaration statement itself emits nothing. A call `twice(x)` resolves to
+    // a direct `call` (capture-free, call-only) or fails to resolve at the call
+    // site if it is used in an unsupported way (captured/escaping).
+    return out ?? newOutput();
   }
 
   @override
@@ -9502,6 +9583,10 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     } else if (type is ASTTypeDouble) {
       tag = _boxTagDouble;
       valLocalType = _astTypeDouble64; // f64
+    } else if (type is ASTTypeNum) {
+      // A plain `num` (TS/JS `number`) is represented as i64 (int).
+      tag = _boxTagInt;
+      valLocalType = _astTypeInt64;
     } else if (type is ASTTypeString) {
       tag = _boxTagString;
       valLocalType = _astTypeString; // i32 string ptr
@@ -11156,7 +11241,33 @@ extension _ASTFunctionDeclarationExtension on ASTFunctionDeclaration {
     if (modifiers.isAsync && rt is ASTTypeFuture) {
       return rt.futureValueType;
     }
+    // A function typed `dynamic` (e.g. an untyped Lua/Python function) whose own
+    // body never directly returns a value — its only `return <expr>` lives in a
+    // nested closure, which some parsers wrongly attribute to the parent — is
+    // effectively `void`. Treating it as non-void would emit a trailing
+    // terminator that traps when the function falls off its end.
+    if (rt is ASTTypeDynamic && !_bodyHasDirectValueReturn) {
+      return ASTTypeVoid.instance;
+    }
     return rt;
+  }
+
+  /// Whether this function's own body contains a `return <expression>` that is
+  /// not inside a nested anonymous function (closures are skipped).
+  bool get _bodyHasDirectValueReturn {
+    bool scan(ASTNode node) {
+      if (node is ASTExpressionLiteralFunction) return false;
+      if (node is ASTStatementReturnWithExpression) return true;
+      for (var c in node.children) {
+        if (scan(c)) return true;
+      }
+      return false;
+    }
+
+    for (var stm in statements) {
+      if (scan(stm)) return true;
+    }
+    return false;
   }
 
   List<int> get parametersTypesWasmCode {

--- a/lib/src/languages/wasm/wasm_runner.dart
+++ b/lib/src/languages/wasm/wasm_runner.dart
@@ -116,6 +116,16 @@ class ApolloRunnerWasm extends ApolloRunner {
     int elemSizeOf(int elemTag) =>
         (elemTag == _tagInt || elemTag == _tagDouble) ? 8 : 4;
 
+    int encodeBox(Object? value) {
+      var m = loadedModule!;
+      var strPtr = value is String ? allocAndWriteString(value) : null;
+      var box = m.invokeExport('__alloc', [_boxSize]) as int;
+      var mem = m.readMemory()!;
+      var bd = ByteData.sublistView(mem);
+      _writeBox(bd, box, value, strPtr);
+      return box;
+    }
+
     // Encodes a Dart [list] into module memory as `[len:i32][cap:i32][dataPtr:i32]`
     // + a separate elements buffer (the generator's indirect list layout), and
     // returns the header pointer. `int` elements use i64, `double` f64, `bool`
@@ -334,6 +344,10 @@ class ApolloRunnerWasm extends ApolloRunner {
           allParams[i] = encodeList(arg, pt.elemTag);
         } else if (pt.isMap && arg is Map) {
           allParams[i] = encodeMap(arg, pt.elemTag, pt.valTag);
+        } else if (pt.tag == _tagObject && !pt.isList && !pt.isMap) {
+          // A scalar `Object`/`dynamic` parameter: pass a host-allocated box,
+          // not a raw scalar the module would read as a garbage pointer.
+          allParams[i] = encodeBox(arg);
         }
       }
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, C#, JavaScript, TypeScript, Lua and Python with on-the-fly Wasm compilation.
-version: 0.1.45
+version: 0.1.46
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/wasm/apollovm_wasm_generics_lambda_test.dart
+++ b/test/wasm/apollovm_wasm_generics_lambda_test.dart
@@ -1,0 +1,222 @@
+@Tags(['wasm'])
+library;
+
+import 'dart:typed_data';
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Runs [code] in [language] via the AST interpreter AND the compiled Wasm
+/// module, capturing `print` output, and asserts both equal [expected].
+///
+/// When [className] is given the entry is a class method (`executeClassMethod`
+/// for the interpreter, `Class.method` for Wasm); otherwise it is a top-level
+/// function.
+Future<void> _testPrints({
+  required String language,
+  required String code,
+  String className = '',
+  required String functionName,
+  required List args,
+  required List<String> expected,
+}) async {
+  var vm = ApolloVM();
+  var loadOK = await vm.loadCodeUnit(
+    SourceCodeUnit(language, code, id: 'test'),
+  );
+  expect(loadOK, isTrue, reason: "Can't load `$language` source");
+
+  var astRunner = vm.createRunner(language)!;
+  var astOut = <String>[];
+  astRunner.externalPrintFunction = (o) => astOut.add('$o');
+  if (className.isNotEmpty) {
+    await astRunner.executeClassMethod(
+      '',
+      className,
+      functionName,
+      positionalParameters: args,
+    );
+  } else {
+    await astRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: args,
+    );
+  }
+  expect(astOut, equals(expected), reason: 'interpreter');
+
+  var storageWasm = vm.generateAllIn<BytesOutput>('wasm');
+  var wasmModules = await storageWasm.allEntries();
+  BytesOutput? compiled;
+  for (var ns in wasmModules.entries) {
+    for (var m in ns.value.entries) {
+      compiled ??= m.value;
+    }
+  }
+  expect(compiled, isNotNull);
+
+  var wasmRuntime = WasmRuntime();
+  wasmRuntime.ensureBooted();
+  if (!wasmRuntime.isSupported) return;
+
+  var vmWasm = ApolloVM();
+  await vmWasm.loadCodeUnit(
+    BinaryCodeUnit(
+      'wasm',
+      Uint8List.fromList(compiled!.output()),
+      id: 'test.wasm',
+      namespace: '',
+    ),
+  );
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  var wasmOut = <String>[];
+  wasmRunner.externalPrintFunction = (o) => wasmOut.add('$o');
+  var entry = className.isNotEmpty ? '$className.$functionName' : functionName;
+  await wasmRunner.executeFunction('', entry, positionalParameters: args);
+  expect(wasmOut, equals(expected), reason: 'wasm');
+}
+
+void main() {
+  // An untyped anonymous-function parameter (`n => n * 2`) is inferred from its
+  // body. Lua/Python additionally exercise the "a nested closure's `return`
+  // does not make the enclosing void function non-void" fix.
+  group('Wasm: anonymous functions with an untyped parameter', () {
+    test('C# lambda bound to a Func', () {
+      return _testPrints(
+        language: 'csharp',
+        code: r'''class Foo {
+  public static void main(int x) {
+    Func twice = n => n * 2;
+    Func inc = n => n + 1;
+    print("twice: " + twice(x) + " ; inc: " + inc(x));
+  }
+}''',
+        className: 'Foo',
+        functionName: 'main',
+        args: [5],
+        expected: ['twice: 10 ; inc: 6'],
+      );
+    });
+
+    test('Lua anonymous functions', () {
+      return _testPrints(
+        language: 'lua',
+        code: r'''function main(x)
+  local twice = function(n) return n * 2 end
+  local inc = function(n) return n + 1 end
+  print("twice: " .. twice(x) .. " ; inc: " .. inc(x))
+end''',
+        functionName: 'main',
+        args: [5],
+        expected: ['twice: 10 ; inc: 6'],
+      );
+    });
+
+    test('Python lambdas', () {
+      return _testPrints(
+        language: 'python',
+        code:
+            'def main(x):\n'
+            '    twice = lambda n: n * 2\n'
+            '    inc = lambda n: n + 1\n'
+            '    print(twice(x))\n'
+            '    print(inc(x))\n',
+        functionName: 'main',
+        args: [5],
+        expected: ['10', '6'],
+      );
+    });
+  });
+
+  // JS/TS parse `let twice = (n) => …` as a named nested function declaration,
+  // which is hoisted and called via a direct `call`.
+  group('Wasm: named nested function declarations (JS/TS lambdas)', () {
+    test('JavaScript arrow functions', () {
+      return _testPrints(
+        language: 'javascript',
+        code: r'''function main(x) {
+  let twice = (n) => n * 2;
+  let inc = (n) => n + 1;
+  print("twice: " + twice(x) + " ; inc: " + inc(x));
+}''',
+        functionName: 'main',
+        args: [5],
+        expected: ['twice: 10 ; inc: 6'],
+      );
+    });
+
+    test('TypeScript arrow functions', () {
+      return _testPrints(
+        language: 'typescript',
+        code: r'''function main(x: number): void {
+  let twice = (n: number) => n * 2;
+  let inc = (n: number) => n + 1;
+  print("twice: " + twice(x) + " ; inc: " + inc(x));
+}''',
+        functionName: 'main',
+        args: [5],
+        expected: ['twice: 10 ; inc: 6'],
+      );
+    });
+  });
+
+  // A generic `T` field is represented as a boxed `Object`; a concrete value
+  // stored into it is boxed, and read back via box-to-String.
+  group('Wasm: generic class field (Box<T>)', () {
+    test('Dart Box<int>', () {
+      return _testPrints(
+        language: 'dart',
+        code: r'''class Box<T> {
+  T value;
+  Box(this.value);
+}
+void run(int x) {
+  var b = Box<int>(x);
+  print('box: ${b.value}');
+}''',
+        functionName: 'run',
+        args: [10],
+        expected: ['box: 10'],
+      );
+    });
+
+    test('Java Box<Integer>', () {
+      return _testPrints(
+        language: 'java11',
+        code: r'''class Box<T> {
+  T value;
+  Box(T value) { this.value = value; }
+}
+class Foo {
+  static public void main(int x) {
+    Box<Integer> b = new Box<Integer>(x);
+    print("box: " + b.value);
+  }
+}''',
+        className: 'Foo',
+        functionName: 'main',
+        args: [10],
+        expected: ['box: 10'],
+      );
+    });
+
+    test('TypeScript Box<number>', () {
+      return _testPrints(
+        language: 'typescript',
+        code: r'''class Box<T> {
+  value: T;
+  constructor(value: T) {
+    this.value = value;
+  }
+}
+function run(x: number): void {
+  let b: Box<number> = new Box<number>(x);
+  print("box: " + b.value);
+}''',
+        functionName: 'run',
+        args: [10],
+        expected: ['box: 10'],
+      );
+    });
+  });
+}

--- a/test/wasm/apollovm_wasm_num_test.dart
+++ b/test/wasm/apollovm_wasm_num_test.dart
@@ -1,0 +1,163 @@
+@Tags(['wasm'])
+library;
+
+import 'dart:typed_data';
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Compiles [code] in [language] to Wasm, runs the exported [functionName] both
+/// via the AST interpreter and the compiled Wasm module for each
+/// `args -> expected` entry, and asserts both return the expected value.
+Future<void> _testWasm({
+  required String language,
+  required String code,
+  required String functionName,
+  required Map<List, Object?> executions,
+}) async {
+  var vm = ApolloVM();
+  var loadOK = await vm.loadCodeUnit(
+    SourceCodeUnit(language, code, id: 'test'),
+  );
+  expect(loadOK, isTrue, reason: "Can't load `$language` source");
+
+  var astRunner = vm.createRunner(language)!;
+  for (var e in executions.entries) {
+    var astValue = await astRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(astValue.getValueNoContext(), e.value, reason: 'interpreter');
+  }
+
+  var storageWasm = vm.generateAllIn<BytesOutput>('wasm');
+  var wasmModules = await storageWasm.allEntries();
+  BytesOutput? compiled;
+  for (var ns in wasmModules.entries) {
+    for (var m in ns.value.entries) {
+      compiled ??= m.value;
+    }
+  }
+  expect(compiled, isNotNull);
+
+  var wasmRuntime = WasmRuntime();
+  wasmRuntime.ensureBooted();
+  if (!wasmRuntime.isSupported) return; // No native runtime available.
+
+  var vmWasm = ApolloVM();
+  var ok = await vmWasm.loadCodeUnit(
+    BinaryCodeUnit(
+      'wasm',
+      Uint8List.fromList(compiled!.output()),
+      id: 'test.wasm',
+      namespace: '',
+    ),
+  );
+  expect(ok, isTrue);
+
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  for (var e in executions.entries) {
+    var v = await wasmRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(v.getValueNoContext(), e.value, reason: 'wasm');
+  }
+}
+
+void main() {
+  // A plain `num` (TypeScript / JavaScript `number`) has no fixed width; the VM
+  // treats integer-valued numbers as `int`, so the Wasm backend represents
+  // `num` as i64. These exercise the paths that previously rejected `num`.
+  group('Wasm: TypeScript `number` (num) arithmetic & coercion', () {
+    test('num arithmetic returns int', () {
+      return _testWasm(
+        language: 'typescript',
+        code: r'''
+          function run(a: number, b: number): number {
+            return a + b;
+          }
+        ''',
+        functionName: 'run',
+        executions: {
+          [10, 20]: 30,
+        },
+      );
+    });
+
+    test('num coerced to String (interpolation / concat)', () {
+      return _testWasm(
+        language: 'typescript',
+        code: r'''
+          function run(a: number, b: number): string {
+            return "sum=" + (a + b);
+          }
+        ''',
+        functionName: 'run',
+        executions: {
+          [10, 20]: 'sum=30',
+        },
+      );
+    });
+
+    test('switch on a num scrutinee', () {
+      return _testWasm(
+        language: 'typescript',
+        code: r'''
+          function run(n: number): number {
+            switch (n) {
+              case 1:
+                return 10;
+              case 2:
+                return 20;
+              default:
+                return 30;
+            }
+          }
+        ''',
+        functionName: 'run',
+        executions: {
+          [1]: 10,
+          [2]: 20,
+          [9]: 30,
+        },
+      );
+    });
+  });
+
+  // A boxed `dynamic`/`Object` switch scrutinee is unboxed to a concrete i64 so
+  // it can drive the int branch table.
+  group('Wasm: switch on a boxed dynamic/Object scrutinee', () {
+    test('switch on a List<Object> element', () {
+      return _testWasm(
+        language: 'dart',
+        code: r'''
+          String run(List<Object> args) {
+            switch (args[0]) {
+              case 1:
+                return 'one';
+              case 2:
+                return 'two';
+              default:
+                return 'many';
+            }
+          }
+        ''',
+        functionName: 'run',
+        executions: {
+          [
+            [1],
+          ]: 'one',
+          [
+            [2],
+          ]: 'two',
+          [
+            [7],
+          ]: 'many',
+        },
+      );
+    });
+  });
+}

--- a/test/wasm/apollovm_wasm_num_test.dart
+++ b/test/wasm/apollovm_wasm_num_test.dart
@@ -67,6 +67,60 @@ Future<void> _testWasm({
   }
 }
 
+/// Like [_testWasm] but compares captured `print` output (for `void` functions).
+Future<void> _testWasmPrints({
+  required String language,
+  required String code,
+  required String functionName,
+  required List args,
+  required List<String> expected,
+}) async {
+  var vm = ApolloVM();
+  var loadOK = await vm.loadCodeUnit(
+    SourceCodeUnit(language, code, id: 'test'),
+  );
+  expect(loadOK, isTrue, reason: "Can't load `$language` source");
+
+  var astRunner = vm.createRunner(language)!;
+  var astOut = <String>[];
+  astRunner.externalPrintFunction = (o) => astOut.add('$o');
+  await astRunner.executeFunction('', functionName, positionalParameters: args);
+  expect(astOut, equals(expected), reason: 'interpreter');
+
+  var storageWasm = vm.generateAllIn<BytesOutput>('wasm');
+  var wasmModules = await storageWasm.allEntries();
+  BytesOutput? compiled;
+  for (var ns in wasmModules.entries) {
+    for (var m in ns.value.entries) {
+      compiled ??= m.value;
+    }
+  }
+  expect(compiled, isNotNull);
+
+  var wasmRuntime = WasmRuntime();
+  wasmRuntime.ensureBooted();
+  if (!wasmRuntime.isSupported) return;
+
+  var vmWasm = ApolloVM();
+  await vmWasm.loadCodeUnit(
+    BinaryCodeUnit(
+      'wasm',
+      Uint8List.fromList(compiled!.output()),
+      id: 'test.wasm',
+      namespace: '',
+    ),
+  );
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  var wasmOut = <String>[];
+  wasmRunner.externalPrintFunction = (o) => wasmOut.add('$o');
+  await wasmRunner.executeFunction(
+    '',
+    functionName,
+    positionalParameters: args,
+  );
+  expect(wasmOut, equals(expected), reason: 'wasm');
+}
+
 void main() {
   // A plain `num` (TypeScript / JavaScript `number`) has no fixed width; the VM
   // treats integer-valued numbers as `int`, so the Wasm backend represents
@@ -123,6 +177,73 @@ void main() {
           [2]: 20,
           [9]: 30,
         },
+      );
+    });
+  });
+
+  // A scalar `Object`/`dynamic` parameter is passed as a host-allocated box (so
+  // the module reads a real box, not a raw scalar). This covers untyped
+  // parameters from JavaScript/Python and an explicit Dart `dynamic` parameter.
+  group('Wasm: scalar dynamic/Object parameter marshalling', () {
+    test('Dart `dynamic` parameter arithmetic', () {
+      return _testWasm(
+        language: 'dart',
+        code: r'''
+          int run(dynamic a, dynamic b) {
+            return a + b;
+          }
+        ''',
+        functionName: 'run',
+        executions: {
+          [10, 20]: 30,
+        },
+      );
+    });
+
+    test('JavaScript untyped parameters (print)', () {
+      return _testWasmPrints(
+        language: 'javascript',
+        code: r'''
+          function run(a, b) {
+            print(a + b);
+          }
+        ''',
+        functionName: 'run',
+        args: [10, 20],
+        expected: ['30'],
+      );
+    });
+
+    test('JavaScript switch on an untyped (dynamic) parameter (print)', () {
+      return _testWasmPrints(
+        language: 'javascript',
+        code: r'''
+          function run(n) {
+            switch (n) {
+              case 1:
+                print("one");
+                break;
+              case 2:
+                print("two");
+                break;
+              default:
+                print("many");
+            }
+          }
+        ''',
+        functionName: 'run',
+        args: [2],
+        expected: ['two'],
+      );
+    });
+
+    test('Python untyped parameters (print)', () {
+      return _testWasmPrints(
+        language: 'python',
+        code: 'def run(a, b):\n    print(a + b)\n',
+        functionName: 'run',
+        args: [10, 20],
+        expected: ['30'],
       );
     });
   });

--- a/test/wasm/apollovm_wasm_num_test.dart
+++ b/test/wasm/apollovm_wasm_num_test.dart
@@ -248,6 +248,50 @@ void main() {
     });
   });
 
+  // Operations whose operands are boxed `Object`/`dynamic` values.
+  group('Wasm: operations on boxed dynamic values', () {
+    test('a + b with both operands boxed (var result refined to int)', () {
+      // `a` and `b` are boxed `List<Object>` elements; the sum is an i64 and the
+      // unresolved `var s` is refined to it.
+      return _testWasm(
+        language: 'dart',
+        code: r'''
+          int run(List<Object> args) {
+            var a = args[0];
+            var b = args[1];
+            var s = a + b;
+            return s;
+          }
+        ''',
+        functionName: 'run',
+        executions: {
+          [
+            [10, 20],
+          ]: 30,
+        },
+      );
+    });
+
+    test('equality-to-zero on a boxed dynamic parameter', () {
+      // `b == 0` uses the `i64.eqz` fast path, which must unbox `b` first.
+      return _testWasmPrints(
+        language: 'javascript',
+        code: r'''
+          function run(b) {
+            if (b == 0) {
+              print("zero");
+            } else {
+              print("nonzero");
+            }
+          }
+        ''',
+        functionName: 'run',
+        args: [0],
+        expected: ['zero'],
+      );
+    });
+  });
+
   // A boxed `dynamic`/`Object` switch scrutinee is unboxed to a concrete i64 so
   // it can drive the int branch table.
   group('Wasm: switch on a boxed dynamic/Object scrutinee', () {


### PR DESCRIPTION
## Summary

Audited every example in the playground (`apollovm_web_example/web/src/code_examples.dart`) by compiling each source to Wasm and comparing its output/return to the AST interpreter, then fixed the failing categories in priority order.

## Audit impact

Interpreter-vs-Wasm correctness across the 77 examples: **53 OK → 73 OK** on this branch (+20). Remaining: 3 wrong-output + 1 error (all out of scope, see below).

| Root cause | Examples | Status |
|---|---|---|
| `num` (TS/JS `number`) unsupported (coercion, switch, arithmetic, boxing) | TS Class, Conditional, Exceptions, Switch | ✅ |
| switch on a boxed `dynamic`/`Object` scrutinee | Dart `List<Object>`, JS/Python switch | ✅ |
| scalar `Object`/`dynamic` entry params arrive as `0` | JS/Lua/Python Class + Conditional + Switch/Match | ✅ |
| generic `Box<T>` field (concrete value ↔ boxed `T` slot) | Dart/Java/Kotlin/C#/TS Generics | ✅ |
| untyped lambda *parameter* inference (`n => n*2`) | C#/Lua/Python Lambdas | ✅ |
| named nested function declaration (`let f = (n) => …`) | JS/TS Lambdas | ✅ |
| `var s = a + b` with boxed operands (var refined to result type) | Java Class | ✅ |
| `== 0` fast path on a boxed operand (`i64.eqz` unbox) | JS try/catch | ✅ |
| integer-`/`-by-zero *semantics* (throw vs `0`/`Infinity`) | Dart/Java/Kotlin Exceptions | ⏳ out of scope |
| `async`/`Future<T>` (value width + terminator, not just coercion) | Dart Async | ⏳ out of scope |

## Fixes (`wasm_generator.dart` / `wasm_runner.dart`)

1. **`num` as i64** — `wasmType`, string coercion, `switch`, boxing.
2. **switch on a boxed scrutinee** — unboxed to i64 before the branch table.
3. **Scalar `Object`/`dynamic` parameter marshalling** — emit `apollovm_sig` for object params, tag `num` as `int` (distinct from `Object`), box a scalar object argument host-side.
4. **Generic `T` field** — `_autoConvertStackTypes` boxes a concrete value into an `Object`/`dynamic` target and unboxes the reverse; `_emitBoxValue` handles `num`.
5. **Untyped lambda parameter inference**, plus: a `dynamic` function whose only `return <expr>` is inside a nested closure is treated as `void` (no trapping fall-through terminator).
6. **Named nested function declarations** — collected as closures, lowered to a direct `call` (resolved before the module-function table since the closure carries a hidden env parameter).
7. **Boxed-operand `var` refinement** — an unresolved `var` is refined to its initializer's concrete type.
8. **Equality-to-zero unboxing** — `i64.eqz` unboxes a boxed operand.

## Tests

- `test/wasm/apollovm_wasm_num_test.dart` — `num`, boxed switch, dynamic params, boxed-operand `a + b`, boxed `== 0`.
- `test/wasm/apollovm_wasm_generics_lambda_test.dart` — C#/Lua/Python/JS/TS lambdas and Dart/Java/TS `Box<T>` generics.

All dual-run (interpreter + Wasm), green on the native `wasm_run` runtime and **Chrome (WasmGC)**. Full suite `+1102`. `dart format` / `dart analyze` clean. Version 0.1.45 → 0.1.46.

## Out of scope (documented follow-ups)

- **Exception examples** (Dart/Java/Kotlin): integer division by zero should throw a catchable runtime error whose message matches the interpreter (`IntegerDivisionByZeroException` / `Infinity or NaN toInt`); Wasm currently yields `0`/`Infinity`.
- **`async`/`Future<T>`**: compiling Dart async to Wasm needs value-width and function-end-terminator handling for `Future<T>`, not just string coercion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)