### PR TITLE
feat(cli): add `mcp` command group (serve, list, call, info, schema, doctor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@
 
 ### MCP-native runtime: expose ApolloVM to AI agents over the Model Context Protocol
 
-- **New `apollovm serve` command** starts an MCP (Model Context Protocol) server,
+- **New `apollovm mcp-serve` command** starts an MCP (Model Context Protocol) server,
   turning ApolloVM into a programmable, sandboxed execution engine for AI agents.
   Built on the official `dart_mcp` SDK; serves over **stdio** (default) or
   **HTTP/SSE** (`--http <port>`).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,10 +23,12 @@
 
 ### MCP-native runtime: expose ApolloVM to AI agents over the Model Context Protocol
 
-- **New `apollovm mcp-serve` command** starts an MCP (Model Context Protocol) server,
-  turning ApolloVM into a programmable, sandboxed execution engine for AI agents.
-  Built on the official `dart_mcp` SDK; serves over **stdio** (default) or
-  **HTTP/SSE** (`--http <port>`).
+- **New `apollovm mcp` command group** exposes ApolloVM as an MCP (Model Context
+  Protocol) server and tools, turning it into a programmable, sandboxed execution
+  engine for AI agents. Built on the official `dart_mcp` SDK. Subcommands:
+  `mcp serve` (run the server over **stdio** or **HTTP/SSE** via `--http <port>`),
+  `mcp list` (tool definitions), `mcp call <tool>` (one-shot tool invocation for
+  scripting/CI), `mcp info`, `mcp schema`, and `mcp doctor`.
 - **Seven tools**: `apollo.parse`, `apollo.execute`, `apollo.translate`,
   `apollo.ast`, `apollo.symbols`, `apollo.types`, `apollo.wasm` — parse, run,
   translate, compile to Wasm, and inspect AST / symbol graph / type table across

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,12 +29,12 @@
   `mcp serve` (run the server over **stdio** or **HTTP/SSE** via `--http <port>`),
   `mcp list` (tool definitions), `mcp call <tool>` (one-shot tool invocation for
   scripting/CI), `mcp info`, `mcp schema`, and `mcp doctor`.
-- **Seven tools**: `apollo.parse`, `apollo.execute`, `apollo.translate`,
-  `apollo.ast`, `apollo.symbols`, `apollo.types`, `apollo.wasm` — parse, run,
+- **Seven tools**: `apollovm.parse`, `apollovm.execute`, `apollovm.translate`,
+  `apollovm.ast`, `apollovm.symbols`, `apollovm.types`, `apollovm.wasm` — parse, run,
   translate, compile to Wasm, and inspect AST / symbol graph / type table across
   all supported languages.
 - **Security model**: file/network access denied by construction (only `print` is
-  exposed; inputs are inline source only); `apollo.execute` runs in a **killable
+  exposed; inputs are inline source only); `apollovm.execute` runs in a **killable
   isolate** so a hard timeout is enforced even against runaway synchronous loops
   (per-tool configurable via `--isolate-tools`); input/output size caps
   (`--max-source-chars`, `--max-output-chars`); best-effort process-level memory.

--- a/README.md
+++ b/README.md
@@ -1191,13 +1191,13 @@ compile, and inspect code across all supported languages through MCP tools.
 Start it over stdio (the standard local transport):
 
 ```bash
-apollovm serve
+apollovm mcp-serve
 ```
 
 or over HTTP/SSE for networked agents:
 
 ```bash
-apollovm serve --http 8080          # binds 127.0.0.1:8080, SSE at /sse
+apollovm mcp-serve --http 8080          # binds 127.0.0.1:8080, SSE at /sse
 ```
 
 Example MCP client configuration (e.g. for an agent/IDE):
@@ -1205,7 +1205,7 @@ Example MCP client configuration (e.g. for an agent/IDE):
 ```json
 {
   "mcpServers": {
-    "apollovm": { "command": "apollovm", "args": ["serve"] }
+    "apollovm": { "command": "apollovm", "args": ["mcp-serve"] }
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -1223,23 +1223,23 @@ Example MCP client configuration (e.g. for an agent/IDE):
 
 ```bash
 # Run a tool from the shell without an MCP client:
-apollovm mcp call apollo.execute --language dart \
+apollovm mcp call apollovm.execute --language dart \
   --source 'int main(List a){ print("hi"); return 42; }'
 
-apollovm mcp call apollo.translate --from go --to dart --file main.go
+apollovm mcp call apollovm.translate --from go --to dart --file main.go
 ```
 
 ### Tools
 
 | Tool | Input | Output |
 |------|-------|--------|
-| `apollo.parse` | `language`, `source` | parse `ok`, `diagnostics`, `summary` (classes/functions/imports) |
-| `apollo.execute` | `language`, `source`, `function?`, `className?`, `args?`, `timeoutMs?` | `result`, `output` (console), `diagnostics` |
-| `apollo.translate` | `from`, `to`, `source` | `generated` source |
-| `apollo.ast` | `language`, `source`, `maxDepth?` | full AST as JSON |
-| `apollo.symbols` | `language`, `source` | symbol graph (functions/classes/fields/methods/constructors) |
-| `apollo.types` | `language`, `source` | deduplicated type table (`class`/`builtin`/`unknown`) |
-| `apollo.wasm` | `language`, `source` | WebAssembly modules as base64 bytes |
+| `apollovm.parse` | `language`, `source` | parse `ok`, `diagnostics`, `summary` (classes/functions/imports) |
+| `apollovm.execute` | `language`, `source`, `function?`, `className?`, `args?`, `timeoutMs?` | `result`, `output` (console), `diagnostics` |
+| `apollovm.translate` | `from`, `to`, `source` | `generated` source |
+| `apollovm.ast` | `language`, `source`, `maxDepth?` | full AST as JSON |
+| `apollovm.symbols` | `language`, `source` | symbol graph (functions/classes/fields/methods/constructors) |
+| `apollovm.types` | `language`, `source` | deduplicated type table (`class`/`builtin`/`unknown`) |
+| `apollovm.wasm` | `language`, `source` | WebAssembly modules as base64 bytes |
 
 Supported `language` values: `dart`, `java`, `kotlin`, `go`, `csharp`, `javascript`,
 `typescript`, `lua`, `python`, `wasm`.
@@ -1249,7 +1249,7 @@ Supported `language` values: `dart`, `java`, `kotlin`, `go`, `csharp`, `javascri
 - **File/network access is denied by construction** — executed code is only ever
   granted `print`; no filesystem or socket bridge is exposed, and tools operate on
   inline source strings only (never a path).
-- **Timeout / CPU** — `apollo.execute` runs inside a killable **isolate** by default,
+- **Timeout / CPU** — `apollovm.execute` runs inside a killable **isolate** by default,
   so a hard wall-clock timeout is enforced even against a runaway synchronous loop
   (`--timeout-ms`, default 5000). Other tools run in-process. Which tools use an
   isolate is configurable (`--isolate-tools`).

--- a/README.md
+++ b/README.md
@@ -1191,13 +1191,13 @@ compile, and inspect code across all supported languages through MCP tools.
 Start it over stdio (the standard local transport):
 
 ```bash
-apollovm mcp-serve
+apollovm mcp serve
 ```
 
 or over HTTP/SSE for networked agents:
 
 ```bash
-apollovm mcp-serve --http 8080          # binds 127.0.0.1:8080, SSE at /sse
+apollovm mcp serve --http 8080          # binds 127.0.0.1:8080, SSE at /sse
 ```
 
 Example MCP client configuration (e.g. for an agent/IDE):
@@ -1205,9 +1205,28 @@ Example MCP client configuration (e.g. for an agent/IDE):
 ```json
 {
   "mcpServers": {
-    "apollovm": { "command": "apollovm", "args": ["mcp-serve"] }
+    "apollovm": { "command": "apollovm", "args": ["mcp", "serve"] }
   }
 }
+```
+
+### `mcp` subcommands
+
+| Subcommand | Purpose |
+|------------|---------|
+| `mcp serve` | Run the MCP server over stdio (default) or HTTP/SSE (`--http <port>`). |
+| `mcp list` | List the available tools (names, descriptions, input schemas) as JSON. |
+| `mcp call <tool>` | Invoke one tool once and print its JSON result — source via `--source`/`--file`/stdin, args via flags. Use it from scripts/CI with no MCP client. |
+| `mcp info` | Print server metadata: version, MCP protocol, transports, languages, limits. |
+| `mcp schema [tool]` | Print the JSON input schema(s) for one or all tools. |
+| `mcp doctor` | Check the server/tools and report capabilities (e.g. whether the native `wasm_run` lib is available to run compiled Wasm). |
+
+```bash
+# Run a tool from the shell without an MCP client:
+apollovm mcp call apollo.execute --language dart \
+  --source 'int main(List a){ print("hi"); return 42; }'
+
+apollovm mcp call apollo.translate --from go --to dart --file main.go
 ```
 
 ### Tools

--- a/bin/apollovm.dart
+++ b/bin/apollovm.dart
@@ -19,7 +19,7 @@ void main(List<String> args) async {
         ..addCommand(CommandRun())
         ..addCommand(CommandTranslate())
         ..addCommand(CommandCompile())
-        ..addCommand(CommandMcpServe());
+        ..addCommand(CommandMcp());
 
   commandRunner.argParser.addFlag(
     'version',
@@ -375,105 +375,5 @@ class CommandCompile extends CommandSourceFileBase {
       return '$base.$moduleName$suffix';
     }
     return '$outputPath.$moduleName$suffix';
-  }
-}
-
-/// Runs the ApolloVM MCP server, exposing the VM's parse/execute/translate/
-/// compile/inspect capabilities to AI agents as MCP tools.
-///
-/// Defaults to the stdio transport; pass `--http <port>` for HTTP/SSE.
-class CommandMcpServe extends Command<bool> {
-  @override
-  final String description =
-      'Run the ApolloVM MCP server (Model Context Protocol) over stdio or HTTP/SSE.';
-
-  @override
-  final String name = 'mcp-serve';
-
-  CommandMcpServe() {
-    argParser
-      ..addOption(
-        'http',
-        help:
-            'Serve over HTTP/SSE on the given port instead of stdio.\n'
-            '(omit to use the stdio transport)',
-        valueHelp: 'port',
-      )
-      ..addOption(
-        'host',
-        help: 'Host/interface to bind for --http.',
-        defaultsTo: '127.0.0.1',
-      )
-      ..addOption(
-        'timeout-ms',
-        help: 'Execution timeout, in milliseconds.',
-        defaultsTo: '5000',
-      )
-      ..addOption(
-        'max-output-chars',
-        help: 'Maximum captured console output per execution.',
-        defaultsTo: '65536',
-      )
-      ..addOption(
-        'max-source-chars',
-        help: 'Maximum accepted source size, in characters.',
-        defaultsTo: '262144',
-      )
-      ..addOption(
-        'isolate-tools',
-        help:
-            'Comma-separated tools to run inside a killable isolate\n'
-            '(the only way to enforce a hard timeout on runaway code).',
-        defaultsTo: 'apollo.execute',
-      );
-  }
-
-  int _intOption(String name) {
-    var raw = argResults![name] as String?;
-    var value = raw != null ? int.tryParse(raw.trim()) : null;
-    if (value == null) {
-      throw StateError("Invalid integer for --$name: $raw");
-    }
-    return value;
-  }
-
-  @override
-  Future<bool> run() async {
-    var isolateTools = (argResults!['isolate-tools'] as String)
-        .split(',')
-        .map((e) => e.trim())
-        .where((e) => e.isNotEmpty)
-        .toSet();
-
-    var limits = McpLimits(
-      timeoutMs: _intOption('timeout-ms'),
-      maxOutputChars: _intOption('max-output-chars'),
-      maxSourceChars: _intOption('max-source-chars'),
-      isolateTools: isolateTools,
-    );
-
-    var httpPort = argResults!['http'] as String?;
-
-    if (httpPort != null) {
-      var port = int.tryParse(httpPort.trim());
-      if (port == null) {
-        throw StateError("Invalid port for --http: $httpPort");
-      }
-      var host = argResults!['host'] as String;
-
-      var transport = HttpSseTransport(limits: limits);
-      await transport.start(port: port, host: host);
-      // `stderr` so stdout stays clean for any tooling that scrapes it.
-      stderr.writeln(
-        'ApolloVM MCP server (HTTP/SSE) listening on http://$host:$port/sse',
-      );
-      // Serve until the process is terminated.
-      await Completer<void>().future;
-      return true;
-    }
-
-    var server = serveStdio(limits: limits);
-    await server.done;
-    return true;
   }
 }

--- a/bin/apollovm.dart
+++ b/bin/apollovm.dart
@@ -108,6 +108,15 @@ class CommandRun extends CommandSourceFileBase {
   @override
   final String name = 'run';
 
+  @override
+  String get usageFooter => '''
+
+Examples:
+  apollovm run script.dart
+  apollovm run app.py --function start
+  apollovm run prog.java main foo bar      # call `main` with args foo, bar
+  apollovm run module.wasm''';
+
   CommandRun() {
     argParser.addOption(
       'function',
@@ -209,6 +218,14 @@ class CommandTranslate extends CommandSourceFileBase {
   @override
   final String name = 'translate';
 
+  @override
+  String get usageFooter => '''
+
+Examples:
+  apollovm translate Foo.java --target dart
+  apollovm translate script.py --target javascript
+  apollovm translate app.go --target kotlin''';
+
   CommandTranslate() {
     argParser.addOption(
       'target',
@@ -269,6 +286,13 @@ class CommandCompile extends CommandSourceFileBase {
 
   @override
   final String name = 'compile';
+
+  @override
+  String get usageFooter => '''
+
+Examples:
+  apollovm compile calc.dart               # writes calc.wasm
+  apollovm compile calc.dart -o build/calc.wasm''';
 
   CommandCompile() {
     argParser.addOption(

--- a/bin/apollovm.dart
+++ b/bin/apollovm.dart
@@ -19,7 +19,7 @@ void main(List<String> args) async {
         ..addCommand(CommandRun())
         ..addCommand(CommandTranslate())
         ..addCommand(CommandCompile())
-        ..addCommand(CommandServe());
+        ..addCommand(CommandMcpServe());
 
   commandRunner.argParser.addFlag(
     'version',
@@ -382,15 +382,15 @@ class CommandCompile extends CommandSourceFileBase {
 /// compile/inspect capabilities to AI agents as MCP tools.
 ///
 /// Defaults to the stdio transport; pass `--http <port>` for HTTP/SSE.
-class CommandServe extends Command<bool> {
+class CommandMcpServe extends Command<bool> {
   @override
   final String description =
       'Run the ApolloVM MCP server (Model Context Protocol) over stdio or HTTP/SSE.';
 
   @override
-  final String name = 'serve';
+  final String name = 'mcp-serve';
 
-  CommandServe() {
+  CommandMcpServe() {
     argParser
       ..addOption(
         'http',

--- a/doc/MCP.md
+++ b/doc/MCP.md
@@ -9,17 +9,30 @@ It is built on the official Dart [`dart_mcp`](https://pub.dev/packages/dart_mcp)
 SDK and speaks MCP (`initialize` / `tools/list` / `tools/call`) over two
 transports.
 
-## Running
+## The `mcp` command
+
+All MCP functionality lives under the `apollovm mcp` command group:
+
+| Subcommand | Purpose |
+|------------|---------|
+| `mcp serve` | Run the MCP server over stdio (default) or HTTP/SSE (`--http`). |
+| `mcp list` | List the available tools (names/descriptions/input schemas) as JSON. |
+| `mcp call <tool>` | Invoke one tool once and print its JSON result. |
+| `mcp info` | Print server metadata (version, protocol, transports, languages, limits). |
+| `mcp schema [tool]` | Print the JSON input schema(s) for one or all tools. |
+| `mcp doctor` | Check the server/tools and report available capabilities. |
+
+### `mcp serve`
 
 ```bash
 # stdio (standard local transport)
-apollovm mcp-serve
+apollovm mcp serve
 
 # HTTP/SSE (networked agents) — binds 127.0.0.1:8080, SSE stream at /sse
-apollovm mcp-serve --http 8080 [--host 0.0.0.0]
+apollovm mcp serve --http 8080 [--host 0.0.0.0]
 ```
 
-CLI options:
+Options (shared with `mcp call`):
 
 | Option | Default | Meaning |
 |--------|---------|---------|
@@ -29,6 +42,32 @@ CLI options:
 | `--max-output-chars <n>` | `65536` | Max captured console output per execution. |
 | `--max-source-chars <n>` | `262144` | Max accepted source size. |
 | `--isolate-tools <list>` | `apollo.execute` | Comma-separated tools to run in a killable isolate. |
+
+### `mcp call`
+
+Invoke a single tool from the shell — handy for scripting/CI without an MCP client.
+Source is read from `--source`/`-s`, `--file`/`-f` (language inferred from the
+extension), or stdin. Exit code is non-zero when the result `isError`.
+
+```bash
+apollovm mcp call apollo.execute --language dart \
+  --source 'int main(List a){ print("hi"); return 42; }'
+
+apollovm mcp call apollo.translate --from go --to dart --file main.go
+
+echo 'int main(List a){ return 1; }' | apollovm mcp call apollo.parse -l dart
+```
+
+`apollo.execute` extras: `--function`, `--class-name`, `--args '<json array>'`.
+
+### `mcp list` / `mcp schema` / `mcp info` / `mcp doctor`
+
+```bash
+apollovm mcp list                 # all tool definitions (JSON)
+apollovm mcp schema apollo.wasm   # one tool's input schema (JSON)
+apollovm mcp info [--json]        # server/version/protocol/languages/limits
+apollovm mcp doctor               # environment & capability checks
+```
 
 ### Embedding
 

--- a/doc/MCP.md
+++ b/doc/MCP.md
@@ -13,10 +13,10 @@ transports.
 
 ```bash
 # stdio (standard local transport)
-apollovm serve
+apollovm mcp-serve
 
 # HTTP/SSE (networked agents) — binds 127.0.0.1:8080, SSE stream at /sse
-apollovm serve --http 8080 [--host 0.0.0.0]
+apollovm mcp-serve --http 8080 [--host 0.0.0.0]
 ```
 
 CLI options:

--- a/doc/MCP.md
+++ b/doc/MCP.md
@@ -41,7 +41,7 @@ Options (shared with `mcp call`):
 | `--timeout-ms <n>` | `5000` | Per-execution wall-clock timeout. |
 | `--max-output-chars <n>` | `65536` | Max captured console output per execution. |
 | `--max-source-chars <n>` | `262144` | Max accepted source size. |
-| `--isolate-tools <list>` | `apollo.execute` | Comma-separated tools to run in a killable isolate. |
+| `--isolate-tools <list>` | `apollovm.execute` | Comma-separated tools to run in a killable isolate. |
 
 ### `mcp call`
 
@@ -50,21 +50,21 @@ Source is read from `--source`/`-s`, `--file`/`-f` (language inferred from the
 extension), or stdin. Exit code is non-zero when the result `isError`.
 
 ```bash
-apollovm mcp call apollo.execute --language dart \
+apollovm mcp call apollovm.execute --language dart \
   --source 'int main(List a){ print("hi"); return 42; }'
 
-apollovm mcp call apollo.translate --from go --to dart --file main.go
+apollovm mcp call apollovm.translate --from go --to dart --file main.go
 
-echo 'int main(List a){ return 1; }' | apollovm mcp call apollo.parse -l dart
+echo 'int main(List a){ return 1; }' | apollovm mcp call apollovm.parse -l dart
 ```
 
-`apollo.execute` extras: `--function`, `--class-name`, `--args '<json array>'`.
+`apollovm.execute` extras: `--function`, `--class-name`, `--args '<json array>'`.
 
 ### `mcp list` / `mcp schema` / `mcp info` / `mcp doctor`
 
 ```bash
 apollovm mcp list                 # all tool definitions (JSON)
-apollovm mcp schema apollo.wasm   # one tool's input schema (JSON)
+apollovm mcp schema apollovm.wasm   # one tool's input schema (JSON)
 apollovm mcp info [--json]        # server/version/protocol/languages/limits
 apollovm mcp doctor               # environment & capability checks
 ```
@@ -97,7 +97,7 @@ Supported `language` values: `dart`, `java` (`java11`), `kotlin`, `go` (`golang`
 `csharp` (`cs`), `javascript` (`js`), `typescript` (`ts`), `lua`, `python` (`py`),
 `wasm`.
 
-### apollo.parse
+### apollovm.parse
 
 Input: `{ language, source }`
 
@@ -110,7 +110,7 @@ Output:
 }
 ```
 
-### apollo.execute
+### apollovm.execute
 
 Input: `{ language, source, function?, className?, args?, timeoutMs? }`
 (`function` defaults to `main`; `args` is a positional argument list.)
@@ -129,13 +129,13 @@ Output:
 `output` is the captured `print` stream. `truncated` is `true` when output hit
 `maxOutputChars`. On timeout, `isError` is `true` with a "timed out" diagnostic.
 
-### apollo.translate
+### apollovm.translate
 
 Input: `{ from, to, source }`
 
 Output: `{ "generated": "<source in the target language>", "diagnostics": [] }`
 
-### apollo.ast
+### apollovm.ast
 
 Input: `{ language, source, maxDepth? }`
 
@@ -148,7 +148,7 @@ literal `value`s.
 > **Note:** ApolloVM AST nodes carry no source positions (line/column), so none
 > are emitted per node. Positions are available only in parse-error diagnostics.
 
-### apollo.symbols
+### apollovm.symbols
 
 Input: `{ language, source }`
 
@@ -164,7 +164,7 @@ Output:
 }
 ```
 
-### apollo.types
+### apollovm.types
 
 Input: `{ language, source }`
 
@@ -175,7 +175,7 @@ Output:
 
 `kind` is `class` (declared in the unit), `builtin`, or `unknown`.
 
-### apollo.wasm
+### apollovm.wasm
 
 Input: `{ language, source }`
 
@@ -189,7 +189,7 @@ Each module's bytes are base64-encoded and begin with the `\0asm` magic
 |---------|-----------|----------|
 | File access | No file external is mapped; tools take inline source only | **Guaranteed** |
 | Network access | No socket external is mapped | **Guaranteed** |
-| Timeout / CPU | `apollo.execute` runs in a killable isolate (`Timer` + `Isolate.kill`) | **Enforced** |
+| Timeout / CPU | `apollovm.execute` runs in a killable isolate (`Timer` + `Isolate.kill`) | **Enforced** |
 | Input size | `maxSourceChars` | Enforced |
 | Output size | `maxOutputChars` (truncates) | Enforced |
 | Memory | Process-level only (`--old_gen_heap_size`) | **Best-effort** |
@@ -199,7 +199,7 @@ Each module's bytes are base64-encoded and begin with the `\0asm` magic
 ApolloVM executes CPU-bound work synchronously (its Dart dialect has no
 async-yield primitive). An in-process `Future.timeout` therefore **cannot**
 interrupt a runaway loop — the event loop is blocked and the timer never fires.
-Running `apollo.execute` inside an isolate is the only reliable way to enforce a
+Running `apollovm.execute` inside an isolate is the only reliable way to enforce a
 hard timeout: the isolate is `kill()`-ed when the deadline passes. The pure,
 bounded tools (`parse`/`ast`/`symbols`/`types`/`translate`/`wasm`) run in-process
 by default; adjust with `--isolate-tools` / `McpLimits.isolateTools`.

--- a/lib/apollovm_mcp.dart
+++ b/lib/apollovm_mcp.dart
@@ -12,6 +12,7 @@
 library;
 
 export 'src/mcp/apollo_mcp_server.dart';
+export 'src/mcp/cli/mcp_command.dart';
 export 'src/mcp/mcp_config.dart';
 export 'src/mcp/runtime/isolate_executor.dart'
     show computeToolIsolated, runToolInIsolate;

--- a/lib/src/mcp/cli/mcp_command.dart
+++ b/lib/src/mcp/cli/mcp_command.dart
@@ -72,7 +72,7 @@ abstract class _McpLimitsCommand extends Command<bool> {
         help:
             'Comma-separated tools to run inside a killable isolate\n'
             '(the only way to enforce a hard timeout on runaway code).',
-        defaultsTo: 'apollo.execute',
+        defaultsTo: 'apollovm.execute',
       );
   }
 
@@ -105,6 +105,14 @@ class CommandMcpServe extends _McpLimitsCommand {
 
   @override
   final String name = 'serve';
+
+  @override
+  String get usageFooter => '''
+
+Examples:
+  apollovm mcp serve                       # stdio transport
+  apollovm mcp serve --http 8080           # HTTP/SSE on 127.0.0.1:8080
+  apollovm mcp serve --timeout-ms 10000 --isolate-tools apollovm.execute,apollovm.wasm''';
 
   CommandMcpServe() {
     argParser
@@ -159,6 +167,13 @@ class CommandMcpList extends Command<bool> {
   final String name = 'list';
 
   @override
+  String get usageFooter => '''
+
+Examples:
+  apollovm mcp list
+  apollovm mcp list | jq '.[].name'       # just the tool names''';
+
+  @override
   bool run() {
     final tools = [
       for (final tool in buildTools())
@@ -181,6 +196,13 @@ class CommandMcpSchema extends Command<bool> {
 
   @override
   final String name = 'schema';
+
+  @override
+  String get usageFooter => '''
+
+Examples:
+  apollovm mcp schema                      # every tool's input schema
+  apollovm mcp schema apollovm.execute       # one tool (bare `execute` also works)''';
 
   @override
   bool run() {
@@ -211,6 +233,13 @@ class CommandMcpInfo extends Command<bool> {
 
   @override
   final String name = 'info';
+
+  @override
+  String get usageFooter => '''
+
+Examples:
+  apollovm mcp info
+  apollovm mcp info --json''';
 
   CommandMcpInfo() {
     argParser.addFlag(
@@ -267,6 +296,17 @@ class CommandMcpCall extends _McpLimitsCommand {
   @override
   final String name = 'call';
 
+  @override
+  String get usageFooter => '''
+
+The `apollovm.` tool-name prefix is optional: `execute` == `apollovm.execute`.
+
+Examples:
+  apollovm mcp call execute -l dart -s "void main() => print('Hello!');"
+  apollovm mcp call apollovm.translate --from go --to dart --file main.go
+  apollovm mcp call execute -f app.dart --args '["a","b"]'
+  echo 'print("hi")' | apollovm mcp call parse -l python''';
+
   CommandMcpCall() {
     argParser
       ..addOption('language', abbr: 'l', help: 'Source language.')
@@ -276,13 +316,13 @@ class CommandMcpCall extends _McpLimitsCommand {
         abbr: 'f',
         help: 'Read source from a file (language inferred from extension).',
       )
-      ..addOption('from', help: 'Source language (apollo.translate).')
-      ..addOption('to', help: 'Target language (apollo.translate).')
-      ..addOption('function', help: 'Entry function (apollo.execute).')
-      ..addOption('class-name', help: 'Entry class (apollo.execute).')
+      ..addOption('from', help: 'Source language (apollovm.translate).')
+      ..addOption('to', help: 'Target language (apollovm.translate).')
+      ..addOption('function', help: 'Entry function (apollovm.execute).')
+      ..addOption('class-name', help: 'Entry class (apollovm.execute).')
       ..addOption(
         'args',
-        help: 'JSON array of positional arguments (apollo.execute).',
+        help: 'JSON array of positional arguments (apollovm.execute).',
       );
   }
 
@@ -358,6 +398,12 @@ class CommandMcpDoctor extends Command<bool> {
   final String name = 'doctor';
 
   @override
+  String get usageFooter => '''
+
+Examples:
+  apollovm mcp doctor''';
+
+  @override
   Future<bool> run() async {
     var ok = true;
 
@@ -381,26 +427,26 @@ class CommandMcpDoctor extends Command<bool> {
       'language': 'dart',
       'source': dart,
     }, limits);
-    report(parse['isError'] != true, 'apollo.parse');
+    report(parse['isError'] != true, 'apollovm.parse');
 
     final exec = await computeTool(executeToolName, {
       'language': 'dart',
       'source': dart,
     }, limits);
-    report(exec['isError'] != true, 'apollo.execute');
+    report(exec['isError'] != true, 'apollovm.execute');
 
     final translate = await computeTool(translateToolName, {
       'from': 'dart',
       'to': 'python',
       'source': dart,
     }, limits);
-    report(translate['isError'] != true, 'apollo.translate');
+    report(translate['isError'] != true, 'apollovm.translate');
 
     final wasm = await computeTool(wasmToolName, {
       'language': 'dart',
       'source': 'int run(int a, int b){ return a + b; }',
     }, limits);
-    report(wasm['isError'] != true, 'apollo.wasm (compile)');
+    report(wasm['isError'] != true, 'apollovm.wasm (compile)');
 
     // Optional: the native runtime needed to *run* compiled Wasm.
     try {
@@ -408,8 +454,8 @@ class CommandMcpDoctor extends Command<bool> {
       report(
         runtime,
         runtime
-            ? 'wasm_run native runtime available (apollo.wasm modules are runnable)'
-            : 'wasm_run native runtime missing — apollo.wasm still COMPILES; '
+            ? 'wasm_run native runtime available (apollovm.wasm modules are runnable)'
+            : 'wasm_run native runtime missing — apollovm.wasm still COMPILES; '
                   'running compiled modules needs `dart run wasm_run:setup`',
         warnOnly: !runtime,
       );
@@ -432,8 +478,8 @@ bool _wasmRuntimeSupported() {
 }
 
 /// Accepts a bare tool name (`execute`) or a fully-qualified one
-/// (`apollo.execute`) and returns the canonical `apollo.*` name.
+/// (`apollovm.execute`) and returns the canonical `apollovm.*` name.
 String _normalizeToolName(String name) {
   final n = name.trim();
-  return n.startsWith('apollo.') ? n : 'apollo.$n';
+  return n.startsWith('apollovm.') ? n : 'apollovm.$n';
 }

--- a/lib/src/mcp/cli/mcp_command.dart
+++ b/lib/src/mcp/cli/mcp_command.dart
@@ -1,0 +1,439 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:args/command_runner.dart';
+import 'package:collection/collection.dart' show IterableExtension;
+import 'package:dart_mcp/server.dart' show ProtocolVersion;
+
+import '../../../apollovm.dart' show ApolloVM, WasmRuntime;
+import '../mcp_config.dart';
+import '../runtime/isolate_executor.dart';
+import '../tools/apollo_tools.dart';
+import '../transport/http_sse_transport.dart';
+import '../transport/stdio_transport.dart';
+
+const _json = JsonEncoder.withIndent('  ');
+
+/// The `mcp` command group: run the ApolloVM MCP server and inspect/use its
+/// tools from the CLI.
+///
+/// Subcommands: `serve`, `list`, `call`, `info`, `schema`, `doctor`.
+class CommandMcp extends Command<bool> {
+  @override
+  final String name = 'mcp';
+
+  @override
+  final String description =
+      'ApolloVM MCP (Model Context Protocol) server and tools.';
+
+  CommandMcp() {
+    addSubcommand(CommandMcpServe());
+    addSubcommand(CommandMcpList());
+    addSubcommand(CommandMcpCall());
+    addSubcommand(CommandMcpInfo());
+    addSubcommand(CommandMcpSchema());
+    addSubcommand(CommandMcpDoctor());
+  }
+
+  @override
+  bool run() {
+    // Invoked as bare `apollovm mcp` (no subcommand): show usage.
+    printUsage();
+    return true;
+  }
+}
+
+/// Base for subcommands that accept the shared resource-limit options.
+abstract class _McpLimitsCommand extends Command<bool> {
+  _McpLimitsCommand() {
+    argParser
+      ..addOption(
+        'timeout-ms',
+        help: 'Execution timeout, in milliseconds.',
+        defaultsTo: '5000',
+      )
+      ..addOption(
+        'max-output-chars',
+        help: 'Maximum captured console output per execution.',
+        defaultsTo: '65536',
+      )
+      ..addOption(
+        'max-source-chars',
+        help: 'Maximum accepted source size, in characters.',
+        defaultsTo: '262144',
+      )
+      ..addOption(
+        'isolate-tools',
+        help:
+            'Comma-separated tools to run inside a killable isolate\n'
+            '(the only way to enforce a hard timeout on runaway code).',
+        defaultsTo: 'apollo.execute',
+      );
+  }
+
+  int _intOption(String name) {
+    var raw = argResults![name] as String?;
+    var value = raw != null ? int.tryParse(raw.trim()) : null;
+    if (value == null) {
+      throw StateError("Invalid integer for --$name: $raw");
+    }
+    return value;
+  }
+
+  McpLimits get limits => McpLimits(
+    timeoutMs: _intOption('timeout-ms'),
+    maxOutputChars: _intOption('max-output-chars'),
+    maxSourceChars: _intOption('max-source-chars'),
+    isolateTools: (argResults!['isolate-tools'] as String)
+        .split(',')
+        .map((e) => e.trim())
+        .where((e) => e.isNotEmpty)
+        .toSet(),
+  );
+}
+
+/// `apollovm mcp serve` — run the MCP server over stdio or HTTP/SSE.
+class CommandMcpServe extends _McpLimitsCommand {
+  @override
+  final String description =
+      'Run the MCP server over stdio (default) or HTTP/SSE (`--http`).';
+
+  @override
+  final String name = 'serve';
+
+  CommandMcpServe() {
+    argParser
+      ..addOption(
+        'http',
+        help:
+            'Serve over HTTP/SSE on the given port instead of stdio.\n'
+            '(omit to use the stdio transport)',
+        valueHelp: 'port',
+      )
+      ..addOption(
+        'host',
+        help: 'Host/interface to bind for --http.',
+        defaultsTo: '127.0.0.1',
+      );
+  }
+
+  @override
+  Future<bool> run() async {
+    final limits = this.limits;
+    final httpPort = argResults!['http'] as String?;
+
+    if (httpPort != null) {
+      final port = int.tryParse(httpPort.trim());
+      if (port == null) {
+        throw StateError("Invalid port for --http: $httpPort");
+      }
+      final host = argResults!['host'] as String;
+
+      final transport = HttpSseTransport(limits: limits);
+      await transport.start(port: port, host: host);
+      stderr.writeln(
+        'ApolloVM MCP server (HTTP/SSE) listening on http://$host:$port/sse',
+      );
+      await Completer<void>().future; // serve until terminated
+      return true;
+    }
+
+    final server = serveStdio(limits: limits);
+    await server.done;
+    return true;
+  }
+}
+
+/// `apollovm mcp list` — list the available MCP tools (JSON).
+class CommandMcpList extends Command<bool> {
+  @override
+  final String description =
+      'List the available MCP tools (names, descriptions, input schemas) as JSON.';
+
+  @override
+  final String name = 'list';
+
+  @override
+  bool run() {
+    final tools = [
+      for (final tool in buildTools())
+        <String, Object?>{
+          'name': tool.name,
+          'description': tool.description,
+          'inputSchema': tool.inputSchema,
+        },
+    ];
+    print(_json.convert(tools));
+    return true;
+  }
+}
+
+/// `apollovm mcp schema [tool]` — print the JSON input schema(s) for tools.
+class CommandMcpSchema extends Command<bool> {
+  @override
+  final String description =
+      'Print the JSON input schema(s) for one tool (argument) or all tools.';
+
+  @override
+  final String name = 'schema';
+
+  @override
+  bool run() {
+    final tools = buildTools();
+    final rest = argResults!.rest;
+
+    if (rest.isNotEmpty) {
+      final wanted = _normalizeToolName(rest.first);
+      final tool = tools.where((t) => t.name == wanted).firstOrNull;
+      if (tool == null) {
+        throw StateError(
+          'Unknown tool: ${rest.first}. Known: ${allToolNames.join(', ')}',
+        );
+      }
+      print(_json.convert(tool.inputSchema));
+    } else {
+      print(_json.convert({for (final t in tools) t.name: t.inputSchema}));
+    }
+    return true;
+  }
+}
+
+/// `apollovm mcp info` — print server metadata and capabilities.
+class CommandMcpInfo extends Command<bool> {
+  @override
+  final String description =
+      'Print MCP server info: version, protocol, transports, languages, limits.';
+
+  @override
+  final String name = 'info';
+
+  CommandMcpInfo() {
+    argParser.addFlag(
+      'json',
+      help: 'Output as JSON instead of text.',
+      negatable: false,
+    );
+  }
+
+  @override
+  bool run() {
+    const limits = McpLimits();
+    final info = <String, Object?>{
+      'server': 'apollovm-mcp',
+      'version': ApolloVM.VERSION,
+      'protocol': ProtocolVersion.latestSupported.versionString,
+      'transports': ['stdio', 'http-sse'],
+      'tools': allToolNames,
+      'languages': mcpSupportedLanguages,
+      'limits': {
+        'timeoutMs': limits.timeoutMs,
+        'maxOutputChars': limits.maxOutputChars,
+        'maxSourceChars': limits.maxSourceChars,
+        'isolateTools': limits.isolateTools.toList(),
+      },
+    };
+
+    if (argResults!['json'] as bool) {
+      print(_json.convert(info));
+    } else {
+      print('server:     ${info['server']} ${info['version']}');
+      print('protocol:   ${info['protocol']}');
+      print('transports: ${(info['transports'] as List).join(', ')}');
+      print('tools:      ${(info['tools'] as List).join(', ')}');
+      print('languages:  ${(info['languages'] as List).join(', ')}');
+      final l = info['limits'] as Map;
+      print(
+        'limits:     timeoutMs=${l['timeoutMs']} '
+        'maxOutputChars=${l['maxOutputChars']} '
+        'maxSourceChars=${l['maxSourceChars']} '
+        'isolateTools=${(l['isolateTools'] as List).join(',')}',
+      );
+    }
+    return true;
+  }
+}
+
+/// `apollovm mcp call <tool>` — invoke one tool once and print its JSON result.
+class CommandMcpCall extends _McpLimitsCommand {
+  @override
+  final String description =
+      'Invoke a single MCP tool once and print its JSON result.';
+
+  @override
+  final String name = 'call';
+
+  CommandMcpCall() {
+    argParser
+      ..addOption('language', abbr: 'l', help: 'Source language.')
+      ..addOption('source', abbr: 's', help: 'Inline source code.')
+      ..addOption(
+        'file',
+        abbr: 'f',
+        help: 'Read source from a file (language inferred from extension).',
+      )
+      ..addOption('from', help: 'Source language (apollo.translate).')
+      ..addOption('to', help: 'Target language (apollo.translate).')
+      ..addOption('function', help: 'Entry function (apollo.execute).')
+      ..addOption('class-name', help: 'Entry class (apollo.execute).')
+      ..addOption(
+        'args',
+        help: 'JSON array of positional arguments (apollo.execute).',
+      );
+  }
+
+  @override
+  Future<bool> run() async {
+    final rest = argResults!.rest;
+    if (rest.isEmpty) {
+      throw StateError('Missing tool name. Usage: apollovm mcp call <tool>');
+    }
+    final toolName = _normalizeToolName(rest.first);
+    if (!allToolNames.contains(toolName)) {
+      throw StateError(
+        'Unknown tool: ${rest.first}. Known: ${allToolNames.join(', ')}',
+      );
+    }
+
+    final file = argResults!['file'] as String?;
+    final source = await _resolveSource(argResults!['source'] as String?, file);
+    final language =
+        (argResults!['language'] as String?) ??
+        (file != null
+            ? ApolloVM.parseLanguageFromFilePathExtension(file)
+            : null);
+
+    final args = <String, Object?>{};
+    if (toolName == translateToolName) {
+      args['from'] = argResults!['from'] ?? language;
+      args['to'] = argResults!['to'];
+      args['source'] = source;
+    } else {
+      args['language'] = language;
+      args['source'] = source;
+      if (toolName == executeToolName) {
+        if (argResults!['function'] != null) {
+          args['function'] = argResults!['function'];
+        }
+        if (argResults!['class-name'] != null) {
+          args['className'] = argResults!['class-name'];
+        }
+        final rawArgs = argResults!['args'] as String?;
+        if (rawArgs != null) {
+          args['args'] = jsonDecode(rawArgs) as List;
+        }
+      }
+    }
+
+    final limits = this.limits;
+    final result = limits.runsInIsolate(toolName)
+        ? await computeToolIsolated(toolName, args, limits)
+        : await computeTool(toolName, args, limits);
+
+    print(_json.convert(result));
+    if (result['isError'] == true) exitCode = 1;
+    return result['isError'] != true;
+  }
+
+  /// Resolves the source string from `--source`, `--file`, or stdin.
+  Future<String> _resolveSource(String? inline, String? file) async {
+    if (inline != null) return inline;
+    if (file != null) return File(file).readAsStringSync();
+    // Fall back to stdin (e.g. piped input).
+    return await stdin.transform(utf8.decoder).join();
+  }
+}
+
+/// `apollovm mcp doctor` — check the MCP server and its capabilities.
+class CommandMcpDoctor extends Command<bool> {
+  @override
+  final String description =
+      'Check the MCP server environment and report available capabilities.';
+
+  @override
+  final String name = 'doctor';
+
+  @override
+  Future<bool> run() async {
+    var ok = true;
+
+    void report(bool pass, String message, {bool warnOnly = false}) {
+      final tag = pass ? 'ok  ' : (warnOnly ? 'warn' : 'FAIL');
+      if (!pass && !warnOnly) ok = false;
+      print('$tag  $message');
+    }
+
+    // Tools register.
+    final tools = buildTools();
+    report(
+      tools.length == allToolNames.length,
+      '${tools.length} tools registered',
+    );
+
+    const limits = McpLimits();
+    const dart = 'int main(List a){ print("ok"); return 1; }';
+
+    final parse = await computeTool(parseToolName, {
+      'language': 'dart',
+      'source': dart,
+    }, limits);
+    report(parse['isError'] != true, 'apollo.parse');
+
+    final exec = await computeTool(executeToolName, {
+      'language': 'dart',
+      'source': dart,
+    }, limits);
+    report(exec['isError'] != true, 'apollo.execute');
+
+    final translate = await computeTool(translateToolName, {
+      'from': 'dart',
+      'to': 'python',
+      'source': dart,
+    }, limits);
+    report(translate['isError'] != true, 'apollo.translate');
+
+    final wasm = await computeTool(wasmToolName, {
+      'language': 'dart',
+      'source': 'int run(int a, int b){ return a + b; }',
+    }, limits);
+    report(wasm['isError'] != true, 'apollo.wasm (compile)');
+
+    // Optional: the native runtime needed to *run* compiled Wasm.
+    try {
+      final runtime = _wasmRuntimeSupported();
+      report(
+        runtime,
+        runtime
+            ? 'wasm_run native runtime available (apollo.wasm modules are runnable)'
+            : 'wasm_run native runtime missing — apollo.wasm still COMPILES; '
+                  'running compiled modules needs `dart run wasm_run:setup`',
+        warnOnly: !runtime,
+      );
+    } catch (_) {
+      report(
+        false,
+        'wasm_run native runtime missing — run `dart run wasm_run:setup` to run modules',
+        warnOnly: true,
+      );
+    }
+
+    print(ok ? '\nAll checks passed.' : '\nSome checks failed.');
+    return ok;
+  }
+}
+
+bool _wasmRuntimeSupported() {
+  final runtime = WasmRuntime()..ensureBooted();
+  return runtime.isSupported;
+}
+
+/// Accepts a bare tool name (`execute`) or a fully-qualified one
+/// (`apollo.execute`) and returns the canonical `apollo.*` name.
+String _normalizeToolName(String name) {
+  final n = name.trim();
+  return n.startsWith('apollo.') ? n : 'apollo.$n';
+}

--- a/lib/src/mcp/mcp_config.dart
+++ b/lib/src/mcp/mcp_config.dart
@@ -9,7 +9,7 @@
 /// can push through the server. Memory is NOT hard-capped by these values
 /// (Dart has no per-isolate heap cap) — see the `doc/MCP.md` security notes.
 class McpLimits {
-  /// Maximum wall-clock time for a single `apollo.execute` run, in milliseconds.
+  /// Maximum wall-clock time for a single `apollovm.execute` run, in milliseconds.
   ///
   /// Enforced via `Future.timeout`. ApolloVM's executor yields regularly
   /// (`FutureOr`/`resolveMapped`) so the timeout fires promptly; a purely
@@ -25,7 +25,7 @@ class McpLimits {
   /// are rejected before parsing/execution.
   final int maxSourceChars;
 
-  /// Maximum depth of the serialized AST tree (`apollo.ast`). Guards against
+  /// Maximum depth of the serialized AST tree (`apollovm.ast`). Guards against
   /// pathological/deep trees producing huge payloads.
   final int maxAstDepth;
 
@@ -34,7 +34,7 @@ class McpLimits {
   /// Isolate execution is the ONLY way to enforce a real wall-clock timeout in
   /// Dart: ApolloVM runs CPU work synchronously (no async yield), so an
   /// in-process `Future.timeout` cannot interrupt a runaway loop, but an
-  /// isolate can be `kill()`-ed. `apollo.execute` (which runs arbitrary user
+  /// isolate can be `kill()`-ed. `apollovm.execute` (which runs arbitrary user
   /// code) defaults to isolate execution; the pure/bounded tools default to
   /// in-process. Configurable per tool.
   final Set<String> isolateTools;
@@ -44,7 +44,7 @@ class McpLimits {
     this.maxOutputChars = 65536,
     this.maxSourceChars = 262144,
     this.maxAstDepth = 200,
-    this.isolateTools = const {'apollo.execute'},
+    this.isolateTools = const {'apollovm.execute'},
   });
 
   /// Whether [toolName] should run inside an isolate.

--- a/lib/src/mcp/tools/apollo_tools.dart
+++ b/lib/src/mcp/tools/apollo_tools.dart
@@ -13,13 +13,13 @@ import '../serialize/symbols.dart';
 import '../serialize/types.dart';
 
 /// Canonical tool names.
-const parseToolName = 'apollo.parse';
-const executeToolName = 'apollo.execute';
-const translateToolName = 'apollo.translate';
-const astToolName = 'apollo.ast';
-const symbolsToolName = 'apollo.symbols';
-const typesToolName = 'apollo.types';
-const wasmToolName = 'apollo.wasm';
+const parseToolName = 'apollovm.parse';
+const executeToolName = 'apollovm.execute';
+const translateToolName = 'apollovm.translate';
+const astToolName = 'apollovm.ast';
+const symbolsToolName = 'apollovm.symbols';
+const typesToolName = 'apollovm.types';
+const wasmToolName = 'apollovm.wasm';
 
 /// The names of all tools this server exposes, in registration order.
 const allToolNames = <String>[

--- a/lib/src/mcp/tools/apollo_tools.dart
+++ b/lib/src/mcp/tools/apollo_tools.dart
@@ -32,8 +32,21 @@ const allToolNames = <String>[
   wasmToolName,
 ];
 
-const _languageValues =
-    'dart, java, kotlin, go, csharp, javascript, typescript, lua, python, wasm';
+/// The source languages the MCP tools accept (canonical names).
+const mcpSupportedLanguages = <String>[
+  'dart',
+  'java',
+  'kotlin',
+  'go',
+  'csharp',
+  'javascript',
+  'typescript',
+  'lua',
+  'python',
+  'wasm',
+];
+
+final _languageValues = mcpSupportedLanguages.join(', ');
 
 Schema get _languageSchema =>
     Schema.string(description: 'Source language ($_languageValues).');

--- a/test/mcp/apollo_runtime_test.dart
+++ b/test/mcp/apollo_runtime_test.dart
@@ -6,11 +6,11 @@ import 'package:apollovm/apollovm_mcp.dart';
 import 'package:test/test.dart';
 
 void main() {
-  group('isolate execution (apollo.execute)', () {
+  group('isolate execution (apollovm.execute)', () {
     test('a synchronous infinite loop is killed at the timeout', () async {
       final limits = const McpLimits(timeoutMs: 500);
       final sw = Stopwatch()..start();
-      final result = await computeToolIsolated('apollo.execute', {
+      final result = await computeToolIsolated('apollovm.execute', {
         'language': 'dart',
         'source': 'void main(List a){ while(true){} }',
       }, limits);
@@ -29,7 +29,7 @@ void main() {
 
     test('a thrown error is isolated and reported', () async {
       final limits = const McpLimits(timeoutMs: 2000);
-      final result = await computeToolIsolated('apollo.execute', {
+      final result = await computeToolIsolated('apollovm.execute', {
         'language': 'dart',
         'source': 'int main(List a){ throw StateError("boom"); }',
       }, limits);
@@ -41,7 +41,7 @@ void main() {
   group('in-process execution', () {
     test('captured output is truncated at maxOutputChars', () async {
       final limits = const McpLimits(maxOutputChars: 10);
-      final result = await computeTool('apollo.execute', {
+      final result = await computeTool('apollovm.execute', {
         'language': 'dart',
         'source':
             'void main(List a){ print("0123456789ABCDEF"); print("more"); }',
@@ -53,7 +53,7 @@ void main() {
 
     test('source over maxSourceChars is rejected', () async {
       final limits = const McpLimits(maxSourceChars: 5);
-      final result = await computeTool('apollo.parse', {
+      final result = await computeTool('apollovm.parse', {
         'language': 'dart',
         'source': 'int main(List a){ return 1; }',
       }, limits);
@@ -63,7 +63,7 @@ void main() {
     });
 
     test('executes a class method (non-static) via className', () async {
-      final result = await computeTool('apollo.execute', {
+      final result = await computeTool('apollovm.execute', {
         'language': 'dart',
         'source': 'class Foo { int run(List a){ return 7; } }',
         'function': 'run',
@@ -74,7 +74,7 @@ void main() {
     });
 
     test('reports when the entry function is missing', () async {
-      final result = await computeTool('apollo.execute', {
+      final result = await computeTool('apollovm.execute', {
         'language': 'dart',
         'source': 'int other(){ return 1; }',
       }, const McpLimits());
@@ -90,7 +90,11 @@ void main() {
     const src = 'int main(List a){ return 1; }';
 
     test('unsupported language is rejected by every tool', () async {
-      for (final tool in ['apollo.parse', 'apollo.execute', 'apollo.wasm']) {
+      for (final tool in [
+        'apollovm.parse',
+        'apollovm.execute',
+        'apollovm.wasm',
+      ]) {
         final r = await computeTool(tool, {
           'language': 'ruby',
           'source': src,
@@ -104,7 +108,7 @@ void main() {
     });
 
     test('translate to a language without a generator errors', () async {
-      final r = await computeTool('apollo.translate', {
+      final r = await computeTool('apollovm.translate', {
         'from': 'dart',
         'to': 'ruby',
         'source': src,
@@ -115,7 +119,11 @@ void main() {
     });
 
     test('an unknown tool name yields an error result', () async {
-      final r = await computeTool('apollo.bogus', const {}, const McpLimits());
+      final r = await computeTool(
+        'apollovm.bogus',
+        const {},
+        const McpLimits(),
+      );
       expect(r['isError'], isTrue);
       expect('${(r['diagnostics'] as List).first}', contains('Unknown tool'));
     });
@@ -123,7 +131,7 @@ void main() {
     test(
       'execute on broken source returns parse diagnostics (in-process)',
       () async {
-        final r = await computeTool('apollo.execute', {
+        final r = await computeTool('apollovm.execute', {
           'language': 'dart',
           'source': 'int main(List a){ return',
         }, const McpLimits());
@@ -134,7 +142,7 @@ void main() {
 
     test('a runtime error during in-process execution is caught', () async {
       final r = await computeTool(
-        'apollo.execute',
+        'apollovm.execute',
         {
           'language': 'dart',
           'source': 'int main(List a){ throw StateError("kaboom"); }',
@@ -147,7 +155,7 @@ void main() {
     });
 
     test('execute passes a String[] arg list to a top-level main', () async {
-      final r = await computeTool('apollo.execute', {
+      final r = await computeTool('apollovm.execute', {
         'language': 'dart',
         'source': 'void main(List<String> a){ print(a[0]); }',
         'args': ['hello', 'world'],
@@ -161,22 +169,22 @@ void main() {
     test('defaults, runsInIsolate, copyWith and toString', () {
       const limits = McpLimits();
       expect(limits.timeoutMs, 5000);
-      expect(limits.runsInIsolate('apollo.execute'), isTrue);
-      expect(limits.runsInIsolate('apollo.parse'), isFalse);
+      expect(limits.runsInIsolate('apollovm.execute'), isTrue);
+      expect(limits.runsInIsolate('apollovm.parse'), isFalse);
 
       final custom = limits.copyWith(
         timeoutMs: 100,
         maxOutputChars: 10,
         maxSourceChars: 20,
         maxAstDepth: 5,
-        isolateTools: const {'apollo.wasm'},
+        isolateTools: const {'apollovm.wasm'},
       );
       expect(custom.timeoutMs, 100);
       expect(custom.maxOutputChars, 10);
       expect(custom.maxSourceChars, 20);
       expect(custom.maxAstDepth, 5);
-      expect(custom.runsInIsolate('apollo.wasm'), isTrue);
-      expect(custom.runsInIsolate('apollo.execute'), isFalse);
+      expect(custom.runsInIsolate('apollovm.wasm'), isTrue);
+      expect(custom.runsInIsolate('apollovm.execute'), isFalse);
       expect(custom.toString(), contains('timeoutMs: 100'));
 
       // copyWith with no overrides preserves every field.

--- a/test/mcp/mcp_command_test.dart
+++ b/test/mcp/mcp_command_test.dart
@@ -110,8 +110,8 @@ void main() {
     test('runs the capability checks and reports the tool count', () async {
       final output = await runMcp(['doctor']);
       expect(output, contains('7 tools registered'));
-      expect(output, contains('apollo.execute'));
-      expect(output, contains('apollo.wasm'));
+      expect(output, contains('apollovm.execute'));
+      expect(output, contains('apollovm.wasm'));
     });
   });
 }

--- a/test/mcp/mcp_command_test.dart
+++ b/test/mcp/mcp_command_test.dart
@@ -1,0 +1,117 @@
+@TestOn('vm')
+@Tags(['mcp'])
+library;
+
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:apollovm/apollovm.dart' show ApolloVM;
+import 'package:apollovm/apollovm_mcp.dart';
+import 'package:args/command_runner.dart';
+import 'package:test/test.dart';
+
+/// Runs `apollovm mcp <args...>` through a real [CommandRunner], capturing
+/// everything written to stdout via `print`.
+Future<String> runMcp(List<String> args) async {
+  final out = StringBuffer();
+  final runner = CommandRunner<bool>('apollovm', 'test')
+    ..addCommand(CommandMcp());
+  await runZoned(
+    () => runner.run(['mcp', ...args]),
+    zoneSpecification: ZoneSpecification(
+      print: (_, _, _, line) => out.writeln(line),
+    ),
+  );
+  return out.toString();
+}
+
+void main() {
+  group('mcp list', () {
+    test('emits all seven tool definitions with input schemas', () async {
+      final tools = jsonDecode(await runMcp(['list'])) as List;
+      expect(tools.map((t) => (t as Map)['name']), containsAll(allToolNames));
+      for (final t in tools) {
+        expect((t as Map)['inputSchema'], isA<Map>());
+        expect((t['inputSchema'] as Map)['properties'], isNotEmpty);
+      }
+    });
+  });
+
+  group('mcp info', () {
+    test('reports server, protocol, languages and limits as JSON', () async {
+      final info = jsonDecode(await runMcp(['info', '--json'])) as Map;
+      expect(info['server'], 'apollovm-mcp');
+      expect(info['version'], ApolloVM.VERSION);
+      expect(info['transports'], containsAll(['stdio', 'http-sse']));
+      expect(info['languages'], contains('go'));
+      expect((info['limits'] as Map)['timeoutMs'], 5000);
+    });
+  });
+
+  group('mcp schema', () {
+    test('prints a single tool schema (bare name accepted)', () async {
+      final schema = jsonDecode(await runMcp(['schema', 'execute'])) as Map;
+      expect(
+        (schema['properties'] as Map).keys,
+        containsAll(['language', 'source']),
+      );
+      expect(schema['required'], containsAll(['language', 'source']));
+    });
+
+    test('rejects an unknown tool', () {
+      expect(runMcp(['schema', 'nope']), throwsA(isA<StateError>()));
+    });
+  });
+
+  group('mcp call', () {
+    test('executes source passed via --source', () async {
+      final r =
+          jsonDecode(
+                await runMcp([
+                  'call',
+                  'execute',
+                  '-l',
+                  'dart',
+                  '-s',
+                  'int main(List a){ print("cli"); return 7; }',
+                ]),
+              )
+              as Map;
+      expect(r['isError'], isFalse);
+      expect(r['result'], 7);
+      expect(r['output'], ['cli']);
+    });
+
+    test('translates go->dart', () async {
+      final r =
+          jsonDecode(
+                await runMcp([
+                  'call',
+                  'translate',
+                  '--from',
+                  'go',
+                  '--to',
+                  'dart',
+                  '-s',
+                  'package main\nfunc Add(a int, b int) int { return a + b }\n',
+                ]),
+              )
+              as Map;
+      expect(r['isError'], isFalse);
+      expect(r['generated'], contains('int Add(int a, int b)'));
+    });
+
+    test('errors on an unknown tool', () {
+      expect(runMcp(['call', 'bogus', '-s', 'x']), throwsA(isA<StateError>()));
+    });
+  });
+
+  group('mcp doctor', () {
+    test('runs the capability checks and reports the tool count', () async {
+      final output = await runMcp(['doctor']);
+      expect(output, contains('7 tools registered'));
+      expect(output, contains('apollo.execute'));
+      expect(output, contains('apollo.wasm'));
+    });
+  });
+}

--- a/test/mcp/mcp_server_test.dart
+++ b/test/mcp/mcp_server_test.dart
@@ -115,13 +115,13 @@ class Calc {
       final tools = (resp['result'] as Map)['tools'] as List;
       final names = tools.map((t) => (t as Map)['name']).toSet();
       expect(names, {
-        'apollo.parse',
-        'apollo.execute',
-        'apollo.translate',
-        'apollo.ast',
-        'apollo.symbols',
-        'apollo.types',
-        'apollo.wasm',
+        'apollovm.parse',
+        'apollovm.execute',
+        'apollovm.translate',
+        'apollovm.ast',
+        'apollovm.symbols',
+        'apollovm.types',
+        'apollovm.wasm',
       });
       for (final t in tools) {
         final schema = (t as Map)['inputSchema'] as Map;
@@ -133,8 +133,8 @@ class Calc {
   group('tools', () {
     setUp(() => client.initialize());
 
-    test('apollo.parse returns a summary for valid source', () async {
-      final r = await client.callTool('apollo.parse', {
+    test('apollovm.parse returns a summary for valid source', () async {
+      final r = await client.callTool('apollovm.parse', {
         'language': 'dart',
         'source': dartSource,
       });
@@ -145,9 +145,9 @@ class Calc {
     });
 
     test(
-      'apollo.parse on broken source returns line/column diagnostics',
+      'apollovm.parse on broken source returns line/column diagnostics',
       () async {
-        final r = await client.callTool('apollo.parse', {
+        final r = await client.callTool('apollovm.parse', {
           'language': 'dart',
           'source': 'class { oops',
         });
@@ -161,8 +161,8 @@ class Calc {
       },
     );
 
-    test('apollo.execute returns result and captured output', () async {
-      final r = await client.callTool('apollo.execute', {
+    test('apollovm.execute returns result and captured output', () async {
+      final r = await client.callTool('apollovm.execute', {
         'language': 'dart',
         'source': dartSource,
       });
@@ -171,8 +171,8 @@ class Calc {
       expect(r['output'], ['running']);
     });
 
-    test('apollo.translate dart->python produces source', () async {
-      final r = await client.callTool('apollo.translate', {
+    test('apollovm.translate dart->python produces source', () async {
+      final r = await client.callTool('apollovm.translate', {
         'from': 'dart',
         'to': 'python',
         'source': dartSource,
@@ -181,8 +181,8 @@ class Calc {
       expect(r['generated'], contains('def add'));
     });
 
-    test('apollo.ast returns the root node', () async {
-      final r = await client.callTool('apollo.ast', {
+    test('apollovm.ast returns the root node', () async {
+      final r = await client.callTool('apollovm.ast', {
         'language': 'dart',
         'source': dartSource,
       });
@@ -192,8 +192,8 @@ class Calc {
       expect(ast['classes'], contains('Calc'));
     });
 
-    test('apollo.symbols returns the symbol graph', () async {
-      final r = await client.callTool('apollo.symbols', {
+    test('apollovm.symbols returns the symbol graph', () async {
+      final r = await client.callTool('apollovm.symbols', {
         'language': 'dart',
         'source': dartSource,
       });
@@ -206,8 +206,8 @@ class Calc {
       expect(methods, containsAll(['add', 'main']));
     });
 
-    test('apollo.types returns a classified type table', () async {
-      final r = await client.callTool('apollo.types', {
+    test('apollovm.types returns a classified type table', () async {
+      final r = await client.callTool('apollovm.types', {
         'language': 'dart',
         'source': dartSource,
       });
@@ -218,16 +218,19 @@ class Calc {
       expect(byName['int'], 'builtin');
     });
 
-    test('apollo.wasm returns a base64 module with the \\0asm magic', () async {
-      final r = await client.callTool('apollo.wasm', {
-        'language': 'dart',
-        'source': 'int run(int a, int b) { return a + b; }',
-      });
-      expect(r['_isError'], isFalse);
-      final modules = r['modules'] as List;
-      final bytes = base64.decode((modules.first as Map)['base64'] as String);
-      expect(bytes.sublist(0, 4), [0x00, 0x61, 0x73, 0x6D]);
-    });
+    test(
+      'apollovm.wasm returns a base64 module with the \\0asm magic',
+      () async {
+        final r = await client.callTool('apollovm.wasm', {
+          'language': 'dart',
+          'source': 'int run(int a, int b) { return a + b; }',
+        });
+        expect(r['_isError'], isFalse);
+        final modules = r['modules'] as List;
+        final bytes = base64.decode((modules.first as Map)['base64'] as String);
+        expect(bytes.sublist(0, 4), [0x00, 0x61, 0x73, 0x6D]);
+      },
+    );
 
     test('supports Go: execute and translate go->dart', () async {
       const goSource = '''
@@ -241,14 +244,14 @@ func main() {
 }
 ''';
 
-      final exec = await client.callTool('apollo.execute', {
+      final exec = await client.callTool('apollovm.execute', {
         'language': 'go',
         'source': goSource,
       });
       expect(exec['_isError'], isFalse);
       expect(exec['output'], contains('42'));
 
-      final translated = await client.callTool('apollo.translate', {
+      final translated = await client.callTool('apollovm.translate', {
         'from': 'go',
         'to': 'dart',
         'source': goSource,
@@ -259,7 +262,7 @@ func main() {
 
     test('unknown tool name yields an error result', () async {
       final resp = await client.request('tools/call', {
-        'name': 'apollo.nope',
+        'name': 'apollovm.nope',
         'arguments': <String, Object?>{},
       });
       final result = resp['result'] as Map<String, Object?>;

--- a/test/mcp/stdio_transport_test.dart
+++ b/test/mcp/stdio_transport_test.dart
@@ -52,7 +52,7 @@ void main() {
         'id': 2,
         'method': 'tools/call',
         'params': {
-          'name': 'apollo.execute',
+          'name': 'apollovm.execute',
           'arguments': {
             'language': 'dart',
             'source': 'int main(List a){ return 5; }',


### PR DESCRIPTION
Restructures the MCP CLI into an **`mcp` command group** (superseding the interim `mcp-serve`), and moves the command implementations into the library (`lib/src/mcp/cli/mcp_command.dart`, exported from `apollovm_mcp.dart`) so `bin/apollovm.dart` just wires `..addCommand(CommandMcp())`.

## Subcommands

| Command | Purpose |
|---------|---------|
| `mcp serve` | Run the MCP server over stdio (default) or HTTP/SSE (`--http <port>`). |
| `mcp list` | List tool definitions (names, descriptions, input schemas) as JSON. |
| `mcp call <tool>` | Invoke one tool once and print its JSON result — source via `--source`/`--file`/stdin, args via flags; exit code reflects `isError`. Use ApolloVM from scripts/CI with **no MCP client**. |
| `mcp info` | Server metadata: version, MCP protocol, transports, languages, limits. |
| `mcp schema [tool]` | JSON input schema(s) for one or all tools. |
| `mcp doctor` | Capability checks (incl. whether the native `wasm_run` lib is present to *run* compiled Wasm). |

```bash
apollovm mcp call apollo.execute --language dart \
  --source 'int main(List a){ print("hi"); return 42; }'
apollovm mcp call apollo.translate --from go --to dart --file main.go
apollovm mcp info
```

## Notes
- `mcp serve` is the former `mcp-serve` / `serve`; the library API (`serveStdio`, `ApolloMcpServer`, `HttpSseTransport`, `McpLimits`) is unchanged.
- New `test/mcp/mcp_command_test.dart` drives all subcommands through a real `CommandRunner` with captured stdout (8 cases). Full `mcp` suite: 50 tests green.
- `dart format` + `dart analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)