### PR TITLE
feat(mcp): MCP-native runtime exposing ApolloVM to AI agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.49
+## 1.2.0
 
 ### MCP-native runtime: expose ApolloVM to AI agents over the Model Context Protocol
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 0.1.49
+
+### MCP-native runtime: expose ApolloVM to AI agents over the Model Context Protocol
+
+- **New `apollovm serve` command** starts an MCP (Model Context Protocol) server,
+  turning ApolloVM into a programmable, sandboxed execution engine for AI agents.
+  Built on the official `dart_mcp` SDK; serves over **stdio** (default) or
+  **HTTP/SSE** (`--http <port>`).
+- **Seven tools**: `apollo.parse`, `apollo.execute`, `apollo.translate`,
+  `apollo.ast`, `apollo.symbols`, `apollo.types`, `apollo.wasm` — parse, run,
+  translate, compile to Wasm, and inspect AST / symbol graph / type table across
+  all supported languages.
+- **Security model**: file/network access denied by construction (only `print` is
+  exposed; inputs are inline source only); `apollo.execute` runs in a **killable
+  isolate** so a hard timeout is enforced even against runaway synchronous loops
+  (per-tool configurable via `--isolate-tools`); input/output size caps
+  (`--max-source-chars`, `--max-output-chars`); best-effort process-level memory.
+- **New public library** `package:apollovm/apollovm_mcp.dart` (`ApolloMcpServer`,
+  `serveStdio`, `HttpSseTransport`, `McpLimits`, `computeTool`).
+- Added dependency `dart_mcp: ^0.5.2` (and `stream_channel`). New `mcp`-tagged
+  integration tests under `test/mcp/`. See `doc/MCP.md`.
+
 ## 0.1.48
 
 ### CLI: `run` executes `.wasm` files through the Wasm runtime

--- a/README.md
+++ b/README.md
@@ -1088,6 +1088,69 @@ Generated `Wasm` bytes with description:
 
 -----------------------------
 
+## MCP Server
+
+ApolloVM ships an **MCP (Model Context Protocol)** server that exposes the VM as a
+programmable execution engine for AI agents. Agents can parse, execute, translate,
+compile, and inspect code across all supported languages through MCP tools.
+
+Start it over stdio (the standard local transport):
+
+```bash
+apollovm serve
+```
+
+or over HTTP/SSE for networked agents:
+
+```bash
+apollovm serve --http 8080          # binds 127.0.0.1:8080, SSE at /sse
+```
+
+Example MCP client configuration (e.g. for an agent/IDE):
+
+```json
+{
+  "mcpServers": {
+    "apollovm": { "command": "apollovm", "args": ["serve"] }
+  }
+}
+```
+
+### Tools
+
+| Tool | Input | Output |
+|------|-------|--------|
+| `apollo.parse` | `language`, `source` | parse `ok`, `diagnostics`, `summary` (classes/functions/imports) |
+| `apollo.execute` | `language`, `source`, `function?`, `className?`, `args?`, `timeoutMs?` | `result`, `output` (console), `diagnostics` |
+| `apollo.translate` | `from`, `to`, `source` | `generated` source |
+| `apollo.ast` | `language`, `source`, `maxDepth?` | full AST as JSON |
+| `apollo.symbols` | `language`, `source` | symbol graph (functions/classes/fields/methods/constructors) |
+| `apollo.types` | `language`, `source` | deduplicated type table (`class`/`builtin`/`unknown`) |
+| `apollo.wasm` | `language`, `source` | WebAssembly modules as base64 bytes |
+
+Supported `language` values: `dart`, `java`, `kotlin`, `csharp`, `javascript`,
+`typescript`, `lua`, `python`, `wasm`.
+
+### Security model
+
+- **File/network access is denied by construction** — executed code is only ever
+  granted `print`; no filesystem or socket bridge is exposed, and tools operate on
+  inline source strings only (never a path).
+- **Timeout / CPU** — `apollo.execute` runs inside a killable **isolate** by default,
+  so a hard wall-clock timeout is enforced even against a runaway synchronous loop
+  (`--timeout-ms`, default 5000). Other tools run in-process. Which tools use an
+  isolate is configurable (`--isolate-tools`).
+- **Input/output caps** — `--max-source-chars` (default 262144) and
+  `--max-output-chars` (default 65536) bound request/response size.
+- **Memory** — Dart has no per-isolate hard heap cap, so memory limiting is
+  best-effort; run the process with `--old_gen_heap_size=<MB>` for a hard ceiling.
+
+The embeddable API lives in `package:apollovm/apollovm_mcp.dart`
+(`ApolloMcpServer`, `serveStdio`, `HttpSseTransport`, `McpLimits`). See
+[`doc/MCP.md`](doc/MCP.md) for the full tool schemas and protocol notes.
+
+-----------------------------
+
 ## See Also
 
 ApolloVM uses [PetitParser for Dart][petitparser-pub] to define the grammars of the languages and to analyze the source codes.

--- a/README.md
+++ b/README.md
@@ -1222,7 +1222,7 @@ Example MCP client configuration (e.g. for an agent/IDE):
 | `apollo.types` | `language`, `source` | deduplicated type table (`class`/`builtin`/`unknown`) |
 | `apollo.wasm` | `language`, `source` | WebAssembly modules as base64 bytes |
 
-Supported `language` values: `dart`, `java`, `kotlin`, `csharp`, `javascript`,
+Supported `language` values: `dart`, `java`, `kotlin`, `go`, `csharp`, `javascript`,
 `typescript`, `lua`, `python`, `wasm`.
 
 ### Security model

--- a/bin/apollovm.dart
+++ b/bin/apollovm.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:apollovm/apollovm.dart';
+import 'package:apollovm/apollovm_mcp.dart';
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:swiss_knife/swiss_knife.dart';
@@ -17,7 +18,8 @@ void main(List<String> args) async {
         )
         ..addCommand(CommandRun())
         ..addCommand(CommandTranslate())
-        ..addCommand(CommandCompile());
+        ..addCommand(CommandCompile())
+        ..addCommand(CommandServe());
 
   commandRunner.argParser.addFlag(
     'version',
@@ -373,5 +375,105 @@ class CommandCompile extends CommandSourceFileBase {
       return '$base.$moduleName$suffix';
     }
     return '$outputPath.$moduleName$suffix';
+  }
+}
+
+/// Runs the ApolloVM MCP server, exposing the VM's parse/execute/translate/
+/// compile/inspect capabilities to AI agents as MCP tools.
+///
+/// Defaults to the stdio transport; pass `--http <port>` for HTTP/SSE.
+class CommandServe extends Command<bool> {
+  @override
+  final String description =
+      'Run the ApolloVM MCP server (Model Context Protocol) over stdio or HTTP/SSE.';
+
+  @override
+  final String name = 'serve';
+
+  CommandServe() {
+    argParser
+      ..addOption(
+        'http',
+        help:
+            'Serve over HTTP/SSE on the given port instead of stdio.\n'
+            '(omit to use the stdio transport)',
+        valueHelp: 'port',
+      )
+      ..addOption(
+        'host',
+        help: 'Host/interface to bind for --http.',
+        defaultsTo: '127.0.0.1',
+      )
+      ..addOption(
+        'timeout-ms',
+        help: 'Execution timeout, in milliseconds.',
+        defaultsTo: '5000',
+      )
+      ..addOption(
+        'max-output-chars',
+        help: 'Maximum captured console output per execution.',
+        defaultsTo: '65536',
+      )
+      ..addOption(
+        'max-source-chars',
+        help: 'Maximum accepted source size, in characters.',
+        defaultsTo: '262144',
+      )
+      ..addOption(
+        'isolate-tools',
+        help:
+            'Comma-separated tools to run inside a killable isolate\n'
+            '(the only way to enforce a hard timeout on runaway code).',
+        defaultsTo: 'apollo.execute',
+      );
+  }
+
+  int _intOption(String name) {
+    var raw = argResults![name] as String?;
+    var value = raw != null ? int.tryParse(raw.trim()) : null;
+    if (value == null) {
+      throw StateError("Invalid integer for --$name: $raw");
+    }
+    return value;
+  }
+
+  @override
+  Future<bool> run() async {
+    var isolateTools = (argResults!['isolate-tools'] as String)
+        .split(',')
+        .map((e) => e.trim())
+        .where((e) => e.isNotEmpty)
+        .toSet();
+
+    var limits = McpLimits(
+      timeoutMs: _intOption('timeout-ms'),
+      maxOutputChars: _intOption('max-output-chars'),
+      maxSourceChars: _intOption('max-source-chars'),
+      isolateTools: isolateTools,
+    );
+
+    var httpPort = argResults!['http'] as String?;
+
+    if (httpPort != null) {
+      var port = int.tryParse(httpPort.trim());
+      if (port == null) {
+        throw StateError("Invalid port for --http: $httpPort");
+      }
+      var host = argResults!['host'] as String;
+
+      var transport = HttpSseTransport(limits: limits);
+      await transport.start(port: port, host: host);
+      // `stderr` so stdout stays clean for any tooling that scrapes it.
+      stderr.writeln(
+        'ApolloVM MCP server (HTTP/SSE) listening on http://$host:$port/sse',
+      );
+      // Serve until the process is terminated.
+      await Completer<void>().future;
+      return true;
+    }
+
+    var server = serveStdio(limits: limits);
+    await server.done;
+    return true;
   }
 }

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -21,6 +21,8 @@
 #   dart test -x wasm -x wasm-chrome  # everything except the Wasm backend
 
 tags:
+  # The MCP (Model Context Protocol) server exposing ApolloVM as agent tools.
+  mcp:
   # Backend / target.
   wasm:
     # The WebAssembly compiler + runner (native `wasm_run` or Chrome).

--- a/doc/MCP.md
+++ b/doc/MCP.md
@@ -1,0 +1,184 @@
+# ApolloVM MCP Server
+
+The ApolloVM MCP server exposes the VM's capabilities to AI agents as
+[Model Context Protocol](https://modelcontextprotocol.io) tools, turning ApolloVM
+into a programmable, sandboxed execution engine: parse, execute, translate,
+compile, and inspect code across every supported language.
+
+It is built on the official Dart [`dart_mcp`](https://pub.dev/packages/dart_mcp)
+SDK and speaks MCP (`initialize` / `tools/list` / `tools/call`) over two
+transports.
+
+## Running
+
+```bash
+# stdio (standard local transport)
+apollovm serve
+
+# HTTP/SSE (networked agents) — binds 127.0.0.1:8080, SSE stream at /sse
+apollovm serve --http 8080 [--host 0.0.0.0]
+```
+
+CLI options:
+
+| Option | Default | Meaning |
+|--------|---------|---------|
+| `--http <port>` | *(stdio)* | Serve over HTTP/SSE on this port instead of stdio. |
+| `--host <host>` | `127.0.0.1` | Interface to bind for `--http`. |
+| `--timeout-ms <n>` | `5000` | Per-execution wall-clock timeout. |
+| `--max-output-chars <n>` | `65536` | Max captured console output per execution. |
+| `--max-source-chars <n>` | `262144` | Max accepted source size. |
+| `--isolate-tools <list>` | `apollo.execute` | Comma-separated tools to run in a killable isolate. |
+
+### Embedding
+
+```dart
+import 'package:apollovm/apollovm_mcp.dart';
+
+// stdio
+final server = serveStdio(limits: const McpLimits(timeoutMs: 3000));
+await server.done;
+
+// HTTP/SSE
+final transport = HttpSseTransport(limits: const McpLimits());
+await transport.start(port: 8080);
+```
+
+You can also call the tool logic directly, without a transport, via
+`computeTool(name, args, limits)` (in-process) or
+`computeToolIsolated(name, args, limits)` (killable isolate).
+
+## Tools
+
+All tools return a single `TextContent` whose `text` is a JSON object. Every
+payload includes an `isError` flag mirrored onto the MCP `CallToolResult.isError`.
+Common inputs are `language` and `source` (inline source string).
+
+Supported `language` values: `dart`, `java` (`java11`), `kotlin`, `csharp`
+(`cs`), `javascript` (`js`), `typescript` (`ts`), `lua`, `python` (`py`), `wasm`.
+
+### apollo.parse
+
+Input: `{ language, source }`
+
+Output:
+```json
+{
+  "ok": true,
+  "diagnostics": [],
+  "summary": { "namespace": "", "classes": ["Foo"], "functions": ["main"], "imports": [] }
+}
+```
+
+### apollo.execute
+
+Input: `{ language, source, function?, className?, args?, timeoutMs? }`
+(`function` defaults to `main`; `args` is a positional argument list.)
+
+Output:
+```json
+{
+  "result": 42,
+  "hasResult": true,
+  "output": ["hello"],
+  "truncated": false,
+  "diagnostics": []
+}
+```
+
+`output` is the captured `print` stream. `truncated` is `true` when output hit
+`maxOutputChars`. On timeout, `isError` is `true` with a "timed out" diagnostic.
+
+### apollo.translate
+
+Input: `{ from, to, source }`
+
+Output: `{ "generated": "<source in the target language>", "diagnostics": [] }`
+
+### apollo.ast
+
+Input: `{ language, source, maxDepth? }`
+
+Output: `{ "ast": <node> }` where each node is
+`{ "node": "<runtimeType>", ...node-specific fields, "children": [...] }`.
+Node-specific fields include names, `type`, `modifiers`, `returnType`,
+`parameters`, class `kind`/`superClassName`/`implements`, import `path`, and
+literal `value`s.
+
+> **Note:** ApolloVM AST nodes carry no source positions (line/column), so none
+> are emitted per node. Positions are available only in parse-error diagnostics.
+
+### apollo.symbols
+
+Input: `{ language, source }`
+
+Output:
+```json
+{
+  "symbols": {
+    "namespace": "",
+    "imports": [],
+    "functions": [ { "name": "main", "returnType": {"name":"void"}, "modifiers": [], "parameters": [...] } ],
+    "classes": [ { "name": "Foo", "kind": "normalClass", "fields": [...], "constructors": [...], "methods": [...] } ]
+  }
+}
+```
+
+### apollo.types
+
+Input: `{ language, source }`
+
+Output:
+```json
+{ "types": [ { "name": "Foo", "kind": "class" }, { "name": "int", "kind": "builtin" } ] }
+```
+
+`kind` is `class` (declared in the unit), `builtin`, or `unknown`.
+
+### apollo.wasm
+
+Input: `{ language, source }`
+
+Output: `{ "modules": [ { "name": "mcp", "base64": "<wasm bytes>" } ] }`.
+Each module's bytes are base64-encoded and begin with the `\0asm` magic
+(`00 61 73 6D`).
+
+## Security model
+
+| Concern | Mechanism | Strength |
+|---------|-----------|----------|
+| File access | No file external is mapped; tools take inline source only | **Guaranteed** |
+| Network access | No socket external is mapped | **Guaranteed** |
+| Timeout / CPU | `apollo.execute` runs in a killable isolate (`Timer` + `Isolate.kill`) | **Enforced** |
+| Input size | `maxSourceChars` | Enforced |
+| Output size | `maxOutputChars` (truncates) | Enforced |
+| Memory | Process-level only (`--old_gen_heap_size`) | **Best-effort** |
+
+### Why isolate execution matters
+
+ApolloVM executes CPU-bound work synchronously (its Dart dialect has no
+async-yield primitive). An in-process `Future.timeout` therefore **cannot**
+interrupt a runaway loop — the event loop is blocked and the timer never fires.
+Running `apollo.execute` inside an isolate is the only reliable way to enforce a
+hard timeout: the isolate is `kill()`-ed when the deadline passes. The pure,
+bounded tools (`parse`/`ast`/`symbols`/`types`/`translate`/`wasm`) run in-process
+by default; adjust with `--isolate-tools` / `McpLimits.isolateTools`.
+
+Trade-off: on an isolate timeout/kill, console output produced before the kill is
+not recovered (the result is reported as a timeout).
+
+### HTTP/SSE exposure
+
+The HTTP/SSE transport binds `127.0.0.1` by default. Exposing it on a public
+interface grants unauthenticated code execution — front it with authentication
+and TLS, and set an explicit `--host`, only in a trusted environment.
+
+## Protocol notes
+
+- Transport is newline-delimited JSON-RPC 2.0. Over HTTP/SSE the server follows
+  the SSE transport: `GET /sse` opens the event stream and emits an
+  `event: endpoint` frame naming the POST URL (`/message?sessionId=...`);
+  `POST /message?sessionId=...` delivers one client→server message (returns
+  `202 Accepted`) and responses stream back as `event: message` frames.
+- The server advertises `serverInfo.name = "apollovm-mcp"` and
+  `serverInfo.version = <ApolloVM.VERSION>`.

--- a/doc/MCP.md
+++ b/doc/MCP.md
@@ -54,8 +54,9 @@ All tools return a single `TextContent` whose `text` is a JSON object. Every
 payload includes an `isError` flag mirrored onto the MCP `CallToolResult.isError`.
 Common inputs are `language` and `source` (inline source string).
 
-Supported `language` values: `dart`, `java` (`java11`), `kotlin`, `csharp`
-(`cs`), `javascript` (`js`), `typescript` (`ts`), `lua`, `python` (`py`), `wasm`.
+Supported `language` values: `dart`, `java` (`java11`), `kotlin`, `go` (`golang`),
+`csharp` (`cs`), `javascript` (`js`), `typescript` (`ts`), `lua`, `python` (`py`),
+`wasm`.
 
 ### apollo.parse
 

--- a/lib/apollovm_mcp.dart
+++ b/lib/apollovm_mcp.dart
@@ -1,0 +1,20 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+/// MCP (Model Context Protocol) server for ApolloVM.
+///
+/// Exposes ApolloVM's parse / execute / translate / compile / inspect
+/// capabilities to AI agents as MCP tools (`apollo.parse`, `apollo.execute`,
+/// `apollo.translate`, `apollo.ast`, `apollo.symbols`, `apollo.types`,
+/// `apollo.wasm`) over stdio or HTTP/SSE, with a configurable security model
+/// (per-tool isolate execution, timeout, and input/output limits).
+library;
+
+export 'src/mcp/apollo_mcp_server.dart';
+export 'src/mcp/mcp_config.dart';
+export 'src/mcp/runtime/isolate_executor.dart'
+    show computeToolIsolated, runToolInIsolate;
+export 'src/mcp/tools/apollo_tools.dart' show allToolNames, computeTool;
+export 'src/mcp/transport/http_sse_transport.dart';
+export 'src/mcp/transport/stdio_transport.dart';

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -53,7 +53,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.49';
+  static final String VERSION = '1.2.0';
 
   static int _idCount = 0;
 

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -53,7 +53,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.48';
+  static final String VERSION = '0.1.49';
 
   static int _idCount = 0;
 

--- a/lib/src/mcp/apollo_mcp_server.dart
+++ b/lib/src/mcp/apollo_mcp_server.dart
@@ -22,19 +22,17 @@ import 'tools/apollo_tools.dart';
 final class ApolloMcpServer extends MCPServer with ToolsSupport {
   final McpLimits limits;
 
-  ApolloMcpServer(
-    super.channel, {
-    this.limits = const McpLimits(),
-  }) : super.fromStreamChannel(
-         implementation: Implementation(
-           name: 'apollovm-mcp',
-           version: ApolloVM.VERSION,
-         ),
-         instructions:
-             'ApolloVM programmable execution engine. Tools: '
-             '${allToolNames.join(', ')}. All operate on inline source strings; '
-             'no file or network access is granted to executed code.',
-       ) {
+  ApolloMcpServer(super.channel, {this.limits = const McpLimits()})
+    : super.fromStreamChannel(
+        implementation: Implementation(
+          name: 'apollovm-mcp',
+          version: ApolloVM.VERSION,
+        ),
+        instructions:
+            'ApolloVM programmable execution engine. Tools: '
+            '${allToolNames.join(', ')}. All operate on inline source strings; '
+            'no file or network access is granted to executed code.',
+      ) {
     for (final tool in buildTools()) {
       registerTool(tool, (request) => _handle(tool.name, request));
     }

--- a/lib/src/mcp/apollo_mcp_server.dart
+++ b/lib/src/mcp/apollo_mcp_server.dart
@@ -1,0 +1,64 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'dart:convert';
+
+import 'package:apollovm/apollovm.dart' show ApolloVM;
+import 'package:dart_mcp/server.dart';
+import 'package:stream_channel/stream_channel.dart';
+
+import 'mcp_config.dart';
+import 'runtime/isolate_executor.dart';
+import 'tools/apollo_tools.dart';
+
+/// An MCP server exposing ApolloVM as agent tools over a [StreamChannel].
+///
+/// Built on the official `dart_mcp` SDK: it speaks MCP (`initialize` /
+/// `tools/list` / `tools/call`) over any newline-delimited `StreamChannel`
+/// — a stdio channel for local use, or the HTTP/SSE channel adapter for
+/// networked use. Each tool runs either in-process or (per [McpLimits.isolateTools])
+/// inside a killable isolate for a hard timeout.
+final class ApolloMcpServer extends MCPServer with ToolsSupport {
+  final McpLimits limits;
+
+  ApolloMcpServer(
+    super.channel, {
+    this.limits = const McpLimits(),
+  }) : super.fromStreamChannel(
+         implementation: Implementation(
+           name: 'apollovm-mcp',
+           version: ApolloVM.VERSION,
+         ),
+         instructions:
+             'ApolloVM programmable execution engine. Tools: '
+             '${allToolNames.join(', ')}. All operate on inline source strings; '
+             'no file or network access is granted to executed code.',
+       ) {
+    for (final tool in buildTools()) {
+      registerTool(tool, (request) => _handle(tool.name, request));
+    }
+  }
+
+  Future<CallToolResult> _handle(String name, CallToolRequest request) async {
+    final args = request.arguments ?? const <String, Object?>{};
+
+    final Map<String, Object?> result;
+    if (limits.runsInIsolate(name)) {
+      final timeoutMs = (args['timeoutMs'] as int?) ?? limits.timeoutMs;
+      result = await runToolInIsolate(
+        name,
+        args,
+        limits,
+        Duration(milliseconds: timeoutMs),
+      );
+    } else {
+      result = await computeTool(name, args, limits);
+    }
+
+    return CallToolResult(
+      content: [TextContent(text: jsonEncode(result))],
+      isError: result['isError'] == true,
+    );
+  }
+}

--- a/lib/src/mcp/mcp_config.dart
+++ b/lib/src/mcp/mcp_config.dart
@@ -1,0 +1,73 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+/// Resource limits enforced by the ApolloVM MCP server.
+///
+/// These are the security knobs of the MCP runtime. Timeout is enforced per
+/// execution; the source/output caps bound the amount of data a single request
+/// can push through the server. Memory is NOT hard-capped by these values
+/// (Dart has no per-isolate heap cap) — see the `doc/MCP.md` security notes.
+class McpLimits {
+  /// Maximum wall-clock time for a single `apollo.execute` run, in milliseconds.
+  ///
+  /// Enforced via `Future.timeout`. ApolloVM's executor yields regularly
+  /// (`FutureOr`/`resolveMapped`) so the timeout fires promptly; a purely
+  /// synchronous non-yielding loop can delay it until the next suspension.
+  final int timeoutMs;
+
+  /// Maximum number of characters of captured console (`print`) output kept for
+  /// a single execution. Output past this cap is dropped and the result is
+  /// flagged `truncated: true`.
+  final int maxOutputChars;
+
+  /// Maximum size (in characters) of an accepted `source` input. Larger inputs
+  /// are rejected before parsing/execution.
+  final int maxSourceChars;
+
+  /// Maximum depth of the serialized AST tree (`apollo.ast`). Guards against
+  /// pathological/deep trees producing huge payloads.
+  final int maxAstDepth;
+
+  /// Names of tools that run inside a spawned [Isolate] instead of in-process.
+  ///
+  /// Isolate execution is the ONLY way to enforce a real wall-clock timeout in
+  /// Dart: ApolloVM runs CPU work synchronously (no async yield), so an
+  /// in-process `Future.timeout` cannot interrupt a runaway loop, but an
+  /// isolate can be `kill()`-ed. `apollo.execute` (which runs arbitrary user
+  /// code) defaults to isolate execution; the pure/bounded tools default to
+  /// in-process. Configurable per tool.
+  final Set<String> isolateTools;
+
+  const McpLimits({
+    this.timeoutMs = 5000,
+    this.maxOutputChars = 65536,
+    this.maxSourceChars = 262144,
+    this.maxAstDepth = 200,
+    this.isolateTools = const {'apollo.execute'},
+  });
+
+  /// Whether [toolName] should run inside an isolate.
+  bool runsInIsolate(String toolName) => isolateTools.contains(toolName);
+
+  /// Returns a copy of these limits with the given overrides.
+  McpLimits copyWith({
+    int? timeoutMs,
+    int? maxOutputChars,
+    int? maxSourceChars,
+    int? maxAstDepth,
+    Set<String>? isolateTools,
+  }) => McpLimits(
+    timeoutMs: timeoutMs ?? this.timeoutMs,
+    maxOutputChars: maxOutputChars ?? this.maxOutputChars,
+    maxSourceChars: maxSourceChars ?? this.maxSourceChars,
+    maxAstDepth: maxAstDepth ?? this.maxAstDepth,
+    isolateTools: isolateTools ?? this.isolateTools,
+  );
+
+  @override
+  String toString() =>
+      'McpLimits{timeoutMs: $timeoutMs, maxOutputChars: $maxOutputChars, '
+      'maxSourceChars: $maxSourceChars, maxAstDepth: $maxAstDepth, '
+      'isolateTools: $isolateTools}';
+}

--- a/lib/src/mcp/runtime/apollo_runtime.dart
+++ b/lib/src/mcp/runtime/apollo_runtime.dart
@@ -1,0 +1,355 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'dart:convert';
+
+import 'package:apollovm/apollovm.dart';
+
+import '../mcp_config.dart';
+import '../serialize/diagnostics.dart';
+import '../serialize/value_json.dart';
+
+/// Result of a parse request.
+typedef ParseOutcome = ({ASTRoot? root, List<Diagnostic> diagnostics});
+
+/// Result of an execute request.
+typedef ExecuteOutcome = ({
+  Object? result,
+  bool hasResult,
+  List<String> output,
+  bool truncated,
+  List<Diagnostic> diagnostics,
+});
+
+/// Result of a translate request.
+typedef TranslateOutcome = ({String? generated, List<Diagnostic> diagnostics});
+
+/// Result of a wasm compile request.
+typedef WasmOutcome = ({
+  List<Map<String, Object?>>? modules,
+  List<Diagnostic> diagnostics,
+});
+
+/// In-process façade over [ApolloVM] used by the MCP tools.
+///
+/// Security model: only the `print` external is ever exposed to interpreted
+/// code (no file/socket bridge is registered), and inputs are inline source
+/// strings only — so file/network access is denied by construction. Execution
+/// is bounded by [McpLimits.timeoutMs] via `Future.timeout`; input/output are
+/// bounded by [McpLimits.maxSourceChars]/[McpLimits.maxOutputChars].
+class ApolloRuntime {
+  final McpLimits limits;
+
+  ApolloRuntime({this.limits = const McpLimits()});
+
+  Diagnostic _err(String message) =>
+      <String, Object?>{'severity': 'error', 'message': message};
+
+  /// Returns a source-too-large diagnostic list, or `null` if within limits.
+  List<Diagnostic>? _checkSource(String source) {
+    if (source.length > limits.maxSourceChars) {
+      return [
+        _err(
+          'Source exceeds maxSourceChars (${source.length} > '
+          '${limits.maxSourceChars})',
+        ),
+      ];
+    }
+    return null;
+  }
+
+  /// Parses [source] in [language] and returns its [ASTRoot] plus diagnostics.
+  ///
+  /// Uses the parser directly (not `loadCodeUnit`) so a parse failure yields
+  /// structured line/column diagnostics instead of a thrown [SyntaxError].
+  Future<ParseOutcome> parse(String language, String source) async {
+    final tooLarge = _checkSource(source);
+    if (tooLarge != null) return (root: null, diagnostics: tooLarge);
+
+    final vm = ApolloVM();
+    final parser = vm.getParser<String>(language);
+    if (parser == null) {
+      return (root: null, diagnostics: [_err('Unsupported language: $language')]);
+    }
+
+    final codeUnit = SourceCodeUnit(language, source, id: 'mcp');
+    final result = await parser.parse(codeUnit);
+    if (result.isOK) {
+      return (root: result.root, diagnostics: const <Diagnostic>[]);
+    }
+    return (root: null, diagnostics: [diagnosticFromParseResult(result)]);
+  }
+
+  /// Loads [source] into a fresh [ApolloVM], returning `(vm, null)` on success
+  /// or `(null, diagnostics)` on failure.
+  Future<(ApolloVM?, List<Diagnostic>?)> _load(
+    String language,
+    String source,
+  ) async {
+    final vm = ApolloVM();
+    final codeUnit = SourceCodeUnit(language, source, id: 'mcp');
+    try {
+      final ok = await vm.loadCodeUnit(codeUnit);
+      if (!ok) {
+        return (null, [_err('Unsupported language: $language')]);
+      }
+      return (vm, null);
+    } on SyntaxError catch (e) {
+      return (null, [diagnosticFromError(e)]);
+    }
+  }
+
+  /// Executes [source]: loads it, calls [function] (default `main`) — optionally
+  /// as a method of [className] — with [args], and returns the resolved result,
+  /// captured console output, and diagnostics. Bounded by the configured
+  /// timeout and output cap.
+  Future<ExecuteOutcome> execute(
+    String language,
+    String source, {
+    String function = 'main',
+    String? className,
+    List<Object?> args = const [],
+    int? timeoutMs,
+  }) async {
+    final tooLarge = _checkSource(source);
+    if (tooLarge != null) {
+      return (
+        result: null,
+        hasResult: false,
+        output: const <String>[],
+        truncated: false,
+        diagnostics: tooLarge,
+      );
+    }
+
+    final (vm, loadDiagnostics) = await _load(language, source);
+    if (vm == null) {
+      return (
+        result: null,
+        hasResult: false,
+        output: const <String>[],
+        truncated: false,
+        diagnostics: loadDiagnostics!,
+      );
+    }
+
+    final output = <String>[];
+    var outputChars = 0;
+    var truncated = false;
+    final cap = limits.maxOutputChars;
+
+    void capture(Object? o) {
+      if (truncated) return;
+      final line = '$o';
+      if (outputChars + line.length > cap) {
+        final remaining = cap - outputChars;
+        if (remaining > 0) output.add(line.substring(0, remaining));
+        truncated = true;
+        outputChars = cap;
+      } else {
+        output.add(line);
+        outputChars += line.length;
+      }
+    }
+
+    final runner = vm.createRunner(language)!;
+    runner.externalPrintFunction = capture;
+
+    final timeout = Duration(milliseconds: timeoutMs ?? limits.timeoutMs);
+
+    try {
+      final astValue = await _runEntry(
+        vm,
+        runner,
+        language,
+        function,
+        className,
+        args,
+      ).timeout(timeout);
+
+      Object? result;
+      var hasResult = false;
+      if (astValue != null) {
+        var native = astValue.getValueNoContext();
+        if (native is Future) native = await native;
+        result = valueToJson(native);
+        hasResult = true;
+      }
+
+      final diagnostics = <Diagnostic>[];
+      if (!hasResult) {
+        diagnostics.add(
+          _err(
+            "Entry function not found: ${className != null ? '$className.' : ''}"
+            '$function',
+          ),
+        );
+      }
+
+      return (
+        result: result,
+        hasResult: hasResult,
+        output: output,
+        truncated: truncated,
+        diagnostics: diagnostics,
+      );
+    } on TimeoutException {
+      return (
+        result: null,
+        hasResult: false,
+        output: output,
+        truncated: truncated,
+        diagnostics: [
+          _err('Execution timed out after ${timeout.inMilliseconds}ms'),
+        ],
+      );
+    } catch (e) {
+      return (
+        result: null,
+        hasResult: false,
+        output: output,
+        truncated: truncated,
+        diagnostics: [diagnosticFromError(e)],
+      );
+    }
+  }
+
+  /// Finds and runs the entry point, mirroring the CLI's discovery order:
+  /// an explicit [className] method, then a top-level function across
+  /// namespaces, then any class method of that name.
+  Future<ASTValue?> _runEntry(
+    ApolloVM vm,
+    ApolloRunner runner,
+    String language,
+    String function,
+    String? className,
+    List<Object?> args,
+  ) async {
+    final namespaces = vm.getLanguageNamespaces(language).namespaces;
+    if (!namespaces.contains('')) namespaces.insert(0, '');
+
+    if (className != null) {
+      for (var ns in namespaces) {
+        final r = await _tryClassMethod(runner, ns, className, function, args);
+        if (r != null) return r;
+      }
+      return null;
+    }
+
+    for (var ns in namespaces) {
+      final r = await runner.tryExecuteFunction(ns, function, args);
+      if (r != null) return r;
+    }
+
+    for (var ns in namespaces) {
+      final classes = vm.getLanguageNamespaces(language).get(ns).classesNames;
+      for (var clazz in classes) {
+        final r = await _tryClassMethod(runner, ns, clazz, function, args);
+        if (r != null) return r;
+      }
+    }
+
+    return null;
+  }
+
+  /// Invokes a class method providing a fresh (field-less) instance, so that
+  /// non-static entry methods run — `tryExecuteClassFunction` alone omits the
+  /// instance and fails for non-static methods. Mirrors that method's
+  /// argument-shape variations.
+  Future<ASTValue?> _tryClassMethod(
+    ApolloRunner runner,
+    String namespace,
+    String className,
+    String function,
+    List<Object?> args,
+  ) async {
+    Future<ASTValue?> call(List positional) => runner.executeClassMethod(
+      namespace,
+      className,
+      function,
+      positionalParameters: positional,
+      classInstanceFields: const {},
+    );
+
+    if (await runner.getClassMethod(namespace, className, function, args) !=
+        null) {
+      return call(args);
+    }
+    if (await runner.getClassMethod(namespace, className, function, [args]) !=
+        null) {
+      return call([args]);
+    }
+    if (await runner.getClassMethod(namespace, className, function, [
+          ASTTypeArray.instanceOfString,
+        ]) !=
+        null) {
+      return call([args.map((e) => '$e').toList()]);
+    }
+    if (await runner.getClassMethod(namespace, className, function, [
+          ASTTypeArray.instanceOfDynamic,
+        ]) !=
+        null) {
+      return call([args]);
+    }
+    return null;
+  }
+
+  /// Translates [source] from [from] to [to], returning the concatenated raw
+  /// generated source (without the `<<<< SOURCES >>>>` markers).
+  Future<TranslateOutcome> translate(
+    String from,
+    String to,
+    String source,
+  ) async {
+    final tooLarge = _checkSource(source);
+    if (tooLarge != null) return (generated: null, diagnostics: tooLarge);
+
+    final (vm, loadDiagnostics) = await _load(from, source);
+    if (vm == null) return (generated: null, diagnostics: loadDiagnostics!);
+
+    try {
+      final storage = vm.generateAllCodeIn(to);
+      final buf = StringBuffer();
+      for (var ns in await storage.getNamespaces()) {
+        for (var id in await storage.getNamespaceCodeUnitsIDs(ns)) {
+          final src = await storage.getNamespaceCodeUnit(ns, id);
+          if (src != null) buf.write(src);
+        }
+      }
+      return (generated: buf.toString(), diagnostics: const <Diagnostic>[]);
+    } catch (e) {
+      return (generated: null, diagnostics: [diagnosticFromError(e)]);
+    }
+  }
+
+  /// Compiles [source] to WebAssembly, returning each produced module as
+  /// `{name, base64}` (the module bytes, base64-encoded for JSON transport).
+  Future<WasmOutcome> compileWasm(String language, String source) async {
+    final tooLarge = _checkSource(source);
+    if (tooLarge != null) return (modules: null, diagnostics: tooLarge);
+
+    final (vm, loadDiagnostics) = await _load(language, source);
+    if (vm == null) return (modules: null, diagnostics: loadDiagnostics!);
+
+    try {
+      final storage = vm.generateAllIn<BytesOutput>('wasm');
+      final entries = await storage.allEntries();
+      final modules = <Map<String, Object?>>[];
+      entries.forEach((namespace, moduleMap) {
+        moduleMap.forEach((moduleName, output) {
+          modules.add(<String, Object?>{
+            'name': moduleName,
+            'base64': base64.encode(output.output()),
+          });
+        });
+      });
+      if (modules.isEmpty) {
+        return (modules: null, diagnostics: [_err('No Wasm modules generated')]);
+      }
+      return (modules: modules, diagnostics: const <Diagnostic>[]);
+    } catch (e) {
+      return (modules: null, diagnostics: [diagnosticFromError(e)]);
+    }
+  }
+}

--- a/lib/src/mcp/runtime/apollo_runtime.dart
+++ b/lib/src/mcp/runtime/apollo_runtime.dart
@@ -43,8 +43,10 @@ class ApolloRuntime {
 
   ApolloRuntime({this.limits = const McpLimits()});
 
-  Diagnostic _err(String message) =>
-      <String, Object?>{'severity': 'error', 'message': message};
+  Diagnostic _err(String message) => <String, Object?>{
+    'severity': 'error',
+    'message': message,
+  };
 
   /// Returns a source-too-large diagnostic list, or `null` if within limits.
   List<Diagnostic>? _checkSource(String source) {
@@ -70,7 +72,10 @@ class ApolloRuntime {
     final vm = ApolloVM();
     final parser = vm.getParser<String>(language);
     if (parser == null) {
-      return (root: null, diagnostics: [_err('Unsupported language: $language')]);
+      return (
+        root: null,
+        diagnostics: [_err('Unsupported language: $language')],
+      );
     }
 
     final codeUnit = SourceCodeUnit(language, source, id: 'mcp');
@@ -350,7 +355,10 @@ class ApolloRuntime {
         });
       });
       if (modules.isEmpty) {
-        return (modules: null, diagnostics: [_err('No Wasm modules generated')]);
+        return (
+          modules: null,
+          diagnostics: [_err('No Wasm modules generated')],
+        );
       }
       return (modules: modules, diagnostics: const <Diagnostic>[]);
     } catch (e) {

--- a/lib/src/mcp/runtime/apollo_runtime.dart
+++ b/lib/src/mcp/runtime/apollo_runtime.dart
@@ -88,6 +88,11 @@ class ApolloRuntime {
     String source,
   ) async {
     final vm = ApolloVM();
+    // Reject unknown languages up front: `loadCodeUnit` throws a `StateError`
+    // (rather than returning false) when there is no parser for the language.
+    if (vm.getParser<String>(language) == null) {
+      return (null, [_err('Unsupported language: $language')]);
+    }
     final codeUnit = SourceCodeUnit(language, source, id: 'mcp');
     try {
       final ok = await vm.loadCodeUnit(codeUnit);

--- a/lib/src/mcp/runtime/isolate_executor.dart
+++ b/lib/src/mcp/runtime/isolate_executor.dart
@@ -1,0 +1,120 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'dart:async';
+import 'dart:isolate';
+
+import '../mcp_config.dart';
+import '../tools/apollo_tools.dart';
+
+/// A sendable description of a tool computation to run inside an isolate.
+class _IsolateJob {
+  final String toolName;
+  final Map<String, Object?> args;
+  final McpLimits limits;
+  final SendPort replyPort;
+
+  _IsolateJob(this.toolName, this.args, this.limits, this.replyPort);
+}
+
+/// Runs the tool named [toolName] inside an isolate, using
+/// [McpLimits.timeoutMs] (or an override in `args['timeoutMs']`) as the hard
+/// timeout. Convenience wrapper over [runToolInIsolate].
+Future<Map<String, Object?>> computeToolIsolated(
+  String toolName,
+  Map<String, Object?> args,
+  McpLimits limits,
+) {
+  final timeoutMs = (args['timeoutMs'] as int?) ?? limits.timeoutMs;
+  return runToolInIsolate(
+    toolName,
+    args,
+    limits,
+    Duration(milliseconds: timeoutMs),
+  );
+}
+
+/// Runs [computeTool] for [toolName] inside a spawned [Isolate], enforcing a
+/// hard [timeout] via `Timer` + `Isolate.kill`.
+///
+/// This is the only reliable way to bound CPU/wall-clock in Dart: a runaway
+/// loop that ignores the event loop cannot be stopped in-process, but the
+/// isolate running it can be killed. On timeout (or isolate error/premature
+/// exit) an error result map is returned; captured output produced before the
+/// kill is not recovered.
+Future<Map<String, Object?>> runToolInIsolate(
+  String toolName,
+  Map<String, Object?> args,
+  McpLimits limits,
+  Duration timeout,
+) async {
+  final replyPort = ReceivePort();
+  final errorPort = ReceivePort();
+  final exitPort = ReceivePort();
+  final completer = Completer<Map<String, Object?>>();
+
+  Isolate? isolate;
+  Timer? timer;
+
+  void complete(Map<String, Object?> result) {
+    if (!completer.isCompleted) completer.complete(result);
+  }
+
+  try {
+    isolate = await Isolate.spawn(
+      _isolateEntry,
+      _IsolateJob(toolName, args, limits, replyPort.sendPort),
+      onError: errorPort.sendPort,
+      onExit: exitPort.sendPort,
+      errorsAreFatal: true,
+    );
+
+    timer = Timer(timeout, () {
+      isolate?.kill(priority: Isolate.immediate);
+      complete(_errorResult(
+        'Execution timed out after ${timeout.inMilliseconds}ms',
+      ));
+    });
+
+    replyPort.listen((message) {
+      complete((message as Map).cast<String, Object?>());
+    });
+
+    errorPort.listen((message) {
+      // message is [errorString, stackTraceString].
+      final error = (message is List && message.isNotEmpty)
+          ? '${message.first}'
+          : '$message';
+      complete(_errorResult('Isolate error: $error'));
+    });
+
+    exitPort.listen((_) {
+      complete(_errorResult('Isolate exited before returning a result'));
+    });
+
+    return await completer.future;
+  } finally {
+    timer?.cancel();
+    replyPort.close();
+    errorPort.close();
+    exitPort.close();
+    isolate?.kill(priority: Isolate.immediate);
+  }
+}
+
+Future<void> _isolateEntry(_IsolateJob job) async {
+  try {
+    final result = await computeTool(job.toolName, job.args, job.limits);
+    job.replyPort.send(result);
+  } catch (e) {
+    job.replyPort.send(_errorResult('$e'));
+  }
+}
+
+Map<String, Object?> _errorResult(String message) => <String, Object?>{
+  'diagnostics': [
+    <String, Object?>{'severity': 'error', 'message': message},
+  ],
+  'isError': true,
+};

--- a/lib/src/mcp/runtime/isolate_executor.dart
+++ b/lib/src/mcp/runtime/isolate_executor.dart
@@ -72,9 +72,9 @@ Future<Map<String, Object?>> runToolInIsolate(
 
     timer = Timer(timeout, () {
       isolate?.kill(priority: Isolate.immediate);
-      complete(_errorResult(
-        'Execution timed out after ${timeout.inMilliseconds}ms',
-      ));
+      complete(
+        _errorResult('Execution timed out after ${timeout.inMilliseconds}ms'),
+      );
     });
 
     replyPort.listen((message) {

--- a/lib/src/mcp/serialize/ast_json.dart
+++ b/lib/src/mcp/serialize/ast_json.dart
@@ -111,7 +111,20 @@ Map<String, Object?> astNodeToJson(
   }
 
   if (depth < maxDepth) {
-    final children = node.children.toList(growable: false);
+    // `ASTNode.children` omits some container members: an `ASTRoot` does not
+    // list its classes, and an `ASTClassNormal` lists only its methods (not its
+    // fields or constructors). Augment the walk so the tree is complete.
+    final children = <ASTNode>[
+      ...node.children,
+      ...switch (node) {
+        ASTRoot() => [...node.imports, ...node.classes],
+        ASTClassNormal() => [
+          ...node.fields,
+          for (final set in node.constructors) ...set.functions,
+        ],
+        _ => const <ASTNode>[],
+      },
+    ];
     if (children.isNotEmpty) {
       json['children'] = [
         for (var c in children)

--- a/lib/src/mcp/serialize/ast_json.dart
+++ b/lib/src/mcp/serialize/ast_json.dart
@@ -1,0 +1,124 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'package:apollovm/apollovm.dart';
+
+import 'value_json.dart';
+
+/// Serializes an [ASTType] to a JSON-safe map: `{name, generics?, superType?}`.
+Map<String, Object?> typeToJson(ASTType type) {
+  final generics = type.generics;
+  final superType = type.superType;
+  return <String, Object?>{
+    'name': type.name,
+    if (generics != null && generics.isNotEmpty)
+      'generics': [for (var g in generics) typeToJson(g)],
+    if (superType != null) 'superType': superType.name,
+  };
+}
+
+/// Serializes an [ASTModifiers] to its active modifier list (e.g. `['static']`).
+List<String> modifiersToJson(ASTModifiers modifiers) => modifiers.modifiers;
+
+/// Serializes a parameters declaration to a list of `{name, type, optional?,
+/// named?, hasDefault?}` maps (positional, then optional, then named).
+List<Map<String, Object?>> parametersToJson(ASTParametersDeclaration params) {
+  Map<String, Object?> one(
+    ASTParameterDeclaration p, {
+    required bool optional,
+    required bool named,
+  }) => <String, Object?>{
+    'name': p.name,
+    'type': typeToJson(p.type),
+    if (optional) 'optional': true,
+    if (named) 'named': true,
+    if (p.defaultValue != null) 'hasDefault': true,
+  };
+
+  return <Map<String, Object?>>[
+    for (var p in params.positionalParameters ?? const [])
+      one(p, optional: false, named: false),
+    for (var p in params.optionalParameters ?? const [])
+      one(p, optional: true, named: false),
+    for (var p in params.namedParameters ?? const [])
+      one(p, optional: true, named: true),
+  ];
+}
+
+/// Serializes an invocable declaration (function / method / constructor) to
+/// `{name, returnType, modifiers, parameters}`.
+Map<String, Object?> invocableToJson(ASTInvocableDeclaration inv) =>
+    <String, Object?>{
+      'name': inv.name,
+      'returnType': typeToJson(inv.returnType),
+      'modifiers': modifiersToJson(inv.modifiers),
+      'parameters': parametersToJson(inv.parameters),
+    };
+
+/// Serializes any [ASTNode] into a JSON tree.
+///
+/// Every node contributes its concrete `runtimeType` as `node`, a set of
+/// node-specific fields (see below), and — up to [maxDepth] — its `children`.
+/// The walk is total: an unhandled node still yields `{node, children}`.
+///
+/// Note: ApolloVM AST nodes carry NO source positions (line/column), so none
+/// are emitted here. Positions are available only for parse-error diagnostics.
+Map<String, Object?> astNodeToJson(
+  ASTNode node, {
+  int depth = 0,
+  int maxDepth = 200,
+}) {
+  final json = <String, Object?>{'node': node.runtimeType.toString()};
+
+  switch (node) {
+    case ASTRoot():
+      json['namespace'] = node.namespace;
+      json['classes'] = node.classesNames;
+      json['functions'] = node.functions.map((f) => f.name).toList();
+      json['imports'] = node.imports.map((i) => i.path).toList();
+    case ASTClassNormal():
+      json['name'] = node.name;
+      json['kind'] = node.kind.name;
+      if (node.superClassName != null) {
+        json['superClassName'] = node.superClassName;
+      }
+      if (node.implementsTypes != null) {
+        json['implements'] = node.implementsTypes;
+      }
+      json['fields'] = node.fieldsNames;
+      json['constructors'] = node.constructorsNames;
+    case ASTInvocableDeclaration():
+      json.addAll(invocableToJson(node));
+    case ASTClassField():
+      json['name'] = node.name;
+      json['type'] = typeToJson(node.type);
+      json['modifiers'] = modifiersToJson(node.modifiers);
+    case ASTType():
+      json.addAll(typeToJson(node));
+    case ASTStatementImport():
+      json['path'] = node.path;
+      if (node.prefix != null) json['prefix'] = node.prefix;
+    case ASTValue():
+      final native = node.getValueNoContext();
+      if (native is! Future) {
+        json['value'] = valueToJson(native);
+      }
+    case ASTVariable():
+      json['name'] = node.name;
+    default:
+    // No extra fields; the generic node + children still describe it.
+  }
+
+  if (depth < maxDepth) {
+    final children = node.children.toList(growable: false);
+    if (children.isNotEmpty) {
+      json['children'] = [
+        for (var c in children)
+          astNodeToJson(c, depth: depth + 1, maxDepth: maxDepth),
+      ];
+    }
+  }
+
+  return json;
+}

--- a/lib/src/mcp/serialize/diagnostics.dart
+++ b/lib/src/mcp/serialize/diagnostics.dart
@@ -1,0 +1,43 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'package:apollovm/apollovm.dart';
+
+/// A single diagnostic (parse or runtime) as a JSON-safe map.
+///
+/// Shape: `{severity, message, position?, line?, column?, sourceLine?}`.
+typedef Diagnostic = Map<String, Object?>;
+
+/// Builds a diagnostic from a parser [ParseResult] that carries an error.
+///
+/// Surfaces the position/line/column info that only exists at parse time
+/// (AST nodes themselves carry no source positions).
+Diagnostic diagnosticFromParseResult(ParseResult result) {
+  final lineCol = result.errorLineAndColumn;
+  return <String, Object?>{
+    'severity': 'error',
+    'message': result.errorMessage ?? 'Parse error',
+    if (result.errorPosition != null) 'position': result.errorPosition,
+    if (lineCol != null && lineCol.isNotEmpty) 'line': lineCol[0],
+    if (lineCol != null && lineCol.length >= 2) 'column': lineCol[1],
+    if (result.errorLine != null) 'sourceLine': result.errorLine,
+    'detail': result.errorMessageExtended,
+  };
+}
+
+/// Builds a diagnostic from a thrown error/exception.
+///
+/// Unwraps a [SyntaxError]'s [ParseResult] when present so parse failures
+/// raised via `loadCodeUnit` still yield line/column info.
+Diagnostic diagnosticFromError(Object error, {String severity = 'error'}) {
+  if (error is SyntaxError) {
+    final parseResult = error.parseResult;
+    if (parseResult != null) {
+      return diagnosticFromParseResult(parseResult);
+    }
+    return <String, Object?>{'severity': severity, 'message': error.message};
+  }
+
+  return <String, Object?>{'severity': severity, 'message': '$error'};
+}

--- a/lib/src/mcp/serialize/symbols.dart
+++ b/lib/src/mcp/serialize/symbols.dart
@@ -1,0 +1,47 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'package:apollovm/apollovm.dart';
+
+import 'ast_json.dart';
+
+/// Builds a symbol graph from a parsed [ASTRoot]: top-level functions and
+/// classes (with their fields, methods and constructors). Pure introspection —
+/// no execution required.
+Map<String, Object?> symbolsToJson(ASTRoot root) {
+  List<Map<String, Object?>> invocables(Iterable<ASTFunctionSet> sets) => [
+    for (var set in sets)
+      for (var f in set.functions) invocableToJson(f),
+  ];
+
+  return <String, Object?>{
+    'namespace': root.namespace,
+    'imports': root.imports.map((i) => i.path).toList(),
+    'functions': invocables(root.functions),
+    'classes': [
+      for (var clazz in root.classes)
+        <String, Object?>{
+          'name': clazz.name,
+          'kind': clazz.kind.name,
+          if (clazz.superClassName != null)
+            'superClassName': clazz.superClassName,
+          if (clazz.implementsTypes != null)
+            'implements': clazz.implementsTypes,
+          'fields': [
+            for (var field in clazz.fields)
+              <String, Object?>{
+                'name': field.name,
+                'type': typeToJson(field.type),
+                'modifiers': modifiersToJson(field.modifiers),
+              },
+          ],
+          'constructors': [
+            for (var set in clazz.constructors)
+              for (var c in set.functions) invocableToJson(c),
+          ],
+          'methods': invocables(clazz.functions),
+        },
+    ],
+  };
+}

--- a/lib/src/mcp/serialize/types.dart
+++ b/lib/src/mcp/serialize/types.dart
@@ -1,0 +1,79 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'package:apollovm/apollovm.dart';
+
+import 'ast_json.dart';
+
+/// Well-known builtin/primitive type names (used to classify `kind`).
+const _builtinTypeNames = <String>{
+  'int', 'double', 'num', 'bool', 'String', 'Object', 'dynamic', 'void',
+  'Null', 'var', 'List', 'Map', 'Set', 'Future', 'Function', 'Iterable',
+};
+
+/// Builds a deduplicated type table for a parsed [ASTRoot].
+///
+/// Every [ASTType] referenced by a signature, field, return type or class is
+/// collected once (keyed by name) and classified as `class` (declared in this
+/// unit), `builtin`, or `unknown`.
+Map<String, Object?> typesToJson(ASTRoot root) {
+  final collected = <String, ASTType>{};
+
+  void add(ASTType type) {
+    collected.putIfAbsent(type.name, () => type);
+    final generics = type.generics;
+    if (generics != null) {
+      for (var g in generics) {
+        add(g);
+      }
+    }
+  }
+
+  void addInvocable(ASTInvocableDeclaration inv) {
+    add(inv.returnType);
+    for (var p in inv.parameters.allParameters) {
+      add(p.type);
+    }
+  }
+
+  for (var set in root.functions) {
+    for (var f in set.functions) {
+      addInvocable(f);
+    }
+  }
+
+  final declaredClasses = root.classesNames.toSet();
+
+  for (var clazz in root.classes) {
+    add(clazz.type);
+    for (var field in clazz.fields) {
+      add(field.type);
+    }
+    for (var set in clazz.functions) {
+      for (var m in set.functions) {
+        addInvocable(m);
+      }
+    }
+    for (var set in clazz.constructors) {
+      for (var c in set.functions) {
+        addInvocable(c);
+      }
+    }
+  }
+
+  String kindOf(String name) {
+    if (declaredClasses.contains(name)) return 'class';
+    if (_builtinTypeNames.contains(name)) return 'builtin';
+    return 'unknown';
+  }
+
+  final names = collected.keys.toList()..sort();
+
+  return <String, Object?>{
+    'types': [
+      for (var name in names)
+        <String, Object?>{...typeToJson(collected[name]!), 'kind': kindOf(name)},
+    ],
+  };
+}

--- a/lib/src/mcp/serialize/types.dart
+++ b/lib/src/mcp/serialize/types.dart
@@ -8,8 +8,22 @@ import 'ast_json.dart';
 
 /// Well-known builtin/primitive type names (used to classify `kind`).
 const _builtinTypeNames = <String>{
-  'int', 'double', 'num', 'bool', 'String', 'Object', 'dynamic', 'void',
-  'Null', 'var', 'List', 'Map', 'Set', 'Future', 'Function', 'Iterable',
+  'int',
+  'double',
+  'num',
+  'bool',
+  'String',
+  'Object',
+  'dynamic',
+  'void',
+  'Null',
+  'var',
+  'List',
+  'Map',
+  'Set',
+  'Future',
+  'Function',
+  'Iterable',
 };
 
 /// Builds a deduplicated type table for a parsed [ASTRoot].
@@ -73,7 +87,10 @@ Map<String, Object?> typesToJson(ASTRoot root) {
   return <String, Object?>{
     'types': [
       for (var name in names)
-        <String, Object?>{...typeToJson(collected[name]!), 'kind': kindOf(name)},
+        <String, Object?>{
+          ...typeToJson(collected[name]!),
+          'kind': kindOf(name),
+        },
     ],
   };
 }

--- a/lib/src/mcp/serialize/value_json.dart
+++ b/lib/src/mcp/serialize/value_json.dart
@@ -1,0 +1,52 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'package:apollovm/apollovm.dart';
+
+/// Converts an arbitrary value produced by ApolloVM execution
+/// (`ASTValue.getValueNoContext()`) into a JSON-safe structure
+/// (`null` / `num` / `bool` / `String` / `List` / `Map<String, Object?>`).
+///
+/// Non-representable values (closures, unresolved futures, unknown objects)
+/// degrade to their `toString()`. A [depth] guard prevents runaway recursion.
+Object? valueToJson(Object? value, {int depth = 0, int maxDepth = 64}) {
+  if (depth > maxDepth) return '$value';
+
+  if (value == null || value is num || value is bool || value is String) {
+    return value;
+  }
+
+  // A `VMObject` is an object instance with named fields.
+  if (value is VMObject) {
+    final fields = value.getFieldsValues();
+    return <String, Object?>{
+      r'$type': value.type.name,
+      for (var e in fields.entries)
+        e.key: valueToJson(e.value, depth: depth + 1, maxDepth: maxDepth),
+    };
+  }
+
+  // Resolve ApolloVM value wrappers down to their native value.
+  if (value is ASTValue) {
+    final native = value.getValueNoContext();
+    if (native is Future || identical(native, value)) return '$value';
+    return valueToJson(native, depth: depth + 1, maxDepth: maxDepth);
+  }
+
+  if (value is Map) {
+    return <String, Object?>{
+      for (var e in value.entries)
+        '${e.key}': valueToJson(e.value, depth: depth + 1, maxDepth: maxDepth),
+    };
+  }
+
+  if (value is Iterable) {
+    return [
+      for (var e in value) valueToJson(e, depth: depth + 1, maxDepth: maxDepth),
+    ];
+  }
+
+  // Fallback: a readable textual form.
+  return '$value';
+}

--- a/lib/src/mcp/tools/apollo_tools.dart
+++ b/lib/src/mcp/tools/apollo_tools.dart
@@ -87,7 +87,9 @@ List<Tool> buildTools() => [
         'return the generated source.',
     inputSchema: ObjectSchema(
       properties: {
-        'from': Schema.string(description: 'Source language ($_languageValues).'),
+        'from': Schema.string(
+          description: 'Source language ($_languageValues).',
+        ),
         'to': Schema.string(description: 'Target language ($_languageValues).'),
         'source': _sourceSchema,
       },
@@ -246,7 +248,10 @@ Future<Map<String, Object?>> computeTool(
     default:
       return <String, Object?>{
         'diagnostics': [
-          <String, Object?>{'severity': 'error', 'message': 'Unknown tool: $name'},
+          <String, Object?>{
+            'severity': 'error',
+            'message': 'Unknown tool: $name',
+          },
         ],
         'isError': true,
       };

--- a/lib/src/mcp/tools/apollo_tools.dart
+++ b/lib/src/mcp/tools/apollo_tools.dart
@@ -1,0 +1,254 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'dart:math' as math;
+
+import 'package:dart_mcp/server.dart';
+
+import '../mcp_config.dart';
+import '../runtime/apollo_runtime.dart';
+import '../serialize/ast_json.dart';
+import '../serialize/symbols.dart';
+import '../serialize/types.dart';
+
+/// Canonical tool names.
+const parseToolName = 'apollo.parse';
+const executeToolName = 'apollo.execute';
+const translateToolName = 'apollo.translate';
+const astToolName = 'apollo.ast';
+const symbolsToolName = 'apollo.symbols';
+const typesToolName = 'apollo.types';
+const wasmToolName = 'apollo.wasm';
+
+/// The names of all tools this server exposes, in registration order.
+const allToolNames = <String>[
+  parseToolName,
+  executeToolName,
+  translateToolName,
+  astToolName,
+  symbolsToolName,
+  typesToolName,
+  wasmToolName,
+];
+
+const _languageValues =
+    'dart, java, kotlin, csharp, javascript, typescript, lua, python, wasm';
+
+Schema get _languageSchema =>
+    Schema.string(description: 'Source language ($_languageValues).');
+
+Schema get _sourceSchema =>
+    Schema.string(description: 'The source code to process.');
+
+/// The [Tool] definitions (name, description, JSON input schema) for all seven
+/// ApolloVM tools. These schemas are the single source of truth advertised via
+/// `tools/list`.
+List<Tool> buildTools() => [
+  Tool(
+    name: parseToolName,
+    description:
+        'Parse source code and return parse diagnostics plus a summary of the '
+        'top-level classes, functions and imports.',
+    inputSchema: ObjectSchema(
+      properties: {'language': _languageSchema, 'source': _sourceSchema},
+      required: ['language', 'source'],
+    ),
+  ),
+  Tool(
+    name: executeToolName,
+    description:
+        'Execute source code (running an entry function, default `main`) and '
+        'return the result value, captured console output and diagnostics.',
+    inputSchema: ObjectSchema(
+      properties: {
+        'language': _languageSchema,
+        'source': _sourceSchema,
+        'function': Schema.string(
+          description: 'Entry function name (default `main`).',
+        ),
+        'className': Schema.string(
+          description: 'Optional class owning the entry method.',
+        ),
+        'args': Schema.list(
+          description: 'Positional arguments passed to the entry function.',
+        ),
+        'timeoutMs': Schema.int(
+          description: 'Execution timeout override, in milliseconds.',
+        ),
+      },
+      required: ['language', 'source'],
+    ),
+  ),
+  Tool(
+    name: translateToolName,
+    description:
+        'Translate/transpile source code from one language to another and '
+        'return the generated source.',
+    inputSchema: ObjectSchema(
+      properties: {
+        'from': Schema.string(description: 'Source language ($_languageValues).'),
+        'to': Schema.string(description: 'Target language ($_languageValues).'),
+        'source': _sourceSchema,
+      },
+      required: ['from', 'to', 'source'],
+    ),
+  ),
+  Tool(
+    name: astToolName,
+    description: 'Parse source code and return its full AST as JSON.',
+    inputSchema: ObjectSchema(
+      properties: {
+        'language': _languageSchema,
+        'source': _sourceSchema,
+        'maxDepth': Schema.int(
+          description: 'Maximum AST tree depth to serialize.',
+        ),
+      },
+      required: ['language', 'source'],
+    ),
+  ),
+  Tool(
+    name: symbolsToolName,
+    description:
+        'Parse source code and return its symbol graph: top-level functions '
+        'and classes with their fields, methods and constructors.',
+    inputSchema: ObjectSchema(
+      properties: {'language': _languageSchema, 'source': _sourceSchema},
+      required: ['language', 'source'],
+    ),
+  ),
+  Tool(
+    name: typesToolName,
+    description:
+        'Parse source code and return the deduplicated table of types it '
+        'references (classified as class/builtin/unknown).',
+    inputSchema: ObjectSchema(
+      properties: {'language': _languageSchema, 'source': _sourceSchema},
+      required: ['language', 'source'],
+    ),
+  ),
+  Tool(
+    name: wasmToolName,
+    description:
+        'Compile source code to WebAssembly and return each produced module '
+        'as base64-encoded bytes.',
+    inputSchema: ObjectSchema(
+      properties: {'language': _languageSchema, 'source': _sourceSchema},
+      required: ['language', 'source'],
+    ),
+  ),
+];
+
+String _str(Map<String, Object?> args, String key, [String fallback = '']) =>
+    (args[key] as String?) ?? fallback;
+
+/// Runs the tool named [name] with [args] and returns its JSON result map.
+///
+/// The returned map always contains an `isError` flag. This function is pure
+/// with respect to the host (no shared state), so it can run either in-process
+/// or inside a spawned isolate (see `runtime/isolate_executor.dart`).
+Future<Map<String, Object?>> computeTool(
+  String name,
+  Map<String, Object?> args,
+  McpLimits limits,
+) async {
+  final rt = ApolloRuntime(limits: limits);
+
+  switch (name) {
+    case parseToolName:
+      final o = await rt.parse(_str(args, 'language'), _str(args, 'source'));
+      final root = o.root;
+      return <String, Object?>{
+        'ok': root != null,
+        'diagnostics': o.diagnostics,
+        if (root != null)
+          'summary': <String, Object?>{
+            'namespace': root.namespace,
+            'classes': root.classesNames,
+            'functions': root.functions.map((f) => f.name).toList(),
+            'imports': root.imports.map((i) => i.path).toList(),
+          },
+        'isError': root == null,
+      };
+
+    case astToolName:
+      final o = await rt.parse(_str(args, 'language'), _str(args, 'source'));
+      if (o.root == null) {
+        return <String, Object?>{'diagnostics': o.diagnostics, 'isError': true};
+      }
+      final requested = (args['maxDepth'] as int?) ?? limits.maxAstDepth;
+      final depth = math.min(requested, limits.maxAstDepth);
+      return <String, Object?>{
+        'ast': astNodeToJson(o.root!, maxDepth: depth),
+        'isError': false,
+      };
+
+    case symbolsToolName:
+      final o = await rt.parse(_str(args, 'language'), _str(args, 'source'));
+      if (o.root == null) {
+        return <String, Object?>{'diagnostics': o.diagnostics, 'isError': true};
+      }
+      return <String, Object?>{
+        'symbols': symbolsToJson(o.root!),
+        'isError': false,
+      };
+
+    case typesToolName:
+      final o = await rt.parse(_str(args, 'language'), _str(args, 'source'));
+      if (o.root == null) {
+        return <String, Object?>{'diagnostics': o.diagnostics, 'isError': true};
+      }
+      return <String, Object?>{...typesToJson(o.root!), 'isError': false};
+
+    case executeToolName:
+      final rawArgs = (args['args'] as List?)?.cast<Object?>() ?? const [];
+      final o = await rt.execute(
+        _str(args, 'language'),
+        _str(args, 'source'),
+        function: _str(args, 'function', 'main'),
+        className: args['className'] as String?,
+        args: rawArgs,
+        timeoutMs: args['timeoutMs'] as int?,
+      );
+      return <String, Object?>{
+        'result': o.result,
+        'hasResult': o.hasResult,
+        'output': o.output,
+        'truncated': o.truncated,
+        'diagnostics': o.diagnostics,
+        'isError': o.diagnostics.isNotEmpty,
+      };
+
+    case translateToolName:
+      final o = await rt.translate(
+        _str(args, 'from'),
+        _str(args, 'to'),
+        _str(args, 'source'),
+      );
+      return <String, Object?>{
+        'generated': o.generated,
+        'diagnostics': o.diagnostics,
+        'isError': o.generated == null,
+      };
+
+    case wasmToolName:
+      final o = await rt.compileWasm(
+        _str(args, 'language'),
+        _str(args, 'source'),
+      );
+      return <String, Object?>{
+        'modules': o.modules,
+        'diagnostics': o.diagnostics,
+        'isError': o.modules == null,
+      };
+
+    default:
+      return <String, Object?>{
+        'diagnostics': [
+          <String, Object?>{'severity': 'error', 'message': 'Unknown tool: $name'},
+        ],
+        'isError': true,
+      };
+  }
+}

--- a/lib/src/mcp/tools/apollo_tools.dart
+++ b/lib/src/mcp/tools/apollo_tools.dart
@@ -33,7 +33,7 @@ const allToolNames = <String>[
 ];
 
 const _languageValues =
-    'dart, java, kotlin, csharp, javascript, typescript, lua, python, wasm';
+    'dart, java, kotlin, go, csharp, javascript, typescript, lua, python, wasm';
 
 Schema get _languageSchema =>
     Schema.string(description: 'Source language ($_languageValues).');

--- a/lib/src/mcp/transport/http_sse_transport.dart
+++ b/lib/src/mcp/transport/http_sse_transport.dart
@@ -1,0 +1,149 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:stream_channel/stream_channel.dart';
+
+import '../apollo_mcp_server.dart';
+import '../mcp_config.dart';
+
+/// A single client session: the SSE response used to push server→client
+/// messages, and the incoming controller fed by the client's POSTs.
+class _Session {
+  final HttpResponse sseResponse;
+  final StreamController<String> incoming;
+  final StreamController<String> outgoing;
+  final ApolloMcpServer server;
+
+  _Session(this.sseResponse, this.incoming, this.outgoing, this.server);
+
+  Future<void> close() async {
+    await server.shutdown();
+    await incoming.close();
+    await outgoing.close();
+  }
+}
+
+/// An MCP transport that exposes [ApolloMcpServer] over HTTP using the
+/// Server-Sent Events (SSE) transport:
+///
+/// - `GET /sse` opens an SSE stream. The first event (`event: endpoint`) tells
+///   the client which URL to POST messages to (`/message?sessionId=...`).
+///   Server→client JSON-RPC messages are streamed as `event: message` frames.
+/// - `POST /message?sessionId=...` delivers one client→server JSON-RPC message;
+///   the server replies over the session's SSE stream. Returns `202 Accepted`.
+///
+/// SECURITY: binds to `127.0.0.1` by default. Exposing this on a public
+/// interface grants unauthenticated code execution — front it with auth/TLS
+/// and an explicit `host` only in a trusted environment.
+class HttpSseTransport {
+  final McpLimits limits;
+
+  final Map<String, _Session> _sessions = {};
+  HttpServer? _server;
+  int _sessionCounter = 0;
+
+  HttpSseTransport({this.limits = const McpLimits()});
+
+  /// The bound address, available after [start].
+  InternetAddress? get address => _server?.address;
+
+  /// The bound port, available after [start].
+  int? get port => _server?.port;
+
+  /// Binds an [HttpServer] on [host]:[port] and starts serving.
+  Future<void> start({int port = 8080, String host = '127.0.0.1'}) async {
+    final server = await HttpServer.bind(host, port);
+    _server = server;
+    server.listen(_handleRequest);
+  }
+
+  /// Stops the server and closes all active sessions.
+  Future<void> stop() async {
+    for (final session in _sessions.values.toList()) {
+      await session.close();
+    }
+    _sessions.clear();
+    await _server?.close(force: true);
+    _server = null;
+  }
+
+  Future<void> _handleRequest(HttpRequest request) async {
+    final path = request.uri.path;
+    if (request.method == 'GET' && (path == '/sse' || path == '/')) {
+      _openSseSession(request);
+    } else if (request.method == 'POST' &&
+        (path == '/message' || path == '/sse' || path == '/')) {
+      await _handlePost(request);
+    } else {
+      request.response.statusCode = HttpStatus.notFound;
+      await request.response.close();
+    }
+  }
+
+  void _openSseSession(HttpRequest request) {
+    final response = request.response;
+    response.statusCode = HttpStatus.ok;
+    // Stream each SSE frame to the socket immediately (no output buffering).
+    response.bufferOutput = false;
+    response.headers
+      ..set(HttpHeaders.contentTypeHeader, 'text/event-stream')
+      ..set(HttpHeaders.cacheControlHeader, 'no-cache')
+      ..set('Connection', 'keep-alive')
+      ..set('Access-Control-Allow-Origin', '*');
+
+    final sessionId = '${++_sessionCounter}';
+    final incoming = StreamController<String>();
+    final outgoing = StreamController<String>();
+
+    void writeFrame(String event, String data) {
+      response.add(utf8.encode('event: $event\ndata: $data\n\n'));
+      response.flush();
+    }
+
+    // Each server→client JSON-RPC message becomes one SSE `message` frame.
+    outgoing.stream.listen((message) => writeFrame('message', message));
+
+    final channel = StreamChannel<String>(incoming.stream, outgoing.sink);
+    final server = ApolloMcpServer(channel, limits: limits);
+    _sessions[sessionId] = _Session(response, incoming, outgoing, server);
+
+    // Tell the client where to POST its messages.
+    writeFrame('endpoint', '/message?sessionId=$sessionId');
+
+    // Clean up when the client disconnects.
+    response.done.whenComplete(() => _closeSession(sessionId));
+  }
+
+  Future<void> _handlePost(HttpRequest request) async {
+    final sessionId = request.uri.queryParameters['sessionId'];
+    final session = sessionId == null ? null : _sessions[sessionId];
+    if (session == null) {
+      request.response.statusCode = HttpStatus.notFound;
+      await request.response.close();
+      return;
+    }
+
+    final body = await utf8.decodeStream(request);
+    if (body.trim().isNotEmpty) {
+      session.incoming.add(body);
+    }
+
+    request.response.statusCode = HttpStatus.accepted;
+    request.response.headers.set('Access-Control-Allow-Origin', '*');
+    await request.response.close();
+  }
+
+  Future<void> _closeSession(String sessionId) async {
+    final session = _sessions.remove(sessionId);
+    if (session != null) {
+      await session.incoming.close();
+      await session.outgoing.close();
+      await session.server.shutdown();
+    }
+  }
+}

--- a/lib/src/mcp/transport/stdio_transport.dart
+++ b/lib/src/mcp/transport/stdio_transport.dart
@@ -2,6 +2,7 @@
 // This code is governed by the Apache License, Version 2.0.
 // Please refer to the LICENSE and AUTHORS files for details.
 
+import 'dart:async';
 import 'dart:io';
 
 import 'package:dart_mcp/stdio.dart';
@@ -17,7 +18,7 @@ import '../mcp_config.dart';
 ApolloMcpServer serveStdio({
   McpLimits limits = const McpLimits(),
   Stream<List<int>>? input,
-  IOSink? output,
+  StreamSink<List<int>>? output,
 }) {
   final channel = stdioChannel(
     input: input ?? stdin,

--- a/lib/src/mcp/transport/stdio_transport.dart
+++ b/lib/src/mcp/transport/stdio_transport.dart
@@ -1,0 +1,27 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'dart:io';
+
+import 'package:dart_mcp/stdio.dart';
+
+import '../apollo_mcp_server.dart';
+import '../mcp_config.dart';
+
+/// Starts an [ApolloMcpServer] over stdio (the standard local MCP transport),
+/// reading newline-delimited JSON-RPC from [input] and writing to [output]
+/// (defaulting to this process's stdin/stdout).
+///
+/// Returns the running server; await its `done` to know when the peer closes.
+ApolloMcpServer serveStdio({
+  McpLimits limits = const McpLimits(),
+  Stream<List<int>>? input,
+  IOSink? output,
+}) {
+  final channel = stdioChannel(
+    input: input ?? stdin,
+    output: output ?? stdout,
+  );
+  return ApolloMcpServer(channel, limits: limits);
+}

--- a/lib/src/mcp/transport/stdio_transport.dart
+++ b/lib/src/mcp/transport/stdio_transport.dart
@@ -20,9 +20,6 @@ ApolloMcpServer serveStdio({
   Stream<List<int>>? input,
   StreamSink<List<int>>? output,
 }) {
-  final channel = stdioChannel(
-    input: input ?? stdin,
-    output: output ?? stdout,
-  );
+  final channel = stdioChannel(input: input ?? stdin, output: output ?? stdout);
   return ApolloMcpServer(channel, limits: limits);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, C#, JavaScript, TypeScript, Lua and Python with on-the-fly Wasm compilation.
-version: 0.1.49
+version: 1.2.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, C#, JavaScript, TypeScript, Lua and Python with on-the-fly Wasm compilation.
-version: 0.1.48
+version: 0.1.49
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 
@@ -30,6 +30,8 @@ dependencies:
   crypto: ^3.0.7
   path: ^1.9.1
   web: ^1.1.1
+  dart_mcp: ^0.5.2
+  stream_channel: ^2.1.4
 
 dev_dependencies:
   lints: ^6.1.0

--- a/test/mcp/apollo_runtime_test.dart
+++ b/test/mcp/apollo_runtime_test.dart
@@ -1,0 +1,72 @@
+@TestOn('vm')
+@Tags(['mcp'])
+library;
+
+import 'package:apollovm/apollovm_mcp.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('isolate execution (apollo.execute)', () {
+    test('a synchronous infinite loop is killed at the timeout', () async {
+      final limits = const McpLimits(timeoutMs: 500);
+      final sw = Stopwatch()..start();
+      final result = await computeToolIsolated(
+        'apollo.execute',
+        {'language': 'dart', 'source': 'void main(List a){ while(true){} }'},
+        limits,
+      );
+      sw.stop();
+
+      expect(result['isError'], isTrue,
+          reason: 'runaway loop must be reported as an error');
+      final diag = (result['diagnostics'] as List).first as Map;
+      expect('${diag['message']}', contains('timed out'));
+      // The isolate kill must land promptly (well under a hang).
+      expect(sw.elapsedMilliseconds, lessThan(4000));
+    });
+
+    test('a thrown error is isolated and reported', () async {
+      final limits = const McpLimits(timeoutMs: 2000);
+      final result = await computeToolIsolated(
+        'apollo.execute',
+        {
+          'language': 'dart',
+          'source': 'int main(List a){ throw StateError("boom"); }',
+        },
+        limits,
+      );
+      expect(result['isError'], isTrue);
+      expect(result['diagnostics'], isNotEmpty);
+    });
+  });
+
+  group('in-process execution', () {
+    test('captured output is truncated at maxOutputChars', () async {
+      final limits = const McpLimits(maxOutputChars: 10);
+      final result = await computeTool(
+        'apollo.execute',
+        {
+          'language': 'dart',
+          'source':
+              'void main(List a){ print("0123456789ABCDEF"); print("more"); }',
+        },
+        limits,
+      );
+      expect(result['truncated'], isTrue);
+      final output = (result['output'] as List).join();
+      expect(output.length, lessThanOrEqualTo(10));
+    });
+
+    test('source over maxSourceChars is rejected', () async {
+      final limits = const McpLimits(maxSourceChars: 5);
+      final result = await computeTool(
+        'apollo.parse',
+        {'language': 'dart', 'source': 'int main(List a){ return 1; }'},
+        limits,
+      );
+      expect(result['isError'], isTrue);
+      final diag = (result['diagnostics'] as List).first as Map;
+      expect('${diag['message']}', contains('maxSourceChars'));
+    });
+  });
+}

--- a/test/mcp/apollo_runtime_test.dart
+++ b/test/mcp/apollo_runtime_test.dart
@@ -10,15 +10,17 @@ void main() {
     test('a synchronous infinite loop is killed at the timeout', () async {
       final limits = const McpLimits(timeoutMs: 500);
       final sw = Stopwatch()..start();
-      final result = await computeToolIsolated(
-        'apollo.execute',
-        {'language': 'dart', 'source': 'void main(List a){ while(true){} }'},
-        limits,
-      );
+      final result = await computeToolIsolated('apollo.execute', {
+        'language': 'dart',
+        'source': 'void main(List a){ while(true){} }',
+      }, limits);
       sw.stop();
 
-      expect(result['isError'], isTrue,
-          reason: 'runaway loop must be reported as an error');
+      expect(
+        result['isError'],
+        isTrue,
+        reason: 'runaway loop must be reported as an error',
+      );
       final diag = (result['diagnostics'] as List).first as Map;
       expect('${diag['message']}', contains('timed out'));
       // The isolate kill must land promptly (well under a hang).
@@ -27,14 +29,10 @@ void main() {
 
     test('a thrown error is isolated and reported', () async {
       final limits = const McpLimits(timeoutMs: 2000);
-      final result = await computeToolIsolated(
-        'apollo.execute',
-        {
-          'language': 'dart',
-          'source': 'int main(List a){ throw StateError("boom"); }',
-        },
-        limits,
-      );
+      final result = await computeToolIsolated('apollo.execute', {
+        'language': 'dart',
+        'source': 'int main(List a){ throw StateError("boom"); }',
+      }, limits);
       expect(result['isError'], isTrue);
       expect(result['diagnostics'], isNotEmpty);
     });
@@ -43,15 +41,11 @@ void main() {
   group('in-process execution', () {
     test('captured output is truncated at maxOutputChars', () async {
       final limits = const McpLimits(maxOutputChars: 10);
-      final result = await computeTool(
-        'apollo.execute',
-        {
-          'language': 'dart',
-          'source':
-              'void main(List a){ print("0123456789ABCDEF"); print("more"); }',
-        },
-        limits,
-      );
+      final result = await computeTool('apollo.execute', {
+        'language': 'dart',
+        'source':
+            'void main(List a){ print("0123456789ABCDEF"); print("more"); }',
+      }, limits);
       expect(result['truncated'], isTrue);
       final output = (result['output'] as List).join();
       expect(output.length, lessThanOrEqualTo(10));
@@ -59,40 +53,36 @@ void main() {
 
     test('source over maxSourceChars is rejected', () async {
       final limits = const McpLimits(maxSourceChars: 5);
-      final result = await computeTool(
-        'apollo.parse',
-        {'language': 'dart', 'source': 'int main(List a){ return 1; }'},
-        limits,
-      );
+      final result = await computeTool('apollo.parse', {
+        'language': 'dart',
+        'source': 'int main(List a){ return 1; }',
+      }, limits);
       expect(result['isError'], isTrue);
       final diag = (result['diagnostics'] as List).first as Map;
       expect('${diag['message']}', contains('maxSourceChars'));
     });
 
     test('executes a class method (non-static) via className', () async {
-      final result = await computeTool(
-        'apollo.execute',
-        {
-          'language': 'dart',
-          'source': 'class Foo { int run(List a){ return 7; } }',
-          'function': 'run',
-          'className': 'Foo',
-        },
-        const McpLimits(),
-      );
+      final result = await computeTool('apollo.execute', {
+        'language': 'dart',
+        'source': 'class Foo { int run(List a){ return 7; } }',
+        'function': 'run',
+        'className': 'Foo',
+      }, const McpLimits());
       expect(result['isError'], isFalse);
       expect(result['result'], 7);
     });
 
     test('reports when the entry function is missing', () async {
-      final result = await computeTool(
-        'apollo.execute',
-        {'language': 'dart', 'source': 'int other(){ return 1; }'},
-        const McpLimits(),
-      );
+      final result = await computeTool('apollo.execute', {
+        'language': 'dart',
+        'source': 'int other(){ return 1; }',
+      }, const McpLimits());
       expect(result['isError'], isTrue);
-      expect('${(result['diagnostics'] as List).first}',
-          contains('Entry function not found'));
+      expect(
+        '${(result['diagnostics'] as List).first}',
+        contains('Entry function not found'),
+      );
     });
   });
 
@@ -101,23 +91,24 @@ void main() {
 
     test('unsupported language is rejected by every tool', () async {
       for (final tool in ['apollo.parse', 'apollo.execute', 'apollo.wasm']) {
-        final r = await computeTool(
-          tool,
-          {'language': 'ruby', 'source': src},
-          const McpLimits(),
-        );
+        final r = await computeTool(tool, {
+          'language': 'ruby',
+          'source': src,
+        }, const McpLimits());
         expect(r['isError'], isTrue, reason: '$tool should reject ruby');
-        expect('${(r['diagnostics'] as List).first}',
-            contains('Unsupported language'));
+        expect(
+          '${(r['diagnostics'] as List).first}',
+          contains('Unsupported language'),
+        );
       }
     });
 
     test('translate to a language without a generator errors', () async {
-      final r = await computeTool(
-        'apollo.translate',
-        {'from': 'dart', 'to': 'ruby', 'source': src},
-        const McpLimits(),
-      );
+      final r = await computeTool('apollo.translate', {
+        'from': 'dart',
+        'to': 'ruby',
+        'source': src,
+      }, const McpLimits());
       expect(r['isError'], isTrue);
       expect(r['generated'], isNull);
       expect(r['diagnostics'], isNotEmpty);
@@ -129,16 +120,17 @@ void main() {
       expect('${(r['diagnostics'] as List).first}', contains('Unknown tool'));
     });
 
-    test('execute on broken source returns parse diagnostics (in-process)',
-        () async {
-      final r = await computeTool(
-        'apollo.execute',
-        {'language': 'dart', 'source': 'int main(List a){ return'},
-        const McpLimits(),
-      );
-      expect(r['isError'], isTrue);
-      expect(r['diagnostics'], isNotEmpty);
-    });
+    test(
+      'execute on broken source returns parse diagnostics (in-process)',
+      () async {
+        final r = await computeTool('apollo.execute', {
+          'language': 'dart',
+          'source': 'int main(List a){ return',
+        }, const McpLimits());
+        expect(r['isError'], isTrue);
+        expect(r['diagnostics'], isNotEmpty);
+      },
+    );
 
     test('a runtime error during in-process execution is caught', () async {
       final r = await computeTool(
@@ -155,15 +147,11 @@ void main() {
     });
 
     test('execute passes a String[] arg list to a top-level main', () async {
-      final r = await computeTool(
-        'apollo.execute',
-        {
-          'language': 'dart',
-          'source': 'void main(List<String> a){ print(a[0]); }',
-          'args': ['hello', 'world'],
-        },
-        const McpLimits(isolateTools: {}),
-      );
+      final r = await computeTool('apollo.execute', {
+        'language': 'dart',
+        'source': 'void main(List<String> a){ print(a[0]); }',
+        'args': ['hello', 'world'],
+      }, const McpLimits(isolateTools: {}));
       expect(r['isError'], isFalse);
       expect(r['output'], ['hello']);
     });

--- a/test/mcp/apollo_runtime_test.dart
+++ b/test/mcp/apollo_runtime_test.dart
@@ -68,5 +68,136 @@ void main() {
       final diag = (result['diagnostics'] as List).first as Map;
       expect('${diag['message']}', contains('maxSourceChars'));
     });
+
+    test('executes a class method (non-static) via className', () async {
+      final result = await computeTool(
+        'apollo.execute',
+        {
+          'language': 'dart',
+          'source': 'class Foo { int run(List a){ return 7; } }',
+          'function': 'run',
+          'className': 'Foo',
+        },
+        const McpLimits(),
+      );
+      expect(result['isError'], isFalse);
+      expect(result['result'], 7);
+    });
+
+    test('reports when the entry function is missing', () async {
+      final result = await computeTool(
+        'apollo.execute',
+        {'language': 'dart', 'source': 'int other(){ return 1; }'},
+        const McpLimits(),
+      );
+      expect(result['isError'], isTrue);
+      expect('${(result['diagnostics'] as List).first}',
+          contains('Entry function not found'));
+    });
+  });
+
+  group('error paths', () {
+    const src = 'int main(List a){ return 1; }';
+
+    test('unsupported language is rejected by every tool', () async {
+      for (final tool in ['apollo.parse', 'apollo.execute', 'apollo.wasm']) {
+        final r = await computeTool(
+          tool,
+          {'language': 'ruby', 'source': src},
+          const McpLimits(),
+        );
+        expect(r['isError'], isTrue, reason: '$tool should reject ruby');
+        expect('${(r['diagnostics'] as List).first}',
+            contains('Unsupported language'));
+      }
+    });
+
+    test('translate to a language without a generator errors', () async {
+      final r = await computeTool(
+        'apollo.translate',
+        {'from': 'dart', 'to': 'ruby', 'source': src},
+        const McpLimits(),
+      );
+      expect(r['isError'], isTrue);
+      expect(r['generated'], isNull);
+      expect(r['diagnostics'], isNotEmpty);
+    });
+
+    test('an unknown tool name yields an error result', () async {
+      final r = await computeTool('apollo.bogus', const {}, const McpLimits());
+      expect(r['isError'], isTrue);
+      expect('${(r['diagnostics'] as List).first}', contains('Unknown tool'));
+    });
+
+    test('execute on broken source returns parse diagnostics (in-process)',
+        () async {
+      final r = await computeTool(
+        'apollo.execute',
+        {'language': 'dart', 'source': 'int main(List a){ return'},
+        const McpLimits(),
+      );
+      expect(r['isError'], isTrue);
+      expect(r['diagnostics'], isNotEmpty);
+    });
+
+    test('a runtime error during in-process execution is caught', () async {
+      final r = await computeTool(
+        'apollo.execute',
+        {
+          'language': 'dart',
+          'source': 'int main(List a){ throw StateError("kaboom"); }',
+        },
+        // in-process (not an isolate tool) so the execute() catch runs here.
+        const McpLimits(isolateTools: {}),
+      );
+      expect(r['isError'], isTrue);
+      expect('${(r['diagnostics'] as List).first}', contains('kaboom'));
+    });
+
+    test('execute passes a String[] arg list to a top-level main', () async {
+      final r = await computeTool(
+        'apollo.execute',
+        {
+          'language': 'dart',
+          'source': 'void main(List<String> a){ print(a[0]); }',
+          'args': ['hello', 'world'],
+        },
+        const McpLimits(isolateTools: {}),
+      );
+      expect(r['isError'], isFalse);
+      expect(r['output'], ['hello']);
+    });
+  });
+
+  group('McpLimits', () {
+    test('defaults, runsInIsolate, copyWith and toString', () {
+      const limits = McpLimits();
+      expect(limits.timeoutMs, 5000);
+      expect(limits.runsInIsolate('apollo.execute'), isTrue);
+      expect(limits.runsInIsolate('apollo.parse'), isFalse);
+
+      final custom = limits.copyWith(
+        timeoutMs: 100,
+        maxOutputChars: 10,
+        maxSourceChars: 20,
+        maxAstDepth: 5,
+        isolateTools: const {'apollo.wasm'},
+      );
+      expect(custom.timeoutMs, 100);
+      expect(custom.maxOutputChars, 10);
+      expect(custom.maxSourceChars, 20);
+      expect(custom.maxAstDepth, 5);
+      expect(custom.runsInIsolate('apollo.wasm'), isTrue);
+      expect(custom.runsInIsolate('apollo.execute'), isFalse);
+      expect(custom.toString(), contains('timeoutMs: 100'));
+
+      // copyWith with no overrides preserves every field.
+      final same = custom.copyWith();
+      expect(same.timeoutMs, custom.timeoutMs);
+      expect(same.maxOutputChars, custom.maxOutputChars);
+      expect(same.maxSourceChars, custom.maxSourceChars);
+      expect(same.maxAstDepth, custom.maxAstDepth);
+      expect(same.isolateTools, custom.isolateTools);
+    });
   });
 }

--- a/test/mcp/http_sse_transport_test.dart
+++ b/test/mcp/http_sse_transport_test.dart
@@ -83,4 +83,25 @@ void main() {
     // Clean teardown: stop listening before closing the client.
     await sub.cancel();
   });
+
+  test('unknown path returns 404', () async {
+    final port = transport.port!;
+    final resp = await (await http.getUrl(
+      Uri.parse('http://127.0.0.1:$port/nope'),
+    )).close();
+    expect(resp.statusCode, HttpStatus.notFound);
+    await resp.drain<void>();
+  });
+
+  test('POST to an unknown session returns 404', () async {
+    final port = transport.port!;
+    final req = await http.postUrl(
+      Uri.parse('http://127.0.0.1:$port/message?sessionId=does-not-exist'),
+    );
+    req.headers.contentType = ContentType.json;
+    req.write('{"jsonrpc":"2.0","id":1,"method":"ping"}');
+    final resp = await req.close();
+    expect(resp.statusCode, HttpStatus.notFound);
+    await resp.drain<void>();
+  });
 }

--- a/test/mcp/http_sse_transport_test.dart
+++ b/test/mcp/http_sse_transport_test.dart
@@ -24,65 +24,72 @@ void main() {
     await transport.stop();
   });
 
-  test('SSE endpoint event + POST initialize replies over the stream',
-      () async {
-    final port = transport.port!;
-    final endpoint = Completer<String>();
-    final initResult = Completer<Map<String, Object?>>();
+  test(
+    'SSE endpoint event + POST initialize replies over the stream',
+    () async {
+      final port = transport.port!;
+      final endpoint = Completer<String>();
+      final initResult = Completer<Map<String, Object?>>();
 
-    // Open the SSE stream.
-    final sseResp = await (await http.getUrl(
-      Uri.parse('http://127.0.0.1:$port/sse'),
-    )).close();
-    expect(sseResp.statusCode, 200);
+      // Open the SSE stream.
+      final sseResp = await (await http.getUrl(
+        Uri.parse('http://127.0.0.1:$port/sse'),
+      )).close();
+      expect(sseResp.statusCode, 200);
 
-    late StreamSubscription<String> sub;
-    sub = sseResp
-        .transform(utf8.decoder)
-        .transform(const LineSplitter())
-        .listen((line) {
-      if (!line.startsWith('data: ')) return;
-      final data = line.substring(6);
-      if (data.contains('sessionId') && !endpoint.isCompleted) {
-        endpoint.complete(data);
-      } else if (data.startsWith('{')) {
-        final msg = jsonDecode(data) as Map<String, Object?>;
-        if (msg['id'] == 1 && !initResult.isCompleted) {
-          initResult.complete(msg['result'] as Map<String, Object?>);
-        }
-      }
-    });
+      late StreamSubscription<String> sub;
+      sub = sseResp
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .listen((line) {
+            if (!line.startsWith('data: ')) return;
+            final data = line.substring(6);
+            if (data.contains('sessionId') && !endpoint.isCompleted) {
+              endpoint.complete(data);
+            } else if (data.startsWith('{')) {
+              final msg = jsonDecode(data) as Map<String, Object?>;
+              if (msg['id'] == 1 && !initResult.isCompleted) {
+                initResult.complete(msg['result'] as Map<String, Object?>);
+              }
+            }
+          });
 
-    final endpointPath =
-        await endpoint.future.timeout(const Duration(seconds: 5));
-    expect(endpointPath, contains('/message?sessionId='));
+      final endpointPath = await endpoint.future.timeout(
+        const Duration(seconds: 5),
+      );
+      expect(endpointPath, contains('/message?sessionId='));
 
-    // POST initialize to the advertised endpoint.
-    final postReq = await http.postUrl(
-      Uri.parse('http://127.0.0.1:$port$endpointPath'),
-    );
-    postReq.headers.contentType = ContentType.json;
-    postReq.write(jsonEncode({
-      'jsonrpc': '2.0',
-      'id': 1,
-      'method': 'initialize',
-      'params': {
-        'protocolVersion': '2024-11-05',
-        'capabilities': <String, Object?>{},
-        'clientInfo': {'name': 'http-test', 'version': '1.0'},
-      },
-    }));
-    final postResp = await postReq.close();
-    expect(postResp.statusCode, HttpStatus.accepted);
-    await postResp.drain<void>();
+      // POST initialize to the advertised endpoint.
+      final postReq = await http.postUrl(
+        Uri.parse('http://127.0.0.1:$port$endpointPath'),
+      );
+      postReq.headers.contentType = ContentType.json;
+      postReq.write(
+        jsonEncode({
+          'jsonrpc': '2.0',
+          'id': 1,
+          'method': 'initialize',
+          'params': {
+            'protocolVersion': '2024-11-05',
+            'capabilities': <String, Object?>{},
+            'clientInfo': {'name': 'http-test', 'version': '1.0'},
+          },
+        }),
+      );
+      final postResp = await postReq.close();
+      expect(postResp.statusCode, HttpStatus.accepted);
+      await postResp.drain<void>();
 
-    final result = await initResult.future.timeout(const Duration(seconds: 5));
-    final serverInfo = result['serverInfo'] as Map<String, Object?>;
-    expect(serverInfo['name'], 'apollovm-mcp');
+      final result = await initResult.future.timeout(
+        const Duration(seconds: 5),
+      );
+      final serverInfo = result['serverInfo'] as Map<String, Object?>;
+      expect(serverInfo['name'], 'apollovm-mcp');
 
-    // Clean teardown: stop listening before closing the client.
-    await sub.cancel();
-  });
+      // Clean teardown: stop listening before closing the client.
+      await sub.cancel();
+    },
+  );
 
   test('unknown path returns 404', () async {
     final port = transport.port!;

--- a/test/mcp/http_sse_transport_test.dart
+++ b/test/mcp/http_sse_transport_test.dart
@@ -1,0 +1,86 @@
+@TestOn('vm')
+@Tags(['mcp'])
+library;
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:apollovm/apollovm_mcp.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late HttpSseTransport transport;
+  late HttpClient http;
+
+  setUp(() async {
+    transport = HttpSseTransport(limits: const McpLimits());
+    await transport.start(port: 0);
+    http = HttpClient();
+  });
+
+  tearDown(() async {
+    http.close(force: true);
+    await transport.stop();
+  });
+
+  test('SSE endpoint event + POST initialize replies over the stream',
+      () async {
+    final port = transport.port!;
+    final endpoint = Completer<String>();
+    final initResult = Completer<Map<String, Object?>>();
+
+    // Open the SSE stream.
+    final sseResp = await (await http.getUrl(
+      Uri.parse('http://127.0.0.1:$port/sse'),
+    )).close();
+    expect(sseResp.statusCode, 200);
+
+    late StreamSubscription<String> sub;
+    sub = sseResp
+        .transform(utf8.decoder)
+        .transform(const LineSplitter())
+        .listen((line) {
+      if (!line.startsWith('data: ')) return;
+      final data = line.substring(6);
+      if (data.contains('sessionId') && !endpoint.isCompleted) {
+        endpoint.complete(data);
+      } else if (data.startsWith('{')) {
+        final msg = jsonDecode(data) as Map<String, Object?>;
+        if (msg['id'] == 1 && !initResult.isCompleted) {
+          initResult.complete(msg['result'] as Map<String, Object?>);
+        }
+      }
+    });
+
+    final endpointPath =
+        await endpoint.future.timeout(const Duration(seconds: 5));
+    expect(endpointPath, contains('/message?sessionId='));
+
+    // POST initialize to the advertised endpoint.
+    final postReq = await http.postUrl(
+      Uri.parse('http://127.0.0.1:$port$endpointPath'),
+    );
+    postReq.headers.contentType = ContentType.json;
+    postReq.write(jsonEncode({
+      'jsonrpc': '2.0',
+      'id': 1,
+      'method': 'initialize',
+      'params': {
+        'protocolVersion': '2024-11-05',
+        'capabilities': <String, Object?>{},
+        'clientInfo': {'name': 'http-test', 'version': '1.0'},
+      },
+    }));
+    final postResp = await postReq.close();
+    expect(postResp.statusCode, HttpStatus.accepted);
+    await postResp.drain<void>();
+
+    final result = await initResult.future.timeout(const Duration(seconds: 5));
+    final serverInfo = result['serverInfo'] as Map<String, Object?>;
+    expect(serverInfo['name'], 'apollovm-mcp');
+
+    // Clean teardown: stop listening before closing the client.
+    await sub.cancel();
+  });
+}

--- a/test/mcp/mcp_server_test.dart
+++ b/test/mcp/mcp_server_test.dart
@@ -144,20 +144,22 @@ class Calc {
       expect(summary['classes'], contains('Calc'));
     });
 
-    test('apollo.parse on broken source returns line/column diagnostics',
-        () async {
-      final r = await client.callTool('apollo.parse', {
-        'language': 'dart',
-        'source': 'class { oops',
-      });
-      expect(r['_isError'], isTrue);
-      expect(r['ok'], isFalse);
-      final diag = (r['diagnostics'] as List).first as Map;
-      expect(diag['severity'], 'error');
-      expect(diag['line'], isNotNull);
-      expect(diag['column'], isNotNull);
-      expect(diag['sourceLine'], contains('class'));
-    });
+    test(
+      'apollo.parse on broken source returns line/column diagnostics',
+      () async {
+        final r = await client.callTool('apollo.parse', {
+          'language': 'dart',
+          'source': 'class { oops',
+        });
+        expect(r['_isError'], isTrue);
+        expect(r['ok'], isFalse);
+        final diag = (r['diagnostics'] as List).first as Map;
+        expect(diag['severity'], 'error');
+        expect(diag['line'], isNotNull);
+        expect(diag['column'], isNotNull);
+        expect(diag['sourceLine'], contains('class'));
+      },
+    );
 
     test('apollo.execute returns result and captured output', () async {
       final r = await client.callTool('apollo.execute', {
@@ -211,9 +213,7 @@ class Calc {
       });
       expect(r['_isError'], isFalse);
       final types = r['types'] as List;
-      final byName = {
-        for (final t in types) (t as Map)['name']: t['kind'],
-      };
+      final byName = {for (final t in types) (t as Map)['name']: t['kind']};
       expect(byName['Calc'], 'class');
       expect(byName['int'], 'builtin');
     });

--- a/test/mcp/mcp_server_test.dart
+++ b/test/mcp/mcp_server_test.dart
@@ -229,6 +229,34 @@ class Calc {
       expect(bytes.sublist(0, 4), [0x00, 0x61, 0x73, 0x6D]);
     });
 
+    test('supports Go: execute and translate go->dart', () async {
+      const goSource = '''
+package main
+import "fmt"
+func Add(a int, b int) int {
+	return a + b
+}
+func main() {
+	fmt.Println(Add(40, 2))
+}
+''';
+
+      final exec = await client.callTool('apollo.execute', {
+        'language': 'go',
+        'source': goSource,
+      });
+      expect(exec['_isError'], isFalse);
+      expect(exec['output'], contains('42'));
+
+      final translated = await client.callTool('apollo.translate', {
+        'from': 'go',
+        'to': 'dart',
+        'source': goSource,
+      });
+      expect(translated['_isError'], isFalse);
+      expect(translated['generated'], contains('int Add(int a, int b)'));
+    });
+
     test('unknown tool name yields an error result', () async {
       final resp = await client.request('tools/call', {
         'name': 'apollo.nope',

--- a/test/mcp/mcp_server_test.dart
+++ b/test/mcp/mcp_server_test.dart
@@ -1,0 +1,241 @@
+@TestOn('vm')
+@Tags(['mcp'])
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:apollovm/apollovm.dart' show ApolloVM;
+import 'package:apollovm/apollovm_mcp.dart';
+import 'package:stream_channel/stream_channel.dart';
+import 'package:test/test.dart';
+
+/// Drives an [ApolloMcpServer] over an in-memory [StreamChannel], speaking raw
+/// JSON-RPC 2.0 so the tests exercise the real protocol surface.
+class McpTestClient {
+  final StreamChannelController<String> _ctrl;
+  int _id = 0;
+  final Map<int, Completer<Map<String, Object?>>> _pending = {};
+
+  McpTestClient._(this._ctrl) {
+    _ctrl.foreign.stream.listen((line) {
+      final msg = jsonDecode(line) as Map<String, Object?>;
+      final id = msg['id'];
+      if (id is int) _pending.remove(id)?.complete(msg);
+    });
+  }
+
+  factory McpTestClient(McpLimits limits) {
+    final ctrl = StreamChannelController<String>(allowForeignErrors: false);
+    ApolloMcpServer(ctrl.local, limits: limits);
+    return McpTestClient._(ctrl);
+  }
+
+  Future<Map<String, Object?>> request(
+    String method, [
+    Map<String, Object?>? params,
+  ]) {
+    final id = ++_id;
+    final completer = Completer<Map<String, Object?>>();
+    _pending[id] = completer;
+    _ctrl.foreign.sink.add(
+      jsonEncode({
+        'jsonrpc': '2.0',
+        'id': id,
+        'method': method,
+        'params': ?params,
+      }),
+    );
+    return completer.future.timeout(const Duration(seconds: 15));
+  }
+
+  Future<void> initialize() async {
+    await request('initialize', {
+      'protocolVersion': '2024-11-05',
+      'capabilities': <String, Object?>{},
+      'clientInfo': {'name': 'test', 'version': '1.0'},
+    });
+    _ctrl.foreign.sink.add(
+      jsonEncode({'jsonrpc': '2.0', 'method': 'notifications/initialized'}),
+    );
+  }
+
+  /// Calls a tool and returns its decoded JSON payload (the text content).
+  Future<Map<String, Object?>> callTool(
+    String name,
+    Map<String, Object?> arguments,
+  ) async {
+    final resp = await request('tools/call', {
+      'name': name,
+      'arguments': arguments,
+    });
+    final result = resp['result'] as Map<String, Object?>;
+    final content = (result['content'] as List).first as Map<String, Object?>;
+    return <String, Object?>{
+      '_isError': result['isError'] ?? false,
+      ...jsonDecode(content['text'] as String) as Map<String, Object?>,
+    };
+  }
+
+  Future<void> close() => _ctrl.local.sink.close();
+}
+
+void main() {
+  const dartSource = '''
+class Calc {
+  int add(int a, int b) { return a + b; }
+  int main(List args) {
+    print('running');
+    return add(40, 2);
+  }
+}
+''';
+
+  late McpTestClient client;
+
+  setUp(() => client = McpTestClient(const McpLimits(timeoutMs: 2000)));
+  tearDown(() => client.close());
+
+  group('protocol', () {
+    test('initialize returns serverInfo with the ApolloVM version', () async {
+      final resp = await client.request('initialize', {
+        'protocolVersion': '2024-11-05',
+        'capabilities': <String, Object?>{},
+        'clientInfo': {'name': 'test', 'version': '1.0'},
+      });
+      final result = resp['result'] as Map<String, Object?>;
+      final serverInfo = result['serverInfo'] as Map<String, Object?>;
+      expect(serverInfo['name'], 'apollovm-mcp');
+      expect(serverInfo['version'], ApolloVM.VERSION);
+    });
+
+    test('tools/list returns the 7 tools each with an inputSchema', () async {
+      await client.initialize();
+      final resp = await client.request('tools/list');
+      final tools = (resp['result'] as Map)['tools'] as List;
+      final names = tools.map((t) => (t as Map)['name']).toSet();
+      expect(names, {
+        'apollo.parse',
+        'apollo.execute',
+        'apollo.translate',
+        'apollo.ast',
+        'apollo.symbols',
+        'apollo.types',
+        'apollo.wasm',
+      });
+      for (final t in tools) {
+        final schema = (t as Map)['inputSchema'] as Map;
+        expect(schema['properties'], isNotEmpty);
+      }
+    });
+  });
+
+  group('tools', () {
+    setUp(() => client.initialize());
+
+    test('apollo.parse returns a summary for valid source', () async {
+      final r = await client.callTool('apollo.parse', {
+        'language': 'dart',
+        'source': dartSource,
+      });
+      expect(r['_isError'], isFalse);
+      expect(r['ok'], isTrue);
+      final summary = r['summary'] as Map;
+      expect(summary['classes'], contains('Calc'));
+    });
+
+    test('apollo.parse on broken source returns line/column diagnostics',
+        () async {
+      final r = await client.callTool('apollo.parse', {
+        'language': 'dart',
+        'source': 'class { oops',
+      });
+      expect(r['_isError'], isTrue);
+      expect(r['ok'], isFalse);
+      final diag = (r['diagnostics'] as List).first as Map;
+      expect(diag['severity'], 'error');
+      expect(diag['line'], isNotNull);
+      expect(diag['column'], isNotNull);
+      expect(diag['sourceLine'], contains('class'));
+    });
+
+    test('apollo.execute returns result and captured output', () async {
+      final r = await client.callTool('apollo.execute', {
+        'language': 'dart',
+        'source': dartSource,
+      });
+      expect(r['_isError'], isFalse);
+      expect(r['result'], 42);
+      expect(r['output'], ['running']);
+    });
+
+    test('apollo.translate dart->python produces source', () async {
+      final r = await client.callTool('apollo.translate', {
+        'from': 'dart',
+        'to': 'python',
+        'source': dartSource,
+      });
+      expect(r['_isError'], isFalse);
+      expect(r['generated'], contains('def add'));
+    });
+
+    test('apollo.ast returns the root node', () async {
+      final r = await client.callTool('apollo.ast', {
+        'language': 'dart',
+        'source': dartSource,
+      });
+      expect(r['_isError'], isFalse);
+      final ast = r['ast'] as Map;
+      expect(ast['node'], 'ASTRoot');
+      expect(ast['classes'], contains('Calc'));
+    });
+
+    test('apollo.symbols returns the symbol graph', () async {
+      final r = await client.callTool('apollo.symbols', {
+        'language': 'dart',
+        'source': dartSource,
+      });
+      expect(r['_isError'], isFalse);
+      final symbols = r['symbols'] as Map;
+      final classes = symbols['classes'] as List;
+      final calc = classes.first as Map;
+      expect(calc['name'], 'Calc');
+      final methods = (calc['methods'] as List).map((m) => (m as Map)['name']);
+      expect(methods, containsAll(['add', 'main']));
+    });
+
+    test('apollo.types returns a classified type table', () async {
+      final r = await client.callTool('apollo.types', {
+        'language': 'dart',
+        'source': dartSource,
+      });
+      expect(r['_isError'], isFalse);
+      final types = r['types'] as List;
+      final byName = {
+        for (final t in types) (t as Map)['name']: t['kind'],
+      };
+      expect(byName['Calc'], 'class');
+      expect(byName['int'], 'builtin');
+    });
+
+    test('apollo.wasm returns a base64 module with the \\0asm magic', () async {
+      final r = await client.callTool('apollo.wasm', {
+        'language': 'dart',
+        'source': 'int run(int a, int b) { return a + b; }',
+      });
+      expect(r['_isError'], isFalse);
+      final modules = r['modules'] as List;
+      final bytes = base64.decode((modules.first as Map)['base64'] as String);
+      expect(bytes.sublist(0, 4), [0x00, 0x61, 0x73, 0x6D]);
+    });
+
+    test('unknown tool name yields an error result', () async {
+      final resp = await client.request('tools/call', {
+        'name': 'apollo.nope',
+        'arguments': <String, Object?>{},
+      });
+      final result = resp['result'] as Map<String, Object?>;
+      expect(result['isError'], isTrue);
+    });
+  });
+}

--- a/test/mcp/serialize_test.dart
+++ b/test/mcp/serialize_test.dart
@@ -1,0 +1,212 @@
+@TestOn('vm')
+@Tags(['mcp'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:apollovm/src/mcp/serialize/ast_json.dart';
+import 'package:apollovm/src/mcp/serialize/diagnostics.dart';
+import 'package:apollovm/src/mcp/serialize/symbols.dart';
+import 'package:apollovm/src/mcp/serialize/types.dart';
+import 'package:apollovm/src/mcp/serialize/value_json.dart';
+import 'package:test/test.dart';
+
+/// A source unit that exercises a wide spread of AST node kinds: a class with
+/// initialized fields, a constructor, static and instance methods, and a
+/// top-level function with a generic (`List`) parameter, locals and literals.
+const _richSource = '''
+import 'dart:math';
+
+class Shape {}
+
+class Point extends Shape {
+  int x = 0;
+  int y = 0;
+
+  Point(this.x, this.y);
+
+  static int origin() { return 0; }
+
+  int sum() { return x + y; }
+}
+
+int compute(int a, List args, {int scale = 1}) {
+  var total = (a + 1) * scale;
+  print(total);
+  return total;
+}
+''';
+
+Future<ASTRoot> _parse(String source, [String language = 'dart']) async {
+  final vm = ApolloVM();
+  final parser = vm.getParser<String>(language)!;
+  final result = await parser.parse(SourceCodeUnit(language, source, id: 't'));
+  expect(result.isOK, isTrue, reason: 'source should parse: ${result.errorMessage}');
+  return result.root!;
+}
+
+/// Collects every `node` runtimeType string in a serialized AST tree.
+Set<String> _nodeTypes(Map<String, Object?> json) {
+  final types = <String>{json['node'] as String};
+  final children = json['children'] as List?;
+  if (children != null) {
+    for (final c in children) {
+      types.addAll(_nodeTypes(c as Map<String, Object?>));
+    }
+  }
+  return types;
+}
+
+void main() {
+  group('valueToJson', () {
+    test('passes primitives through', () {
+      expect(valueToJson(null), isNull);
+      expect(valueToJson(42), 42);
+      expect(valueToJson(3.5), 3.5);
+      expect(valueToJson(true), isTrue);
+      expect(valueToJson('hi'), 'hi');
+    });
+
+    test('recurses into lists and maps, stringifying map keys', () {
+      expect(valueToJson([1, [2, 3]]), [1, [2, 3]]);
+      expect(valueToJson({'a': 1, 'b': [2]}), {'a': 1, 'b': [2]});
+      expect(valueToJson({1: 'x', 2: 'y'}), {'1': 'x', '2': 'y'});
+    });
+
+    test('honors the depth guard with a self-referential list', () {
+      final cyclic = <Object?>[];
+      cyclic.add(cyclic);
+      // Must terminate (fall back to a string) rather than overflow.
+      expect(() => valueToJson(cyclic, maxDepth: 4), returnsNormally);
+    });
+
+    test('serializes a VMObject result from execution with its fields', () async {
+      final vm = ApolloVM();
+      await vm.loadCodeUnit(SourceCodeUnit('dart',
+          'class Box { int v = 7; } Box main(List a){ return Box(); }',
+          id: 't'));
+      final runner = vm.createRunner('dart')!;
+      final r = await runner.tryExecuteFunction('', 'main', []);
+      final json = valueToJson(r!.getValueNoContext());
+      expect(json, isA<Map>());
+      expect((json as Map)[r'\$type'] ?? json['\$type'], anyOf('Box', isNull));
+      // The field value is present regardless of the type-key spelling.
+      expect(json.values, contains(7));
+    });
+  });
+
+  group('astNodeToJson', () {
+    test('emits node-specific fields across many node kinds', () async {
+      final root = await _parse(_richSource);
+      final json = astNodeToJson(root, maxDepth: 500);
+
+      expect(json['node'], 'ASTRoot');
+      expect(json['classes'], contains('Point'));
+      expect(json['functions'], contains('compute'));
+
+      final types = _nodeTypes(json);
+      expect(types, contains('ASTClassNormal'));
+      expect(types, contains('ASTStatementImport'),
+          reason: 'import nodes should be walked, not just listed');
+      expect(
+        types.any((t) => t.contains('FunctionDeclaration')),
+        isTrue,
+        reason: 'method/function declarations should be serialized',
+      );
+      expect(types.any((t) => t.startsWith('ASTType')), isTrue);
+    });
+
+    test('serializes an invocable with returnType, modifiers and parameters',
+        () async {
+      final root = await _parse(_richSource);
+      final compute = root.functions
+          .expand((s) => s.functions)
+          .firstWhere((f) => f.name == 'compute');
+      final json = invocableToJson(compute);
+      expect(json['name'], 'compute');
+      expect((json['returnType'] as Map)['name'], 'int');
+      expect(json['modifiers'], isA<List>());
+      final params = (json['parameters'] as List).cast<Map>();
+      expect(params.map((p) => p['name']), containsAll(['a', 'args', 'scale']));
+      final scale = params.firstWhere((p) => p['name'] == 'scale');
+      expect(scale['named'], isTrue);
+      expect(scale['hasDefault'], isTrue);
+    });
+
+    test('respects maxDepth by omitting deeper children', () async {
+      final root = await _parse(_richSource);
+      final shallow = astNodeToJson(root, maxDepth: 0);
+      expect(shallow.containsKey('children'), isFalse);
+    });
+
+    test('serializes generic types recursively', () async {
+      final root = await _parse(_richSource);
+      final compute = root.functions
+          .expand((s) => s.functions)
+          .firstWhere((f) => f.name == 'compute');
+      final listParam = compute.parameters.allParameters
+          .firstWhere((p) => p.name == 'args');
+      final typeJson = typeToJson(listParam.type);
+      expect(typeJson['name'], 'List');
+      expect(typeJson['generics'], isNotNull);
+    });
+  });
+
+  group('symbolsToJson', () {
+    test('captures fields, constructors and methods of a class', () async {
+      final root = await _parse(_richSource);
+      final symbols = symbolsToJson(root);
+
+      expect((symbols['functions'] as List).map((f) => (f as Map)['name']),
+          contains('compute'));
+
+      final point = (symbols['classes'] as List)
+          .cast<Map>()
+          .firstWhere((c) => c['name'] == 'Point');
+      expect(point['superClassName'], 'Shape');
+      expect((point['fields'] as List).map((f) => (f as Map)['name']),
+          containsAll(['x', 'y']));
+      expect(point['constructors'], isNotEmpty);
+      expect((point['methods'] as List).map((m) => (m as Map)['name']),
+          containsAll(['origin', 'sum']));
+    });
+  });
+
+  group('diagnostics', () {
+    test('diagnosticFromError handles a plain error', () {
+      final d = diagnosticFromError(StateError('boom'));
+      expect(d['severity'], 'error');
+      expect('${d['message']}', contains('boom'));
+    });
+
+    test('diagnosticFromError handles a SyntaxError without a ParseResult', () {
+      final d = diagnosticFromError(SyntaxError('bad syntax'));
+      expect(d['severity'], 'error');
+      expect(d['message'], 'bad syntax');
+    });
+
+    test('diagnosticFromParseResult carries position and source line',
+        () async {
+      final vm = ApolloVM();
+      final parser = vm.getParser<String>('dart')!;
+      final result =
+          await parser.parse(SourceCodeUnit('dart', 'class { oops', id: 't'));
+      final d = diagnosticFromParseResult(result);
+      expect(d['line'], isNotNull);
+      expect(d['column'], isNotNull);
+      expect('${d['sourceLine']}', contains('class'));
+    });
+  });
+
+  group('typesToJson', () {
+    test('classifies declared classes vs builtins and dedups', () async {
+      final root = await _parse(_richSource);
+      final result = typesToJson(root);
+      final byName = {
+        for (final t in result['types'] as List) (t as Map)['name']: t['kind'],
+      };
+      expect(byName['Point'], 'class');
+      expect(byName['int'], 'builtin');
+      expect(byName['List'], 'builtin');
+    });
+  });
+}

--- a/test/mcp/serialize_test.dart
+++ b/test/mcp/serialize_test.dart
@@ -40,7 +40,11 @@ Future<ASTRoot> _parse(String source, [String language = 'dart']) async {
   final vm = ApolloVM();
   final parser = vm.getParser<String>(language)!;
   final result = await parser.parse(SourceCodeUnit(language, source, id: 't'));
-  expect(result.isOK, isTrue, reason: 'source should parse: ${result.errorMessage}');
+  expect(
+    result.isOK,
+    isTrue,
+    reason: 'source should parse: ${result.errorMessage}',
+  );
   return result.root!;
 }
 
@@ -67,8 +71,26 @@ void main() {
     });
 
     test('recurses into lists and maps, stringifying map keys', () {
-      expect(valueToJson([1, [2, 3]]), [1, [2, 3]]);
-      expect(valueToJson({'a': 1, 'b': [2]}), {'a': 1, 'b': [2]});
+      expect(
+        valueToJson([
+          1,
+          [2, 3],
+        ]),
+        [
+          1,
+          [2, 3],
+        ],
+      );
+      expect(
+        valueToJson({
+          'a': 1,
+          'b': [2],
+        }),
+        {
+          'a': 1,
+          'b': [2],
+        },
+      );
       expect(valueToJson({1: 'x', 2: 'y'}), {'1': 'x', '2': 'y'});
     });
 
@@ -79,19 +101,29 @@ void main() {
       expect(() => valueToJson(cyclic, maxDepth: 4), returnsNormally);
     });
 
-    test('serializes a VMObject result from execution with its fields', () async {
-      final vm = ApolloVM();
-      await vm.loadCodeUnit(SourceCodeUnit('dart',
-          'class Box { int v = 7; } Box main(List a){ return Box(); }',
-          id: 't'));
-      final runner = vm.createRunner('dart')!;
-      final r = await runner.tryExecuteFunction('', 'main', []);
-      final json = valueToJson(r!.getValueNoContext());
-      expect(json, isA<Map>());
-      expect((json as Map)[r'\$type'] ?? json['\$type'], anyOf('Box', isNull));
-      // The field value is present regardless of the type-key spelling.
-      expect(json.values, contains(7));
-    });
+    test(
+      'serializes a VMObject result from execution with its fields',
+      () async {
+        final vm = ApolloVM();
+        await vm.loadCodeUnit(
+          SourceCodeUnit(
+            'dart',
+            'class Box { int v = 7; } Box main(List a){ return Box(); }',
+            id: 't',
+          ),
+        );
+        final runner = vm.createRunner('dart')!;
+        final r = await runner.tryExecuteFunction('', 'main', []);
+        final json = valueToJson(r!.getValueNoContext());
+        expect(json, isA<Map>());
+        expect(
+          (json as Map)[r'\$type'] ?? json['\$type'],
+          anyOf('Box', isNull),
+        );
+        // The field value is present regardless of the type-key spelling.
+        expect(json.values, contains(7));
+      },
+    );
   });
 
   group('astNodeToJson', () {
@@ -105,8 +137,11 @@ void main() {
 
       final types = _nodeTypes(json);
       expect(types, contains('ASTClassNormal'));
-      expect(types, contains('ASTStatementImport'),
-          reason: 'import nodes should be walked, not just listed');
+      expect(
+        types,
+        contains('ASTStatementImport'),
+        reason: 'import nodes should be walked, not just listed',
+      );
       expect(
         types.any((t) => t.contains('FunctionDeclaration')),
         isTrue,
@@ -115,22 +150,27 @@ void main() {
       expect(types.any((t) => t.startsWith('ASTType')), isTrue);
     });
 
-    test('serializes an invocable with returnType, modifiers and parameters',
-        () async {
-      final root = await _parse(_richSource);
-      final compute = root.functions
-          .expand((s) => s.functions)
-          .firstWhere((f) => f.name == 'compute');
-      final json = invocableToJson(compute);
-      expect(json['name'], 'compute');
-      expect((json['returnType'] as Map)['name'], 'int');
-      expect(json['modifiers'], isA<List>());
-      final params = (json['parameters'] as List).cast<Map>();
-      expect(params.map((p) => p['name']), containsAll(['a', 'args', 'scale']));
-      final scale = params.firstWhere((p) => p['name'] == 'scale');
-      expect(scale['named'], isTrue);
-      expect(scale['hasDefault'], isTrue);
-    });
+    test(
+      'serializes an invocable with returnType, modifiers and parameters',
+      () async {
+        final root = await _parse(_richSource);
+        final compute = root.functions
+            .expand((s) => s.functions)
+            .firstWhere((f) => f.name == 'compute');
+        final json = invocableToJson(compute);
+        expect(json['name'], 'compute');
+        expect((json['returnType'] as Map)['name'], 'int');
+        expect(json['modifiers'], isA<List>());
+        final params = (json['parameters'] as List).cast<Map>();
+        expect(
+          params.map((p) => p['name']),
+          containsAll(['a', 'args', 'scale']),
+        );
+        final scale = params.firstWhere((p) => p['name'] == 'scale');
+        expect(scale['named'], isTrue);
+        expect(scale['hasDefault'], isTrue);
+      },
+    );
 
     test('respects maxDepth by omitting deeper children', () async {
       final root = await _parse(_richSource);
@@ -143,8 +183,9 @@ void main() {
       final compute = root.functions
           .expand((s) => s.functions)
           .firstWhere((f) => f.name == 'compute');
-      final listParam = compute.parameters.allParameters
-          .firstWhere((p) => p.name == 'args');
+      final listParam = compute.parameters.allParameters.firstWhere(
+        (p) => p.name == 'args',
+      );
       final typeJson = typeToJson(listParam.type);
       expect(typeJson['name'], 'List');
       expect(typeJson['generics'], isNotNull);
@@ -156,18 +197,24 @@ void main() {
       final root = await _parse(_richSource);
       final symbols = symbolsToJson(root);
 
-      expect((symbols['functions'] as List).map((f) => (f as Map)['name']),
-          contains('compute'));
+      expect(
+        (symbols['functions'] as List).map((f) => (f as Map)['name']),
+        contains('compute'),
+      );
 
-      final point = (symbols['classes'] as List)
-          .cast<Map>()
-          .firstWhere((c) => c['name'] == 'Point');
+      final point = (symbols['classes'] as List).cast<Map>().firstWhere(
+        (c) => c['name'] == 'Point',
+      );
       expect(point['superClassName'], 'Shape');
-      expect((point['fields'] as List).map((f) => (f as Map)['name']),
-          containsAll(['x', 'y']));
+      expect(
+        (point['fields'] as List).map((f) => (f as Map)['name']),
+        containsAll(['x', 'y']),
+      );
       expect(point['constructors'], isNotEmpty);
-      expect((point['methods'] as List).map((m) => (m as Map)['name']),
-          containsAll(['origin', 'sum']));
+      expect(
+        (point['methods'] as List).map((m) => (m as Map)['name']),
+        containsAll(['origin', 'sum']),
+      );
     });
   });
 
@@ -184,17 +231,20 @@ void main() {
       expect(d['message'], 'bad syntax');
     });
 
-    test('diagnosticFromParseResult carries position and source line',
-        () async {
-      final vm = ApolloVM();
-      final parser = vm.getParser<String>('dart')!;
-      final result =
-          await parser.parse(SourceCodeUnit('dart', 'class { oops', id: 't'));
-      final d = diagnosticFromParseResult(result);
-      expect(d['line'], isNotNull);
-      expect(d['column'], isNotNull);
-      expect('${d['sourceLine']}', contains('class'));
-    });
+    test(
+      'diagnosticFromParseResult carries position and source line',
+      () async {
+        final vm = ApolloVM();
+        final parser = vm.getParser<String>('dart')!;
+        final result = await parser.parse(
+          SourceCodeUnit('dart', 'class { oops', id: 't'),
+        );
+        final d = diagnosticFromParseResult(result);
+        expect(d['line'], isNotNull);
+        expect(d['column'], isNotNull);
+        expect('${d['sourceLine']}', contains('class'));
+      },
+    );
   });
 
   group('typesToJson', () {

--- a/test/mcp/stdio_transport_test.dart
+++ b/test/mcp/stdio_transport_test.dart
@@ -1,0 +1,72 @@
+@TestOn('vm')
+@Tags(['mcp'])
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:apollovm/apollovm.dart' show ApolloVM;
+import 'package:apollovm/apollovm_mcp.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('serveStdio answers initialize + a tool call over the given streams',
+      () async {
+    final input = StreamController<List<int>>();
+    final output = StreamController<List<int>>();
+
+    final server = serveStdio(input: input.stream, output: output.sink);
+
+    final responses = StreamIterator(
+      output.stream
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .where((l) => l.trim().isNotEmpty)
+          .map((l) => jsonDecode(l) as Map<String, Object?>),
+    );
+
+    void send(Map<String, Object?> msg) =>
+        input.add(utf8.encode('${jsonEncode(msg)}\n'));
+
+    send({
+      'jsonrpc': '2.0',
+      'id': 1,
+      'method': 'initialize',
+      'params': {
+        'protocolVersion': '2024-11-05',
+        'capabilities': <String, Object?>{},
+        'clientInfo': {'name': 'stdio', 'version': '1.0'},
+      },
+    });
+
+    expect(await responses.moveNext(), isTrue);
+    final serverInfo =
+        (responses.current['result'] as Map)['serverInfo'] as Map;
+    expect(serverInfo['name'], 'apollovm-mcp');
+    expect(serverInfo['version'], ApolloVM.VERSION);
+
+    send({'jsonrpc': '2.0', 'method': 'notifications/initialized'});
+    send({
+      'jsonrpc': '2.0',
+      'id': 2,
+      'method': 'tools/call',
+      'params': {
+        'name': 'apollo.execute',
+        'arguments': {
+          'language': 'dart',
+          'source': 'int main(List a){ return 5; }',
+        },
+      },
+    });
+
+    expect(await responses.moveNext(), isTrue);
+    final result = responses.current['result'] as Map<String, Object?>;
+    final text = (result['content'] as List).first as Map<String, Object?>;
+    final payload = jsonDecode(text['text'] as String) as Map<String, Object?>;
+    expect(payload['result'], 5);
+
+    await responses.cancel();
+    await server.shutdown();
+    await input.close();
+  });
+}

--- a/test/mcp/stdio_transport_test.dart
+++ b/test/mcp/stdio_transport_test.dart
@@ -10,63 +10,66 @@ import 'package:apollovm/apollovm_mcp.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('serveStdio answers initialize + a tool call over the given streams',
-      () async {
-    final input = StreamController<List<int>>();
-    final output = StreamController<List<int>>();
+  test(
+    'serveStdio answers initialize + a tool call over the given streams',
+    () async {
+      final input = StreamController<List<int>>();
+      final output = StreamController<List<int>>();
 
-    final server = serveStdio(input: input.stream, output: output.sink);
+      final server = serveStdio(input: input.stream, output: output.sink);
 
-    final responses = StreamIterator(
-      output.stream
-          .transform(utf8.decoder)
-          .transform(const LineSplitter())
-          .where((l) => l.trim().isNotEmpty)
-          .map((l) => jsonDecode(l) as Map<String, Object?>),
-    );
+      final responses = StreamIterator(
+        output.stream
+            .transform(utf8.decoder)
+            .transform(const LineSplitter())
+            .where((l) => l.trim().isNotEmpty)
+            .map((l) => jsonDecode(l) as Map<String, Object?>),
+      );
 
-    void send(Map<String, Object?> msg) =>
-        input.add(utf8.encode('${jsonEncode(msg)}\n'));
+      void send(Map<String, Object?> msg) =>
+          input.add(utf8.encode('${jsonEncode(msg)}\n'));
 
-    send({
-      'jsonrpc': '2.0',
-      'id': 1,
-      'method': 'initialize',
-      'params': {
-        'protocolVersion': '2024-11-05',
-        'capabilities': <String, Object?>{},
-        'clientInfo': {'name': 'stdio', 'version': '1.0'},
-      },
-    });
-
-    expect(await responses.moveNext(), isTrue);
-    final serverInfo =
-        (responses.current['result'] as Map)['serverInfo'] as Map;
-    expect(serverInfo['name'], 'apollovm-mcp');
-    expect(serverInfo['version'], ApolloVM.VERSION);
-
-    send({'jsonrpc': '2.0', 'method': 'notifications/initialized'});
-    send({
-      'jsonrpc': '2.0',
-      'id': 2,
-      'method': 'tools/call',
-      'params': {
-        'name': 'apollo.execute',
-        'arguments': {
-          'language': 'dart',
-          'source': 'int main(List a){ return 5; }',
+      send({
+        'jsonrpc': '2.0',
+        'id': 1,
+        'method': 'initialize',
+        'params': {
+          'protocolVersion': '2024-11-05',
+          'capabilities': <String, Object?>{},
+          'clientInfo': {'name': 'stdio', 'version': '1.0'},
         },
-      },
-    });
+      });
 
-    expect(await responses.moveNext(), isTrue);
-    final result = responses.current['result'] as Map<String, Object?>;
-    final text = (result['content'] as List).first as Map<String, Object?>;
-    final payload = jsonDecode(text['text'] as String) as Map<String, Object?>;
-    expect(payload['result'], 5);
+      expect(await responses.moveNext(), isTrue);
+      final serverInfo =
+          (responses.current['result'] as Map)['serverInfo'] as Map;
+      expect(serverInfo['name'], 'apollovm-mcp');
+      expect(serverInfo['version'], ApolloVM.VERSION);
 
-    await responses.cancel();
-    await server.shutdown();
-    await input.close();
-  });
+      send({'jsonrpc': '2.0', 'method': 'notifications/initialized'});
+      send({
+        'jsonrpc': '2.0',
+        'id': 2,
+        'method': 'tools/call',
+        'params': {
+          'name': 'apollo.execute',
+          'arguments': {
+            'language': 'dart',
+            'source': 'int main(List a){ return 5; }',
+          },
+        },
+      });
+
+      expect(await responses.moveNext(), isTrue);
+      final result = responses.current['result'] as Map<String, Object?>;
+      final text = (result['content'] as List).first as Map<String, Object?>;
+      final payload =
+          jsonDecode(text['text'] as String) as Map<String, Object?>;
+      expect(payload['result'], 5);
+
+      await responses.cancel();
+      await server.shutdown();
+      await input.close();
+    },
+  );
 }


### PR DESCRIPTION
## Summary

Adds an **MCP (Model Context Protocol) server** — `apollovm serve` — that turns ApolloVM into a programmable, sandboxed execution engine for AI agents. Agents can parse, execute, translate, compile, and inspect code across all supported languages through MCP tools.

Built on the official Dart-team [`dart_mcp`](https://pub.dev/packages/dart_mcp) SDK. Purely additive: a new `serve` command, a new `lib/src/mcp/` layer, and a new public library `package:apollovm/apollovm_mcp.dart`. No language cores change.

## Tools

| Tool | Purpose |
|------|---------|
| `apollo.parse` | Parse → diagnostics + summary (classes/functions/imports) |
| `apollo.execute` | Run an entry function → result value + captured console output |
| `apollo.translate` | Transpile `from` → `to` |
| `apollo.ast` | Full AST as JSON |
| `apollo.symbols` | Symbol graph (functions/classes/fields/methods/constructors) |
| `apollo.types` | Deduplicated type table (class/builtin/unknown) |
| `apollo.wasm` | Compile to WebAssembly (base64 modules) |

## Transports

- **stdio** (default): `apollovm serve`
- **HTTP/SSE**: `apollovm serve --http 8080`. `dart_mcp` has no native HTTP transport, so this is a custom `StreamChannel<String>` SSE adapter (`dart:io HttpServer`) fed into the same `MCPServer`.

## Security model

- **File/network access denied by construction** — only `print` is exposed to executed code; tools accept inline source strings only (never a path).
- **Timeout / CPU** — `apollo.execute` runs in a **killable isolate**. This matters: ApolloVM executes CPU work synchronously (its dialect has no `async`/`await`), so an in-process `Future.timeout` **cannot** interrupt a runaway loop (confirmed: `while(true){}` hangs until killed). The isolate is `kill()`-ed at the deadline. Configurable per tool via `--isolate-tools`.
- **Input/output caps** — `--max-source-chars`, `--max-output-chars`.
- **Memory** — best-effort process-level only (Dart has no per-isolate heap cap); documented, with `--old_gen_heap_size` guidance.

## Tests

New `mcp`-tagged suite under `test/mcp/` (16 tests, all green): protocol (`initialize`/`tools/list`), every tool, parse-error line/column diagnostics, **isolate timeout-kill of a synchronous infinite loop** (~500ms), output truncation, source-size rejection, and the HTTP/SSE transport (endpoint event + POST + SSE reply).

- `dart analyze`: clean
- `dart run dependency_validator`: clean
- `dart test -x wasm -x wasm-gc -x wasm-chrome`: **719 passed, no regressions**
- (Wasm *execution* tests require the `wasm_run` native lib — `dart run wasm_run:setup` — unrelated to this change.)

## Notes

- New deps: `dart_mcp: ^0.5.2`, `stream_channel: ^2.1.4`.
- Version bumped to `0.1.49`; docs in README ("MCP Server") and `doc/MCP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)