### PR TITLE
feat(cli): run .wasm files through the Wasm runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,6 @@ build/
 doc/api/
 
 .DS_Store
+*.exe
 
 articles/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 0.1.48
+
+### CLI: `run` executes `.wasm` files through the Wasm runtime
+
+- **`apollovm run foo.wasm` now runs the binary module** via the Wasm runtime
+  (`ApolloRunnerWasm`) instead of trying to decode it as UTF-8 source. The file
+  is loaded as a `BinaryCodeUnit`, parsed for its exported functions by
+  `ApolloParserWasm`, and its entry function (e.g. `main`) is invoked — closing
+  the `compile` → `run` loop from the command line.
+- The `.wasm` file extension now maps to the `wasm` language in
+  `ApolloVM.parseLanguageFromFilePathExtension`.
+
 ## 0.1.47
 
 ### Wasm backend: integer division semantics (`/` on ints) + division-by-zero

--- a/bin/apollovm.dart
+++ b/bin/apollovm.dart
@@ -133,7 +133,21 @@ class CommandRun extends CommandSourceFileBase {
 
     var vm = ApolloVM();
 
-    var codeUnit = SourceCodeUnit(language, source, id: sourceFilePath);
+    // A `.wasm` file is a binary module: load its bytes as a `BinaryCodeUnit`
+    // (parsed by `ApolloParserWasm` into its exported functions) and run it
+    // through the Wasm runtime, rather than decoding the binary as UTF-8 source.
+    CodeUnit<Object> codeUnit;
+    if (language == 'wasm') {
+      var bytes = sourceFile.readAsBytesSync();
+      codeUnit = BinaryCodeUnit(
+        'wasm',
+        bytes,
+        id: sourceFilePath,
+        namespace: '',
+      );
+    } else {
+      codeUnit = SourceCodeUnit(language, source, id: sourceFilePath);
+    }
 
     var loadOK = await vm.loadCodeUnit(codeUnit);
 

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -53,7 +53,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.47';
+  static final String VERSION = '0.1.48';
 
   static int _idCount = 0;
 
@@ -409,6 +409,8 @@ class ApolloVM implements VMTypeResolver {
         return 'csharp';
       case 'kt':
         return 'kotlin';
+      case 'wasm':
+        return 'wasm';
       case 'cpp':
       case 'c++':
         return 'cpp';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, C#, JavaScript, TypeScript, Lua and Python with on-the-fly Wasm compilation.
-version: 0.1.47
+version: 0.1.48
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 


### PR DESCRIPTION
## Summary

`apollovm run foo.wasm` now executes the binary module through the Wasm runtime instead of trying to decode it as UTF-8 source — closing the `compile` → `run` loop from the command line.

## Changes

- **`bin/apollovm.dart`** (`CommandRun.run()`): when the language is `wasm`, read the file as bytes and load a `BinaryCodeUnit('wasm', …, namespace: '')`. `ApolloParserWasm` parses the module's exports into an `ASTRoot`, and the existing run loop (`tryExecuteFunction` → `ApolloRunnerWasm.executeFunction`) invokes the entry function (e.g. `main`). All other languages are unchanged.
- **`lib/src/apollovm_base.dart`**: `parseLanguageFromFilePathExtension` now maps the `.wasm` extension to the `wasm` language.
- Version bump `0.1.47` → `0.1.48`; CHANGELOG updated.

## Verification

- `compile -o /tmp/hello.wasm hello.dart` then `run /tmp/hello.wasm` → loads `wasm_run` and prints the program output (`Hello from Wasm!` / `x*2 = 42`).
- Sanity: `run test/hello_world.js` still works.
- `dart analyze bin/ lib/` → no issues; `dart format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)