### PR TITLE
feat(lsp): LspClient + documentHighlight & prepareRename (v1.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,40 @@
+## 1.3.0
+
+### Language Server Protocol — new server features
+
+- **`textDocument/documentHighlight`** — highlights every occurrence of the
+  identifier under the cursor, marking the declaration site as `Write` and other
+  uses as `Read` (`documentHighlightProvider` capability).
+- **`textDocument/prepareRename`** — validates a rename target, returning its
+  range and placeholder, or null when the cursor is not on an identifier
+  (advertised via the rename provider's `prepareProvider`).
+
+### Language Server Protocol — client
+
+- **New `LspClient`** in `package:apollovm/apollovm_lsp.dart`: a JSON-RPC client
+  that consumes the ApolloVM `LspServer`. It correlates responses to the
+  requests it sends, streams server-pushed diagnostics
+  (`Stream<PublishDiagnosticsParams> get diagnostics`), and exposes typed
+  helpers — `initialize`, `didOpen`/`didChange`/`didClose`, `hover`,
+  `definition`, `documentSymbol`, `completion`, `references`,
+  `documentHighlight`, `prepareRename`, `rename`, `workspaceSymbol`,
+  `shutdown`/`exit` — plus low-level `sendRequest`/`sendNotification`.
+- **`LspClient.inProcess()`** pairs a client with a fresh `LspServer` over a
+  linked `MessageLspEndpoint` pair, all in one isolate — no subprocess, no
+  `dart:io`. The client works over any `LspEndpoint`, so an out-of-process
+  server can be driven with `LspClient(StreamLspEndpoint(out, in))`.
+- `LspEndpoint` now routes JSON-RPC *responses* (previously ignored) to a new
+  `onResponse` hook, enabling the client role. Pure-server usage is unchanged.
+- Protocol data types gained `fromJson` factories (`Hover`, `Location`,
+  `Diagnostic`, `DocumentSymbol`, `CompletionItem`, `TextEdit`, `WorkspaceEdit`),
+  and new types were added: `InitializeResult`, `ServerInfo`,
+  `PublishDiagnosticsParams`, `WorkspaceSymbol`, `CompletionList`,
+  `DocumentHighlight`/`DocumentHighlightKind`, `PrepareRenameResult`.
+- New example [`example/apollovm_example_lsp.dart`](example/apollovm_example_lsp.dart)
+  drives a full session (handshake, diagnostics, symbols, hover, definition,
+  completion, highlight, prepare-rename, rename) through
+  `LspClient.inProcess()`.
+
 ## 1.2.1
 
 - Fix broken 1.2.0 package on pub.dev: the `.pubignore` pattern `lsp/` was

--- a/README.md
+++ b/README.md
@@ -902,6 +902,36 @@ final server = LspServer(endpoint);
 endpoint.receive(incomingMessage); // deliver each incoming JSON-RPC object
 ```
 
+To *consume* the server, use `LspClient`. It correlates responses to requests,
+streams server-pushed diagnostics, and offers typed helpers (`hover`,
+`definition`, `documentSymbol`, `completion`, `references`, `documentHighlight`,
+`prepareRename`, `rename`, `workspaceSymbol`). `LspClient.inProcess()` pairs a
+client with a fresh server in the same isolate — no subprocess, no `dart:io`:
+
+```dart
+import 'package:apollovm/apollovm_lsp.dart';
+
+final client = LspClient.inProcess();
+client.diagnostics.listen((d) => print('${d.uri}: ${d.diagnostics.length} problems'));
+
+await client.initialize();
+client.initialized();
+client.didOpen('file:///Foo.dart', source);
+
+final hover = await client.hover('file:///Foo.dart', Position(2, 13));
+print(hover?.contents.value);
+
+await client.shutdown();
+client.exit();
+```
+
+For an out-of-process server, wrap its transport instead —
+`LspClient(StreamLspEndpoint(process.stdout, process.stdin))..start()`.
+
+A runnable, self-contained walkthrough (handshake, diagnostics, document
+symbols, hover, go-to-definition, completion and rename) is in
+[`example/apollovm_example_lsp.dart`](example/apollovm_example_lsp.dart).
+
 A minimal VS Code client, an example workspace and a latency benchmark live in
 the repository's [`lsp/`](lsp/) directory (not part of the published package) —
 see [`lsp/README.md`](lsp/README.md) for features, design and editor setup.

--- a/example/apollovm_example_lsp.dart
+++ b/example/apollovm_example_lsp.dart
@@ -1,0 +1,140 @@
+import 'package:apollovm/apollovm_lsp.dart';
+
+/// Example: driving the ApolloVM Language Server (LSP 3.17) with [LspClient].
+///
+/// `LspClient.inProcess()` spins up a client wired to a fresh [LspServer] in the
+/// same isolate — no subprocess, no `dart:io` — so an editor, a web IDE or an AI
+/// agent can embed the whole language server. For an out-of-process server,
+/// wrap its transport instead, e.g. `LspClient(StreamLspEndpoint(out, in))`.
+void main() async {
+  final client = LspClient.inProcess();
+
+  // Print diagnostics as the server publishes them.
+  client.diagnostics.listen((d) {
+    final where = d.uri.split('/').last;
+    if (d.diagnostics.isEmpty) {
+      print('[$where] no problems');
+    } else {
+      for (final problem in d.diagnostics) {
+        print('[$where] ${problem.range.start}: ${problem.message}');
+      }
+    }
+  });
+
+  // 1) Handshake.
+  final init = await client.initialize();
+  print('Connected to ${init.serverInfo?.name} v${init.serverInfo?.version}');
+  print('Capabilities: ${init.capabilities.keys.join(', ')}');
+  client.initialized();
+
+  print('---------------------------------------');
+
+  // 2) Open a document. Diagnostics arrive on the stream above.
+  const uri = 'file:///Foo.dart';
+  const source = r'''
+class Foo {
+  /// Doubles [x] and adds [y].
+  static int calc(int x, int y) {
+    var doubled = x * 2;
+    return doubled + y;
+  }
+
+  static int run() {
+    return calc(10, 5);
+  }
+}
+''';
+  client.didOpen(uri, source);
+  await client.diagnostics.first; // wait for the first analysis
+
+  print('---------------------------------------');
+
+  // 3) Document outline.
+  print('Symbols:');
+  for (final s in await client.documentSymbol(uri)) {
+    print('  • ${s.name}');
+    for (final c in s.children) {
+      print('      - ${c.name}  (${c.detail})');
+    }
+  }
+
+  print('---------------------------------------');
+
+  // 4) Hover over the `calc` method name. `positionOf` finds LSP
+  //    {line, character} coordinates without hardcoding them.
+  final hover = await client.hover(uri, positionOf(source, 'calc'));
+  print('Hover at calc:\n${hover?.contents.value}');
+
+  print('---------------------------------------');
+
+  // 5) Go-to-definition of `calc` from its call site inside `run`.
+  final def = await client.definition(
+    uri,
+    positionOf(source, 'calc', occurrence: 2),
+  );
+  print('Definition of `calc` (called in run): ${def?.range.start}');
+
+  print('---------------------------------------');
+
+  // 6) Completion proposals at the cursor.
+  final completion = await client.completion(
+    uri,
+    positionOf(source, 'doubled'),
+  );
+  final labels = completion.items.take(6).map((i) => i.label).join(', ');
+  print('Completion (${completion.items.length} items): $labels, …');
+
+  print('---------------------------------------');
+
+  // 7) Highlight every occurrence of `calc` (declaration = write, uses = read).
+  final highlights = await client.documentHighlight(
+    uri,
+    positionOf(source, 'calc'),
+  );
+  final kinds = highlights
+      .map((h) => h.kind == DocumentHighlightKind.write ? 'write' : 'read')
+      .join(', ');
+  print('Highlights for calc: ${highlights.length} ($kinds)');
+
+  print('---------------------------------------');
+
+  // 8) Validate a rename, then rename every occurrence of `calc` to `compute`.
+  final prep = await client.prepareRename(uri, positionOf(source, 'calc'));
+  print('prepareRename → renaming `${prep?.placeholder}` at ${prep?.range}');
+  final edit = await client.rename(uri, positionOf(source, 'calc'), 'compute');
+  final edits = edit?.changes[uri] ?? const [];
+  print('Rename calc → compute: ${edits.length} edits');
+
+  print('---------------------------------------');
+
+  // 9) Break the source and watch diagnostics update.
+  final broken = client.diagnostics.firstWhere((d) => d.diagnostics.isNotEmpty);
+  client.didChange(uri, 'class Foo {\n  static int calc( {\n}\n', version: 2);
+  await broken;
+
+  print('---------------------------------------');
+
+  // 10) Graceful shutdown.
+  await client.shutdown();
+  client.exit();
+  await client.dispose();
+  print('Session closed.');
+}
+
+/// Returns the LSP `{line, character}` [Position] (both zero-based) of the
+/// [occurrence]-th appearance of [needle] in [text].
+Position positionOf(String text, String needle, {int occurrence = 1}) {
+  var index = -1;
+  for (var i = 0; i < occurrence; i++) {
+    index = text.indexOf(needle, index + 1);
+    if (index < 0) throw ArgumentError('Not found: $needle (#$occurrence)');
+  }
+  var line = 0, lineStart = 0;
+  for (var i = 0; i < index; i++) {
+    if (text.codeUnitAt(i) == 0x0A) {
+      line++;
+      lineStart = i + 1;
+    }
+  }
+  return Position(line, index - lineStart);
+}

--- a/lib/apollovm_lsp.dart
+++ b/lib/apollovm_lsp.dart
@@ -20,6 +20,18 @@
 ///
 /// * [StreamLspEndpoint] — byte streams with `Content-Length` framing (stdio,
 ///   sockets). The CLI exposes this via `apollovm lsp`.
+///
+/// To *consume* the server, use [LspClient], which correlates responses, streams
+/// diagnostics, and exposes typed helpers ([LspClient.hover],
+/// [LspClient.definition], …). [LspClient.inProcess] pairs a client with a fresh
+/// server in the same isolate:
+///
+/// ```dart
+/// final client = LspClient.inProcess();
+/// await client.initialize();
+/// client.didOpen('file:///Foo.dart', source);
+/// final hover = await client.hover('file:///Foo.dart', Position(2, 13));
+/// ```
 library;
 
 export 'src/lsp/analysis/analyzer.dart';
@@ -29,6 +41,7 @@ export 'src/lsp/analysis/line_index.dart';
 export 'src/lsp/analysis/parse_error_locator.dart';
 export 'src/lsp/analysis/symbols.dart';
 export 'src/lsp/analysis/token_index.dart';
+export 'src/lsp/client/client.dart';
 export 'src/lsp/protocol/protocol.dart';
 export 'src/lsp/server/server.dart';
 export 'src/lsp/transport/json_rpc.dart';

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '1.2.1';
+  static final String VERSION = '1.3.0';
 
   static int _idCount = 0;
 

--- a/lib/src/lsp/client/client.dart
+++ b/lib/src/lsp/client/client.dart
@@ -1,0 +1,354 @@
+// A JSON-RPC client for the ApolloVM language server. It correlates responses
+// to the requests it sends, streams server-pushed diagnostics, and exposes
+// typed convenience wrappers over the LSP requests the server implements.
+//
+// Like the rest of `apollovm_lsp`, this imports no `dart:io`; it drives any
+// [LspEndpoint] — [MessageLspEndpoint] in-process/web, [StreamLspEndpoint] over
+// stdio or a socket.
+import 'dart:async';
+
+import '../protocol/protocol.dart';
+import '../server/server.dart';
+import '../transport/json_rpc.dart';
+
+/// Handles a server->client request (rare; e.g. `window/showMessageRequest`).
+/// Return the result, or throw [ResponseError]; returning null replies with a
+/// null result.
+typedef ServerRequestHandler =
+    FutureOr<Object?> Function(String method, Object? params);
+
+/// A client for the ApolloVM [LspServer].
+///
+/// Send requests with the typed helpers ([hover], [definition], [completion],
+/// …) or the low-level [sendRequest]/[sendNotification], and listen for
+/// server-pushed diagnostics on [diagnostics].
+///
+/// ```dart
+/// final client = LspClient.inProcess();     // client + server, same isolate
+/// await client.initialize();
+/// client.initialized();
+/// client.diagnostics.listen((d) => print('${d.uri}: ${d.diagnostics.length}'));
+/// client.didOpen('file:///Foo.dart', source);
+/// final hover = await client.hover('file:///Foo.dart', Position(2, 13));
+/// ```
+///
+/// For an out-of-process server, wrap its transport instead:
+/// ```dart
+/// final client = LspClient(StreamLspEndpoint(proc.stdout, proc.stdin))..start();
+/// ```
+class LspClient {
+  final LspEndpoint _endpoint;
+
+  var _nextId = 1;
+  final _pending = <int, Completer<Object?>>{};
+  final _diagnostics = StreamController<PublishDiagnosticsParams>.broadcast();
+  bool _closed = false;
+
+  /// Optional handler for requests the server sends to the client. When null,
+  /// such requests are answered with a `methodNotFound` error.
+  ServerRequestHandler? onServerRequest;
+
+  /// Optional sink for every incoming notification, called after built-in
+  /// handling (e.g. diagnostics are still delivered to [diagnostics]).
+  NotificationHandler? onNotification;
+
+  /// Wraps an existing [endpoint]. Call [start] before exchanging messages so a
+  /// stream-based endpoint begins reading; message-based endpoints deliver
+  /// incoming messages through their own `receive`.
+  LspClient(this._endpoint) {
+    _endpoint.onResponse = _onResponse;
+    _endpoint.onNotification = _onNotification;
+    _endpoint.onRequest = _onRequest;
+  }
+
+  /// Creates a client wired to a fresh in-process [LspServer] over a linked pair
+  /// of [MessageLspEndpoint]s. Ideal for embedding (web IDE, AI agent) and
+  /// tests — no subprocess, no `dart:io`.
+  factory LspClient.inProcess() {
+    late final MessageLspEndpoint serverEndpoint;
+    final clientEndpoint = MessageLspEndpoint(
+      (msg) => serverEndpoint.receive(msg),
+    );
+    serverEndpoint = MessageLspEndpoint((msg) => clientEndpoint.receive(msg));
+
+    LspServer(serverEndpoint).start();
+    return LspClient(clientEndpoint)..start();
+  }
+
+  /// The underlying transport.
+  LspEndpoint get endpoint => _endpoint;
+
+  /// Server-pushed `textDocument/publishDiagnostics` notifications.
+  Stream<PublishDiagnosticsParams> get diagnostics => _diagnostics.stream;
+
+  /// Completes when the transport closes.
+  Future<void> get done => _endpoint.done;
+
+  /// Begins consuming the transport (no-op for message-based endpoints).
+  void start() => _endpoint.listen();
+
+  // --- Low-level JSON-RPC ---
+
+  /// Sends a request and completes with its `result`, or completes with a
+  /// [ResponseError] if the server replied with an error.
+  Future<Object?> sendRequest(String method, [Object? params]) {
+    if (_closed) {
+      throw StateError('LspClient is closed');
+    }
+    final id = _nextId++;
+    final completer = Completer<Object?>();
+    _pending[id] = completer;
+    _endpoint.writeMessage({
+      'jsonrpc': '2.0',
+      'id': id,
+      'method': method,
+      'params': ?params,
+    });
+    return completer.future;
+  }
+
+  /// Sends a fire-and-forget notification.
+  void sendNotification(String method, [Object? params]) {
+    _endpoint.sendNotification(method, params);
+  }
+
+  // --- Lifecycle ---
+
+  /// Performs the `initialize` handshake and returns the server's capabilities.
+  /// Follow with [initialized] once ready.
+  Future<InitializeResult> initialize({
+    Map<String, Object?>? capabilities,
+    String? rootUri,
+    Map<String, Object?>? initializationOptions,
+  }) async {
+    final result = await sendRequest('initialize', {
+      'processId': null,
+      'capabilities': capabilities ?? const <String, Object?>{},
+      'rootUri': ?rootUri,
+      'initializationOptions': ?initializationOptions,
+    });
+    return InitializeResult.fromJson((result as Map).cast<String, Object?>());
+  }
+
+  /// Notifies the server the client is ready (sent after [initialize]).
+  void initialized() => sendNotification('initialized', const {});
+
+  /// Requests a graceful `shutdown`; pair with [exit].
+  Future<void> shutdown() async {
+    await sendRequest('shutdown');
+  }
+
+  /// Tells the server to `exit`.
+  void exit() => sendNotification('exit', null);
+
+  // --- Text document sync ---
+
+  /// Opens [uri] with [text]. Diagnostics arrive on [diagnostics].
+  void didOpen(
+    String uri,
+    String text, {
+    String languageId = 'dart',
+    int version = 1,
+  }) {
+    sendNotification('textDocument/didOpen', {
+      'textDocument': {
+        'uri': uri,
+        'languageId': languageId,
+        'version': version,
+        'text': text,
+      },
+    });
+  }
+
+  /// Replaces the whole content of [uri] with [text] (a full-document change).
+  void didChange(String uri, String text, {int? version}) {
+    sendNotification('textDocument/didChange', {
+      'textDocument': {'uri': uri, 'version': ?version},
+      'contentChanges': [
+        {'text': text},
+      ],
+    });
+  }
+
+  /// Closes [uri]; the server clears its diagnostics.
+  void didClose(String uri) {
+    sendNotification('textDocument/didClose', {
+      'textDocument': {'uri': uri},
+    });
+  }
+
+  // --- Language features ---
+
+  /// Hover information at [position] in [uri], or null if none.
+  Future<Hover?> hover(String uri, Position position) async {
+    final r = await _positional('textDocument/hover', uri, position);
+    return r is Map ? Hover.fromJson(r.cast<String, Object?>()) : null;
+  }
+
+  /// The declaration location for the symbol at [position], or null.
+  Future<Location?> definition(String uri, Position position) async {
+    final r = await _positional('textDocument/definition', uri, position);
+    if (r is Map) return Location.fromJson(r.cast<String, Object?>());
+    if (r is List && r.isNotEmpty) {
+      return Location.fromJson((r.first as Map).cast<String, Object?>());
+    }
+    return null;
+  }
+
+  /// The document outline (hierarchical [DocumentSymbol]s) for [uri].
+  Future<List<DocumentSymbol>> documentSymbol(String uri) async {
+    final r = await sendRequest('textDocument/documentSymbol', {
+      'textDocument': {'uri': uri},
+    });
+    return [
+      for (final s in (r as List?) ?? const [])
+        DocumentSymbol.fromJson((s as Map).cast<String, Object?>()),
+    ];
+  }
+
+  /// Completion proposals at [position] in [uri].
+  Future<CompletionList> completion(String uri, Position position) async {
+    final r = await _positional('textDocument/completion', uri, position);
+    if (r is Map) return CompletionList.fromJson(r.cast<String, Object?>());
+    if (r is List) {
+      return CompletionList(
+        items: [
+          for (final i in r)
+            CompletionItem.fromJson((i as Map).cast<String, Object?>()),
+        ],
+      );
+    }
+    return const CompletionList();
+  }
+
+  /// All references to the symbol at [position] in [uri].
+  Future<List<Location>> references(
+    String uri,
+    Position position, {
+    bool includeDeclaration = true,
+  }) async {
+    final r = await sendRequest('textDocument/references', {
+      'textDocument': {'uri': uri},
+      'position': position.toJson(),
+      'context': {'includeDeclaration': includeDeclaration},
+    });
+    return [
+      for (final l in (r as List?) ?? const [])
+        Location.fromJson((l as Map).cast<String, Object?>()),
+    ];
+  }
+
+  /// Every occurrence to highlight for the symbol at [position] in [uri].
+  Future<List<DocumentHighlight>> documentHighlight(
+    String uri,
+    Position position,
+  ) async {
+    final r = await _positional(
+      'textDocument/documentHighlight',
+      uri,
+      position,
+    );
+    return [
+      for (final h in (r as List?) ?? const [])
+        DocumentHighlight.fromJson((h as Map).cast<String, Object?>()),
+    ];
+  }
+
+  /// Checks whether the symbol at [position] can be renamed, returning its range
+  /// and current text, or null if it cannot (no identifier under the cursor).
+  Future<PrepareRenameResult?> prepareRename(
+    String uri,
+    Position position,
+  ) async {
+    final r = await _positional('textDocument/prepareRename', uri, position);
+    return r is Map
+        ? PrepareRenameResult.fromJson(r.cast<String, Object?>())
+        : null;
+  }
+
+  /// A [WorkspaceEdit] renaming the symbol at [position] to [newName], or null.
+  Future<WorkspaceEdit?> rename(
+    String uri,
+    Position position,
+    String newName,
+  ) async {
+    final r = await sendRequest('textDocument/rename', {
+      'textDocument': {'uri': uri},
+      'position': position.toJson(),
+      'newName': newName,
+    });
+    return r is Map ? WorkspaceEdit.fromJson(r.cast<String, Object?>()) : null;
+  }
+
+  /// Workspace-wide symbols matching [query] (empty matches all).
+  Future<List<WorkspaceSymbol>> workspaceSymbol(String query) async {
+    final r = await sendRequest('workspace/symbol', {'query': query});
+    return [
+      for (final s in (r as List?) ?? const [])
+        WorkspaceSymbol.fromJson((s as Map).cast<String, Object?>()),
+    ];
+  }
+
+  // --- Internals ---
+
+  Future<Object?> _positional(String method, String uri, Position position) =>
+      sendRequest(method, {
+        'textDocument': {'uri': uri},
+        'position': position.toJson(),
+      });
+
+  void _onResponse(Map<String, Object?> message) {
+    final id = message['id'];
+    final key = id is num ? id.toInt() : null;
+    final completer = key == null ? null : _pending.remove(key);
+    if (completer == null || completer.isCompleted) return;
+
+    final error = message['error'];
+    if (error is Map) {
+      completer.completeError(
+        ResponseError(
+          (error['code'] as num?)?.toInt() ?? ResponseError.internalError,
+          (error['message'] ?? 'LSP error').toString(),
+        ),
+      );
+    } else {
+      completer.complete(message['result']);
+    }
+  }
+
+  void _onNotification(String method, Object? params) {
+    if (method == 'textDocument/publishDiagnostics' && params is Map) {
+      if (!_diagnostics.isClosed) {
+        _diagnostics.add(
+          PublishDiagnosticsParams.fromJson(params.cast<String, Object?>()),
+        );
+      }
+    }
+    onNotification?.call(method, params);
+  }
+
+  FutureOr<Object?> _onRequest(String method, Object? params) {
+    final handler = onServerRequest;
+    if (handler == null) {
+      throw ResponseError(
+        ResponseError.methodNotFound,
+        "Client cannot handle request '$method'",
+      );
+    }
+    return handler(method, params);
+  }
+
+  /// Releases resources: fails any in-flight requests and closes [diagnostics].
+  /// Does not itself send `shutdown`/`exit` — call those first for a clean stop.
+  Future<void> dispose() async {
+    if (_closed) return;
+    _closed = true;
+    for (final completer in _pending.values) {
+      if (!completer.isCompleted) {
+        completer.completeError(StateError('LspClient disposed'));
+      }
+    }
+    _pending.clear();
+    await _diagnostics.close();
+  }
+}

--- a/lib/src/lsp/protocol/protocol.dart
+++ b/lib/src/lsp/protocol/protocol.dart
@@ -54,6 +54,11 @@ class Location {
 
   const Location(this.uri, this.range);
 
+  factory Location.fromJson(Map<String, Object?> json) => Location(
+    json['uri'] as String,
+    Range.fromJson(json['range'] as Map<String, Object?>),
+  );
+
   Map<String, Object?> toJson() => {'uri': uri, 'range': range.toJson()};
 }
 
@@ -81,6 +86,14 @@ class Diagnostic {
     this.code,
   });
 
+  factory Diagnostic.fromJson(Map<String, Object?> json) => Diagnostic(
+    range: Range.fromJson(json['range'] as Map<String, Object?>),
+    message: (json['message'] ?? '').toString(),
+    severity: (json['severity'] as num?)?.toInt() ?? DiagnosticSeverity.error,
+    source: json['source'] as String? ?? 'apollovm',
+    code: json['code']?.toString(),
+  );
+
   Map<String, Object?> toJson() => {
     'range': range.toJson(),
     'severity': severity,
@@ -98,6 +111,18 @@ class MarkupContent {
   const MarkupContent.markdown(this.value) : kind = 'markdown';
   const MarkupContent.plaintext(this.value) : kind = 'plaintext';
 
+  /// Parses a `MarkupContent` object, or a bare string (`MarkedString`), into a
+  /// [MarkupContent].
+  factory MarkupContent.from(Object? contents) {
+    if (contents is Map) {
+      final value = (contents['value'] ?? '').toString();
+      return contents['kind'] == 'markdown'
+          ? MarkupContent.markdown(value)
+          : MarkupContent.plaintext(value);
+    }
+    return MarkupContent.plaintext((contents ?? '').toString());
+  }
+
   Map<String, Object?> toJson() => {'kind': kind, 'value': value};
 }
 
@@ -108,9 +133,63 @@ class Hover {
 
   const Hover(this.contents, {this.range});
 
+  factory Hover.fromJson(Map<String, Object?> json) => Hover(
+    MarkupContent.from(json['contents']),
+    range: json['range'] is Map
+        ? Range.fromJson(json['range'] as Map<String, Object?>)
+        : null,
+  );
+
   Map<String, Object?> toJson() => {
     'contents': contents.toJson(),
     if (range != null) 'range': range!.toJson(),
+  };
+}
+
+/// LSP `DocumentHighlightKind`.
+class DocumentHighlightKind {
+  static const int text = 1;
+  static const int read = 2;
+  static const int write = 3;
+}
+
+/// A range to highlight in a document (`textDocument/documentHighlight`), e.g.
+/// every occurrence of the identifier under the cursor.
+class DocumentHighlight {
+  final Range range;
+  final int? kind;
+
+  const DocumentHighlight(this.range, {this.kind});
+
+  factory DocumentHighlight.fromJson(Map<String, Object?> json) =>
+      DocumentHighlight(
+        Range.fromJson(json['range'] as Map<String, Object?>),
+        kind: (json['kind'] as num?)?.toInt(),
+      );
+
+  Map<String, Object?> toJson() => {
+    'range': range.toJson(),
+    if (kind != null) 'kind': kind,
+  };
+}
+
+/// Result of `textDocument/prepareRename`: the [range] of the symbol that would
+/// be renamed and a [placeholder] (its current text).
+class PrepareRenameResult {
+  final Range range;
+  final String placeholder;
+
+  const PrepareRenameResult(this.range, this.placeholder);
+
+  factory PrepareRenameResult.fromJson(Map<String, Object?> json) =>
+      PrepareRenameResult(
+        Range.fromJson(json['range'] as Map<String, Object?>),
+        json['placeholder'] as String? ?? '',
+      );
+
+  Map<String, Object?> toJson() => {
+    'range': range.toJson(),
+    'placeholder': placeholder,
   };
 }
 
@@ -146,6 +225,20 @@ class DocumentSymbol {
     this.detail,
     this.children = const [],
   });
+
+  factory DocumentSymbol.fromJson(Map<String, Object?> json) => DocumentSymbol(
+    name: json['name'] as String,
+    detail: json['detail'] as String?,
+    kind: (json['kind'] as num).toInt(),
+    range: Range.fromJson(json['range'] as Map<String, Object?>),
+    selectionRange: Range.fromJson(
+      json['selectionRange'] as Map<String, Object?>,
+    ),
+    children: [
+      for (final c in (json['children'] as List?) ?? const [])
+        DocumentSymbol.fromJson(c as Map<String, Object?>),
+    ],
+  );
 
   Map<String, Object?> toJson() => {
     'name': name,
@@ -189,6 +282,16 @@ class CompletionItem {
     this.documentation,
   });
 
+  factory CompletionItem.fromJson(Map<String, Object?> json) => CompletionItem(
+    label: json['label'] as String,
+    kind: (json['kind'] as num?)?.toInt() ?? CompletionItemKind.text,
+    detail: json['detail'] as String?,
+    sortText: json['sortText'] as String?,
+    documentation: json['documentation'] == null
+        ? null
+        : MarkupContent.from(json['documentation']),
+  );
+
   Map<String, Object?> toJson() => {
     'label': label,
     'kind': kind,
@@ -205,6 +308,11 @@ class TextEdit {
 
   const TextEdit(this.range, this.newText);
 
+  factory TextEdit.fromJson(Map<String, Object?> json) => TextEdit(
+    Range.fromJson(json['range'] as Map<String, Object?>),
+    json['newText'] as String? ?? '',
+  );
+
   Map<String, Object?> toJson() => {
     'range': range.toJson(),
     'newText': newText,
@@ -217,9 +325,143 @@ class WorkspaceEdit {
 
   const WorkspaceEdit(this.changes);
 
+  factory WorkspaceEdit.fromJson(Map<String, Object?> json) {
+    final changes = <String, List<TextEdit>>{};
+    final raw = json['changes'];
+    if (raw is Map) {
+      raw.forEach((uri, edits) {
+        changes[uri as String] = [
+          for (final e in (edits as List?) ?? const [])
+            TextEdit.fromJson(e as Map<String, Object?>),
+        ];
+      });
+    }
+    return WorkspaceEdit(changes);
+  }
+
   Map<String, Object?> toJson() => {
     'changes': changes.map(
       (uri, edits) => MapEntry(uri, edits.map((e) => e.toJson()).toList()),
     ),
+  };
+}
+
+/// Result of the `initialize` request: the server's advertised
+/// [capabilities] and optional [serverInfo].
+class InitializeResult {
+  final Map<String, Object?> capabilities;
+  final ServerInfo? serverInfo;
+
+  const InitializeResult({this.capabilities = const {}, this.serverInfo});
+
+  factory InitializeResult.fromJson(Map<String, Object?> json) =>
+      InitializeResult(
+        capabilities:
+            (json['capabilities'] as Map?)?.cast<String, Object?>() ?? const {},
+        serverInfo: json['serverInfo'] is Map
+            ? ServerInfo.fromJson(json['serverInfo'] as Map<String, Object?>)
+            : null,
+      );
+
+  /// Whether the server advertised support for [capability] (e.g.
+  /// `hoverProvider`), meaning a truthy value in [capabilities].
+  bool supports(String capability) {
+    final v = capabilities[capability];
+    return v == true || (v != null && v != false);
+  }
+}
+
+/// The server's self-description returned by `initialize`.
+class ServerInfo {
+  final String name;
+  final String? version;
+
+  const ServerInfo(this.name, {this.version});
+
+  factory ServerInfo.fromJson(Map<String, Object?> json) => ServerInfo(
+    json['name'] as String? ?? '',
+    version: json['version'] as String?,
+  );
+}
+
+/// Parameters of a `textDocument/publishDiagnostics` notification.
+class PublishDiagnosticsParams {
+  final String uri;
+  final int? version;
+  final List<Diagnostic> diagnostics;
+
+  const PublishDiagnosticsParams({
+    required this.uri,
+    this.version,
+    this.diagnostics = const [],
+  });
+
+  factory PublishDiagnosticsParams.fromJson(Map<String, Object?> json) =>
+      PublishDiagnosticsParams(
+        uri: json['uri'] as String,
+        version: (json['version'] as num?)?.toInt(),
+        diagnostics: [
+          for (final d in (json['diagnostics'] as List?) ?? const [])
+            Diagnostic.fromJson(d as Map<String, Object?>),
+        ],
+      );
+
+  Map<String, Object?> toJson() => {
+    'uri': uri,
+    if (version != null) 'version': version,
+    'diagnostics': diagnostics.map((d) => d.toJson()).toList(),
+  };
+}
+
+/// An entry returned by `workspace/symbol`: a named declaration and where it
+/// lives.
+class WorkspaceSymbol {
+  final String name;
+  final int kind;
+  final Location location;
+  final String? containerName;
+
+  const WorkspaceSymbol({
+    required this.name,
+    required this.kind,
+    required this.location,
+    this.containerName,
+  });
+
+  factory WorkspaceSymbol.fromJson(Map<String, Object?> json) =>
+      WorkspaceSymbol(
+        name: json['name'] as String,
+        kind: (json['kind'] as num?)?.toInt() ?? 0,
+        location: Location.fromJson(json['location'] as Map<String, Object?>),
+        containerName: json['containerName'] as String?,
+      );
+
+  Map<String, Object?> toJson() => {
+    'name': name,
+    'kind': kind,
+    'location': location.toJson(),
+    if (containerName != null) 'containerName': containerName,
+  };
+}
+
+/// Result of `textDocument/completion`: the [items] and whether the list is
+/// [isIncomplete] (should be recomputed as the user keeps typing).
+class CompletionList {
+  final bool isIncomplete;
+  final List<CompletionItem> items;
+
+  const CompletionList({this.isIncomplete = false, this.items = const []});
+
+  factory CompletionList.fromJson(Map<String, Object?> json) => CompletionList(
+    isIncomplete: json['isIncomplete'] == true,
+    items: [
+      for (final i in (json['items'] as List?) ?? const [])
+        CompletionItem.fromJson(i as Map<String, Object?>),
+    ],
+  );
+
+  Map<String, Object?> toJson() => {
+    'isIncomplete': isIncomplete,
+    'items': items.map((i) => i.toJson()).toList(),
   };
 }

--- a/lib/src/lsp/server/server.dart
+++ b/lib/src/lsp/server/server.dart
@@ -60,6 +60,10 @@ class LspServer {
         return _completion(p);
       case 'textDocument/references':
         return _references(p);
+      case 'textDocument/documentHighlight':
+        return _documentHighlight(p);
+      case 'textDocument/prepareRename':
+        return _prepareRename(p);
       case 'textDocument/rename':
         return _rename(p);
       case 'workspace/symbol':
@@ -87,7 +91,9 @@ class LspServer {
         'definitionProvider': true,
         'documentSymbolProvider': true,
         'referencesProvider': true,
-        'renameProvider': true,
+        'documentHighlightProvider': true,
+        // `prepareProvider` advertises `textDocument/prepareRename`.
+        'renameProvider': {'prepareProvider': true},
         'workspaceSymbolProvider': true,
         'completionProvider': {
           'triggerCharacters': ['.'],
@@ -423,6 +429,49 @@ class LspServer {
         if (t.name == ident.name)
           Location(uri, unit.lineIndex.rangeAt(t.start, t.end)).toJson(),
     ];
+  }
+
+  // --- Feature: document highlight (occurrences of the cursor's name) ---
+
+  Future<List<Object?>> _documentHighlight(Map<String, Object?> p) async {
+    final unit = await _unit(_uriOf(p));
+    if (unit == null) return const [];
+    final cur = _resolveCursor(unit, p);
+    final ident = cur?.ident;
+    if (ident == null) return const [];
+
+    // Occurrences that coincide with a declaration's name are `Write`; the rest
+    // are `Read`.
+    final declStarts = <int>{
+      for (final d in unit.tokenIndex.declarations)
+        if (d.name == ident.name) d.nameStart,
+    };
+
+    return [
+      for (final t in unit.tokenIndex.identifiers)
+        if (t.name == ident.name)
+          DocumentHighlight(
+            unit.lineIndex.rangeAt(t.start, t.end),
+            kind: declStarts.contains(t.start)
+                ? DocumentHighlightKind.write
+                : DocumentHighlightKind.read,
+          ).toJson(),
+    ];
+  }
+
+  // --- Feature: prepare rename (validate the target under the cursor) ---
+
+  Future<Map<String, Object?>?> _prepareRename(Map<String, Object?> p) async {
+    final unit = await _unit(_uriOf(p));
+    if (unit == null) return null;
+    final cur = _resolveCursor(unit, p);
+    final ident = cur?.ident;
+    if (ident == null) return null;
+
+    return {
+      'range': unit.lineIndex.rangeAt(ident.start, ident.end).toJson(),
+      'placeholder': ident.name,
+    };
   }
 
   // --- Feature: rename (in-file, name-scoped) ---

--- a/lib/src/lsp/transport/json_rpc.dart
+++ b/lib/src/lsp/transport/json_rpc.dart
@@ -40,11 +40,20 @@ typedef RequestHandler =
 /// Handles an incoming notification (no reply).
 typedef NotificationHandler = void Function(String method, Object? params);
 
+/// Handles an incoming response to a request we sent (client role). Receives the
+/// full decoded message, including its `id` and either `result` or `error`.
+typedef ResponseHandler = void Function(Map<String, Object?> message);
+
 /// Transport-agnostic JSON-RPC 2.0 endpoint. Subclasses supply the wire by
 /// implementing [writeMessage] and feeding decoded messages to [handleMessage].
 abstract class LspEndpoint {
   RequestHandler? onRequest;
   NotificationHandler? onNotification;
+
+  /// Invoked for a JSON-RPC response (a message with an `id` but no `method`),
+  /// i.e. the peer's reply to a request this endpoint sent. Set by [LspClient];
+  /// left null by a pure server, which never issues requests.
+  ResponseHandler? onResponse;
 
   /// Begins consuming input. No-op for push-based endpoints (e.g. web).
   void listen() {}
@@ -66,7 +75,9 @@ abstract class LspEndpoint {
     final id = message['id'];
 
     if (method is! String) {
-      // A response to a server->client request; unused for now.
+      // A response to a request we sent (client role); the server role leaves
+      // [onResponse] null and simply ignores it.
+      if (id != null) onResponse?.call(message);
       return;
     }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 1.2.1
+version: 1.3.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/lsp/client_test.dart
+++ b/test/lsp/client_test.dart
@@ -291,4 +291,129 @@ void main() {
       expect(result.serverInfo?.name, 'apollovm-lsp');
     },
   );
+
+  group('LspClient (edge cases)', () {
+    test('exposes the underlying endpoint and a done future', () async {
+      final client = LspClient.inProcess();
+      addTearDown(client.dispose);
+      expect(client.endpoint, isA<LspEndpoint>());
+      expect(client.done, isA<Future<void>>());
+    });
+
+    test('initialize forwards rootUri and initializationOptions', () async {
+      final client = LspClient.inProcess();
+      addTearDown(client.dispose);
+      final result = await client.initialize(
+        rootUri: 'file:///ws',
+        initializationOptions: const {'trace': 'off'},
+      );
+      expect(result.serverInfo?.name, 'apollovm-lsp');
+    });
+
+    test('definition parses a list-shaped response', () async {
+      final client = _clientWithPeer((method, _) {
+        expect(method, 'textDocument/definition');
+        return [
+          Location(
+            'file:///a.dart',
+            const Range(Position(1, 2), Position(1, 6)),
+          ).toJson(),
+        ];
+      });
+      addTearDown(client.dispose);
+      final def = await client.definition(
+        'file:///a.dart',
+        const Position(0, 0),
+      );
+      expect(def, isNotNull);
+      expect(def!.range.start.line, 1);
+      expect(def.range.end.character, 6);
+    });
+
+    test('completion parses a bare-list response', () async {
+      final client = _clientWithPeer((method, _) {
+        expect(method, 'textDocument/completion');
+        return [
+          const CompletionItem(
+            label: 'foo',
+            kind: CompletionItemKind.function,
+          ).toJson(),
+        ];
+      });
+      addTearDown(client.dispose);
+      final list = await client.completion(
+        'file:///a.dart',
+        const Position(0, 0),
+      );
+      expect(list.isIncomplete, isFalse);
+      expect(list.items.single.label, 'foo');
+    });
+
+    test('answers a server->client request via onServerRequest', () async {
+      final replies = <Map<String, Object?>>[];
+      final client = _clientWithPeer(null, onPeerResponse: replies.add);
+      addTearDown(client.dispose);
+      client.onServerRequest = (method, params) => {'echo': method};
+
+      _peerSend(client, {
+        'jsonrpc': '2.0',
+        'id': 55,
+        'method': 'window/showMessageRequest',
+        'params': const {'a': 1},
+      });
+      await pumpEventQueue();
+
+      expect(replies, hasLength(1));
+      expect(replies.single['id'], 55);
+      expect(
+        (replies.single['result'] as Map)['echo'],
+        'window/showMessageRequest',
+      );
+    });
+
+    test('rejects a server->client request with no handler', () async {
+      final replies = <Map<String, Object?>>[];
+      final client = _clientWithPeer(null, onPeerResponse: replies.add);
+      addTearDown(client.dispose);
+
+      _peerSend(client, {
+        'jsonrpc': '2.0',
+        'id': 56,
+        'method': 'foo/bar',
+        'params': null,
+      });
+      await pumpEventQueue();
+
+      expect(replies, hasLength(1));
+      expect(
+        (replies.single['error'] as Map)['code'],
+        ResponseError.methodNotFound,
+      );
+    });
+  });
+}
+
+/// Peer endpoints registered per client, so a test can push a server->client
+/// message into the client via [_peerSend].
+final _peers = <LspClient, MessageLspEndpoint>{};
+
+/// Builds a client whose peer answers requests with [peerOnRequest] and, when
+/// given, forwards the client's responses to [onPeerResponse].
+LspClient _clientWithPeer(
+  RequestHandler? peerOnRequest, {
+  ResponseHandler? onPeerResponse,
+}) {
+  late final MessageLspEndpoint peer;
+  final clientEndpoint = MessageLspEndpoint((m) => peer.receive(m));
+  peer = MessageLspEndpoint((m) => clientEndpoint.receive(m));
+  peer.onRequest = peerOnRequest;
+  peer.onResponse = onPeerResponse;
+  final client = LspClient(clientEndpoint)..start();
+  _peers[client] = peer;
+  return client;
+}
+
+/// Sends [message] from the peer into [client] as if the server originated it.
+void _peerSend(LspClient client, Map<String, Object?> message) {
+  _peers[client]!.writeMessage(message);
 }

--- a/test/lsp/client_test.dart
+++ b/test/lsp/client_test.dart
@@ -1,0 +1,294 @@
+import 'package:apollovm/apollovm_lsp.dart';
+import 'package:test/test.dart';
+
+const _uri = 'file:///workspace/Foo.dart';
+const _source = '''
+class Foo {
+  /// Doubles [x] and adds [y].
+  static int calc(int x, int y) {
+    var doubled = x * 2;
+    return doubled + y;
+  }
+
+  static int run() {
+    return calc(10, 5);
+  }
+}
+''';
+
+/// Locates the LSP position of a substring in [_source].
+Position _posOf(String needle, {int occurrence = 1}) {
+  final line = LineIndex(_source);
+  var index = -1;
+  for (var i = 0; i < occurrence; i++) {
+    index = _source.indexOf(needle, index + 1);
+  }
+  final p = line.positionAt(index);
+  return Position(p.line, p.character);
+}
+
+void main() {
+  group('LspClient (in-process)', () {
+    late LspClient client;
+
+    setUp(() => client = LspClient.inProcess());
+    tearDown(() => client.dispose());
+
+    test('initialize advertises server capabilities', () async {
+      final result = await client.initialize();
+      expect(result.serverInfo?.name, 'apollovm-lsp');
+      expect(result.serverInfo?.version, isNotEmpty);
+      expect(result.supports('hoverProvider'), isTrue);
+      expect(result.supports('definitionProvider'), isTrue);
+      expect(result.supports('renameProvider'), isTrue);
+      expect(result.supports('documentHighlightProvider'), isTrue);
+      // rename advertises prepareProvider (an object, still truthy).
+      expect(
+        (result.capabilities['renameProvider'] as Map)['prepareProvider'],
+        isTrue,
+      );
+    });
+
+    test('didOpen publishes diagnostics on the stream', () async {
+      await client.initialize();
+      client.initialized();
+
+      final first = client.diagnostics.first;
+      client.didOpen(_uri, _source);
+      final published = await first;
+
+      expect(published.uri, _uri);
+      expect(published.diagnostics, isEmpty); // clean source
+    });
+
+    test('didChange re-publishes diagnostics for a broken source', () async {
+      await client.initialize();
+      client.didOpen(_uri, _source);
+      await client.diagnostics.first;
+
+      final next = client.diagnostics.firstWhere(
+        (d) => d.diagnostics.isNotEmpty,
+      );
+      client.didChange(
+        _uri,
+        'class Foo {\n  static int calc( {\n}\n',
+        version: 2,
+      );
+      final broken = await next;
+
+      expect(broken.diagnostics, isNotEmpty);
+      expect(broken.diagnostics.first.severity, DiagnosticSeverity.error);
+    });
+
+    test('documentSymbol returns the outline', () async {
+      await client.initialize();
+      client.didOpen(_uri, _source);
+      await client.diagnostics.first;
+
+      final symbols = await client.documentSymbol(_uri);
+      expect(symbols.map((s) => s.name), contains('Foo'));
+      final foo = symbols.firstWhere((s) => s.name == 'Foo');
+      expect(foo.kind, SymbolKind.classKind);
+      expect(foo.children.map((c) => c.name), containsAll(['calc', 'run']));
+    });
+
+    test('hover returns a typed markup for a method', () async {
+      await client.initialize();
+      client.didOpen(_uri, _source);
+      await client.diagnostics.first;
+
+      final hover = await client.hover(_uri, _posOf('calc'));
+      expect(hover, isNotNull);
+      expect(hover!.contents.value, contains('calc'));
+      expect(hover.contents.value, contains('Doubles'));
+    });
+
+    test('definition resolves a call to its declaration', () async {
+      await client.initialize();
+      client.didOpen(_uri, _source);
+      await client.diagnostics.first;
+
+      // 2nd `calc` is the call site inside `run`.
+      final def = await client.definition(_uri, _posOf('calc', occurrence: 2));
+      expect(def, isNotNull);
+      // 1st `calc` is the declaration name.
+      final declStart = _posOf('calc');
+      expect(def!.range.start.line, declStart.line);
+      expect(def.range.start.character, declStart.character);
+    });
+
+    test('completion proposes symbols and keywords', () async {
+      await client.initialize();
+      client.didOpen(_uri, _source);
+      await client.diagnostics.first;
+
+      final list = await client.completion(_uri, _posOf('doubled'));
+      final labels = list.items.map((i) => i.label).toSet();
+      expect(labels, contains('calc'));
+      expect(labels, contains('return')); // a keyword
+    });
+
+    test('references finds every occurrence of a name', () async {
+      await client.initialize();
+      client.didOpen(_uri, _source);
+      await client.diagnostics.first;
+
+      final refs = await client.references(_uri, _posOf('calc'));
+      // Declaration + call site.
+      expect(refs.length, 2);
+      expect(refs.every((l) => l.uri == _uri), isTrue);
+    });
+
+    test('rename produces a workspace edit for every occurrence', () async {
+      await client.initialize();
+      client.didOpen(_uri, _source);
+      await client.diagnostics.first;
+
+      final edit = await client.rename(_uri, _posOf('calc'), 'compute');
+      expect(edit, isNotNull);
+      final edits = edit!.changes[_uri]!;
+      expect(edits.length, 2);
+      expect(edits.every((e) => e.newText == 'compute'), isTrue);
+    });
+
+    test('documentHighlight marks the declaration write, uses read', () async {
+      await client.initialize();
+      client.didOpen(_uri, _source);
+      await client.diagnostics.first;
+
+      final highlights = await client.documentHighlight(_uri, _posOf('calc'));
+      expect(highlights.length, 2); // declaration + call site
+      final kinds = highlights.map((h) => h.kind).toList();
+      expect(kinds, containsAll([DocumentHighlightKind.write]));
+      expect(kinds, containsAll([DocumentHighlightKind.read]));
+
+      // The write highlight sits on the declaration name.
+      final write = highlights.firstWhere(
+        (h) => h.kind == DocumentHighlightKind.write,
+      );
+      final decl = _posOf('calc');
+      expect(write.range.start.line, decl.line);
+      expect(write.range.start.character, decl.character);
+    });
+
+    test('documentHighlight is empty off any identifier', () async {
+      await client.initialize();
+      client.didOpen(_uri, _source);
+      await client.diagnostics.first;
+
+      // The blank line between the two methods is not an identifier.
+      final highlights = await client.documentHighlight(_uri, Position(6, 0));
+      expect(highlights, isEmpty);
+    });
+
+    test('prepareRename returns the target range and placeholder', () async {
+      await client.initialize();
+      client.didOpen(_uri, _source);
+      await client.diagnostics.first;
+
+      final prep = await client.prepareRename(
+        _uri,
+        _posOf('calc', occurrence: 2),
+      );
+      expect(prep, isNotNull);
+      expect(prep!.placeholder, 'calc');
+      // Range covers the call-site occurrence.
+      final call = _posOf('calc', occurrence: 2);
+      expect(prep.range.start.line, call.line);
+      expect(prep.range.start.character, call.character);
+      expect(prep.range.end.character, call.character + 'calc'.length);
+    });
+
+    test('prepareRename is null when not on an identifier', () async {
+      await client.initialize();
+      client.didOpen(_uri, _source);
+      await client.diagnostics.first;
+
+      final prep = await client.prepareRename(_uri, Position(6, 0));
+      expect(prep, isNull);
+    });
+
+    test('workspaceSymbol matches declarations by query', () async {
+      await client.initialize();
+      client.didOpen(_uri, _source);
+      await client.diagnostics.first;
+
+      final syms = await client.workspaceSymbol('calc');
+      expect(syms.map((s) => s.name), contains('calc'));
+    });
+
+    test('didClose clears the document diagnostics', () async {
+      await client.initialize();
+      client.didOpen(_uri, _source);
+      await client.diagnostics.first;
+
+      final cleared = client.diagnostics.first;
+      client.didClose(_uri);
+      final published = await cleared;
+      expect(published.uri, _uri);
+      expect(published.diagnostics, isEmpty);
+    });
+
+    test('onNotification receives raw server notifications', () async {
+      final methods = <String>[];
+      client.onNotification = (method, _) => methods.add(method);
+
+      await client.initialize();
+      client.didOpen(_uri, _source);
+      await client.diagnostics.first;
+
+      expect(methods, contains('textDocument/publishDiagnostics'));
+    });
+
+    test('dispose fails in-flight requests and rejects further use', () async {
+      await client.initialize();
+      final pending = client.hover(_uri, _posOf('calc'));
+      // Attach the expectation before disposing so the rejection is handled.
+      final rejected = expectLater(pending, throwsA(isA<StateError>()));
+      await client.dispose();
+      await rejected;
+
+      expect(() => client.sendRequest('initialize'), throwsStateError);
+    });
+
+    test('an unknown request completes with a ResponseError', () async {
+      await client.initialize();
+      expect(
+        () => client.sendRequest('textDocument/nonsense'),
+        throwsA(
+          isA<ResponseError>().having(
+            (e) => e.code,
+            'code',
+            ResponseError.methodNotFound,
+          ),
+        ),
+      );
+    });
+
+    test('shutdown then exit completes the session', () async {
+      await client.initialize();
+      await client.shutdown();
+      client.exit();
+      // No throw; the server accepted the lifecycle messages.
+    });
+  });
+
+  test(
+    'LspClient wraps an external endpoint pair (transport-agnostic)',
+    () async {
+      // Simulate an out-of-process link with two message endpoints.
+      late final MessageLspEndpoint serverEndpoint;
+      final clientEndpoint = MessageLspEndpoint(
+        (m) => serverEndpoint.receive(m),
+      );
+      serverEndpoint = MessageLspEndpoint((m) => clientEndpoint.receive(m));
+      LspServer(serverEndpoint).start();
+
+      final client = LspClient(clientEndpoint)..start();
+      addTearDown(client.dispose);
+
+      final result = await client.initialize();
+      expect(result.serverInfo?.name, 'apollovm-lsp');
+    },
+  );
+}

--- a/test/lsp/protocol_test.dart
+++ b/test/lsp/protocol_test.dart
@@ -116,4 +116,253 @@ void main() {
       expect((changes['file:///a.dart'] as List).single['newText'], 'new');
     });
   });
+
+  group('protocol fromJson', () {
+    test('Location round-trips', () {
+      final loc = Location(
+        'file:///a.dart',
+        const Range(Position(0, 0), Position(0, 3)),
+      );
+      final back = Location.fromJson(loc.toJson());
+      expect(back.uri, 'file:///a.dart');
+      expect(back.range.end.character, 3);
+    });
+
+    test('Diagnostic applies defaults and stringifies a numeric code', () {
+      final back = Diagnostic.fromJson({
+        'range': const Range(Position(0, 0), Position(0, 1)).toJson(),
+      });
+      expect(back.message, '');
+      expect(back.severity, DiagnosticSeverity.error);
+      expect(back.source, 'apollovm');
+      expect(back.code, isNull);
+      expect(Diagnostic.fromJson({...back.toJson(), 'code': 42}).code, '42');
+    });
+
+    test('MarkupContent.from parses objects, strings and null', () {
+      expect(
+        MarkupContent.from({'kind': 'markdown', 'value': '# hi'}).kind,
+        'markdown',
+      );
+      expect(
+        MarkupContent.from({'kind': 'plaintext', 'value': 'hi'}).kind,
+        'plaintext',
+      );
+      final bare = MarkupContent.from('text');
+      expect(bare.kind, 'plaintext');
+      expect(bare.value, 'text');
+      expect(MarkupContent.from(null).value, '');
+    });
+
+    test('Hover parses a range, no range, and string contents', () {
+      final withRange = Hover.fromJson(
+        Hover(
+          const MarkupContent.markdown('**x**'),
+          range: const Range(Position(0, 0), Position(0, 1)),
+        ).toJson(),
+      );
+      expect(withRange.contents.value, '**x**');
+      expect(withRange.range!.end.character, 1);
+
+      final noRange = Hover.fromJson(
+        const Hover(MarkupContent.plaintext('y')).toJson(),
+      );
+      expect(noRange.range, isNull);
+
+      final stringContents = Hover.fromJson({'contents': 'plain'});
+      expect(stringContents.contents.value, 'plain');
+    });
+
+    test('DocumentSymbol round-trips with nested children', () {
+      const sym = DocumentSymbol(
+        name: 'Foo',
+        detail: 'class Foo',
+        kind: SymbolKind.classKind,
+        range: Range(Position(0, 0), Position(5, 1)),
+        selectionRange: Range(Position(0, 6), Position(0, 9)),
+        children: [
+          DocumentSymbol(
+            name: 'calc',
+            kind: SymbolKind.method,
+            range: Range(Position(1, 2), Position(3, 3)),
+            selectionRange: Range(Position(1, 6), Position(1, 10)),
+          ),
+        ],
+      );
+      final back = DocumentSymbol.fromJson(sym.toJson());
+      expect(back.name, 'Foo');
+      expect(back.detail, 'class Foo');
+      expect(back.children.single.name, 'calc');
+      expect(back.children.single.children, isEmpty);
+    });
+
+    test('CompletionItem parses markup/string/absent documentation', () {
+      final markup = CompletionItem.fromJson(
+        const CompletionItem(
+          label: 'calc',
+          kind: CompletionItemKind.method,
+          documentation: MarkupContent.markdown('does math'),
+        ).toJson(),
+      );
+      expect(markup.documentation?.value, 'does math');
+
+      final str = CompletionItem.fromJson({
+        'label': 'x',
+        'kind': CompletionItemKind.variable,
+        'documentation': 'a var',
+      });
+      expect(str.documentation?.value, 'a var');
+
+      final bare = CompletionItem.fromJson({'label': 'x'});
+      expect(bare.kind, CompletionItemKind.text);
+      expect(bare.documentation, isNull);
+    });
+
+    test('CompletionList round-trips and tolerates missing fields', () {
+      final back = CompletionList.fromJson(
+        const CompletionList(
+          isIncomplete: true,
+          items: [CompletionItem(label: 'a', kind: CompletionItemKind.keyword)],
+        ).toJson(),
+      );
+      expect(back.isIncomplete, isTrue);
+      expect(back.items.single.label, 'a');
+
+      final empty = CompletionList.fromJson(const {});
+      expect(empty.isIncomplete, isFalse);
+      expect(empty.items, isEmpty);
+    });
+
+    test('WorkspaceEdit round-trips and tolerates absent changes', () {
+      final back = WorkspaceEdit.fromJson(
+        WorkspaceEdit({
+          'file:///a.dart': [
+            TextEdit(const Range(Position(0, 0), Position(0, 4)), 'newName'),
+          ],
+        }).toJson(),
+      );
+      final edits = back.changes['file:///a.dart']!;
+      expect(edits.single.newText, 'newName');
+      expect(edits.single.range.end.character, 4);
+      expect(WorkspaceEdit.fromJson(const {}).changes, isEmpty);
+    });
+
+    test('InitializeResult.supports handles bool/object/absent', () {
+      final result = InitializeResult.fromJson({
+        'capabilities': {
+          'hoverProvider': true,
+          'renameProvider': {'prepareProvider': true},
+          'documentHighlightProvider': false,
+        },
+        'serverInfo': {'name': 'apollovm-lsp', 'version': '9.9.9'},
+      });
+      expect(result.serverInfo?.name, 'apollovm-lsp');
+      expect(result.serverInfo?.version, '9.9.9');
+      expect(result.supports('hoverProvider'), isTrue);
+      expect(result.supports('renameProvider'), isTrue); // object → truthy
+      expect(result.supports('documentHighlightProvider'), isFalse);
+      expect(result.supports('definitionProvider'), isFalse); // absent
+
+      final empty = InitializeResult.fromJson(const {});
+      expect(empty.serverInfo, isNull);
+      expect(empty.capabilities, isEmpty);
+      expect(empty.supports('anything'), isFalse);
+    });
+
+    test('PublishDiagnosticsParams round-trips with and without version', () {
+      final back = PublishDiagnosticsParams.fromJson(
+        PublishDiagnosticsParams(
+          uri: 'file:///a.dart',
+          version: 3,
+          diagnostics: [
+            Diagnostic(
+              range: const Range(Position(0, 0), Position(0, 1)),
+              message: 'oops',
+            ),
+          ],
+        ).toJson(),
+      );
+      expect(back.uri, 'file:///a.dart');
+      expect(back.version, 3);
+      expect(back.diagnostics.single.message, 'oops');
+
+      final noVer = PublishDiagnosticsParams.fromJson({
+        'uri': 'file:///b.dart',
+        'diagnostics': const [],
+      });
+      expect(noVer.version, isNull);
+      expect(noVer.toJson().containsKey('version'), isFalse);
+    });
+
+    test('WorkspaceSymbol round-trips with and without container', () {
+      final sym = WorkspaceSymbol(
+        name: 'calc',
+        kind: SymbolKind.method,
+        location: Location(
+          'file:///a.dart',
+          const Range(Position(1, 2), Position(1, 6)),
+        ),
+        containerName: 'Foo',
+      );
+      final back = WorkspaceSymbol.fromJson(sym.toJson());
+      expect(back.name, 'calc');
+      expect(back.location.uri, 'file:///a.dart');
+      expect(back.containerName, 'Foo');
+
+      final top = WorkspaceSymbol.fromJson({
+        'name': 'main',
+        'kind': SymbolKind.function,
+        'location': sym.location.toJson(),
+      });
+      expect(top.containerName, isNull);
+      expect(top.toJson().containsKey('containerName'), isFalse);
+    });
+
+    test('DocumentHighlight round-trips with/without a kind', () {
+      final withKind = DocumentHighlight.fromJson(
+        DocumentHighlight(
+          const Range(Position(0, 0), Position(0, 4)),
+          kind: DocumentHighlightKind.write,
+        ).toJson(),
+      );
+      expect(withKind.kind, DocumentHighlightKind.write);
+      expect(withKind.range.end.character, 4);
+
+      final noKind = DocumentHighlight(
+        const Range(Position(0, 0), Position(0, 1)),
+      );
+      expect(noKind.toJson().containsKey('kind'), isFalse);
+      expect(DocumentHighlight.fromJson(noKind.toJson()).kind, isNull);
+
+      expect(DocumentHighlightKind.text, 1);
+      expect(DocumentHighlightKind.read, 2);
+      expect(DocumentHighlightKind.write, 3);
+    });
+
+    test('PrepareRenameResult round-trips and defaults placeholder', () {
+      final prep = PrepareRenameResult(
+        const Range(Position(2, 13), Position(2, 17)),
+        'calc',
+      );
+      final back = PrepareRenameResult.fromJson(prep.toJson());
+      expect(back.placeholder, 'calc');
+      expect(back.range.start.character, 13);
+      expect(
+        PrepareRenameResult.fromJson({
+          'range': prep.range.toJson(),
+        }).placeholder,
+        '',
+      );
+    });
+
+    test('ResponseError exposes code, message and JSON', () {
+      const err = ResponseError(ResponseError.invalidParams, 'bad');
+      expect(err.code, ResponseError.invalidParams);
+      expect(err.toJson(), {
+        'code': ResponseError.invalidParams,
+        'message': 'bad',
+      });
+      expect(err.toString(), contains('bad'));
+    });
+  });
 }

--- a/test/lsp/server_features_test.dart
+++ b/test/lsp/server_features_test.dart
@@ -264,4 +264,106 @@ void main() {
     });
     expect(resp['result'], isNull);
   });
+
+  group('all symbol categories/kinds', () {
+    // A source exercising fields, a constructor, enum members and a top-level
+    // variable, so the server's category/kind mappings are all hit.
+    const richUri = 'file:///ws/rich.dart';
+    const rich = '''
+class Dog {
+  int age;
+  Dog(int a) { this.age = a; }
+  int bark(int n) { return n; }
+}
+enum Color { red, green, blue }
+int topVar = 3;
+int makeAge(int seed) { return seed; }
+''';
+
+    Position posOf(String needle, {int occurrence = 1}) {
+      final line = LineIndex(rich);
+      var index = -1;
+      for (var i = 0; i < occurrence; i++) {
+        index = rich.indexOf(needle, index + 1);
+      }
+      return line.positionAt(index);
+    }
+
+    Map<String, Object?> posMap(String needle, {int occurrence = 1}) {
+      final p = posOf(needle, occurrence: occurrence);
+      return {'line': p.line, 'character': p.character};
+    }
+
+    test('documentSymbol maps variable and enum-member kinds', () async {
+      final c = _Client();
+      await c.open(richUri, rich);
+      final resp = await c.request('textDocument/documentSymbol', {
+        'textDocument': _td(richUri),
+      });
+      final roots = (resp['result'] as List).cast<Map>();
+      final byName = {for (final s in roots) s['name']: s};
+
+      expect(byName['topVar']?['kind'], SymbolKind.variable);
+      final color = byName['Color']!;
+      final members = (color['children'] as List).cast<Map>();
+      expect(members.map((m) => m['name']), containsAll(['red', 'green']));
+      expect(members.first['kind'], SymbolKind.enumMember);
+    });
+
+    test('completion maps every present symbol category', () async {
+      final c = _Client();
+      await c.open(richUri, rich);
+      final resp = await c.request('textDocument/completion', {
+        'textDocument': _td(richUri),
+        'position': posMap('return n'), // inside bark's body
+      });
+      final items = ((resp['result'] as Map)['items'] as List).cast<Map>();
+      final kinds = items.map((i) => i['kind']).toSet();
+      // field (age), enum member (green), method (bark), function (makeAge),
+      // class (Dog), enum (Color) are all present in the document.
+      expect(
+        kinds,
+        containsAll([
+          CompletionItemKind.field,
+          CompletionItemKind.enumMember,
+          CompletionItemKind.method,
+          CompletionItemKind.function,
+        ]),
+      );
+    });
+
+    test('hover labels a field and an enum member', () async {
+      final c = _Client();
+      await c.open(richUri, rich);
+
+      final field = await c.request('textDocument/hover', {
+        'textDocument': _td(richUri),
+        'position': posMap('age'), // the `int age;` field
+      });
+      expect(
+        ((field['result'] as Map)['contents'] as Map)['value'],
+        contains('Field'),
+      );
+
+      final member = await c.request('textDocument/hover', {
+        'textDocument': _td(richUri),
+        'position': posMap('green'),
+      });
+      expect(
+        ((member['result'] as Map)['contents'] as Map)['value'],
+        contains('Enum value'),
+      );
+    });
+
+    test('completion on an unopened document is empty', () async {
+      final c = _Client();
+      final resp = await c.request('textDocument/completion', {
+        'textDocument': _td('file:///ws/never-opened.dart'),
+        'position': {'line': 0, 'character': 0},
+      });
+      final result = resp['result'] as Map;
+      expect(result['items'], isEmpty);
+      expect(result['isIncomplete'], isFalse);
+    });
+  });
 }

--- a/test/lsp/server_features_test.dart
+++ b/test/lsp/server_features_test.dart
@@ -193,4 +193,75 @@ void main() {
     final error = resp['error'] as Map;
     expect(error['code'], ResponseError.methodNotFound);
   });
+
+  test('initialize advertises the new providers', () async {
+    final c = _Client();
+    final resp = await c.request('initialize');
+    final caps = (resp['result'] as Map)['capabilities'] as Map;
+    expect(caps['documentHighlightProvider'], isTrue);
+    expect((caps['renameProvider'] as Map)['prepareProvider'], isTrue);
+  });
+
+  test('documentHighlight returns read occurrences of the name', () async {
+    final c = _Client();
+    await c.open(_uri, _content);
+    final resp = await c.request('textDocument/documentHighlight', {
+      'textDocument': _td(_uri),
+      'position': c.pos(3, 24), // the `name` parameter
+    });
+    final highlights = (resp['result'] as List).cast<Map>();
+    // `name` appears as the parameter and in `return name;`.
+    expect(highlights.length, 2);
+    // A parameter is not a tracked declaration, so both are Read.
+    expect(
+      highlights.every((h) => h['kind'] == DocumentHighlightKind.read),
+      isTrue,
+    );
+  });
+
+  test('documentHighlight marks a declaration occurrence as write', () async {
+    final c = _Client();
+    await c.open(_uri, _content);
+    final resp = await c.request('textDocument/documentHighlight', {
+      'textDocument': _td(_uri),
+      'position': c.pos(9, 5), // `makeId`, a top-level function
+    });
+    final highlights = (resp['result'] as List).cast<Map>();
+    expect(highlights, hasLength(1));
+    expect(highlights.single['kind'], DocumentHighlightKind.write);
+  });
+
+  test('documentHighlight off any identifier is empty', () async {
+    final c = _Client();
+    await c.open(_uri, _content);
+    final resp = await c.request('textDocument/documentHighlight', {
+      'textDocument': _td(_uri),
+      'position': c.pos(7, 0), // blank line between the two declarations
+    });
+    expect(resp['result'], isEmpty);
+  });
+
+  test('prepareRename returns the target range and placeholder', () async {
+    final c = _Client();
+    await c.open(_uri, _content);
+    final resp = await c.request('textDocument/prepareRename', {
+      'textDocument': _td(_uri),
+      'position': c.pos(3, 24), // the `name` parameter
+    });
+    final result = resp['result'] as Map;
+    expect(result['placeholder'], 'name');
+    final range = Range.fromJson(result['range'] as Map<String, Object?>);
+    expect(range.start.line, 3);
+    expect(range.end.character - range.start.character, 'name'.length);
+  });
+
+  test('prepareRename off any identifier is null', () async {
+    final c = _Client();
+    await c.open(_uri, _content);
+    final resp = await c.request('textDocument/prepareRename', {
+      'textDocument': _td(_uri),
+      'position': c.pos(7, 0),
+    });
+    expect(resp['result'], isNull);
+  });
 }


### PR DESCRIPTION
## Summary

Adds a **JSON-RPC client** for the ApolloVM Language Server and two new **server features**, all in `package:apollovm/apollovm_lsp.dart`. Bumps the package to **1.3.0**.

### Client — `LspClient`
- Works over any `LspEndpoint` (`MessageLspEndpoint` in-process/web, `StreamLspEndpoint` over stdio/socket). Correlates responses to requests, streams server-pushed diagnostics (`Stream<PublishDiagnosticsParams> get diagnostics`), and exposes typed helpers: `initialize`, `didOpen`/`didChange`/`didClose`, `hover`, `definition`, `documentSymbol`, `completion`, `references`, `documentHighlight`, `prepareRename`, `rename`, `workspaceSymbol`, `shutdown`/`exit`, plus low-level `sendRequest`/`sendNotification`.
- **`LspClient.inProcess()`** pairs a client with a fresh `LspServer` in the same isolate — no subprocess, no `dart:io`.
- `LspEndpoint` now routes JSON-RPC *responses* (previously dropped) to a new `onResponse` hook. Pure-server usage is unchanged.
- Protocol types gained `fromJson` factories (`Hover`, `Location`, `Diagnostic`, `DocumentSymbol`, `CompletionItem`, `TextEdit`, `WorkspaceEdit`) and new types: `InitializeResult`, `ServerInfo`, `PublishDiagnosticsParams`, `WorkspaceSymbol`, `CompletionList`, `DocumentHighlight`/`DocumentHighlightKind`, `PrepareRenameResult`.

### Server — new features
- **`textDocument/documentHighlight`** — highlights every occurrence of the identifier under the cursor (declaration = `Write`, uses = `Read`).
- **`textDocument/prepareRename`** — validates a rename target, returning its range + placeholder (null off an identifier). Advertised via the rename provider's `prepareProvider`.

### Docs & example
- New runnable walkthrough `example/apollovm_example_lsp.dart` driving a full session through `LspClient.inProcess()`.
- README Language-Server section and CHANGELOG updated.

## Testing
- `dart format` — clean; `dart analyze` — **No issues found**
- `dart test test/lsp/` — **103 passing** (new `test/lsp/client_test.dart`, 20 tests; +6 server-feature tests)
- `dart test` (full suite) — **1371 passing**, 2 skipped — no regressions
- `dart run example/apollovm_example_lsp.dart` — full session runs end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)