### PR TITLE
feat(go): add first-class Go language support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 1.2.0
+
+### New language: `Go`
+
+- **Added first-class Go support** — ApolloVM can now **parse**, **execute**, and
+  **translate** Go source (`.go` / `go`, alias `golang`) through the shared AST,
+  bidirectionally with every other supported language (and on-the-fly Wasm).
+- Implemented under `lib/src/languages/go/` (`go_grammar_lexer.dart`,
+  `go_grammar.dart`, `go_generator.dart`, `go_parser.dart`, `go_runner.dart`) and
+  wired into `ApolloVM` (`getParser`/`createRunner`/`createCodeGenerator` and the
+  `.go` file-extension mapping).
+- Supported: top-level and struct **receiver methods** (`func (o *Name) m(...)`),
+  `struct` types with fields and factory constructors (`func NewName(...) *Name`),
+  `var`/`:=` type inference, `if`/`else if`/`else`, the four `for` forms (C-style,
+  condition-only as `while`, `range` as for-each, infinite / `do`-`while`), Go
+  `switch` (no fall-through), slices/maps (`[]T{…}`, `map[K]V{…}`), closures, all
+  arithmetic/comparison/logical/bitwise operators, string `+` concatenation, and
+  `fmt.Println` (normalized to the VM's `print`).
+- Go has no classes: a class is modeled as a `struct` + receiver methods (the same
+  idiom Lua uses for tables), so OOP code round-trips across all languages. See the
+  README feature tables for the full per-feature matrix; `try`/`catch`/`throw`,
+  inheritance/interfaces, rich enums and generics are not yet implemented for Go.
+
 ## 0.1.48
 
 ### CLI: `run` executes `.wasm` files through the Wasm runtime

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 [![Code size](https://img.shields.io/github/languages/code-size/ApolloVM/apollovm_dart?logo=github&logoColor=white)](https://github.com/ApolloVM/apollovm_dart)
 [![License](https://img.shields.io/github/license/ApolloVM/apollovm_dart?logo=open-source-initiative&logoColor=green)](https://github.com/ApolloVM/apollovm_dart/blob/master/LICENSE)
 
-ApolloVM is a portable VM (native, JS/Web, Flutter) that can parse, translate, and execute multiple languages such as Dart, Java, Kotlin, C#, JavaScript, TypeScript, Lua, and Python. It also provides on-the-fly compilation to Wasm.
+ApolloVM is a portable VM (native, JS/Web, Flutter) that can parse, translate, and execute multiple languages such as Dart, Java, Kotlin, Go, C#, JavaScript, TypeScript, Lua, and Python. It also provides on-the-fly compilation to Wasm.
 
 -----------------------------
 
@@ -49,10 +49,10 @@ source code between all supported languages, and **compile to WebAssembly** on t
 
 ### Languages
 
-`Dart`, `Java 11`, `Kotlin`, `C#`, `JavaScript`, `TypeScript`, `Lua` and `Python`.
+`Dart`, `Java 11`, `Kotlin`, `Go`, `C#`, `JavaScript`, `TypeScript`, `Lua` and `Python`.
 
 Any supported language can be translated to any other (e.g. Java → Dart, C# → Python,
-Kotlin → JavaScript), and code can be regenerated back to its original language.
+Kotlin → JavaScript, Go → Dart), and code can be regenerated back to its original language.
 
 ### Core capabilities
 
@@ -72,30 +72,30 @@ language but not implemented yet) · 🚫 not applicable (the language has no su
 The **Wasm** column shows what the on-the-fly WebAssembly compiler currently supports
 (any source language is compiled through the same shared AST).
 
-| Feature | Dart | Java | Kotlin | C# | JS | TS | Lua | Python | Wasm |
-|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
-| `if` / `else if` / `else`        | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `for` (C-style)                  | ✅ | ✅ | 🚫  | ✅ | ✅ | ✅ | 🧩¹ | 🚫 | ✅ |
-| `for-each` / `for-in`            | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `while`                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `do` / `while`                   | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🧩² | 🚫 | ✅ |
-| `switch` / `case`                | ✅ | ✅ | 🧩³ | ✅ | ✅ | ✅ | 🚫  | 🧩⁴ | ✅ |
-| `break`                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `continue`                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | ✅ |
-| `try` / `catch` / `finally`      | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | ✅ |
-| `throw` / `raise`                | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | ✅ |
-| `async` / `await`                | ✅ | 🚫  | 🧩⁷ | ✅ | ✅ | ✅ | 🚫  | ✅ | ✅ |
-| Ternary (`? :`)                  | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | ✅ |
-| Arithmetic (`+ - * / %`)         | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Comparison / logical             | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Bitwise (`& \| ^ << >> ~`)       | ✅ | ✅ | 🧩⁵ | ✅ | ✅ | ✅ | 🧩⁶ | ✅ | ✅ |
-| `++` / `--`, compound assign     | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Lambdas / closures               | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Named / keyword arguments        | ✅ | 🚫  | ✅ | ✅ | 🚫  | 🚫  | 🚫  | ✅ | ✅ |
-| Parameter default values         | ✅ | 🚫  | ✅ | ✅ | 🚫  | 🚫  | 🚫  | ✅ | ✅ |
-| String interpolation / concat    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| List & map / dict literals       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| `null` / `None` / `nil`          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Feature | Dart | Java | Kotlin | Go | C# | JS | TS | Lua | Python | Wasm |
+|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
+| `if` / `else if` / `else`        | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `for` (C-style)                  | ✅ | ✅ | 🚫  | ✅ | ✅ | ✅ | ✅ | 🧩¹ | 🚫 | ✅ |
+| `for-each` / `for-in`            | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `while`                          | ✅ | ✅ | ✅ | 🧩⁸ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `do` / `while`                   | ✅ | ✅ | ✅ | 🧩⁹ | ✅ | ✅ | ✅ | 🧩² | 🚫 | ✅ |
+| `switch` / `case`                | ✅ | ✅ | 🧩³ | ✅ | ✅ | ✅ | ✅ | 🚫  | 🧩⁴ | ✅ |
+| `break`                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `continue`                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | ✅ |
+| `try` / `catch` / `finally`      | ✅ | ✅ | ✅ | 🚧 | ✅ | ✅ | ✅ | 🚫  | ✅ | ✅ |
+| `throw` / `raise`                | ✅ | ✅ | ✅ | 🚧 | ✅ | ✅ | ✅ | 🚫  | ✅ | ✅ |
+| `async` / `await`                | ✅ | 🚫  | 🧩⁷ | 🚫 | ✅ | ✅ | ✅ | 🚫  | ✅ | ✅ |
+| Ternary (`? :`)                  | ✅ | ✅ | ✅ | 🧩¹⁰ | ✅ | ✅ | ✅ | 🚫  | ✅ | ✅ |
+| Arithmetic (`+ - * / %`)         | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Comparison / logical             | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Bitwise (`& \| ^ << >> ~`)       | ✅ | ✅ | 🧩⁵ | 🧩¹¹ | ✅ | ✅ | ✅ | 🧩⁶ | ✅ | ✅ |
+| `++` / `--`, compound assign     | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Lambdas / closures               | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Named / keyword arguments        | ✅ | 🚫  | ✅ | 🚫 | ✅ | 🚫  | 🚫  | 🚫  | ✅ | ✅ |
+| Parameter default values         | ✅ | 🚫  | ✅ | 🚫 | ✅ | 🚫  | 🚫  | 🚫  | ✅ | ✅ |
+| String interpolation / concat    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| List & map / dict literals       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `null` / `None` / `nil`          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 
 ¹ Lua numeric-for (`for i = a, b do`). &nbsp; ² Lua `repeat … until`. &nbsp;
 ³ Kotlin `when`. &nbsp; ⁴ Python `match` / `case`. &nbsp;
@@ -103,7 +103,14 @@ The **Wasm** column shows what the on-the-fly WebAssembly compiler currently sup
 ⁶ Lua bitwise use `&`/`|`/`~` (xor)/`<<`/`>>` and unary `~` (Lua 5.3). &nbsp;
 ⁷ Kotlin's async idiom is `suspend` / coroutines: ApolloVM generates `suspend fun`
 (dropping `await`) when translating to Kotlin, but does not yet parse Kotlin `suspend`.
-`await` unwraps the awaitable (`Future<T>` / `Promise<T>` / `Task<T>`) to `T`.
+`await` unwraps the awaitable (`Future<T>` / `Promise<T>` / `Task<T>`) to `T`. &nbsp;
+⁸ Go has no `while`; the condition-only `for cond {}` is used. &nbsp;
+⁹ Go has no `do`/`while`; emitted as `for { … if !cond { break } }`. &nbsp;
+¹⁰ Go has no `?:`/if-expression; ApolloVM emits an IIFE
+`func() any { if c { return a } else { return b } }()`. &nbsp;
+¹¹ Go bitwise use `&`/`|`/`^` (xor)/`<<`/`>>`, unary `^` for NOT and `&^` (AND-NOT).
+`try`/`catch`/`throw` (Go uses `defer`/`recover`/`panic`) and `async`/`await`
+(Go uses goroutines/channels) are not applicable / not implemented yet.
 
 ### Classes, types & OOP
 
@@ -113,17 +120,17 @@ language but not implemented yet) · 🚫 not applicable (the language has no su
 The **Wasm** column shows what the on-the-fly WebAssembly compiler currently supports
 (any source language is compiled through the same shared AST).
 
-| Feature | Dart | Java | Kotlin | C# | JS | TS | Lua | Python | Wasm |
-|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
-| Classes                                                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | ✅ |
-| Fields (with initializers)                                    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🧩¹ | ✅ | ✅ |
-| Constructors & instantiation (`new Foo(...)` / `Foo(...)`)    | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🧩¹ | ✅ | ✅ |
-| Methods                                                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| Static / visibility modifiers                                 | ✅ | ✅ | 🧩³ | ✅ | 🧩² | ✅ | 🚫  | 🚫  | 🧩⁴ |
-| Inheritance (`extends`) / interfaces                          | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚧 |
-| Enums (rich: ctor args, fields, methods)⁶                     | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚫  | ✅ | ✅⁶ |
-| Generics (generic classes + instantiation + type erasure)    | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚫  | 🚫  | 🚧 |
-| Type inference (`var` / `val` / `auto`)                       | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚫  | 🚫  | ✅⁵ |
+| Feature | Dart | Java | Kotlin | Go | C# | JS | TS | Lua | Python | Wasm |
+|---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
+| Classes                                                       | ✅ | ✅ | ✅ | 🧩⁷ | ✅ | ✅ | ✅ | 🚫  | ✅ | ✅ |
+| Fields (with initializers)                                    | ✅ | ✅ | ✅ | 🧩⁸ | ✅ | ✅ | ✅ | 🧩¹ | ✅ | ✅ |
+| Constructors & instantiation (`new Foo(...)` / `Foo(...)`)    | ✅ | ✅ | ✅ | 🧩⁹ | ✅ | ✅ | ✅ | 🧩¹ | ✅ | ✅ |
+| Methods                                                       | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Static / visibility modifiers                                 | ✅ | ✅ | 🧩³ | 🧩¹⁰ | ✅ | 🧩² | ✅ | 🚫  | 🚫  | 🧩⁴ |
+| Inheritance (`extends`) / interfaces                          | ✅ | ✅ | ✅ | 🚧 | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚧 |
+| Enums (rich: ctor args, fields, methods)⁶                     | ✅ | ✅ | ✅ | 🚧 | ✅ | 🚫  | ✅ | 🚫  | ✅ | ✅⁶ |
+| Generics (generic classes + instantiation + type erasure)    | ✅ | ✅ | ✅ | 🚧 | ✅ | 🚫  | ✅ | 🚫  | 🚫  | 🚧 |
+| Type inference (`var` / `val` / `auto`)                       | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚫  | 🚫  | ✅⁵ |
 
 ¹ Lua is table-based: "fields" are table entries (`obj.x`), "constructors" are factory/`setmetatable`
 idioms, methods are `function Obj:method`. &nbsp;
@@ -138,7 +145,16 @@ receiver); only static methods are callable as entry points, with no source-leve
 Java/Kotlin emit native rich enums; C#/TS/Python use a class + `static`-const-instances idiom; Wasm
 compiles entries to heap instances (a method chained directly on an entry needs a variable first).
 **Breaking change**: an entry is no longer an `int` — use `.index` (and `.value` for `= N` entries). &nbsp;
-Generics are `🚫` for JS/Lua/Python: no static type syntax to parameterize.
+Generics are `🚫` for JS/Lua/Python: no static type syntax to parameterize. &nbsp;
+⁷ Go has no classes; a class is modeled as a `type Name struct { ... }` plus receiver
+methods `func (o *Name) m(...)` (the same idiom Lua uses for tables). &nbsp;
+⁸ Go struct types can't carry inline field initializers, so initializers are moved into the
+generated `NewName` factory. &nbsp;
+⁹ Go constructors/instantiation use a `func NewName(...) *Name` factory (and `Name(...)`
+call sites), since Go has no `new`. &nbsp;
+¹⁰ Go has no `static`/visibility keywords: static methods become package-level `func`s and
+visibility follows identifier capitalization. Inheritance, rich enums and generics
+(Go embedding/`iota`/`[T any]`) are `🚧` — not implemented for Go yet.
 
 > Per-language behavior is normalized to a shared AST, so types and constructs map
 > cleanly when translating between languages (e.g. C# `string` ⇄ Dart `String`,
@@ -160,7 +176,7 @@ Now you can use the `apollovm` Dart executable:
 ```shell
 $> apollovm help
 
-ApolloVM - A compact VM for Dart, Java, Kotlin, C#, JavaScript, TypeScript, Lua and Python.
+ApolloVM - A compact VM for Dart, Java, Kotlin, Go, C#, JavaScript, TypeScript, Lua and Python.
 
 Usage: apollovm <command> [arguments]
 
@@ -284,7 +300,7 @@ even if you don't have Dart installed.
 
 ## Package Usage
 
-The ApolloVM is still in alpha stage. Below, we can see simple usage examples in Dart, Java, Kotlin, C#, JavaScript, TypeScript, Lua and Python.
+The ApolloVM is still in alpha stage. Below, we can see simple usage examples in Dart, Java, Kotlin, Go, C#, JavaScript, TypeScript, Lua and Python.
 
 ### Language: `Dart`
 
@@ -595,6 +611,84 @@ Kotlin support reaches parity with the Java feature set: top-level and class `fu
 declarations, `val`/`var` with type inference, `if`/`else`, `for (x in …)`, `while`,
 `listOf`/`mapOf` literals, and `"$x"` / `"${expr}"` string templates — all
 translatable to Dart, Java or back to Kotlin.
+
+### Language: `Go`
+
+Loading Go source code, executing it, and then converting it to Dart:
+
+```dart
+import 'package:apollovm/apollovm.dart';
+
+void main() async {
+  var vm = ApolloVM();
+
+  var codeUnit = SourceCodeUnit(
+          'go',
+          r'''
+            type Foo struct {
+            }
+
+            func (o *Foo) greet(name string, count int) {
+              msg := "Hello " + name + ", you have " + count + " messages."
+              fmt.Println(msg)
+            }
+          ''',
+          id: 'test');
+
+  var loadOK = await vm.loadCodeUnit(codeUnit);
+
+  if (!loadOK) {
+    throw StateError('Error parsing Go code!');
+  }
+
+  var goRunner = vm.createRunner('go')!;
+
+  // Map the `print` function in the VM:
+  goRunner.externalPrintFunction = (o) => print("» $o");
+
+  // `greet` is a struct method (needs a receiver instance); `classInstanceFields`
+  // provides one (here with no fields).
+  await goRunner.executeClassMethod('', 'Foo', 'greet',
+      positionalParameters: ['World', 3], classInstanceFields: const {});
+
+  print('---------------------------------------');
+
+  // Regenerate code in Dart:
+  var codeStorageDart = vm.generateAllCodeIn('dart');
+  var allSourcesDart = await codeStorageDart.writeAllSources();
+  print(allSourcesDart.toString());
+}
+```
+
+*Note: the parsed function `fmt.Println` is normalized to the VM's `print` (mapped as an external function).*
+
+Output:
+```text
+» Hello World, you have 3 messages.
+---------------------------------------
+<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  void greet(String name, int count) {
+    var msg = 'Hello $name, you have $count messages.';
+    print(msg);
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+```
+
+Go is bidirectional: ApolloVM parses `.go`/`go` source into the AST, executes it, and
+generates idiomatic Go — `package main` with an `import "fmt"` when needed, type-after-name
+declarations (`func f(a int) int`, `x := …`), `for`-only control flow (`for cond {}` for
+`while`, `for { … if !cond { break } }` for `do`/`while`, `for _, x := range xs {}` for
+for-each), Go `switch` (no fall-through), slices/maps (`[]int{…}`, `map[K]V{…}`) and closures
+(`func(x int) int { … }`). Classes map to the Go idiom — a `type Name struct { … }` plus
+receiver methods `func (o *Name) m(...)` — so object-oriented code round-trips to and from
+Dart, Java, Kotlin, C#, JavaScript, TypeScript and Python.
 
 ### Language: `JavaScript`
 
@@ -1136,6 +1230,10 @@ Any help from the open-source community is always welcome and needed:
 
 - Python: extended support (comprehensions, decorators, `with` statements, `*args`/`**kwargs`, multiple assignment/returns). *Functions, classes/`self`-methods, `if`/`elif`/`else`, `while`, `for ... in`, `try`/`except`/`finally` + `raise`, lists & dicts, f-strings, keyword arguments, `lambda` expressions, conditional expressions (`a if c else b`), and `import`/`from ... import` are already supported.*
   - *See the [Python implementation (at "lib/src/languages/python")](https://github.com/ApolloVM/apollovm_dart/tree/master/lib/src/languages/python).*
+
+
+- Go: extended support (`panic`/`recover`/`defer` for `try`/`catch`/`throw`, interfaces + struct embedding for inheritance, `const`/`iota` enums, and `[T any]` generics). *Top-level and struct receiver `func`s, `struct` types + fields + factory constructors, `var`/`:=` with type inference, `if`/`else if`/`else`, `for` (C-style, condition-only, `range`, infinite), `switch`, slices/maps, closures, string `+` concatenation, and `fmt.Println` (normalized to `print`) are already supported.*
+  - *See the [Go implementation (at "lib/src/languages/go")](https://github.com/ApolloVM/apollovm_dart/tree/master/lib/src/languages/go).*
 
 
 - Package Importer.

--- a/bin/apollovm.dart
+++ b/bin/apollovm.dart
@@ -13,7 +13,7 @@ void main(List<String> args) async {
   var commandRunner =
       CommandRunner<bool>(
           'apollovm',
-          'ApolloVM/${ApolloVM.VERSION} - A compact VM for Dart, Java, Kotlin, C#, JavaScript, TypeScript, Lua and Python.',
+          'ApolloVM/${ApolloVM.VERSION} - A compact VM for Dart, Java, Kotlin, Go, C#, JavaScript, TypeScript, Lua and Python.',
         )
         ..addCommand(CommandRun())
         ..addCommand(CommandTranslate())
@@ -61,7 +61,7 @@ abstract class CommandSourceFileBase extends Command<bool> {
       help:
           'Programming language of source file.\n'
           '(defaults to language of the file extension)',
-      valueHelp: 'dart|java|kotlin|javascript|typescript|lua|python',
+      valueHelp: 'dart|java|kotlin|go|javascript|typescript|lua|python',
     );
   }
 
@@ -213,7 +213,7 @@ class CommandTranslate extends CommandSourceFileBase {
       help:
           'Target Programming language for translation.\n'
           '(defaults to the opposite of the source language)',
-      valueHelp: 'dart|java|kotlin|javascript|typescript|lua|python',
+      valueHelp: 'dart|java|kotlin|go|javascript|typescript|lua|python',
     );
   }
 

--- a/dart_test.yaml
+++ b/dart_test.yaml
@@ -11,7 +11,7 @@
 #                browser-only APIs or the WasmGC engine.
 #
 # Source-language tags (the language whose source a test loads / generates):
-#   dart, java, kotlin, javascript, typescript, lua, csharp, python
+#   dart, java, kotlin, go, javascript, typescript, lua, csharp, python
 #
 # Examples:
 #   dart test -x wasm-gc              # native / wasm_run CI (no GC engine)
@@ -32,6 +32,7 @@ tags:
   dart:
   java:
   kotlin:
+  go:
   javascript:
   typescript:
   lua:

--- a/example/apollovm_example_go.dart
+++ b/example/apollovm_example_go.dart
@@ -1,0 +1,75 @@
+import 'package:apollovm/apollovm.dart';
+
+void main() async {
+  var vm = ApolloVM();
+
+  var codeUnit = SourceCodeUnit('go', r'''
+      type Foo struct {
+      }
+
+      func (o *Foo) main(title string, a int, b int, c int) {
+        sumAB := a + b
+        sumABC := a + b + c
+        fmt.Println(title)
+        fmt.Println(sumAB)
+        fmt.Println(sumABC)
+      }
+      ''', id: 'test');
+
+  var loadOK = await vm.loadCodeUnit(codeUnit);
+
+  if (!loadOK) {
+    print("Can't load source!");
+    return;
+  }
+
+  print('---------------------------------------');
+
+  var goRunner = vm.createRunner('go')!;
+
+  // Map the `print` function in the VM:
+  goRunner.externalPrintFunction = (o) => print("» $o");
+
+  // `Foo.main` is a struct method (needs a receiver instance);
+  // `classInstanceFields` provides one (here with no fields).
+  await goRunner.executeClassMethod(
+    '',
+    'Foo',
+    'main',
+    positionalParameters: ['Sums:', 10, 20, 30],
+    classInstanceFields: const {},
+  );
+
+  print('---------------------------------------');
+
+  // Regenerate code in Dart:
+  var codeStorageDart = vm.generateAllCodeIn('dart');
+  var allSourcesDart = await codeStorageDart.writeAllSources();
+  print(allSourcesDart);
+}
+
+/////////////
+// OUTPUT: //
+/////////////
+// ---------------------------------------
+// » Sums:
+// » 30
+// » 60
+// ---------------------------------------
+// <<<< [SOURCES_BEGIN] >>>>
+// <<<< NAMESPACE="" >>>>
+// <<<< CODE_UNIT_START="/test" >>>>
+// class Foo {
+//
+//   void main(String title, int a, int b, int c) {
+//     var sumAB = a + b;
+//     var sumABC = (a + b) + c;
+//     print(title);
+//     print(sumAB);
+//     print(sumABC);
+//   }
+//
+// }
+// <<<< CODE_UNIT_END="/test" >>>>
+// <<<< [SOURCES_END] >>>>
+//

--- a/lib/apollovm.dart
+++ b/lib/apollovm.dart
@@ -28,6 +28,8 @@ export 'src/languages/csharp/csharp_parser.dart';
 export 'src/languages/csharp/csharp_runner.dart';
 export 'src/languages/dart/dart_parser.dart';
 export 'src/languages/dart/dart_runner.dart';
+export 'src/languages/go/go_parser.dart';
+export 'src/languages/go/go_runner.dart';
 export 'src/languages/java/java11/java11_parser.dart';
 export 'src/languages/java/java11/java11_runner.dart';
 export 'src/languages/wasm/wasm_parser.dart';

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -28,6 +28,9 @@ import 'languages/csharp/csharp_runner.dart';
 import 'languages/dart/dart_generator.dart';
 import 'languages/dart/dart_parser.dart';
 import 'languages/dart/dart_runner.dart';
+import 'languages/go/go_generator.dart';
+import 'languages/go/go_parser.dart';
+import 'languages/go/go_runner.dart';
 import 'languages/java/java11/java11_generator.dart';
 import 'languages/java/java11/java11_parser.dart';
 import 'languages/java/java11/java11_runner.dart';
@@ -53,7 +56,7 @@ import 'languages/wasm/wasm_runner.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '0.1.48';
+  static final String VERSION = '1.2.0';
 
   static int _idCount = 0;
 
@@ -75,6 +78,9 @@ class ApolloVM implements VMTypeResolver {
         return ApolloParserTypeScript.instance as ApolloCodeParser<T>;
       case 'kotlin':
         return ApolloParserKotlin.instance as ApolloCodeParser<T>;
+      case 'go':
+      case 'golang':
+        return ApolloParserGo.instance as ApolloCodeParser<T>;
       case 'cs':
       case 'c#':
       case 'csharp':
@@ -229,6 +235,12 @@ class ApolloVM implements VMTypeResolver {
           this,
           importCorePackageMath: importCorePackageMath,
         );
+      case 'go':
+      case 'golang':
+        return ApolloRunnerGo(
+          this,
+          importCorePackageMath: importCorePackageMath,
+        );
       case 'cs':
       case 'c#':
       case 'csharp':
@@ -283,6 +295,9 @@ class ApolloVM implements VMTypeResolver {
         return ApolloCodeGeneratorTypeScript(codeStorage);
       case 'kotlin':
         return ApolloCodeGeneratorKotlin(codeStorage);
+      case 'go':
+      case 'golang':
+        return ApolloCodeGeneratorGo(codeStorage);
       case 'cs':
       case 'c#':
       case 'csharp':
@@ -409,6 +424,8 @@ class ApolloVM implements VMTypeResolver {
         return 'csharp';
       case 'kt':
         return 'kotlin';
+      case 'go':
+        return 'go';
       case 'wasm':
         return 'wasm';
       case 'cpp':

--- a/lib/src/languages/go/go_generator.dart
+++ b/lib/src/languages/go/go_generator.dart
@@ -416,7 +416,12 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
       // Inferred + value: `x := expr`.
       out.write(statement.name);
       out.write(' := ');
-      generateASTExpression(value, out: out, indent: indent, headIndented: false);
+      generateASTExpression(
+        value,
+        out: out,
+        indent: indent,
+        headIndented: false,
+      );
     } else {
       // `var x Type = expr`, `var x Type`, or `var x = expr`.
       out.write('var ');
@@ -516,7 +521,12 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     out ??= newOutput();
     if (headIndented) out.write(indent);
     out.write('return ');
-    generateASTValue(statement.value, out: out, indent: indent, headIndented: false);
+    generateASTValue(
+      statement.value,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
     return out;
   }
 
@@ -914,7 +924,11 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     out.write('func() any { if ');
     generateASTExpression(expression.condition, out: out, headIndented: false);
     out.write(' { return ');
-    generateASTExpression(expression.valueIfTrue, out: out, headIndented: false);
+    generateASTExpression(
+      expression.valueIfTrue,
+      out: out,
+      headIndented: false,
+    );
     out.write(' } else { return ');
     generateASTExpression(
       expression.valueIfFalse,
@@ -1160,10 +1174,7 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     out.write('map[');
     generateASTType(expression.keyType ?? ASTTypeDynamic.instance, out: out);
     out.write(']');
-    generateASTType(
-      expression.valueType ?? ASTTypeDynamic.instance,
-      out: out,
-    );
+    generateASTType(expression.valueType ?? ASTTypeDynamic.instance, out: out);
     out.write('{');
 
     var entriesExpressions = expression.entriesExpressions;

--- a/lib/src/languages/go/go_generator.dart
+++ b/lib/src/languages/go/go_generator.dart
@@ -1,0 +1,1378 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import '../../apollovm_code_generator.dart';
+import '../../apollovm_code_storage.dart';
+import '../../ast/apollovm_ast_base.dart';
+import '../../ast/apollovm_ast_expression.dart';
+import '../../ast/apollovm_ast_statement.dart';
+import '../../ast/apollovm_ast_toplevel.dart';
+import '../../ast/apollovm_ast_type.dart';
+import '../../ast/apollovm_ast_value.dart';
+import '../../ast/apollovm_ast_variable.dart';
+
+/// Go implementation of an [ApolloCodeGenerator].
+///
+/// Go has no classes: a class is emitted as a `type Name struct { ... }` plus
+/// receiver methods (`func (o *Name) m(...)`) and, when needed, a factory
+/// constructor (`func NewName(...) *Name`). Field and sibling-method references
+/// inside a method are rewritten to `o.field` / `o.method(...)`.
+class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
+  ApolloCodeGeneratorGo(ApolloSourceCodeStorage codeStorage)
+    : super('go', codeStorage);
+
+  /// The fixed receiver name used for struct methods.
+  static const String _receiver = 'o';
+
+  /// Field names of the struct currently being generated (for `o.field`).
+  Set<String> _currentClassFields = const {};
+
+  /// Method names of the struct currently being generated (for `o.method()`).
+  Set<String> _currentClassMethods = const {};
+
+  /// Name of the struct currently being generated (for the receiver type).
+  String? _currentClassName;
+
+  @override
+  String normalizeTypeName(String typeName, [String? callingFunction]) {
+    switch (typeName) {
+      case 'int':
+      case 'Int':
+      case 'Integer':
+        return 'int';
+      case 'double':
+      case 'Double':
+      case 'num':
+      case 'Num':
+        return 'float64';
+      case 'bool':
+      case 'Bool':
+      case 'Boolean':
+        return 'bool';
+      case 'String':
+      case 'string':
+        return 'string';
+      case 'void':
+      case 'Void':
+        return '';
+      case 'dynamic':
+      case 'Object':
+      case 'any':
+        return 'any';
+      default:
+        return typeName;
+    }
+  }
+
+  // -----------------------------------------------------------------
+  // Program structure: `package main` + imports.
+  // -----------------------------------------------------------------
+
+  @override
+  StringBuffer generateASTRoot(
+    ASTRoot root, {
+    StringBuffer? out,
+    String indent = '',
+    bool withBrackets = true,
+  }) {
+    out ??= newOutput();
+
+    out.write('package main\n\n');
+
+    // `fmt` is imported only when the AST prints (the canonical `print`).
+    if (_usesPrint(root) || root.classes.any(_usesPrint)) {
+      out.write('import "fmt"\n\n');
+    }
+
+    var imports = root.imports;
+    if (imports.isNotEmpty) {
+      for (var import in imports) {
+        generateASTStatementImport(import, out: out);
+      }
+      out.write('\n');
+    }
+
+    generateASTBlock(root, out: out, withBrackets: false);
+
+    for (var clazz in root.classes) {
+      generateASTClass(clazz, out: out);
+    }
+
+    return out;
+  }
+
+  bool _usesPrint(ASTNode node) {
+    if (node is ASTExpressionLocalFunctionInvocation && node.name == 'print') {
+      return true;
+    }
+    for (var child in node.children) {
+      if (_usesPrint(child)) return true;
+    }
+    return false;
+  }
+
+  @override
+  StringBuffer generateASTStatementImport(
+    ASTStatementImport import, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+    out.write('import "');
+    out.write(import.path);
+    out.write('"\n');
+    return out;
+  }
+
+  // -----------------------------------------------------------------
+  // Structs (classes).
+  // -----------------------------------------------------------------
+
+  @override
+  StringBuffer generateASTClass(
+    ASTClassNormal clazz, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    var name = clazz.name;
+    var fields = clazz.fields.toList();
+
+    // `type Name struct { field Type ... }`.
+    out.write('type ');
+    out.write(name);
+    out.write(' struct {\n');
+    for (var field in fields) {
+      out.write('  ');
+      out.write(field.name);
+      out.write(' ');
+      generateASTType(field.type, out: out);
+      out.write('\n');
+    }
+    out.write('}\n\n');
+
+    _currentClassName = name;
+    _currentClassFields = fields.map((f) => f.name).toSet();
+    _currentClassMethods = {
+      for (var set in clazz.functions)
+        for (var f in set.functions) f.name,
+    };
+
+    // Factory constructor(s) when there are explicit constructors or field
+    // initializers (Go structs can't carry inline initializers).
+    var fieldInits = fields.whereType<ASTClassFieldWithInitialValue>().toList();
+    var constructors = clazz.constructors.toList();
+
+    if (constructors.isNotEmpty) {
+      for (var c in constructors) {
+        for (var ctor in c.functions) {
+          _generateConstructor(ctor, name, fieldInits, out, indent);
+        }
+      }
+    } else if (fieldInits.isNotEmpty) {
+      _generateDefaultConstructor(name, fieldInits, out, indent);
+    }
+
+    // Methods as `func (o *Name) method(...) ret { ... }`.
+    for (var set in clazz.functions) {
+      for (var f in set.functions) {
+        _generateReceiverMethod(f, name, out, indent);
+      }
+    }
+
+    _currentClassName = null;
+    _currentClassFields = const {};
+    _currentClassMethods = const {};
+
+    return out;
+  }
+
+  void _generateReceiverMethod(
+    ASTFunctionDeclaration f,
+    String className,
+    StringBuffer out,
+    String indent,
+  ) {
+    var blockCode = generateASTBlock(f, indent: indent, withBrackets: false);
+
+    out.write('func (');
+    out.write(_receiver);
+    out.write(' *');
+    out.write(className);
+    out.write(') ');
+    out.write(f.name);
+    out.write('(');
+    if (f.parametersSize > 0) {
+      generateASTParametersDeclaration(f.parameters, out: out);
+    }
+    out.write(')');
+    _writeReturnType(f.returnType, out);
+    out.write(' {\n');
+    out.write(blockCode);
+    out.write(indent);
+    out.write('}\n\n');
+  }
+
+  void _generateConstructor(
+    ASTClassConstructorDeclaration ctor,
+    String className,
+    List<ASTClassFieldWithInitialValue> fieldInits,
+    StringBuffer out,
+    String indent,
+  ) {
+    var blockCode = generateASTBlock(ctor, indent: indent, withBrackets: false);
+
+    out.write('func New');
+    out.write(className);
+    out.write('(');
+    if (ctor.parametersSize > 0) {
+      generateASTParametersDeclaration(ctor.parameters, out: out);
+    }
+    out.write(') *');
+    out.write(className);
+    out.write(' {\n');
+    out.write('$indent  ');
+    out.write('$_receiver := &$className{}\n');
+    _writeFieldInits(fieldInits, out, '$indent  ');
+    out.write(blockCode);
+    out.write('$indent  return $_receiver\n');
+    out.write(indent);
+    out.write('}\n\n');
+  }
+
+  void _generateDefaultConstructor(
+    String className,
+    List<ASTClassFieldWithInitialValue> fieldInits,
+    StringBuffer out,
+    String indent,
+  ) {
+    out.write('func New');
+    out.write(className);
+    out.write('() *');
+    out.write(className);
+    out.write(' {\n');
+    out.write('$indent  ');
+    out.write('$_receiver := &$className{}\n');
+    _writeFieldInits(fieldInits, out, '$indent  ');
+    out.write('$indent  return $_receiver\n');
+    out.write(indent);
+    out.write('}\n\n');
+  }
+
+  void _writeFieldInits(
+    List<ASTClassFieldWithInitialValue> fieldInits,
+    StringBuffer out,
+    String indent,
+  ) {
+    for (var field in fieldInits) {
+      out.write(indent);
+      out.write('$_receiver.');
+      out.write(field.name);
+      out.write(' = ');
+      generateASTExpression(field.initialValue, out: out, headIndented: false);
+      out.write('\n');
+    }
+  }
+
+  void _writeReturnType(ASTType returnType, StringBuffer out) {
+    if (returnType is ASTTypeVoid) return;
+    var name = normalizeTypeName(returnType.name);
+    if (name.isEmpty) return;
+    out.write(' ');
+    generateASTType(returnType, out: out);
+  }
+
+  /// Struct methods are emitted directly by [generateASTClass]; this is only a
+  /// fallback for a class function reached outside that path.
+  @override
+  StringBuffer generateASTClassFunctionDeclaration(
+    ASTClassFunctionDeclaration f, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+    _generateReceiverMethod(f, _currentClassName ?? 'Object', out, indent);
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTClassField(
+    ASTClassField field, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    // Fields are rendered inline in the struct by [generateASTClass]; nothing
+    // to emit here.
+    out ??= newOutput();
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTClassConstructorDeclaration(
+    ASTClassConstructorDeclaration c, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    // Constructors are rendered as factories by [generateASTClass].
+    out ??= newOutput();
+    return out;
+  }
+
+  // -----------------------------------------------------------------
+  // Functions.
+  // -----------------------------------------------------------------
+
+  @override
+  StringBuffer generateASTFunctionDeclaration(
+    ASTFunctionDeclaration f, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    var blockCode = generateASTBlock(f, indent: indent, withBrackets: false);
+
+    out.write(indent);
+    out.write('func ');
+    out.write(f.name);
+    out.write('(');
+    if (f.parametersSize > 0) {
+      generateASTParametersDeclaration(f.parameters, out: out);
+    }
+    out.write(')');
+    _writeReturnType(f.returnType, out);
+    out.write(' {\n');
+    out.write(blockCode);
+    out.write(indent);
+    out.write('}\n\n');
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTParametersDeclaration(
+    ASTParametersDeclaration parameters, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    var wrote = 0;
+    for (var p in parameters.allParameters) {
+      if (wrote > 0) out.write(', ');
+      generateASTParameterDeclaration(p, out: out);
+      ++wrote;
+    }
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTParameterDeclaration(
+    ASTParameterDeclaration parameter, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    // Go declares the type *after* the name: `a int`.
+    out.write(parameter.name);
+    out.write(' ');
+    generateASTType(parameter.type, out: out);
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTFunctionParameterDeclaration(
+    ASTFunctionParameterDeclaration parameter, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    return generateASTParameterDeclaration(parameter, out: out, indent: indent);
+  }
+
+  // -----------------------------------------------------------------
+  // Statements.
+  // -----------------------------------------------------------------
+
+  @override
+  StringBuffer generateASTStatementVariableDeclaration(
+    ASTStatementVariableDeclaration statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    final type = statement.type;
+    final value = statement.value;
+
+    if (value != null && type is ASTTypeVar) {
+      // Inferred + value: `x := expr`.
+      out.write(statement.name);
+      out.write(' := ');
+      generateASTExpression(value, out: out, indent: indent, headIndented: false);
+    } else {
+      // `var x Type = expr`, `var x Type`, or `var x = expr`.
+      out.write('var ');
+      out.write(statement.name);
+      if (type is! ASTTypeVar) {
+        out.write(' ');
+        generateASTType(type, out: out);
+      }
+      if (value != null) {
+        out.write(' = ');
+        generateASTExpression(
+          value,
+          out: out,
+          indent: indent,
+          headIndented: false,
+        );
+      }
+    }
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTStatementExpression(
+    ASTStatementExpression statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+    generateASTExpression(statement.expression, out: out);
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTStatementBreak(
+    ASTStatementBreak statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+    out.write('break');
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTStatementContinue(
+    ASTStatementContinue statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+    out.write('continue');
+    return out;
+  }
+
+  // Go statements use no trailing `;`.
+
+  @override
+  StringBuffer generateASTStatementReturn(
+    ASTStatementReturn statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+    out.write('return');
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTStatementReturnNull(
+    ASTStatementReturnNull statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+    out.write('return nil');
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTStatementReturnValue(
+    ASTStatementReturnValue statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+    out.write('return ');
+    generateASTValue(statement.value, out: out, indent: indent, headIndented: false);
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTStatementReturnVariable(
+    ASTStatementReturnVariable statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+    out.write('return ');
+    generateASTVariable(
+      statement.variable,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTStatementReturnWithExpression(
+    ASTStatementReturnWithExpression statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+    out.write('return ');
+    generateASTExpression(
+      statement.expression,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+    return out;
+  }
+
+  // Go `if`/`else if`/`else` use no parentheses around the condition.
+
+  @override
+  StringBuffer generateASTBranchIfBlock(
+    ASTBranchIfBlock branch, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    out.write('if ');
+    generateASTExpression(
+      branch.condition,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+    out.write(' {\n');
+    generateASTBlock(
+      branch.block,
+      out: out,
+      indent: '$indent  ',
+      withBrackets: false,
+    );
+    out.write(indent);
+    out.write('}\n');
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTBranchIfElseBlock(
+    ASTBranchIfElseBlock branch, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    out.write('if ');
+    generateASTExpression(
+      branch.condition,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+    out.write(' {\n');
+    generateASTBlock(
+      branch.blockIf,
+      out: out,
+      indent: '$indent  ',
+      withBrackets: false,
+    );
+    out.write(indent);
+
+    var blockElse = branch.blockElse;
+    if (blockElse != null) {
+      out.write('} else {\n');
+      generateASTBlock(
+        blockElse,
+        out: out,
+        indent: '$indent  ',
+        withBrackets: false,
+      );
+      out.write(indent);
+      out.write('}\n');
+    } else {
+      out.write('}\n');
+    }
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTBranchIfElseIfsElseBlock(
+    ASTBranchIfElseIfsElseBlock branch, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    out.write('if ');
+    generateASTExpression(
+      branch.condition,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+    out.write(' {\n');
+    generateASTBlock(
+      branch.blockIf,
+      out: out,
+      indent: '$indent  ',
+      withBrackets: false,
+    );
+
+    for (var branchElseIf in branch.blocksElseIf) {
+      out.write(indent);
+      out.write('} else if ');
+      generateASTExpression(
+        branchElseIf.condition,
+        out: out,
+        indent: indent,
+        headIndented: false,
+      );
+      out.write(' {\n');
+      generateASTBlock(
+        branchElseIf.block,
+        out: out,
+        indent: '$indent  ',
+        withBrackets: false,
+      );
+    }
+
+    out.write(indent);
+
+    var blockElse = branch.blockElse;
+    if (blockElse != null) {
+      out.write('} else {\n');
+      generateASTBlock(
+        blockElse,
+        out: out,
+        indent: '$indent  ',
+        withBrackets: false,
+      );
+      out.write(indent);
+      out.write('}\n');
+    } else {
+      out.write('}\n');
+    }
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTStatementForLoop(
+    ASTStatementForLoop forLoop, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write('for ');
+    generateASTStatement(
+      forLoop.initStatement,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+    out.write('; ');
+    generateASTExpression(
+      forLoop.conditionExpression,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+    out.write('; ');
+    generateASTExpression(
+      forLoop.continueExpression,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+    out.write(' {\n');
+
+    var blockCode = generateASTBlock(
+      forLoop.loopBlock,
+      indent: indent,
+      withBrackets: false,
+    );
+
+    out.write(blockCode);
+    out.write(indent);
+    out.write('}');
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTStatementForEach(
+    ASTStatementForEach forEach, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write('for _, ');
+    out.write(forEach.variableName);
+    out.write(' := range ');
+    generateASTExpression(
+      forEach.iterableExpression,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+    out.write(' {\n');
+
+    var blockCode = generateASTBlock(
+      forEach.loopBlock,
+      indent: indent,
+      withBrackets: false,
+    );
+
+    out.write(blockCode);
+    out.write(indent);
+    out.write('}');
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTStatementWhileLoop(
+    ASTStatementWhileLoop whileLoop, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write('for ');
+    generateASTExpression(
+      whileLoop.conditionExpression,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+    out.write(' {\n');
+
+    var blockCode = generateASTBlock(
+      whileLoop.loopBlock,
+      indent: indent,
+      withBrackets: false,
+    );
+
+    out.write(blockCode);
+    out.write(indent);
+    out.write('}');
+
+    return out;
+  }
+
+  /// Go has no `do`/`while`; emitted as `for { <body> if !cond { break } }`.
+  @override
+  StringBuffer generateASTStatementDoWhileLoop(
+    ASTStatementDoWhileLoop doWhileLoop, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    var indent2 = '$indent  ';
+
+    out.write('for {\n');
+
+    var blockCode = generateASTBlock(
+      doWhileLoop.loopBlock,
+      indent: indent,
+      withBrackets: false,
+    );
+    out.write(blockCode);
+
+    out.write(indent2);
+    out.write('if ');
+    // Negate the loop condition (a round-trippable, stable form via the base
+    // negation generator's parenthesization).
+    generateASTExpression(
+      ASTExpressionNegation(doWhileLoop.conditionExpression),
+      out: out,
+      indent: indent2,
+      headIndented: false,
+    );
+    out.write(' {\n');
+    out.write('$indent2  break\n');
+    out.write(indent2);
+    out.write('}\n');
+
+    out.write(indent);
+    out.write('}');
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTStatementSwitch(
+    ASTStatementSwitch statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    var indent2 = '$indent  ';
+
+    out.write('switch ');
+    generateASTExpression(
+      statement.expression,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+    out.write(' {\n');
+
+    for (var c in statement.cases) {
+      out.write(indent2);
+      if (c.isDefault) {
+        out.write('default:\n');
+      } else {
+        out.write('case ');
+        generateASTExpression(c.value!, out: out, headIndented: false);
+        out.write(':\n');
+      }
+      out.write(
+        generateASTBlock(c.block, indent: indent2, withBrackets: false),
+      );
+    }
+
+    out.write(indent);
+    out.write('}');
+
+    return out;
+  }
+
+  // -----------------------------------------------------------------
+  // Expressions.
+  // -----------------------------------------------------------------
+
+  /// Go has no ternary/if-expression; emit an IIFE:
+  /// `func() any { if cond { return a } else { return b } }()`.
+  @override
+  StringBuffer generateASTExpressionConditional(
+    ASTExpressionConditional expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    out.write('func() any { if ');
+    generateASTExpression(expression.condition, out: out, headIndented: false);
+    out.write(' { return ');
+    generateASTExpression(expression.valueIfTrue, out: out, headIndented: false);
+    out.write(' } else { return ');
+    generateASTExpression(
+      expression.valueIfFalse,
+      out: out,
+      headIndented: false,
+    );
+    out.write(' } }()');
+
+    return out;
+  }
+
+  /// Go closure: `func(params) ret { body }`.
+  @override
+  StringBuffer generateASTExpressionLiteralFunction(
+    ASTExpressionLiteralFunction expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    var f = expression.function;
+
+    out.write('func(');
+    if (f.parametersSize > 0) {
+      generateASTParametersDeclaration(f.parameters, out: out);
+    }
+    out.write(')');
+    _writeReturnType(f.returnType, out);
+    out.write(' {\n');
+    var blockCode = generateASTBlock(f, indent: indent, withBrackets: false);
+    out.write(blockCode);
+    out.write(indent);
+    out.write('}');
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTExpressionLocalFunctionInvocation(
+    ASTExpressionLocalFunctionInvocation expression, {
+    String indent = '',
+    StringBuffer? out,
+    bool headIndented = true,
+  }) {
+    // The canonical `print` becomes Go's `fmt.Println`.
+    if (expression.name == 'print') {
+      out ??= newOutput();
+      if (headIndented) out.write(indent);
+      out.write('fmt.Println(');
+      var arguments = expression.arguments;
+      for (var i = 0; i < arguments.length; ++i) {
+        if (i > 0) out.write(', ');
+        generateASTExpression(
+          arguments[i],
+          out: out,
+          indent: '$indent  ',
+          headIndented: false,
+        );
+      }
+      out.write(')');
+      return out;
+    }
+
+    // Sibling-method calls inside a struct method become `o.method(...)`.
+    if (_currentClassMethods.contains(expression.name)) {
+      out ??= newOutput();
+      if (headIndented) out.write(indent);
+      out.write('$_receiver.');
+      out.write(expression.name);
+      out.write('(');
+      var arguments = expression.arguments;
+      for (var i = 0; i < arguments.length; ++i) {
+        if (i > 0) out.write(', ');
+        generateASTExpression(
+          arguments[i],
+          out: out,
+          indent: '$indent  ',
+          headIndented: false,
+        );
+      }
+      out.write(')');
+      return out;
+    }
+
+    return super.generateASTExpressionLocalFunctionInvocation(
+      expression,
+      indent: indent,
+      out: out,
+      headIndented: headIndented,
+    );
+  }
+
+  @override
+  StringBuffer generateASTScopeVariable(
+    ASTScopeVariable variable, {
+    String? callingFunction,
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    // Field reads inside a struct method become `o.field`.
+    if (!variable.isTypeIdentifier &&
+        _currentClassFields.contains(variable.name)) {
+      out ??= newOutput();
+      if (headIndented) out.write(indent);
+      out.write('$_receiver.');
+      out.write(variable.name);
+      return out;
+    }
+
+    return super.generateASTScopeVariable(
+      variable,
+      callingFunction: callingFunction,
+      out: out,
+      indent: indent,
+      headIndented: headIndented,
+    );
+  }
+
+  @override
+  StringBuffer generateASTVariableGeneric(
+    ASTVariable variable, {
+    String? callingFunction,
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+    // `this` is the Go receiver `o`.
+    if (variable is ASTThisVariable) {
+      out.write(_receiver);
+    } else {
+      out.write(variable.name);
+    }
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTExpressionNullValue(
+    ASTExpressionNullValue expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+    out.write('nil');
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTValueNull(
+    ASTValueNull value, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+    out.write('nil');
+    return out;
+  }
+
+  @override
+  String resolveASTExpressionOperatorText(
+    ASTExpressionOperator operator,
+    ASTNumType aNumType,
+    ASTNumType bNumType,
+  ) {
+    // Go int `/` already truncates, matching integer division.
+    if (operator == ASTExpressionOperator.divideAsInt) {
+      return getASTExpressionOperatorText(ASTExpressionOperator.divide);
+    }
+    return getASTExpressionOperatorText(operator);
+  }
+
+  /// Go writes bitwise NOT as a prefix `^`.
+  @override
+  StringBuffer generateASTExpressionBitwiseNot(
+    ASTExpressionBitwiseNot expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write('^');
+    final inner = expression.expression;
+    final group = inner.isComplex;
+    if (group) out.write('(');
+    generateASTExpression(inner, out: out, indent: indent, headIndented: false);
+    if (group) out.write(')');
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTExpressionListLiteral(
+    ASTExpressionListLiteral expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write('[]');
+    generateASTType(expression.type ?? ASTTypeDynamic.instance, out: out);
+    out.write('{');
+
+    var valuesExpressions = expression.valuesExpressions;
+    for (var i = 0; i < valuesExpressions.length; ++i) {
+      if (i > 0) out.write(', ');
+      generateASTExpression(
+        valuesExpressions[i],
+        out: out,
+        headIndented: false,
+      );
+    }
+
+    out.write('}');
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTExpressionMapLiteral(
+    ASTExpressionMapLiteral expression, {
+    String indent = '',
+    StringBuffer? out,
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write('map[');
+    generateASTType(expression.keyType ?? ASTTypeDynamic.instance, out: out);
+    out.write(']');
+    generateASTType(
+      expression.valueType ?? ASTTypeDynamic.instance,
+      out: out,
+    );
+    out.write('{');
+
+    var entriesExpressions = expression.entriesExpressions;
+    for (var i = 0; i < entriesExpressions.length; ++i) {
+      var e = entriesExpressions[i];
+      if (i > 0) out.write(', ');
+      generateASTExpression(e.key, out: out, headIndented: false);
+      out.write(': ');
+      generateASTExpression(e.value, out: out, headIndented: false);
+    }
+
+    out.write('}');
+
+    return out;
+  }
+
+  // -----------------------------------------------------------------
+  // Types.
+  // -----------------------------------------------------------------
+
+  @override
+  StringBuffer generateASTType(
+    ASTType type, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    if (type is ASTTypeMap) {
+      out ??= newOutput();
+      out.write(indent);
+      out.write('map[');
+      generateASTType(type.keyType, out: out);
+      out.write(']');
+      generateASTType(type.valueType, out: out);
+      return out;
+    }
+    return super.generateASTType(type, out: out, indent: indent);
+  }
+
+  @override
+  StringBuffer generateASTTypeArray(
+    ASTTypeArray type, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+    out.write(indent);
+    out.write('[]');
+    generateASTType(type.elementType, out: out);
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTTypeArray2D(
+    ASTTypeArray2D type, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+    out.write(indent);
+    out.write('[][]');
+    generateASTType(type.elementType, out: out);
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTTypeArray3D(
+    ASTTypeArray3D type, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+    out.write(indent);
+    out.write('[][][]');
+    generateASTType(type.elementType, out: out);
+    return out;
+  }
+
+  // -----------------------------------------------------------------
+  // String values (Go has no interpolation; use `+` concatenation).
+  // -----------------------------------------------------------------
+
+  @override
+  StringBuffer generateASTValueString(
+    ASTValueString value, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+    out.write('"');
+    out.write(_escapeString(value.value));
+    out.write('"');
+    return out;
+  }
+
+  String _escapeString(String str) {
+    return str
+        .replaceAll('\\', r'\\')
+        .replaceAll('\t', r'\t')
+        .replaceAll('"', r'\"')
+        .replaceAll('\r', r'\r')
+        .replaceAll('\n', r'\n')
+        .replaceAll('\b', r'\b');
+  }
+
+  @override
+  StringBuffer generateASTValueStringConcatenation(
+    ASTValueStringConcatenation value, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    var parts = <({String code, bool isString})>[];
+
+    for (var v in value.values) {
+      if (v is ASTValueStringVariable) {
+        parts.add((code: v.variable.name, isString: false));
+      } else if (v is ASTValueStringExpression) {
+        var exp = generateASTExpression(v.expression).toString();
+        parts.add((code: '($exp)', isString: false));
+      } else if (v is ASTValueStringConcatenation) {
+        var nested = generateASTValueStringConcatenation(v).toString();
+        parts.add((code: nested, isString: false));
+      } else if (v is ASTValueString) {
+        parts.add((code: '"${_escapeString(v.value)}"', isString: true));
+      }
+    }
+
+    if (parts.isEmpty) {
+      out.write('""');
+      return out;
+    }
+
+    // Force string context when the first operand is not a string literal, so
+    // `a + b` cannot become a numeric add (mirrors Java's `String.valueOf`).
+    if (!parts.first.isString) {
+      out.write('"" + ');
+    }
+
+    for (var i = 0; i < parts.length; ++i) {
+      if (i > 0) out.write(' + ');
+      out.write(parts[i].code);
+    }
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTValueStringVariable(
+    ASTValueStringVariable value, {
+    StringBuffer? out,
+    String indent = '',
+    bool precededByString = false,
+  }) {
+    out ??= newOutput();
+    out.write('"" + ');
+    out.write(value.variable.name);
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTValueStringExpression(
+    ASTValueStringExpression value, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+    var exp = generateASTExpression(value.expression).toString();
+    out.write('"" + (');
+    out.write(exp);
+    out.write(')');
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTValueArray(
+    ASTValueArray value, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    out.write(value.value);
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTValueArray2D(
+    ASTValueArray2D value, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    out.write(value.value);
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTValueArray3D(
+    ASTValueArray3D value, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    out.write(value.value);
+    return out;
+  }
+}

--- a/lib/src/languages/go/go_grammar.dart
+++ b/lib/src/languages/go/go_grammar.dart
@@ -177,7 +177,9 @@ class GoGrammarDefinition extends GoGrammarLexer {
     var statements = f.statements.toList();
     statements.removeWhere((s) {
       if (s is ASTStatementVariableDeclaration && s.name == 'o') return true;
-      if (s is ASTStatementReturnVariable && s.variable.name == 'o') return true;
+      if (s is ASTStatementReturnVariable && s.variable.name == 'o') {
+        return true;
+      }
       return false;
     });
 
@@ -208,7 +210,9 @@ class GoGrammarDefinition extends GoGrammarLexer {
   }
 
   Parser packageClause() =>
-      (packageToken().trimHidden() & identifier().trimHidden()).map((v) => null);
+      (packageToken().trimHidden() & identifier().trimHidden()).map(
+        (v) => null,
+      );
 
   Parser<ASTStatementImport?> importDecl() =>
       (importToken().trimHidden() &
@@ -262,9 +266,7 @@ class GoGrammarDefinition extends GoGrammarLexer {
           });
 
   Parser<ASTClassField> structField() =>
-      (identifier().trimHidden() &
-              type() &
-              char(';').trimHidden().optional())
+      (identifier().trimHidden() & type() & char(';').trimHidden().optional())
           .map((v) {
             var name = v[0] as String;
             var type = v[1] as ASTType;
@@ -996,7 +998,9 @@ class GoGrammarDefinition extends GoGrammarLexer {
             var entries = <MapEntry<ASTExpression, ASTExpression>>[];
             var entriesOpt = v[6];
             if (entriesOpt != null) {
-              entries.add(entriesOpt[0] as MapEntry<ASTExpression, ASTExpression>);
+              entries.add(
+                entriesOpt[0] as MapEntry<ASTExpression, ASTExpression>,
+              );
               for (var tail in (entriesOpt[1] as List)) {
                 entries.add(tail[1] as MapEntry<ASTExpression, ASTExpression>);
               }
@@ -1051,13 +1055,12 @@ class GoGrammarDefinition extends GoGrammarLexer {
           .trimHidden()
           .map((v) => getASTAssignmentOperator(v));
 
-  Parser<ASTVariable> variable() =>
-      (identifier()).map((name) {
-        if (name == 'this' || name == _currentReceiver) {
-          return ASTThisVariable();
-        }
-        return ASTScopeVariable(name);
-      }).cast<ASTVariable>();
+  Parser<ASTVariable> variable() => (identifier()).map((name) {
+    if (name == 'this' || name == _currentReceiver) {
+      return ASTThisVariable();
+    }
+    return ASTScopeVariable(name);
+  }).cast<ASTVariable>();
 
   /// Go closure used as an expression: `func(a int, b int) int { ... }`.
   Parser<ASTExpression> expressionLambda() =>
@@ -1120,8 +1123,7 @@ class GoGrammarDefinition extends GoGrammarLexer {
                   .map((_) => ASTTypeObject.instance))
           .cast<ASTType>();
 
-  Parser<ASTType> simpleType() =>
-      (identifier()).map((v) => getTypeByName(v));
+  Parser<ASTType> simpleType() => (identifier()).map((v) => getTypeByName(v));
 
   // -----------------------------------------------------------------
   // Literals.

--- a/lib/src/languages/go/go_grammar.dart
+++ b/lib/src/languages/go/go_grammar.dart
@@ -1,0 +1,1203 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'package:petitparser/petitparser.dart';
+
+import '../../apollovm_base.dart' show VMObject;
+import '../../ast/apollovm_ast_base.dart';
+import '../../ast/apollovm_ast_expression.dart';
+import '../../ast/apollovm_ast_statement.dart';
+import '../../ast/apollovm_ast_toplevel.dart';
+import '../../ast/apollovm_ast_type.dart';
+import '../../ast/apollovm_ast_value.dart';
+import '../../ast/apollovm_ast_variable.dart';
+import 'go_grammar_lexer.dart';
+
+/// Go grammar definition.
+///
+/// Go has no classes: a class is modeled by grouping a `type Name struct { ...
+/// }` declaration together with its receiver methods (`func (o *Name) m(...)`)
+/// and factory constructors (`func NewName(...) *Name`) — the same owner-based
+/// grouping the Lua grammar uses for its table-based classes.
+class GoGrammarDefinition extends GoGrammarLexer {
+  /// Maps Go's standard output functions to the VM's canonical `print`,
+  /// so the same AST runs and translates consistently across languages.
+  static String normalizeFunctionName(String name) {
+    switch (name) {
+      case 'println':
+      case 'print':
+        return 'print';
+      default:
+        return name;
+    }
+  }
+
+  static ASTType getTypeByName(String name) {
+    switch (name) {
+      case 'any':
+        return ASTTypeObject.instance;
+      case 'bool':
+        return ASTTypeBool.instance;
+      case 'int':
+      case 'int8':
+      case 'int16':
+      case 'int32':
+      case 'int64':
+      case 'uint':
+      case 'uint8':
+      case 'uint16':
+      case 'uint32':
+      case 'uint64':
+      case 'byte':
+      case 'rune':
+      case 'uintptr':
+        return ASTTypeInt.instance;
+      case 'float32':
+      case 'float64':
+        return ASTTypeDouble.instance;
+      case 'string':
+        return ASTTypeString.instance;
+      default:
+        return ASTType(name);
+    }
+  }
+
+  /// The receiver name of the method/constructor currently being parsed (e.g.
+  /// `o` in `func (o *Foo) m()`). Inside that scope `o` (and `this`) denote the
+  /// current instance. Set before the body is parsed (like Kotlin's
+  /// `_classTypeParameters`), cleared afterwards.
+  String? _currentReceiver;
+
+  @override
+  Parser start() => ref0(compilationUnit).trim().end();
+
+  Parser<ASTRoot> compilationUnit() =>
+      (ref0(packageClause).optional() &
+              ref0(importDecl).star() &
+              ref0(topLevelItem).star())
+          .map((v) {
+            var items = _expandListDeeply(v[2] as List);
+
+            var root = ASTRoot();
+
+            // Collect declared struct names first.
+            var structOrder = <String>[];
+            var structFields = <String, List<ASTClassField>>{};
+            var structMethods = <String, List<ASTClassFunctionDeclaration>>{};
+            var structConstructors =
+                <String, List<ASTClassConstructorDeclaration>>{};
+
+            void ensureStruct(String name) {
+              if (!structFields.containsKey(name)) {
+                structOrder.add(name);
+                structFields[name] = [];
+                structMethods[name] = [];
+                structConstructors[name] = [];
+              }
+            }
+
+            for (var it in items) {
+              if (it is _StructDecl) ensureStruct(it.name);
+              if (it is _OwnerFunction) ensureStruct(it.owner);
+            }
+
+            var structNames = structFields.keys.toSet();
+
+            var topFunctions = <ASTFunctionDeclaration>[];
+            var topStatements = <ASTStatement>[];
+
+            for (var it in items) {
+              if (it is _StructDecl) {
+                ensureStruct(it.name);
+                structFields[it.name]!.addAll(it.fields);
+              } else if (it is _OwnerFunction) {
+                ensureStruct(it.owner);
+                structMethods[it.owner]!.add(it.toMethod());
+              } else if (it is ASTFunctionDeclaration) {
+                // A top-level `func NewX(...) *X` where `X` is a struct is the
+                // factory constructor for `X`.
+                var ctorOwner = _constructorOwner(it, structNames);
+                if (ctorOwner != null) {
+                  ensureStruct(ctorOwner);
+                  structConstructors[ctorOwner]!.add(
+                    _toConstructor(it, ctorOwner),
+                  );
+                } else {
+                  topFunctions.add(it);
+                }
+              } else if (it is ASTStatementImport) {
+                root.addImport(it);
+              } else if (it is ASTStatement) {
+                topStatements.add(it);
+              }
+            }
+
+            for (var f in topFunctions) {
+              root.addFunction(f);
+            }
+            for (var s in topStatements) {
+              root.addStatement(s);
+            }
+
+            for (var name in structOrder) {
+              var clazz = ASTClassNormal(name, ASTType<VMObject>(name), null);
+              var block = ASTClassNormal('?', ASTType<VMObject>('?'), null);
+              block.addAllFields(structFields[name]!);
+              block.addAllConstructors(structConstructors[name]!);
+              block.addAllFunctions(structMethods[name]!);
+              clazz.set(block);
+              root.addClass(clazz);
+            }
+
+            root.resolveNode(null);
+
+            return root;
+          });
+
+  /// A top-level function is a constructor when it is named `New<Struct>` and
+  /// `<Struct>` is a declared struct.
+  static String? _constructorOwner(
+    ASTFunctionDeclaration f,
+    Set<String> structNames,
+  ) {
+    var name = f.name;
+    if (!name.startsWith('New') || name.length <= 3) return null;
+    var owner = name.substring(3);
+    return structNames.contains(owner) ? owner : null;
+  }
+
+  /// Rebuilds an [ASTClassConstructorDeclaration] from a `func NewX(...) *X`
+  /// factory, dropping the synthetic `o := &X{}` / `return o` scaffolding so
+  /// the constructor body carries only the user statements.
+  static ASTClassConstructorDeclaration _toConstructor(
+    ASTFunctionDeclaration f,
+    String owner,
+  ) {
+    var statements = f.statements.toList();
+    statements.removeWhere((s) {
+      if (s is ASTStatementVariableDeclaration && s.name == 'o') return true;
+      if (s is ASTStatementReturnVariable && s.variable.name == 'o') return true;
+      return false;
+    });
+
+    var block = ASTBlock(null)..addAllStatements(statements);
+
+    var params = f.parameters;
+    var ctorParams = ASTConstructorParametersDeclaration(
+      params.positionalParameters
+          ?.map(
+            (p) => ASTConstructorParameterDeclaration(
+              p.type,
+              p.name,
+              p.index,
+              false,
+            ),
+          )
+          .toList(),
+      null,
+      null,
+    );
+
+    return ASTClassConstructorDeclaration(
+      ASTType<VMObject>(owner),
+      '',
+      ctorParams,
+      block: block,
+    );
+  }
+
+  Parser packageClause() =>
+      (packageToken().trimHidden() & identifier().trimHidden()).map((v) => null);
+
+  Parser<ASTStatementImport?> importDecl() =>
+      (importToken().trimHidden() &
+              (ref0(importBlock) | ref0(importSpec)).trimHidden())
+          .map((v) {
+            // A single quoted path may map to an import; blocks and `fmt` are
+            // dropped (fmt is an implementation detail of `print`).
+            var spec = v[1];
+            if (spec is String) {
+              if (spec == 'fmt' || spec.isEmpty) return null;
+              return ASTStatementImport(spec);
+            }
+            return null;
+          });
+
+  Parser importBlock() =>
+      (char('(').trimHidden() &
+              ref0(importSpec).trimHidden().star() &
+              char(')').trimHidden())
+          .map((v) => null);
+
+  Parser<String> importSpec() => (ref0(goStringLiteral)).map((v) => v);
+
+  Parser<String> goStringLiteral() => (stringLexicalToken()).map((v) {
+    var value = v.asValue();
+    return value is ASTValueString ? value.value : '';
+  });
+
+  Parser topLevelItem() =>
+      (ref0(structDeclaration) |
+              ref0(methodDeclaration) |
+              ref0(functionDeclaration) |
+              ref0(statementVariableDeclaration))
+          .cast();
+
+  // -----------------------------------------------------------------
+  // Structs.
+  // -----------------------------------------------------------------
+
+  Parser structDeclaration() =>
+      (typeToken().trimHidden() &
+              identifier().trimHidden() &
+              structToken().trimHidden() &
+              char('{').trimHidden() &
+              ref0(structField).star() &
+              char('}').trimHidden())
+          .map((v) {
+            var name = v[1] as String;
+            var fields = (v[4] as List).cast<ASTClassField>().toList();
+            return _StructDecl(name, fields);
+          });
+
+  Parser<ASTClassField> structField() =>
+      (identifier().trimHidden() &
+              type() &
+              char(';').trimHidden().optional())
+          .map((v) {
+            var name = v[0] as String;
+            var type = v[1] as ASTType;
+            return ASTClassField(type, name, false);
+          });
+
+  // -----------------------------------------------------------------
+  // Functions and methods.
+  // -----------------------------------------------------------------
+
+  /// `func (o *Name) method(params) ret { body }` — a struct method.
+  Parser methodDeclaration() =>
+      (funcToken().trimHidden() &
+              ref0(methodReceiver) &
+              identifier() &
+              functionParametersDeclaration() &
+              type().optional() &
+              codeBlock())
+          .map((v) {
+            var owner = v[1] as String;
+            var name = v[2] as String;
+            var parameters = v[3] as ASTFunctionParametersDeclaration;
+            var returnType = (v[4] as ASTType?) ?? ASTTypeVoid.instance;
+            var block = v[5] as ASTBlock;
+            _currentReceiver = null;
+            return _OwnerFunction(owner, name, parameters, block, returnType);
+          });
+
+  /// `(o *Name)` / `(o Name)` — sets [_currentReceiver] before the body parses,
+  /// returns the struct name (the owner).
+  Parser<String> methodReceiver() =>
+      (char('(').trimHidden() &
+              identifier().trimHidden() &
+              char('*').trimHidden().optional() &
+              identifier().trimHidden() &
+              char(')').trimHidden())
+          .map((v) {
+            var receiverName = v[1] as String;
+            var structName = v[3] as String;
+            _currentReceiver = receiverName;
+            return structName;
+          });
+
+  /// `func name(params) ret { body }` — a top-level function.
+  Parser<ASTFunctionDeclaration> functionDeclaration() =>
+      (funcToken().trimHidden() &
+              identifier() &
+              functionParametersDeclaration() &
+              type().optional() &
+              codeBlock())
+          .map((v) {
+            var name = v[1] as String;
+            var parameters = v[2] as ASTFunctionParametersDeclaration;
+            var returnType = (v[3] as ASTType?) ?? ASTTypeVoid.instance;
+            var block = v[4] as ASTBlock;
+            return ASTFunctionDeclaration(
+              name,
+              parameters,
+              returnType,
+              block: block,
+              modifiers: ASTModifiers.modifierStatic,
+            );
+          });
+
+  Parser<ASTFunctionParametersDeclaration> functionParametersDeclaration() =>
+      (char('(').trimHidden() &
+              parametersList().optional() &
+              char(')').trimHidden())
+          .map((v) {
+            var params = v[1] as List<ASTFunctionParameterDeclaration>?;
+            return ASTFunctionParametersDeclaration(params, null, null);
+          });
+
+  Parser<List<ASTFunctionParameterDeclaration>> parametersList() =>
+      (parameterDeclaration() &
+              (char(',').trimHidden() & parameterDeclaration()).star() &
+              char(',').trimHidden().optional())
+          .map((v) {
+            var params = _expandListDeeply(v);
+            return params.whereType<ASTFunctionParameterDeclaration>().toList();
+          });
+
+  /// A Go parameter has the type *after* the name: `a int`.
+  Parser<ASTFunctionParameterDeclaration> parameterDeclaration() =>
+      (identifier().trimHidden() & type()).map((v) {
+        return ASTFunctionParameterDeclaration(
+          v[1] as ASTType,
+          v[0] as String,
+          -1,
+          false,
+        );
+      });
+
+  Parser<ASTBlock> codeBlock() =>
+      (char('{').trimHidden() & ref0(statement).star() & char('}').trimHidden())
+          .map((v) {
+            var statements = (v[1] as List).cast<ASTStatement>().toList();
+            return ASTBlock(null)..addAllStatements(statements);
+          });
+
+  Parser<ASTBlock> codeBlockOrSingleLineBlock() =>
+      ((codeBlock() | singleLineCodeBlock())).cast<ASTBlock>();
+
+  Parser<ASTSingleLineStatementBlock> singleLineCodeBlock() =>
+      (singleLineStatement().trimHidden()).map((v) {
+        return ASTSingleLineStatementBlock(null)..addStatement(v);
+      });
+
+  Parser<ASTStatement> singleLineStatement() =>
+      (statementReturn() | statementExpression()).cast<ASTStatement>();
+
+  // -----------------------------------------------------------------
+  // Statements.
+  // -----------------------------------------------------------------
+
+  Parser<ASTStatement> statement() =>
+      (statementSwitch() |
+              branch() |
+              statementBreak() |
+              statementContinue() |
+              statementForRange() |
+              statementForClause() |
+              statementWhileLoop() |
+              statementInfiniteLoop() |
+              statementReturn() |
+              statementVariableDeclaration() |
+              statementExpression())
+          .cast<ASTStatement>();
+
+  Parser<ASTStatement> statementSimple() =>
+      (statementVariableDeclaration() | statementExpression())
+          .cast<ASTStatement>();
+
+  Parser<ASTStatementBreak> statementBreak() =>
+      (breakToken() & char(';').trimHidden().optional()).map(
+        (v) => ASTStatementBreak(),
+      );
+
+  Parser<ASTStatementContinue> statementContinue() =>
+      (continueToken() & char(';').trimHidden().optional()).map(
+        (v) => ASTStatementContinue(),
+      );
+
+  /// C-style `for init; cond; post { body }`. The `init` [statementSimple]
+  /// consumes its own trailing `;` (like the Java grammar), so only the
+  /// separator between `cond` and `post` is matched explicitly.
+  Parser<ASTStatementForLoop> statementForClause() =>
+      (forToken().trimHidden() &
+              ref0(statementSimple) &
+              ref0(expression) &
+              char(';').trimHidden() &
+              ref0(expression) &
+              codeBlock())
+          .map((v) {
+            var init = v[1] as ASTStatement;
+            var cond = v[2] as ASTExpression;
+            var post = v[4] as ASTExpression;
+            var block = v[5] as ASTBlock;
+            return ASTStatementForLoop(init, cond, post, block);
+          });
+
+  /// `for _, x := range xs { body }` / `for x := range xs { body }`.
+  Parser<ASTStatementForEach> statementForRange() =>
+      (forToken().trimHidden() &
+              ((identifier().trimHidden() & char(',').trimHidden()).optional() &
+                  identifier().trimHidden()) &
+              string(':=').trimHidden() &
+              rangeToken().trimHidden() &
+              ref0(expression) &
+              codeBlock())
+          .map((v) {
+            var names = v[1] as List;
+            var valueName = names[1] as String;
+            var iterableExp = v[4] as ASTExpression;
+            var block = v[5] as ASTBlock;
+            return ASTStatementForEach(
+              ASTTypeVar(),
+              valueName,
+              iterableExp,
+              block,
+            );
+          });
+
+  /// `for cond { body }` — Go's `while`.
+  Parser<ASTStatementWhileLoop> statementWhileLoop() =>
+      (forToken().trimHidden() & ref0(expression) & codeBlock()).map((v) {
+        var cond = v[1] as ASTExpression;
+        var block = v[2] as ASTBlock;
+        return ASTStatementWhileLoop(cond, block);
+      });
+
+  /// `for { body }` — infinite loop, plus the `do { } while` desugaring
+  /// `for { body; if !cond { break } }`.
+  Parser<ASTStatement> statementInfiniteLoop() =>
+      (forToken().trimHidden() & codeBlock()).map((v) {
+        var block = v[1] as ASTBlock;
+
+        // Detect the generated do-while shape: a trailing
+        // `if !cond { break }` whose only statement is a break.
+        var statements = block.statements.toList();
+        if (statements.isNotEmpty) {
+          var last = statements.last;
+          if (last is ASTBranchIfBlock) {
+            var onlyBreak =
+                last.block.statements.length == 1 &&
+                last.block.statements.first is ASTStatementBreak;
+            if (onlyBreak) {
+              var cond = last.condition;
+              // Unwrap the negation: `if !cond break` ⇒ do-while(cond).
+              if (cond is ASTExpressionNegation) {
+                statements.removeLast();
+                var body = ASTBlock(null)..addAllStatements(statements);
+                return ASTStatementDoWhileLoop(body, cond.expression);
+              }
+            }
+          }
+        }
+
+        return ASTStatementWhileLoop(
+          ASTExpressionLiteral(ASTValueBool(true)),
+          block,
+        );
+      });
+
+  /// `switch expr { case v: ...; default: ... }` (Go auto-breaks; no
+  /// fall-through).
+  Parser<ASTStatementSwitch> statementSwitch() =>
+      (switchToken().trimHidden() &
+              ref0(expression) &
+              char('{').trimHidden() &
+              switchCase().star() &
+              switchDefault().optional() &
+              char('}').trimHidden())
+          .map((v) {
+            var exp = v[1] as ASTExpression;
+            var cases = (v[3] as List).cast<ASTSwitchCase>().toList();
+            var defaultCase = v[4] as ASTSwitchCase?;
+            if (defaultCase != null) cases.add(defaultCase);
+            return ASTStatementSwitch(exp, cases, fallThrough: false);
+          });
+
+  Parser<ASTSwitchCase> switchCase() =>
+      (caseToken().trimHidden() &
+              ref0(expression) &
+              char(':').trimHidden() &
+              ref0(statement).star())
+          .map((v) {
+            var value = v[1] as ASTExpression;
+            var statements = (v[3] as List).cast<ASTStatement>().toList();
+            var block = ASTBlock(null)..addAllStatements(statements);
+            return ASTSwitchCase(value, block);
+          });
+
+  Parser<ASTSwitchCase> switchDefault() =>
+      (defaultToken().trimHidden() &
+              char(':').trimHidden() &
+              ref0(statement).star())
+          .map((v) {
+            var statements = (v[2] as List).cast<ASTStatement>().toList();
+            var block = ASTBlock(null)..addAllStatements(statements);
+            return ASTSwitchCase(null, block);
+          });
+
+  Parser<ASTStatementReturn> statementReturn() =>
+      (returnToken().trimHidden() &
+              expression().optional() &
+              char(';').trimHidden().optional())
+          .map((v) {
+            var value = v[1];
+
+            if (value == null) {
+              return ASTStatementReturn();
+            } else if (value is ASTExpression) {
+              if (value is ASTExpressionVariableAccess) {
+                if (value.variable.name == 'nil') {
+                  return ASTStatementReturnNull();
+                } else {
+                  return ASTStatementReturnVariable(value.variable);
+                }
+              } else if (value is ASTExpressionLiteral) {
+                return ASTStatementReturnValue(value.value);
+              } else {
+                return ASTStatementReturnWithExpression(value);
+              }
+            }
+
+            throw UnsupportedError("Can't handle return value: $value");
+          });
+
+  Parser<ASTStatementExpression> statementExpression() =>
+      (expression() & char(';').trimHidden().optional()).map((v) {
+        return ASTStatementExpression(v[0]);
+      });
+
+  /// Go variable declarations:
+  /// `x := expr` (short), `var x Type = expr`, `var x Type`, `var x = expr`.
+  Parser<ASTStatementVariableDeclaration> statementVariableDeclaration() =>
+      (statementVarShort() | statementVarKeyword())
+          .cast<ASTStatementVariableDeclaration>();
+
+  Parser<ASTStatementVariableDeclaration> statementVarShort() =>
+      (identifier().trimHidden() &
+              string(':=').trimHidden() &
+              ref0(expression) &
+              char(';').trimHidden().optional())
+          .map((v) {
+            var name = v[0] as String;
+            var value = v[2] as ASTExpression;
+            var type = ASTTypeVar();
+            type.associateToType(value);
+            return ASTStatementVariableDeclaration(type, name, value);
+          });
+
+  Parser<ASTStatementVariableDeclaration> statementVarKeyword() =>
+      (varToken().trimHidden() &
+              identifier().trimHidden() &
+              type().optional() &
+              (char('=').trimHidden() & ref0(expression)).optional() &
+              char(';').trimHidden().optional())
+          .map((v) {
+            var name = v[1] as String;
+            var declaredType = v[2] as ASTType?;
+            var valueOpt = v[3];
+            var value = valueOpt != null ? valueOpt[1] as ASTExpression : null;
+
+            var type = declaredType ?? ASTTypeVar();
+            if (value != null) type.associateToType(value);
+
+            return ASTStatementVariableDeclaration(type, name, value);
+          });
+
+  // -----------------------------------------------------------------
+  // Branches.
+  // -----------------------------------------------------------------
+
+  Parser<ASTBranch> branch() =>
+      (ref0(branchIfElseIfsElseBlock) |
+              ref0(branchIfElseBlock) |
+              ref0(branchIfBlock))
+          .cast<ASTBranch>();
+
+  Parser<ASTBranchIfBlock> branchIfBlock() =>
+      (ifToken().trimHidden() & ref0(expression) & codeBlock()).map((v) {
+        var condition = v[1] as ASTExpression;
+        var block = v[2] as ASTBlock;
+        return ASTBranchIfBlock(condition, block);
+      });
+
+  Parser<ASTBranchIfElseBlock> branchIfElseBlock() =>
+      (ifToken().trimHidden() &
+              ref0(expression) &
+              codeBlock() &
+              elseToken().trimHidden() &
+              codeBlock())
+          .map((v) {
+            var condition = v[1] as ASTExpression;
+            var blockIf = v[2] as ASTBlock;
+            var blockElse = v[4] as ASTBlock;
+            return ASTBranchIfElseBlock(condition, blockIf, blockElse);
+          });
+
+  Parser<ASTBranchIfElseIfsElseBlock> branchIfElseIfsElseBlock() =>
+      (ifToken().trimHidden() &
+              ref0(expression) &
+              codeBlock() &
+              ref0(branchElseIfs).plus() &
+              (elseToken().trimHidden() & codeBlock()).optional())
+          .map((v) {
+            var condition = v[1] as ASTExpression;
+            var blockIf = v[2] as ASTBlock;
+            var blockElseIfs = v[3] as List;
+            var blockElse = v[4]?[1];
+            return ASTBranchIfElseIfsElseBlock(
+              condition,
+              blockIf,
+              blockElseIfs.cast<ASTBranchIfBlock>().toList(),
+              blockElse,
+            );
+          });
+
+  Parser<ASTBranchIfBlock> branchElseIfs() =>
+      (elseToken().trimHidden() &
+              ifToken().trimHidden() &
+              ref0(expression) &
+              codeBlock())
+          .map((v) {
+            var condition = v[2] as ASTExpression;
+            var blockIf = v[3] as ASTBlock;
+            return ASTBranchIfBlock(condition, blockIf);
+          });
+
+  // -----------------------------------------------------------------
+  // Expressions.
+  // -----------------------------------------------------------------
+
+  @override
+  Parser<ASTExpression> expression() =>
+      (ref0(expressionOperationChain)).cast<ASTExpression>();
+
+  Parser<ASTExpression> expressionOperationChain() =>
+      (ref0(expressionNoOperation) &
+              (expressionOperator() & ref0(expressionNoOperation)).star())
+          .map((v) {
+            var exp1 = v[0];
+            var rest = v[1] as List;
+            if (rest.isEmpty) {
+              return exp1;
+            }
+            var extra = _expandListDeeply(rest);
+            var all = <dynamic>[exp1, ...extra];
+            return computeFinalExpression(all);
+          });
+
+  Parser<ASTExpressionOperator> expressionOperator() =>
+      (string('&&') |
+              string('||') |
+              string('&^') |
+              string('<<') |
+              string('>>') |
+              string('==') |
+              string('!=') |
+              string('<=') |
+              string('>=') |
+              char('+') |
+              char('-') |
+              char('*') |
+              char('/') |
+              char('%') |
+              char('&') |
+              char('|') |
+              char('^') |
+              char('<') |
+              char('>'))
+          .trimHidden()
+          .map((v) {
+            // `&^` (AND NOT) has no dedicated AST operator; approximate as
+            // bitwise-AND (rare; keeps parsing robust).
+            if (v == '&^') return ASTExpressionOperator.bitwiseAnd;
+            return getASTExpressionOperator(v as String);
+          });
+
+  Parser<ASTExpression> expressionNoOperation() =>
+      (expressionConditionalIIFE() |
+              expressionLambda() |
+              expressionNegate() |
+              expressionBitwiseNot() |
+              expressionLiteral() |
+              expressionGroupFunctionInvocation() |
+              expressionGroup() |
+              expressionListLiteral() |
+              expressionMapLiteral() |
+              expressionVariableDirectOperation() |
+              expressionObjectFieldAssignment() |
+              expressionVariableAssigment() |
+              expressionFunctionInvocation() |
+              expressionObjectEntryFunctionInvocation() |
+              expressionVariableEntryAccess() |
+              expressionGetterAccess() |
+              expressionNullValue() |
+              expressionVariableAccess() |
+              expressionNegative())
+          .cast<ASTExpression>();
+
+  /// The IIFE ApolloVM emits for a conditional expression (Go has no ternary):
+  /// `func() any { if cond { return a } else { return b } }()`.
+  Parser<ASTExpressionConditional> expressionConditionalIIFE() =>
+      (funcToken().trimHidden() &
+              char('(').trimHidden() &
+              char(')').trimHidden() &
+              string('any').trimHidden() &
+              char('{').trimHidden() &
+              ifToken().trimHidden() &
+              ref0(expression) &
+              char('{').trimHidden() &
+              returnToken().trimHidden() &
+              ref0(expression) &
+              char('}').trimHidden() &
+              elseToken().trimHidden() &
+              char('{').trimHidden() &
+              returnToken().trimHidden() &
+              ref0(expression) &
+              char('}').trimHidden() &
+              char('}').trimHidden() &
+              char('(').trimHidden() &
+              char(')').trimHidden())
+          .map((v) {
+            var cond = v[6] as ASTExpression;
+            var valueTrue = v[9] as ASTExpression;
+            var valueFalse = v[14] as ASTExpression;
+            return ASTExpressionConditional(cond, valueTrue, valueFalse);
+          });
+
+  Parser<ASTExpressionNegation> expressionNegate() =>
+      (char('!').trimHidden() &
+              (ref0(expressionNoOperation) | ref0(expressionGroup)))
+          .map((v) => ASTExpressionNegation(v[1] as ASTExpression));
+
+  /// Go uses prefix `^` for bitwise NOT (complement).
+  Parser<ASTExpressionOperation> expressionBitwiseNot() =>
+      (char('^').trimHidden() &
+              (ref0(expressionGroup) | ref0(expressionNoOperation)))
+          .map((v) {
+            var exp = v[1] as ASTExpression;
+            return ASTExpressionOperation(
+              ASTExpressionLiteral(ASTValueInt(-1)),
+              ASTExpressionOperator.subtract,
+              exp,
+            );
+          });
+
+  Parser<ASTExpressionNegative> expressionNegative() =>
+      (char('-').trimHidden() &
+              (ref0(expressionNoOperation) | ref0(expressionGroup)))
+          .map((v) => ASTExpressionNegative(v[1] as ASTExpression));
+
+  Parser<ASTExpression> expressionGroup() =>
+      (char('(').trimHidden() & ref0(expression) & char(')').trimHidden()).map(
+        (v) => v[1] as ASTExpression,
+      );
+
+  Parser<ASTExpressionGroupFunctionInvocation>
+  expressionGroupFunctionInvocation() =>
+      (ref0(expressionGroup) &
+              char('.') &
+              identifier() &
+              char('(').trimHidden() &
+              ref0(callArguments).optional() &
+              char(')').trimHidden() &
+              expressionChainFunctionInvocation().star())
+          .map((v) {
+            var expression = v[0] as ASTExpression;
+            var name = v[2] as String;
+            var argsRec =
+                v[4]
+                    as ({
+                      List<ASTExpression> positional,
+                      Map<String, ASTExpression>? named,
+                    })?;
+            var args = argsRec?.positional ?? <ASTExpression>[];
+            var chainFunctions = (v[6] as List)
+                .whereType<ASTExpressionChainFunctionInvocation>()
+                .toList();
+            return ASTExpressionGroupFunctionInvocation(
+              expression,
+              name,
+              args,
+              chainFunctions,
+            );
+          });
+
+  /// `name(args)`, `pkg.func(args)` (incl. `fmt.Println(...)`),
+  /// `receiver.method(args)`.
+  Parser<ASTExpression> expressionFunctionInvocation() =>
+      ((identifier() & char('.')).optional() &
+              identifier() &
+              char('(').trimHidden() &
+              ref0(callArguments).optional() &
+              char(')').trimHidden() &
+              expressionChainFunctionInvocation().star())
+          .map((v) {
+            var objOpt = v[0] as List?;
+            var obj = objOpt != null ? objOpt[0] as String : null;
+            var rawName = v[1] as String;
+            var argsRec =
+                v[3]
+                    as ({
+                      List<ASTExpression> positional,
+                      Map<String, ASTExpression>? named,
+                    })?;
+            var args = argsRec?.positional ?? <ASTExpression>[];
+            var chainFunctions = (v[5] as List)
+                .whereType<ASTExpressionChainFunctionInvocation>()
+                .toList();
+
+            // `fmt.Println(...)` → canonical `print`.
+            if (obj == 'fmt') {
+              return ASTExpressionLocalFunctionInvocation(
+                'print',
+                args,
+                chainFunctions,
+              );
+            }
+
+            var name = normalizeFunctionName(rawName);
+
+            if (obj != null && obj != 'this' && obj != _currentReceiver) {
+              var variable = ASTScopeVariable(obj);
+              return ASTExpressionObjectFunctionInvocation(
+                variable,
+                name,
+                args,
+                chainFunctions,
+              );
+            } else {
+              return ASTExpressionLocalFunctionInvocation(
+                name,
+                args,
+                chainFunctions,
+              );
+            }
+          });
+
+  Parser<ASTExpressionGetterAccess> expressionGetterAccess() =>
+      ((identifier() & char('.')) &
+              identifier().trimHidden() &
+              expressionChainFunctionInvocation().star())
+          .map((v) {
+            var obj = v[0] as String;
+            var name = v[2] as String;
+            var chainFunctions = (v[3] as List)
+                .whereType<ASTExpressionChainFunctionInvocation>()
+                .toList();
+
+            ASTVariable variable = (obj == 'this' || obj == _currentReceiver)
+                ? ASTThisVariable()
+                : ASTScopeVariable(obj);
+            return ASTExpressionObjectGetterAccess(
+              variable,
+              name,
+              chainFunctions,
+            );
+          });
+
+  Parser<ASTExpressionChainFunctionInvocation>
+  expressionChainFunctionInvocation() =>
+      (char('.').trimHidden() &
+              identifier() &
+              char('(').trimHidden() &
+              ref0(callArguments).optional() &
+              char(')').trimHidden())
+          .map((v) {
+            var fName = v[1] as String;
+            var argsRec =
+                v[3]
+                    as ({
+                      List<ASTExpression> positional,
+                      Map<String, ASTExpression>? named,
+                    })?;
+            var args = argsRec?.positional ?? <ASTExpression>[];
+            return ASTExpressionChainFunctionInvocation(fName, args);
+          });
+
+  Parser<List<ASTExpression>> expressionSequence() =>
+      (ref0(expression) & (char(',').trimHidden() & ref0(expression)).star())
+          .map((v) {
+            var list = _expandListDeeply(v);
+            return list.whereType<ASTExpression>().toList();
+          });
+
+  Parser<ASTExpressionNullValue> expressionNullValue() =>
+      (nilToken()).map((v) => ASTExpressionNullValue());
+
+  Parser<ASTExpressionVariableAccess> expressionVariableAccess() =>
+      (variable()).map((v) => ASTExpressionVariableAccess(v));
+
+  Parser<ASTExpressionLiteral> expressionLiteral() =>
+      (literal()).map((v) => ASTExpressionLiteral(v));
+
+  Parser<ASTExpressionVariableEntryAccess> expressionVariableEntryAccess() =>
+      (variable() & char('[') & ref0(expression) & char(']')).map((v) {
+        return ASTExpressionVariableEntryAccess(v[0], v[2]);
+      });
+
+  Parser<ASTExpressionObjectEntryFunctionInvocation>
+  expressionObjectEntryFunctionInvocation() =>
+      (variable() &
+              char('[') &
+              ref0(expression) &
+              char(']') &
+              char('.').trimHidden() &
+              identifier() &
+              char('(').trimHidden() &
+              ref0(callArguments).optional() &
+              char(')').trimHidden() &
+              expressionChainFunctionInvocation().star())
+          .map((v) {
+            var variable = v[0];
+            var expression = v[2];
+            var fName = v[5] as String;
+            var argsRec =
+                v[7]
+                    as ({
+                      List<ASTExpression> positional,
+                      Map<String, ASTExpression>? named,
+                    })?;
+            var args = argsRec?.positional ?? <ASTExpression>[];
+            var chainFunctions = (v[9] as List)
+                .whereType<ASTExpressionChainFunctionInvocation>()
+                .toList();
+            return ASTExpressionObjectEntryFunctionInvocation(
+              variable,
+              expression,
+              fName,
+              args,
+              chainFunctions,
+            );
+          });
+
+  /// `[]T{ e0, e1 }` — a Go slice literal.
+  Parser<ASTExpressionListLiteral> expressionListLiteral() =>
+      (char('[').trimHidden() &
+              char(']').trimHidden() &
+              type() &
+              char('{').trimHidden() &
+              ref0(expressionSequence).optional() &
+              char(',').trimHidden().optional() &
+              char('}').trimHidden())
+          .map((v) {
+            var elementType = v[2] as ASTType;
+            var values = (v[4] as List<ASTExpression>?) ?? <ASTExpression>[];
+            return ASTExpressionListLiteral(elementType, values);
+          });
+
+  /// `map[K]V{ k0: v0, k1: v1 }` — a Go map literal.
+  Parser<ASTExpressionMapLiteral> expressionMapLiteral() =>
+      (mapToken().trimHidden() &
+              char('[').trimHidden() &
+              type() &
+              char(']').trimHidden() &
+              type() &
+              char('{').trimHidden() &
+              (mapEntry() & (char(',').trimHidden() & mapEntry()).star())
+                  .optional() &
+              char(',').trimHidden().optional() &
+              char('}').trimHidden())
+          .map((v) {
+            var keyType = v[2] as ASTType;
+            var valueType = v[4] as ASTType;
+            var entries = <MapEntry<ASTExpression, ASTExpression>>[];
+            var entriesOpt = v[6];
+            if (entriesOpt != null) {
+              entries.add(entriesOpt[0] as MapEntry<ASTExpression, ASTExpression>);
+              for (var tail in (entriesOpt[1] as List)) {
+                entries.add(tail[1] as MapEntry<ASTExpression, ASTExpression>);
+              }
+            }
+            return ASTExpressionMapLiteral(keyType, valueType, entries);
+          });
+
+  Parser<MapEntry<ASTExpression, ASTExpression>> mapEntry() =>
+      (ref0(expression) & char(':').trimHidden() & ref0(expression)).map((v) {
+        return MapEntry(v[0] as ASTExpression, v[2] as ASTExpression);
+      });
+
+  Parser<ASTExpressionVariableDirectOperation>
+  expressionVariableDirectOperation() =>
+      (variable() & (string('++') | string('--'))).map((v) {
+        var variable = v[0];
+        var operator = getASTAssignmentDirectOperator(v[1]);
+        return ASTExpressionVariableDirectOperation(variable, operator, false);
+      });
+
+  Parser<ASTExpressionVariableAssignment> expressionVariableAssigment() =>
+      (variable() & assigmentOperator() & ref0(expression)).map((v) {
+        return ASTExpressionVariableAssignment(v[0], v[1], v[2]);
+      });
+
+  /// `o.field = value` / `this.field = value` (and `+=` etc.).
+  Parser<ASTExpressionObjectSetterAssignment>
+  expressionObjectFieldAssignment() =>
+      (identifier() &
+              char('.') &
+              identifier().trimHidden() &
+              assigmentOperator() &
+              ref0(expression))
+          .map((v) {
+            var obj = v[0] as String;
+            var name = v[2] as String;
+            var op = v[3] as ASTAssignmentOperator;
+            var valueExpr = v[4] as ASTExpression;
+            ASTVariable variable = (obj == 'this' || obj == _currentReceiver)
+                ? ASTThisVariable()
+                : ASTScopeVariable(obj);
+            return ASTExpressionObjectSetterAssignment(
+              variable,
+              name,
+              op,
+              valueExpr,
+            );
+          });
+
+  Parser<ASTAssignmentOperator> assigmentOperator() =>
+      (char('=') | string('+=') | string('-=') | string('*=') | string('/='))
+          .trimHidden()
+          .map((v) => getASTAssignmentOperator(v));
+
+  Parser<ASTVariable> variable() =>
+      (identifier()).map((name) {
+        if (name == 'this' || name == _currentReceiver) {
+          return ASTThisVariable();
+        }
+        return ASTScopeVariable(name);
+      }).cast<ASTVariable>();
+
+  /// Go closure used as an expression: `func(a int, b int) int { ... }`.
+  Parser<ASTExpression> expressionLambda() =>
+      (funcToken().trimHidden() &
+              functionParametersDeclaration() &
+              type().optional() &
+              codeBlock())
+          .map((v) {
+            var parameters = v[1] as ASTFunctionParametersDeclaration;
+            var returnType = (v[2] as ASTType?) ?? ASTTypeDynamic.instance;
+            var block = v[3] as ASTBlock;
+            var f = ASTFunctionDeclaration(
+              '',
+              parameters,
+              returnType,
+              block: block,
+              modifiers: ASTModifiers.modifierStatic,
+            );
+            return ASTExpressionLiteralFunction(f);
+          });
+
+  // -----------------------------------------------------------------
+  // Types.
+  // -----------------------------------------------------------------
+
+  Parser<ASTType> type() =>
+      (ref0(pointerType) |
+              ref0(sliceType) |
+              ref0(mapType) |
+              ref0(interfaceType) |
+              ref0(simpleType))
+          .cast<ASTType>();
+
+  /// A pointer type `*T` maps to the underlying `T` (ApolloVM has no pointers).
+  Parser<ASTType> pointerType() =>
+      (char('*').trimHidden() & ref0(type)).map((v) => v[1] as ASTType);
+
+  Parser<ASTTypeArray> sliceType() =>
+      (char('[').trimHidden() & char(']').trimHidden() & ref0(type)).map((v) {
+        return ASTTypeArray(v[2] as ASTType);
+      });
+
+  Parser<ASTTypeMap> mapType() =>
+      (mapToken().trimHidden() &
+              char('[').trimHidden() &
+              ref0(type) &
+              char(']').trimHidden() &
+              ref0(type))
+          .map((v) {
+            return ASTTypeMap(v[2] as ASTType, v[4] as ASTType);
+          });
+
+  Parser<ASTType> interfaceType() =>
+      ((string('interface').trimHidden() &
+                      char('{').trimHidden() &
+                      char('}').trimHidden())
+                  .map((_) => ASTTypeObject.instance) |
+              (string('any') & ref0(identifierPartLexicalToken).not())
+                  .trimHidden()
+                  .map((_) => ASTTypeObject.instance))
+          .cast<ASTType>();
+
+  Parser<ASTType> simpleType() =>
+      (identifier()).map((v) => getTypeByName(v));
+
+  // -----------------------------------------------------------------
+  // Literals.
+  // -----------------------------------------------------------------
+
+  Parser<ASTValue> literal() => (literalBool() | literalNum() | literalString())
+      .trimHidden()
+      .cast<ASTValue>();
+
+  Parser<ASTValueBool> literalBool() =>
+      ((string('true') | string('false')) &
+              ref0(identifierPartLexicalToken).not())
+          .trim()
+          .map((v) => ASTValueBool(v[0] == 'true'));
+
+  Parser<ASTValueNum> literalNum() =>
+      (char('-').optional() & numberLexicalToken()).trim().map((v) {
+        var negative = v[0] == '-';
+        var value = v[1];
+        return ASTValueNum.from(value, negative: negative);
+      });
+
+  Parser<ASTValue<String>> literalString() =>
+      (stringLexicalToken()).map((v) => v.asValue());
+
+  static List _expandListDeeply(List l) {
+    if (l.isEmpty) return l;
+    if (l.length == 1 && l[0] is! List) return l;
+
+    final result = [];
+    _expandInto(l, result);
+    return result;
+  }
+
+  static void _expandInto(List source, List target) {
+    for (final e in source) {
+      if (e is List) {
+        _expandInto(e, target);
+      } else {
+        target.add(e);
+      }
+    }
+  }
+}
+
+/// A `type Name struct { ... }` declaration, grouped into an [ASTClassNormal]
+/// by [GoGrammarDefinition.compilationUnit].
+class _StructDecl {
+  final String name;
+  final List<ASTClassField> fields;
+
+  _StructDecl(this.name, this.fields);
+}
+
+/// A `func (o *Name) method(...)` definition, grouped into an [ASTClassNormal]
+/// by [GoGrammarDefinition.compilationUnit].
+class _OwnerFunction {
+  final String owner;
+  final String name;
+  final ASTFunctionParametersDeclaration parameters;
+  final ASTBlock body;
+  final ASTType returnType;
+
+  _OwnerFunction(
+    this.owner,
+    this.name,
+    this.parameters,
+    this.body,
+    this.returnType,
+  );
+
+  ASTClassFunctionDeclaration toMethod() => ASTClassFunctionDeclaration(
+    null,
+    name,
+    parameters,
+    returnType,
+    block: body,
+  );
+}

--- a/lib/src/languages/go/go_grammar_lexer.dart
+++ b/lib/src/languages/go/go_grammar_lexer.dart
@@ -1,0 +1,199 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'package:petitparser/petitparser.dart';
+
+import '../dart/dart_grammar_lexer.dart' show ParsedString;
+import '../grammar.dart';
+
+export '../dart/dart_grammar_lexer.dart' show ParsedString;
+
+abstract class GoGrammarLexer extends BaseGrammarLexer {
+  // -----------------------------------------------------------------
+  // Identifiers (reserved words are not valid identifiers in Go, so they are
+  // excluded here — otherwise keywords like `case`/`default` at a statement
+  // boundary would be consumed as variable names).
+  // -----------------------------------------------------------------
+  @override
+  Parser<String> identifier() =>
+      (ref0(reservedWord).not() & ref0(identifierLexicalToken))
+          .map((v) => v[1] as String)
+          .trim(ref0(hiddenStuffWhitespace));
+
+  Parser reservedWord() =>
+      ((string('break') |
+                  string('case') |
+                  string('continue') |
+                  string('default') |
+                  string('else') |
+                  string('for') |
+                  string('func') |
+                  string('if') |
+                  string('import') |
+                  string('interface') |
+                  string('map') |
+                  string('package') |
+                  string('range') |
+                  string('return') |
+                  string('struct') |
+                  string('switch') |
+                  string('type') |
+                  string('var') |
+                  string('nil') |
+                  string('true') |
+                  string('false')) &
+              ref0(identifierPartLexicalToken).not())
+          .map((v) => v[0]);
+
+  // -----------------------------------------------------------------
+  // Keyword definitions.
+  // -----------------------------------------------------------------
+  Parser breakToken() => keywordToken('break');
+
+  Parser caseToken() => keywordToken('case');
+
+  Parser continueToken() => keywordToken('continue');
+
+  Parser defaultToken() => keywordToken('default');
+
+  Parser elseToken() => keywordToken('else');
+
+  Parser falseToken() => keywordToken('false');
+
+  Parser forToken() => keywordToken('for');
+
+  Parser funcToken() => keywordToken('func');
+
+  Parser ifToken() => keywordToken('if');
+
+  Parser importToken() => keywordToken('import');
+
+  Parser interfaceToken() => keywordToken('interface');
+
+  Parser mapToken() => keywordToken('map');
+
+  Parser nilToken() => keywordToken('nil');
+
+  Parser packageToken() => keywordToken('package');
+
+  Parser rangeToken() => keywordToken('range');
+
+  Parser returnToken() => keywordToken('return');
+
+  Parser structToken() => keywordToken('struct');
+
+  Parser switchToken() => keywordToken('switch');
+
+  Parser trueToken() => keywordToken('true');
+
+  Parser typeToken() => keywordToken('type');
+
+  Parser varToken() => keywordToken('var');
+
+  // -----------------------------------------------------------------
+  // Number tokens.
+  // -----------------------------------------------------------------
+  Parser hexNumberLexicalToken() =>
+      string('0x') & ref0(hexDigitLexicalToken).plus() |
+      string('0X') & ref0(hexDigitLexicalToken).plus();
+
+  Parser numberLexicalToken() =>
+      ((ref0(digitLexicalToken).plus() &
+                  ref0(numberOptFractionalPartLexicalToken) &
+                  ref0(exponentLexicalToken).optional() &
+                  ref0(numberOptIllegalEndLexicalToken)) |
+              (char('.') &
+                  ref0(digitLexicalToken).plus() &
+                  ref0(exponentLexicalToken).optional() &
+                  ref0(numberOptIllegalEndLexicalToken)))
+          .flatten();
+
+  Parser numberOptFractionalPartLexicalToken() =>
+      char('.') & ref0(digitLexicalToken).plus() | epsilon();
+
+  Parser numberOptIllegalEndLexicalToken() => epsilon();
+
+  Parser hexDigitLexicalToken() => pattern('0-9a-fA-F');
+
+  Parser exponentLexicalToken() =>
+      pattern('eE') & pattern('+-').optional() & ref0(digitLexicalToken).plus();
+
+  // -----------------------------------------------------------------
+  // String tokens (Go uses double-quoted interpreted strings and backtick raw
+  // strings; Go has no string interpolation, so a string is always a single
+  // literal, wrapped as a [ParsedString] for shared-grammar compatibility).
+  // -----------------------------------------------------------------
+  Parser<ParsedString> stringLexicalToken() =>
+      (ref0(rawStringLexicalToken) | ref0(interpretedStringLexicalToken))
+          .trim()
+          .cast<ParsedString>();
+
+  Parser<ParsedString> interpretedStringLexicalToken() =>
+      (char('"') &
+              (ref0(stringContentDoubleQuotedLexicalToken)).star() &
+              char('"'))
+          .map((v) {
+            var content = (v[1] as List).join();
+            return ParsedString.literal(content);
+          });
+
+  /// Go raw string literal using back-quotes: `` `...` `` (no escapes).
+  Parser<ParsedString> rawStringLexicalToken() =>
+      (char('`') & pattern('^`').star().flatten() & char('`')).map((v) {
+        return ParsedString.literal(v[1] as String);
+      });
+
+  Parser<String> stringContentDoubleQuotedLexicalToken() =>
+      (stringContentDoubleQuotedLexicalTokenUnescaped() |
+              stringContentQuotedLexicalTokenEscaped())
+          .cast<String>();
+
+  Parser<String> stringContentDoubleQuotedLexicalTokenUnescaped() =>
+      pattern('^\\"\n\r').plus().flatten();
+
+  Parser<String> stringContentQuotedLexicalTokenEscaped() =>
+      (char('\\') &
+              (char('n').map((_) => '\n') |
+                  char('r').map((_) => '\r') |
+                  char('"').map((_) => '"') |
+                  char("'").map((_) => "'") |
+                  char('t').map((_) => '\t') |
+                  char('b').map((_) => '\b') |
+                  char('\\').map((_) => '\\')))
+          .map((v) {
+            return v[1] as String;
+          });
+
+  static Parser<String> newlineLexicalToken() => pattern('\n\r');
+
+  // -----------------------------------------------------------------
+  // Whitespace and comments.
+  // -----------------------------------------------------------------
+  @override
+  Parser hiddenWhitespace() => ref0(hiddenStuffWhitespace).plus();
+
+  @override
+  Parser hiddenStuffWhitespace() => hiddenStuffWhitespaceStatic();
+
+  static Parser hiddenStuffWhitespaceStatic() =>
+      ref0(visibleWhitespace) |
+      ref0(singleLineComment) |
+      ref0(multiLineComment);
+
+  static Parser visibleWhitespace() => whitespace();
+
+  static Parser singleLineComment() =>
+      string('//') &
+      ref0(newlineLexicalToken).neg().star() &
+      ref0(newlineLexicalToken).optional();
+
+  static Parser multiLineComment() =>
+      string('/*') &
+      (ref0(multiLineComment) | string('*/').neg()).star() &
+      string('*/');
+}
+
+extension TrimHiddenStuffWhitespaceParserExtension<R> on Parser<R> {
+  Parser<R> trimHidden() => trim(GoGrammarLexer.hiddenStuffWhitespaceStatic());
+}

--- a/lib/src/languages/go/go_parser.dart
+++ b/lib/src/languages/go/go_parser.dart
@@ -1,0 +1,27 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import '../../apollovm_parser.dart';
+import 'go_grammar.dart';
+
+/// Go implementation of an [ApolloParser].
+class ApolloParserGo extends ApolloSourceCodeParser {
+  static final ApolloParserGo instance = ApolloParserGo();
+
+  ApolloParserGo() : super(GoGrammarDefinition());
+
+  @override
+  String get language => 'go';
+
+  @override
+  bool acceptsLanguage(String language) {
+    language = language.toLowerCase().trim();
+
+    if (this.language == language || language == 'golang') {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/lib/src/languages/go/go_runner.dart
+++ b/lib/src/languages/go/go_runner.dart
@@ -1,0 +1,18 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import '../../apollovm_runner.dart';
+
+/// Go implementation of an [ApolloRunner].
+class ApolloRunnerGo extends ApolloRunner {
+  ApolloRunnerGo(super.apolloVM, {super.importCorePackageMath});
+
+  @override
+  String get language => 'go';
+
+  @override
+  ApolloRunnerGo copy() {
+    return ApolloRunnerGo(apolloVM);
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apollovm
 description: ApolloVM, a Multilingual portable VM (native, JS/Web, Flutter) for Dart, Java, Kotlin, C#, JavaScript, TypeScript, Lua and Python with on-the-fly Wasm compilation.
-version: 0.1.48
+version: 1.2.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/hello_world.go
+++ b/test/hello_world.go
@@ -1,0 +1,4 @@
+func main(name string) {
+  fmt.Println("Hello World!")
+  fmt.Println("- name: " + name)
+}

--- a/test/languages/apollovm_go_test.dart
+++ b/test/languages/apollovm_go_test.dart
@@ -1,0 +1,441 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+@Tags(['dart', 'java', 'go'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Loads [source] in [language], runs an entry point and returns the captured
+/// `print` output.
+Future<List<Object?>> _run(
+  String language,
+  String source, {
+  String function = 'run',
+  String? className,
+  List positionalParameters = const [],
+}) async {
+  var vm = ApolloVM();
+  var codeUnit = SourceCodeUnit(language, source, id: 'test');
+
+  var loaded = await vm.loadCodeUnit(codeUnit);
+  expect(loaded, isTrue, reason: "Failed to load $language code");
+
+  var runner = vm.createRunner(language)!;
+
+  var output = <Object?>[];
+  runner.externalPrintFunction = (o) => output.add(o);
+
+  if (className != null) {
+    // Entry methods here are non-static, so run them against a (field-less)
+    // instance — only `static` methods run without an instance.
+    await runner.executeClassMethod(
+      '',
+      className,
+      function,
+      positionalParameters: positionalParameters,
+      classInstanceFields: const {},
+    );
+  } else {
+    await runner.executeFunction(
+      '',
+      function,
+      positionalParameters: positionalParameters,
+    );
+  }
+
+  return output;
+}
+
+/// Loads [source] in [language] and returns the value of calling [function].
+Future<ASTValue> _call(
+  String language,
+  String source,
+  String function, {
+  List positionalParameters = const [],
+}) async {
+  var vm = ApolloVM();
+  await vm.loadCodeUnit(SourceCodeUnit(language, source, id: 'test'));
+  var runner = vm.createRunner(language)!;
+  return runner.executeFunction(
+    '',
+    function,
+    positionalParameters: positionalParameters,
+  );
+}
+
+/// Loads [source] in [language] and translates it to [targetLanguage] source.
+Future<String> _translate(
+  String language,
+  String source,
+  String targetLanguage,
+) async {
+  var vm = ApolloVM();
+  await vm.loadCodeUnit(SourceCodeUnit(language, source, id: 'test'));
+  var storage = vm.generateAllCodeIn(targetLanguage);
+  return (await storage.writeAllSources()).toString();
+}
+
+/// Extracts the raw source of the single generated code unit from the
+/// ApolloVM "sources" envelope produced by `writeAllSources`.
+String _extractCodeUnit(String allSources) {
+  var lines = allSources.split('\n');
+  var start = lines.indexWhere((l) => l.startsWith('<<<< CODE_UNIT_START'));
+  var end = lines.indexWhere((l) => l.startsWith('<<<< CODE_UNIT_END'));
+  return lines.sublist(start + 1, end).join('\n');
+}
+
+/// A Go program that is parsed, executed, and translated+re-executed in every
+/// [translateTargets] language, asserting identical observable output.
+class _GoCase {
+  final String name;
+  final String source;
+  final List<Object?> expectedOutput;
+  final String? className;
+  final List positionalParameters;
+  final List<String> translateTargets;
+
+  const _GoCase(
+    this.name,
+    this.source,
+    this.expectedOutput, {
+    this.className,
+    this.positionalParameters = const [],
+    this.translateTargets = const ['dart', 'go'],
+  });
+}
+
+// Portable programs: only constructs whose semantics are identical across Dart,
+// Java and Go (no integer division, fields written before read), so the
+// translated source must produce exactly the same output.
+const _portableCases = <_GoCase>[
+  _GoCase(
+    'control flow: if / else-if / else',
+    r'''
+func classify(n int) string {
+  if n < 0 {
+    return "neg"
+  } else if n == 0 {
+    return "zero"
+  } else {
+    return "pos"
+  }
+}
+
+func run() {
+  fmt.Println(classify(-3))
+  fmt.Println(classify(0))
+  fmt.Println(classify(8))
+}
+''',
+    ['neg', 'zero', 'pos'],
+  ),
+  _GoCase(
+    'loops: while + for-range over slice',
+    r'''
+type C struct {
+}
+
+func (o *C) run() {
+  sum := 0
+  i := 1
+  for i <= 5 {
+    sum = sum + i
+    i = i + 1
+  }
+  fmt.Println("sum=" + sum)
+  items := []int{10, 20, 30}
+  total := 0
+  for _, x := range items {
+    total = total + x
+  }
+  fmt.Println("total=" + total)
+}
+''',
+    ['sum=15', 'total=60'],
+    className: 'C',
+  ),
+  _GoCase(
+    'c-style for loop',
+    r'''
+type C struct {
+}
+
+func (o *C) run(n int) {
+  total := 0
+  for i := 0; i < n; i = i + 1 {
+    total = total + i
+  }
+  fmt.Println("total=" + total)
+}
+''',
+    ['total=10'],
+    className: 'C',
+    positionalParameters: [5],
+  ),
+  _GoCase(
+    'strings: concatenation',
+    r'''
+func greet(name string) string {
+  return "Hello, " + name + "!"
+}
+
+func run() {
+  who := "Go"
+  fmt.Println(greet(who))
+  x := 42
+  fmt.Println("x is " + x + " doubled " + (x * 2))
+}
+''',
+    ['Hello, Go!', 'x is 42 doubled 84'],
+  ),
+  _GoCase(
+    'recursion: factorial',
+    r'''
+func fact(n int) int {
+  if n <= 1 {
+    return 1
+  }
+  return n * fact(n - 1)
+}
+
+func run() {
+  fmt.Println("fact5=" + fact(5))
+}
+''',
+    ['fact5=120'],
+    // Top-level funcs cannot translate to Java (all Java code lives in a class).
+    translateTargets: ['dart', 'go'],
+  ),
+  _GoCase(
+    'struct: methods + nested receiver calls',
+    r'''
+type Calc struct {
+}
+
+func (o *Calc) square(n int) int {
+  return n * n
+}
+
+func (o *Calc) cube(n int) int {
+  return n * o.square(n)
+}
+
+func (o *Calc) run() {
+  fmt.Println("square=" + o.square(9))
+  fmt.Println("cube=" + o.cube(3))
+}
+''',
+    ['square=81', 'cube=27'],
+    className: 'Calc',
+    translateTargets: ['dart', 'java', 'go'],
+  ),
+  _GoCase(
+    'struct: field written then read',
+    r'''
+type Acc struct {
+  total int
+}
+
+func (o *Acc) run(a int, b int) {
+  o.total = a + b
+  fmt.Println("total=" + o.total)
+}
+''',
+    ['total=30'],
+    className: 'Acc',
+    positionalParameters: [10, 20],
+    translateTargets: ['dart', 'java', 'go'],
+  ),
+];
+
+void main() {
+  group('Go parse + execute', () {
+    for (var c in _portableCases) {
+      test(c.name, () async {
+        var output = await _run(
+          'go',
+          c.source,
+          className: c.className,
+          positionalParameters: c.positionalParameters,
+        );
+        expect(output, equals(c.expectedOutput));
+      });
+    }
+
+    test('arithmetic + comparison + logic', () async {
+      var output = await _run('go', r'''
+func run() {
+  a := 7
+  b := 3
+  fmt.Println("add=" + (a + b))
+  fmt.Println("sub=" + (a - b))
+  fmt.Println("mul=" + (a * b))
+  fmt.Println("mod=" + (a % b))
+  fmt.Println("lt=" + (a < b))
+  fmt.Println("ge=" + (a >= b))
+}
+''');
+      expect(
+        output,
+        equals(['add=10', 'sub=4', 'mul=21', 'mod=1', 'lt=false', 'ge=true']),
+      );
+    });
+
+    test('bitwise operators', () async {
+      var ret = await _call(
+        'go',
+        r'''
+func f(a int, b int) int {
+  return ((a & b) | (a ^ b)) + (a << 1) + (a >> 1)
+}
+''',
+        'f',
+        positionalParameters: [6, 3],
+      );
+      expect(ret.getValueNoContext(), equals(22));
+    });
+
+    test('switch (no fall-through)', () async {
+      var ret = await _call(
+        'go',
+        r'''
+func f(x int) int {
+  r := 0
+  switch x {
+  case 1:
+    r = 10
+  case 2:
+    r = 20
+  default:
+    r = 99
+  }
+  return r
+}
+''',
+        'f',
+        positionalParameters: [2],
+      );
+      expect(ret.getValueNoContext(), equals(20));
+    });
+
+    test('closure captured and invoked', () async {
+      var ret = await _call(
+        'go',
+        r'''
+func f(a int) int {
+  double := func(x int) int {
+    return x * 2
+  }
+  return double(a) + 1
+}
+''',
+        'f',
+        positionalParameters: [20],
+      );
+      expect(ret.getValueNoContext(), equals(41));
+    });
+
+    test('function returning String', () async {
+      var ret = await _call(
+        'go',
+        r'''
+func greet(name string) string {
+  return "Hi " + name
+}
+''',
+        'greet',
+        positionalParameters: ['Go'],
+      );
+      expect(ret.getValueNoContext(), equals('Hi Go'));
+    });
+  });
+
+  group('Go translate + re-execute', () {
+    for (var c in _portableCases) {
+      for (var target in c.translateTargets) {
+        test('${c.name} -> $target', () async {
+          var generated = await _translate('go', c.source, target);
+          var code = _extractCodeUnit(generated);
+
+          var output = await _run(
+            target,
+            code,
+            className: c.className,
+            positionalParameters: c.positionalParameters,
+          );
+          expect(
+            output,
+            equals(c.expectedOutput),
+            reason: 'Translated $target output mismatch',
+          );
+        });
+      }
+    }
+
+    test('Go -> Dart emits idiomatic Dart', () async {
+      var dart = await _translate('go', _portableCases[0].source, 'dart');
+      expect(dart, contains('String classify(int n)'));
+      expect(dart, contains('void run()'));
+    });
+
+    test('Go -> Go round-trip emits idiomatic Go', () async {
+      var go = await _translate('go', _portableCases[5].source, 'go');
+      expect(go, contains('package main'));
+      expect(go, contains('type Calc struct'));
+      expect(go, contains('func (o *Calc) square(n int) int'));
+    });
+
+    test('Go struct -> Java emits a class with typed methods', () async {
+      var java = await _translate('go', _portableCases[5].source, 'java');
+      expect(java, contains('class Calc'));
+      expect(java, contains('int square(int n)'));
+      expect(java, contains('int cube(int n)'));
+    });
+  });
+
+  // Cross-language into Go: other languages regenerate as idiomatic Go.
+  group('into Go (translate from other languages)', () {
+    test('Kotlin class -> Go struct + receiver method', () async {
+      const kt = r'''
+class Greeter {
+  fun greet(name: String, count: Int) {
+    val msg = "Hello " + name + ", you have " + count + " messages."
+    println(msg)
+  }
+}
+''';
+      var go = await _translate('kotlin', kt, 'go');
+      expect(go, contains('type Greeter struct'));
+      expect(go, contains('func (o *Greeter) greet(name string, count int)'));
+      expect(go, contains('fmt.Println(msg)'));
+      expect(go, contains('import "fmt"'));
+    });
+
+    test('Dart function -> Go func with typed params', () async {
+      const dart = r'''
+int add(int a, int b) {
+  return a + b;
+}
+''';
+      var go = await _translate('dart', dart, 'go');
+      expect(go, contains('func add(a int, b int) int'));
+    });
+
+    test('Go slice + map literals translate to Dart', () async {
+      const src = r'''
+func build() int {
+  xs := []int{1, 2, 3}
+  m := map[string]int{"a": 1, "b": 2}
+  return xs[0] + m["b"]
+}
+''';
+      var dart = await _translate('go', src, 'dart');
+      expect(dart, contains('build()'));
+      var ret = await _call('go', src, 'build');
+      expect(ret.getValueNoContext(), equals(3));
+    });
+  });
+}

--- a/test/languages/apollovm_go_test.dart
+++ b/test/languages/apollovm_go_test.dart
@@ -438,4 +438,121 @@ func build() int {
       expect(ret.getValueNoContext(), equals(3));
     });
   });
+
+  // Exercises the Go-specific code-generation idioms that come from other
+  // languages' AST shapes: struct factory constructors, the ternary IIFE,
+  // prefix bitwise-NOT, `nil`, `map[...]...` literals and `+`-based string
+  // interpolation.
+  group('Go idiom generation (from other languages)', () {
+    test('Dart class + constructor -> Go struct + factory', () async {
+      const dart = r'''
+class Point {
+  int x;
+  int y = 7;
+  Point(int a, int b) {
+    this.x = a;
+    this.y = b;
+  }
+  int sum() {
+    return this.x + this.y;
+  }
+}
+''';
+      var go = _extractCodeUnit(await _translate('dart', dart, 'go'));
+      expect(go, contains('type Point struct'));
+      expect(go, contains('x int'));
+      expect(go, contains('func NewPoint(a int, b int) *Point'));
+      expect(go, contains(r'o := &Point{}'));
+      expect(go, contains('o.y = 7')); // field initializer moved to factory
+      expect(go, contains('o.x = a'));
+      expect(go, contains('return o'));
+      expect(go, contains('func (o *Point) sum() int'));
+    });
+
+    test('Dart class field initializer -> Go default factory', () async {
+      const dart = r'''
+class Counter {
+  int n = 5;
+  int get() {
+    return this.n;
+  }
+}
+''';
+      var go = _extractCodeUnit(await _translate('dart', dart, 'go'));
+      expect(go, contains('func NewCounter() *Counter'));
+      expect(go, contains('o.n = 5'));
+    });
+
+    test('Dart ternary -> Go IIFE (and runs)', () async {
+      const dart = r'''
+int pick(int a) {
+  var r = a > 5 ? 100 : 1;
+  return r;
+}
+''';
+      var go = _extractCodeUnit(await _translate('dart', dart, 'go'));
+      expect(
+        go,
+        contains('func() any { if a > 5 { return 100 } else { return 1 } }()'),
+      );
+      var ret = await _call('go', go, 'pick', positionalParameters: [10]);
+      expect(ret.getValueNoContext(), equals(100));
+    });
+
+    test('Dart bitwise-NOT -> Go prefix `^` (and runs)', () async {
+      const dart = r'''
+int f(int a) {
+  return ~a;
+}
+''';
+      var go = _extractCodeUnit(await _translate('dart', dart, 'go'));
+      expect(go, contains('return ^a'));
+      var ret = await _call('go', go, 'f', positionalParameters: [6]);
+      expect(ret.getValueNoContext(), equals(-7)); // ^6 == -7
+    });
+
+    test('Dart null -> Go nil', () async {
+      const dart = r'''
+int f() {
+  return null;
+}
+''';
+      var go = _extractCodeUnit(await _translate('dart', dart, 'go'));
+      expect(go, contains('return nil'));
+    });
+
+    test('Go map literal round-trips through Go generation', () async {
+      const src = r'''
+func build() int {
+  m := map[string]int{"a": 1, "b": 2}
+  return m["b"]
+}
+''';
+      var go = _extractCodeUnit(await _translate('go', src, 'go'));
+      expect(go, contains('map[string]int{'));
+      var ret = await _call('go', go, 'build');
+      expect(ret.getValueNoContext(), equals(2));
+    });
+
+    test('Kotlin string templates -> Go `+` concatenation', () async {
+      const kt = r'''
+fun f(x: Int): String {
+  val a = "$x"
+  val b = "${x * 2}"
+  return a + "=" + b
+}
+''';
+      var go = _extractCodeUnit(await _translate('kotlin', kt, 'go'));
+      // Lone `"$x"` -> `"" + x`; `"${x * 2}"` -> `"" + (x * 2)`.
+      expect(go, contains('"" + x'));
+      expect(go, contains('"" + (x * 2)'));
+    });
+
+    test('runner copy() yields a Go runner', () {
+      var vm = ApolloVM();
+      var runner = vm.createRunner('go')!;
+      var copy = runner.copy();
+      expect(copy.language, equals('go'));
+    });
+  });
 }

--- a/test/languages/apollovm_languages_extended_test.dart
+++ b/test/languages/apollovm_languages_extended_test.dart
@@ -8,6 +8,7 @@
   'python',
   'kotlin',
   'lua',
+  'go',
 ])
 library;
 

--- a/test/tests_definitions/go_basic_class_function.test.xml
+++ b/test/tests_definitions/go_basic_class_function.test.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Go struct method: arithmetic + string concat + print">
+    <source language="go">
+        <![CDATA[
+type Calc struct {
+}
+
+func (o *Calc) sum(title string, a int, b int) int {
+  total := a + b
+  msg := "sum " + title + " = " + total
+  fmt.Println(msg)
+  return total
+}
+        ]]>
+    </source>
+    <call class="Calc" function="sum" return="30">
+        ["nums", 10, 20]
+    </call>
+    <output>
+        ["sum nums = 30"]
+    </output>
+
+    <source-generated language="go"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+package main
+
+import "fmt"
+
+type Calc struct {
+}
+
+func (o *Calc) sum(title string, a int, b int) int {
+  total := a + b
+  msg := "sum " + title + " = " + total
+  fmt.Println(msg)
+  return total
+}
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/go_basic_for_loop.test.xml
+++ b/test/tests_definitions/go_basic_for_loop.test.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Go C-style for loop">
+    <source language="go">
+        <![CDATA[
+type C struct {
+}
+
+func (o *C) run(n int) int {
+  total := 0
+  for i := 0; i < n; i = i + 1 {
+    total = total + i
+  }
+  return total
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="10">
+        [5]
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="go"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+package main
+
+type C struct {
+}
+
+func (o *C) run(n int) int {
+  total := 0
+  for i := 0; i < n; i = i + 1 {
+    total = total + i
+  }
+  return total
+}
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/go_basic_foreach.test.xml
+++ b/test/tests_definitions/go_basic_foreach.test.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Go for-range over a slice">
+    <source language="go">
+        <![CDATA[
+type C struct {
+}
+
+func (o *C) run() int {
+  xs := []int{2, 4, 6}
+  total := 0
+  for _, x := range xs {
+    total = total + x
+  }
+  return total
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="12">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="go"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+package main
+
+type C struct {
+}
+
+func (o *C) run() int {
+  xs := []int{2, 4, 6}
+  total := 0
+  for _, x := range xs {
+    total = total + x
+  }
+  return total
+}
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/go_bitwise.test.xml
+++ b/test/tests_definitions/go_bitwise.test.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Go bitwise operators">
+    <source language="go">
+        <![CDATA[
+type C struct {
+}
+
+func (o *C) run(a int, b int) int {
+  return ((a & b) | (a ^ b)) + (a << 1) + (a >> 1)
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="22">
+        [6, 3]
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="go"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+package main
+
+type C struct {
+}
+
+func (o *C) run(a int, b int) int {
+  return (((a & b) | (a ^ b)) + (a << 1)) + (a >> 1)
+}
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/go_control_flow.test.xml
+++ b/test/tests_definitions/go_control_flow.test.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Go control flow: while, break, continue, do-while, switch">
+    <source language="go">
+        <![CDATA[
+type C struct {
+}
+
+func (o *C) run() int {
+  sum := 0
+  i := 0
+  for i < 10 {
+    i = i + 1
+    if i == 3 {
+      continue
+    }
+    if i == 6 {
+      break
+    }
+    sum = sum + i
+  }
+  j := 0
+  for {
+    sum = sum + 10
+    j = j + 1
+    if !(j < 3) {
+      break
+    }
+  }
+  switch j {
+  case 3:
+    sum = sum + 100
+  default:
+    sum = sum + 1
+  }
+  return sum
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="142">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="go"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+package main
+
+type C struct {
+}
+
+func (o *C) run() int {
+  sum := 0
+  i := 0
+  for i < 10 {
+    i = i + 1
+    if i == 3 {
+        continue
+    }
+
+    if i == 6 {
+        break
+    }
+
+    sum = sum + i
+  }
+  j := 0
+  for {
+    sum = sum + 10
+    j = j + 1
+    if !(j < 3) {
+      break
+    }
+  }
+  switch j {
+    case 3:
+      sum = sum + 100
+    default:
+      sum = sum + 1
+  }
+  return sum
+}
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/go_lambda_input.test.xml
+++ b/test/tests_definitions/go_lambda_input.test.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Go closure passed and invoked">
+    <source language="go">
+        <![CDATA[
+type C struct {
+}
+
+func (o *C) run(a int) int {
+  triple := func(x int) int {
+    return x * 3
+  }
+  return triple(a)
+}
+        ]]>
+    </source>
+    <call class="C" function="run" return="21">
+        [7]
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="go"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+package main
+
+type C struct {
+}
+
+func (o *C) run(a int) int {
+  triple := func(x int) int {
+    return x * 3
+  }
+  return triple(a)
+}
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>


### PR DESCRIPTION
## Summary

Adds **Go** as a fully supported language in ApolloVM. Go source (`.go` / `go`, alias `golang`) can now be **parsed**, **executed**, and **translated** bidirectionally with every other supported language (Dart, Java, Kotlin, C#, JS, TS, Lua, Python) and compiled on-the-fly to Wasm — all through the shared AST.

## What's included

- **New implementation** under `lib/src/languages/go/` (`go_grammar_lexer.dart`, `go_grammar.dart`, `go_generator.dart`, `go_parser.dart`, `go_runner.dart`), modeled on the Kotlin implementation with Lua-style struct/owner grouping.
- **Wiring**: `ApolloVM` (`getParser`/`createRunner`/`createCodeGenerator`, `.go` extension mapping), CLI banner + `--language`/`--target` help, `lib/apollovm.dart` exports, `dart_test.yaml` + extended-test `go` tag.

## Go idioms (generator + grammar co-designed for round-trip)

- **Classes → structs + receiver methods**: `type Name struct { … }` plus `func (o *Name) m(...)`; `this`/field reads/sibling calls rewritten to `o.field` / `o.method(...)`; constructors → `func NewName(...) *Name` factory.
- `package main` + auto `import "fmt"`; `fmt.Println` ⇄ canonical `print`.
- Type-after-name (`func f(a int) int`, `x := …`, `var x T`), `for`-only control flow (C-style, condition-only = `while`, `for { … if !cond { break } }` = `do`/`while`, `range` = for-each), Go `switch` (no fall-through), slices/maps (`[]T{…}`, `map[K]V{…}`), closures, bitwise (prefix `^` NOT, `&^`), `+` string concatenation, ternary → IIFE.

## Tests & docs

- 6 round-trip XML test definitions + a 34-case dedicated `apollovm_go_test.dart` (parse/execute, translate-and-re-run per target, cross-language-into-Go).
- `example/apollovm_example_go.dart`, `test/hello_world.go`, README feature tables (Go column + footnotes) and a new "Language: `Go`" section, CHANGELOG entry.
- Version bumped to **1.2.0**. Full suite green (743 tests) and `dart analyze` clean.

## Scope / honesty

Per the shared "core parity + honest footnotes" convention, `try`/`catch`/`throw` (Go uses `defer`/`recover`/`panic`), inheritance/interfaces, rich enums and generics are marked 🚧 (not yet implemented for Go); `async`/`await` and named/default args are 🚫 (Go has no such construct) — matching how Kotlin/Lua/Python footnote their gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)