### PR TITLE
fix(wasm): integer division semantics + division-by-zero exceptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+## 0.1.47
+
+### Wasm backend: integer division semantics (`/` on ints) + division-by-zero
+
+- **`/` on integer operands is now integer (truncating) division** in
+  Java/Kotlin/C# — where the expression resolves to `int` — instead of an f64
+  quotient (so `10 / 3` is `3`, not `3.33`). Dart's `/` keeps its `double`
+  result; `~/` is unchanged.
+- **Integer division by zero raises a catchable exception** whose message
+  matches the interpreter (`IntegerDivisionByZeroException` for `/`,
+  `Unsupported operation: Infinity or NaN toInt` for `~/`). Applies to both `~/`
+  and integer `/`.
+- A `print` whose argument is built from a value that just raised (e.g. the
+  quotient in `print('q = ${a ~/ b}')`) is **skipped when an exception is
+  pending**, matching the interpreter, which never reaches the print.
+
+These fix the Dart, Java and Kotlin exception (try/catch/finally) examples.
+
 ## 0.1.46
 
 ### Wasm backend: `num` (TypeScript/JS `number`) + switch on a boxed scrutinee

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -53,7 +53,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.46';
+  static final String VERSION = '0.1.47';
 
   static int _idCount = 0;
 

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -2659,10 +2659,34 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       WasmType.i32Type,
     ], const []);
 
-    out.write(
-      Wasm.call(importIndex),
-      description: "[OP] call host import `env.print` (index $importIndex)",
-    );
+    if (context.exceptionMode && module.requiresException) {
+      // If an exception was raised while building the argument (e.g. an integer
+      // division by zero inside the interpolation), skip the print: the value is
+      // invalid and the exception is about to unwind. This matches the
+      // interpreter, which never reaches the print. (The handle is stashed in a
+      // local so the `if` branches don't reach below their block frame.)
+      var argLocal = context.scratchLocal(_astTypeString, 57); // i32 handle
+      out.write(Wasm.localSet(argLocal), description: "[OP] stash print arg");
+      out.write(Wasm32.i32Const(0));
+      out.write(
+        Wasm32.i32Load(2, module.excPendingOffset),
+        description: "[OP] load EXC_PENDING (guard print)",
+      );
+      out.write(Wasm.ifInstruction(WasmType.voidType));
+      // pending: skip the print (argument discarded).
+      out.writeByte(Wasm.elseInstruction);
+      out.write(Wasm.localGet(argLocal));
+      out.write(
+        Wasm.call(importIndex),
+        description: "[OP] call host import `env.print` (index $importIndex)",
+      );
+      out.writeByte(Wasm.end);
+    } else {
+      out.write(
+        Wasm.call(importIndex),
+        description: "[OP] call host import `env.print` (index $importIndex)",
+      );
+    }
     context.stackDrop();
 
     context.assertStackLength(stackLng0, "After print (void)");
@@ -3655,6 +3679,27 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
             description: "[OP] operator: divide(f64)",
           );
           context.stackOperationBinary(_astTypeDouble64, "Wasm64.f64Divide");
+
+          // `/` on integer operands is *integer* division in Java/Kotlin/C#
+          // (the AST resolves the expression to `int`): truncate to i64, and on
+          // divide-by-zero raise the matching catchable exception. Dart's `/`
+          // resolves to `double` and stays an f64 quotient.
+          var resolved = expression.resolveType(null);
+          if (resolved is ASTTypeInt) {
+            if (context.exceptionMode) {
+              _emitGuardedF64ToI64(
+                out,
+                context,
+                msg: 'IntegerDivisionByZeroException',
+              );
+            } else {
+              out.writeByte(
+                Wasm64.f64TruncateToI64Signed,
+                description: "[OP] integer divide -> i64",
+              );
+            }
+            context.stackReplace(_astTypeInt64, "integer divide -> i64");
+          }
         }
       case ASTExpressionOperator.divideAsInt:
         {
@@ -6094,11 +6139,14 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   /// finite, truncate; otherwise raise a catchable exception (a `String` whose
   /// message matches the AST interpreter) and yield `0`. Net stack effect:
   /// pops one `f64`, pushes one `i64`.
-  void _emitGuardedF64ToI64(BytesOutput out, WasmContext context) {
+  void _emitGuardedF64ToI64(
+    BytesOutput out,
+    WasmContext context, {
+    String msg = 'Unsupported operation: Infinity or NaN toInt',
+  }) {
     final module = context.module!;
     module.requiresException = true;
     final fdiv = context.scratchLocal(_astTypeDouble64, 950);
-    const msg = 'Unsupported operation: Infinity or NaN toInt';
     final msgPtr = module.internStringLiteral(msg);
 
     out.write(Wasm.localSet(fdiv)); // $fdiv = result
@@ -6144,14 +6192,21 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     return null;
   }
 
+  /// Whether [o] is an integer division that can raise a catchable "division by
+  /// zero" exception: Dart's `~/` (`divideAsInt`), or `/` whose operands are
+  /// integers so the expression resolves to `int` (Java/Kotlin/C# `/`).
+  bool _isIntegerDivision(ASTExpressionOperation o) =>
+      o.operator == ASTExpressionOperator.divideAsInt ||
+      (o.operator == ASTExpressionOperator.divide &&
+          o.resolveType(null) is ASTTypeInt);
+
   /// Whether [tryBlock] can raise (a `throw` statement or an integer division).
   bool _tryHasThrow(ASTBlock tryBlock) =>
       tryBlock.statements.any((s) => s is ASTStatementThrow) ||
       tryBlock.descendantChildren.any(
         (n) =>
             n is ASTStatementThrow ||
-            (n is ASTExpressionOperation &&
-                n.operator == ASTExpressionOperator.divideAsInt),
+            (n is ASTExpressionOperation && _isIntegerDivision(n)),
       );
 
   /// The common static type of the values thrown directly within [tryBlock]
@@ -6174,9 +6229,9 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       if (rt is! ASTType) return null;
       types[rt.name] = rt;
     }
-    // An integer division can raise a `String` ("Infinity or NaN").
+    // An integer division can raise a `String` (the division-by-zero message).
     if (tryBlock.descendantChildren.whereType<ASTExpressionOperation>().any(
-      (o) => o.operator == ASTExpressionOperator.divideAsInt,
+      _isIntegerDivision,
     )) {
       types['String'] = ASTTypeString.instance;
     }
@@ -6244,10 +6299,10 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   /// Number of integer divisions (`~/`) within [s] — each can raise a catchable
   /// "Infinity or NaN" exception under the exception CFG, so the enclosing
   /// statement needs a post-evaluation pending check.
-  int _countIntDivisions(ASTStatement s) => [s, ...s.descendantChildren]
-      .whereType<ASTExpressionOperation>()
-      .where((o) => o.operator == ASTExpressionOperator.divideAsInt)
-      .length;
+  int _countIntDivisions(ASTStatement s) => [
+    s,
+    ...s.descendantChildren,
+  ].whereType<ASTExpressionOperation>().where(_isIntegerDivision).length;
 
   /// Builds the exception-handling CFG for [f]: lowers `throw` / `try` / `catch`
   /// (and the statements around them) into `$pc`-dispatched basic blocks with

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, C#, JavaScript, TypeScript, Lua and Python with on-the-fly Wasm compilation.
-version: 0.1.46
+version: 0.1.47
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/wasm/apollovm_wasm_division_test.dart
+++ b/test/wasm/apollovm_wasm_division_test.dart
@@ -1,0 +1,169 @@
+@Tags(['wasm'])
+library;
+
+import 'dart:typed_data';
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Runs [code] in [language] via the AST interpreter AND the compiled Wasm
+/// module, capturing `print` output, and asserts both equal [expected].
+Future<void> _testPrints({
+  required String language,
+  required String code,
+  String className = '',
+  required String functionName,
+  required List args,
+  required List<String> expected,
+}) async {
+  var vm = ApolloVM();
+  var loadOK = await vm.loadCodeUnit(
+    SourceCodeUnit(language, code, id: 'test'),
+  );
+  expect(loadOK, isTrue, reason: "Can't load `$language` source");
+
+  var astRunner = vm.createRunner(language)!;
+  var astOut = <String>[];
+  astRunner.externalPrintFunction = (o) => astOut.add('$o');
+  if (className.isNotEmpty) {
+    await astRunner.executeClassMethod(
+      '',
+      className,
+      functionName,
+      positionalParameters: args,
+    );
+  } else {
+    await astRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: args,
+    );
+  }
+  expect(astOut, equals(expected), reason: 'interpreter');
+
+  var storageWasm = vm.generateAllIn<BytesOutput>('wasm');
+  var wasmModules = await storageWasm.allEntries();
+  BytesOutput? compiled;
+  for (var ns in wasmModules.entries) {
+    for (var m in ns.value.entries) {
+      compiled ??= m.value;
+    }
+  }
+  expect(compiled, isNotNull);
+
+  var wasmRuntime = WasmRuntime();
+  wasmRuntime.ensureBooted();
+  if (!wasmRuntime.isSupported) return;
+
+  var vmWasm = ApolloVM();
+  await vmWasm.loadCodeUnit(
+    BinaryCodeUnit(
+      'wasm',
+      Uint8List.fromList(compiled!.output()),
+      id: 'test.wasm',
+      namespace: '',
+    ),
+  );
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  var wasmOut = <String>[];
+  wasmRunner.externalPrintFunction = (o) => wasmOut.add('$o');
+  var entry = className.isNotEmpty ? '$className.$functionName' : functionName;
+  await wasmRunner.executeFunction('', entry, positionalParameters: args);
+  expect(wasmOut, equals(expected), reason: 'wasm');
+}
+
+void main() {
+  // `/` on integer operands is integer (truncating) division in Java/Kotlin/C#
+  // — the expression resolves to `int`. Dart keeps `/` as a double quotient and
+  // uses `~/` for integer division.
+  group('Wasm: integer division (`/` on ints)', () {
+    test('Java 10 / 3 == 3', () {
+      return _testPrints(
+        language: 'java11',
+        code: r'''class Foo {
+  static void run(int a, int b) { print("q=" + (a / b)); }
+}''',
+        className: 'Foo',
+        functionName: 'run',
+        args: [10, 3],
+        expected: ['q=3'],
+      );
+    });
+
+    test('Kotlin 10 / 3 == 3', () {
+      return _testPrints(
+        language: 'kotlin',
+        code: 'fun run(a: Int, b: Int) { println("q=" + (a / b)) }',
+        functionName: 'run',
+        args: [10, 3],
+        expected: ['q=3'],
+      );
+    });
+  });
+
+  // Integer division by zero raises a catchable exception whose message matches
+  // the interpreter, and the in-flight statement (e.g. a `print` building its
+  // argument from the quotient) does not run.
+  //
+  // The message-asserting tests run on the VM only: the *interpreter*'s
+  // division-by-zero message differs between the Dart VM and dart2js (e.g.
+  // `Infinity or NaN toInt` vs `Infinity.toInt()`), while the Wasm message is
+  // fixed — so a dual-run comparison is only stable on the VM.
+  group('Wasm: integer division by zero throws', () {
+    test('Dart `~/` 0 (Infinity or NaN toInt)', () {
+      return _testPrints(
+        language: 'dart',
+        code: r'''
+          void run(int a, int b) {
+            try {
+              print('q = ${a ~/ b}');
+            } catch (e) {
+              print('caught: $e');
+            }
+          }
+        ''',
+        functionName: 'run',
+        args: [10, 0],
+        expected: ['caught: Unsupported operation: Infinity or NaN toInt'],
+      );
+    }, testOn: 'vm');
+
+    test('Java `/` 0 (IntegerDivisionByZeroException)', () {
+      return _testPrints(
+        language: 'java11',
+        code: r'''class Foo {
+  static void run(int a, int b) {
+    try {
+      print("q = " + (a / b));
+    } catch (Exception e) {
+      print("caught: " + e);
+    }
+  }
+}''',
+        className: 'Foo',
+        functionName: 'run',
+        args: [10, 0],
+        expected: ['caught: IntegerDivisionByZeroException'],
+      );
+    }, testOn: 'vm');
+
+    test('non-zero divisor still prints the quotient', () {
+      return _testPrints(
+        language: 'java11',
+        code: r'''class Foo {
+  static void run(int a, int b) {
+    try {
+      print("q = " + (a / b));
+    } catch (Exception e) {
+      print("caught: " + e);
+    }
+  }
+}''',
+        className: 'Foo',
+        functionName: 'run',
+        args: [10, 2],
+        expected: ['q = 5'],
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Continues the playground audit (interpreter-vs-Wasm **73/77 → 76/77**) by fixing the **Dart, Java and Kotlin exception (try/catch/finally) examples**, which all hinge on integer division semantics.

## Fixes (`wasm_generator.dart`)

1. **`/` on integer operands is integer division.** Java/Kotlin/C# `/` on two ints is truncating integer division — the AST resolves the expression to `int`. The Wasm backend was always emitting an f64 quotient, so `10 / 3` produced `3.33` instead of `3`. It now truncates to i64 when the resolved type is `int` (Dart's `/` resolves to `double` and is unchanged; `~/` is unchanged).

2. **Integer division by zero raises a catchable exception** with the interpreter's message — `IntegerDivisionByZeroException` for `/`, `Unsupported operation: Infinity or NaN toInt` for `~/`. The throwing-division detection (try-has-throw, thrown-type inference, post-statement pending check) now recognizes integer `/` via a shared `_isIntegerDivision` helper, not just `~/`.

3. **`print` is skipped when an exception is pending.** The exception model defers the pending flag to statement boundaries, so `print('q = ${a ~/ b}')` printed `q = 0` *before* unwinding. The `print` host call now checks `EXC_PENDING` first and skips when set — matching the interpreter, which never reaches the print.

## Tests

`test/wasm/apollovm_wasm_division_test.dart` — integer-division correctness (`10/3 == 3`, cross-platform) and division-by-zero throwing (message + skipped print). The message-asserting tests run on the **VM only**: the *interpreter*'s division-by-zero message differs between the Dart VM and dart2js (`Infinity or NaN toInt` vs `Infinity.toInt()`), while the Wasm message is fixed, so a dual-run comparison is only stable on the VM. Correctness tests pass on native and Chrome.

Full suite `+1104`. `dart format` / `dart analyze` clean. Version 0.1.46 → 0.1.47.

## Remaining (1/77): Dart `async`/`Future`

Investigated and deliberately deferred. Async functions compile through a **dedicated code path** — their signature does **not** flow through `effectiveReturnType` (confirmed: a body-inferred return type never reaches the type section), and the `Future<T>` type argument is lost to `dynamic`. Making the example work needs value-width + return-type handling in that async path, not just the string-coercion tweak I first tried (which cascaded into signature/terminator mismatches). It's an alpha feature and warrants its own focused effort; all exploratory changes were reverted to keep this PR clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)