### PR TITLE
feat(mcp): expose LSP code-inspection tools to agents (part of v1.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 ## 1.4.0
 
+### MCP — code-inspection tools (LSP)
+
+- **The MCP server now exposes ApolloVM's LSP features as `apollovm.lsp.*`
+  tools**, so an AI agent can inspect code the way an editor does. Results carry
+  precise LSP line/character ranges.
+  - `apollovm.lsp.diagnostics` — errors/warnings with ranges.
+  - `apollovm.lsp.symbols` — document outline (nested symbols + ranges).
+  - `apollovm.lsp.hover` — signature, type and documentation at a position.
+  - `apollovm.lsp.definition` — declaration location at a position.
+  - `apollovm.lsp.references` — all references at a position.
+  - `apollovm.lsp.completion` — completion proposals at a position.
+  - `apollovm.lsp.workspaceSymbols` — symbol search across multiple in-memory
+    files (codebase-wide lookup).
+- Each tool is stateless and web-safe (backed by the in-process `LspService`;
+  no socket, no `dart:io`), runs in-process or inside an isolate like the other
+  bounded tools, and honors the existing `maxSourceChars` limit. The parser is
+  selected from the `language` argument, so a mismatched URI cannot change it.
+- New public API in `package:apollovm/apollovm_mcp.dart`: `LspRuntime`,
+  `buildLspTools`, `computeLspTool`, `isLspTool`, `lspToolNames`. The CLI
+  `apollovm mcp call` gained `--line`, `--character` and `--query` flags.
+- New example
+  [`example/apollovm_example_mcp_lsp.dart`](example/apollovm_example_mcp_lsp.dart).
+
 ### Language Server Protocol — in-process API (no socket)
 
 - **New `LspService`** in `package:apollovm/apollovm_lsp.dart`: a

--- a/README.md
+++ b/README.md
@@ -858,6 +858,27 @@ apollovm mcp call apollovm.translate --from go --to dart --file main.go
 Supported `language` values: `dart`, `java`, `kotlin`, `go`, `csharp`, `javascript`,
 `typescript`, `lua`, `python`, `wasm`.
 
+#### Code-inspection tools (LSP)
+
+The `apollovm.lsp.*` tools let an agent inspect code the way an editor does —
+backed by ApolloVM's in-process Language Server (results carry precise LSP
+line/character ranges). They accept the same `language` values above (except
+`wasm`).
+
+| Tool | Input | Output |
+|------|-------|--------|
+| `apollovm.lsp.diagnostics` | `language`, `source`, `uri?` | `diagnostics` (with ranges), `ok` |
+| `apollovm.lsp.symbols` | `language`, `source`, `uri?` | document outline (nested symbols + ranges) |
+| `apollovm.lsp.hover` | `language`, `source`, `line`, `character`, `uri?` | `hover` (signature, type, doc) |
+| `apollovm.lsp.definition` | `language`, `source`, `line`, `character`, `uri?` | `definition` location |
+| `apollovm.lsp.references` | `language`, `source`, `line`, `character`, `includeDeclaration?`, `uri?` | `references` |
+| `apollovm.lsp.completion` | `language`, `source`, `line`, `character`, `uri?` | `completion` items |
+| `apollovm.lsp.workspaceSymbols` | `query`, `files: [{uri, source, language?}]` | matching `symbols` across the files |
+
+`apollovm.lsp.workspaceSymbols` takes multiple in-memory files, enabling
+codebase-wide symbol search. See
+[`example/apollovm_example_mcp_lsp.dart`](example/apollovm_example_mcp_lsp.dart).
+
 ### Security model
 
 - **File/network access is denied by construction** — executed code is only ever

--- a/example/apollovm_example_mcp_lsp.dart
+++ b/example/apollovm_example_mcp_lsp.dart
@@ -1,0 +1,75 @@
+import 'dart:convert';
+
+import 'package:apollovm/apollovm_mcp.dart';
+
+/// Example: an AI agent inspecting code through the MCP `apollovm.lsp.*` tools.
+///
+/// These are the exact tool calls an MCP client (an LLM agent) makes over the
+/// wire — here invoked directly via [computeTool] with a plain args map. Each is
+/// stateless and web-safe: no socket, no `dart:io`, no editor.
+void main() async {
+  const limits = McpLimits();
+  final pretty = JsonEncoder.withIndent('  ');
+
+  const source = '''
+class Account {
+  double balance;
+
+  /// Deposits [amount] into the account.
+  void deposit(double amount) {
+    balance = balance + amount;
+  }
+
+  void report() {
+    deposit(10.0);
+  }
+}
+''';
+
+  Future<void> callTool(String tool, Map<String, Object?> args) async {
+    final result = await computeTool(tool, args, limits);
+    print('\n>>> $tool');
+    print(pretty.convert(result));
+  }
+
+  // 1) Diagnostics — is the code valid? (precise LSP ranges)
+  await callTool('apollovm.lsp.diagnostics', {
+    'language': 'dart',
+    'source': source,
+  });
+
+  // 2) Outline — what does this file define?
+  await callTool('apollovm.lsp.symbols', {
+    'language': 'dart',
+    'source': source,
+  });
+
+  // 3) Hover — what is `deposit`? (signature + doc), at its declaration.
+  await callTool('apollovm.lsp.hover', {
+    'language': 'dart',
+    'source': source,
+    'line': 4,
+    'character': 7,
+  });
+
+  // 4) References — where is `deposit` used?
+  await callTool('apollovm.lsp.references', {
+    'language': 'dart',
+    'source': source,
+    'line': 4,
+    'character': 7,
+  });
+
+  // 5) Workspace symbols — search a whole (in-memory) codebase.
+  await callTool('apollovm.lsp.workspaceSymbols', {
+    'query': 'account',
+    'files': [
+      {'uri': 'file:///lib/account.dart', 'source': source},
+      {
+        'uri': 'file:///lib/bank.py',
+        'language': 'python',
+        'source': 'def open_account():\n  return 1\n',
+      },
+    ],
+  });
+}

--- a/lib/apollovm_mcp.dart
+++ b/lib/apollovm_mcp.dart
@@ -4,11 +4,14 @@
 
 /// MCP (Model Context Protocol) server for ApolloVM.
 ///
-/// Exposes ApolloVM's parse / execute / translate / compile / inspect
-/// capabilities to AI agents as MCP tools (`apollo.parse`, `apollo.execute`,
-/// `apollo.translate`, `apollo.ast`, `apollo.symbols`, `apollo.types`,
-/// `apollo.wasm`) over stdio or HTTP/SSE, with a configurable security model
-/// (per-tool isolate execution, timeout, and input/output limits).
+/// Exposes ApolloVM's parse / execute / translate / compile capabilities to AI
+/// agents as MCP tools (`apollovm.parse`, `apollovm.execute`,
+/// `apollovm.translate`, `apollovm.ast`, `apollovm.symbols`, `apollovm.types`,
+/// `apollovm.wasm`), plus a set of `apollovm.lsp.*` tools that let an agent
+/// inspect code the way an editor does (diagnostics, outline, hover,
+/// definition, references, completion and workspace-wide symbol search) — all
+/// over stdio or HTTP/SSE, with a configurable security model (per-tool isolate
+/// execution, timeout, and input/output limits).
 library;
 
 export 'src/mcp/apollo_mcp_server.dart';
@@ -16,6 +19,9 @@ export 'src/mcp/cli/mcp_command.dart';
 export 'src/mcp/mcp_config.dart';
 export 'src/mcp/runtime/isolate_executor.dart'
     show computeToolIsolated, runToolInIsolate;
+export 'src/mcp/runtime/lsp_runtime.dart' show LspRuntime;
 export 'src/mcp/tools/apollo_tools.dart' show allToolNames, computeTool;
+export 'src/mcp/tools/lsp_tools.dart'
+    show buildLspTools, computeLspTool, isLspTool, lspToolNames;
 export 'src/mcp/transport/http_sse_transport.dart';
 export 'src/mcp/transport/stdio_transport.dart';

--- a/lib/src/mcp/apollo_mcp_server.dart
+++ b/lib/src/mcp/apollo_mcp_server.dart
@@ -29,9 +29,13 @@ final class ApolloMcpServer extends MCPServer with ToolsSupport {
           version: ApolloVM.VERSION,
         ),
         instructions:
-            'ApolloVM programmable execution engine. Tools: '
-            '${allToolNames.join(', ')}. All operate on inline source strings; '
-            'no file or network access is granted to executed code.',
+            'ApolloVM programmable execution engine and code-inspection server. '
+            'Core tools parse, execute, translate and compile source; the '
+            '`apollovm.lsp.*` tools inspect it like an editor (diagnostics, '
+            'outline, hover, definition, references, completion and '
+            'workspace-wide symbol search). Tools: ${allToolNames.join(', ')}. '
+            'All operate on inline source strings; no file or network access is '
+            'granted to executed code.',
       ) {
     for (final tool in buildTools()) {
       registerTool(tool, (request) => _handle(tool.name, request));

--- a/lib/src/mcp/cli/mcp_command.dart
+++ b/lib/src/mcp/cli/mcp_command.dart
@@ -14,6 +14,7 @@ import '../../../apollovm.dart' show ApolloVM, WasmRuntime;
 import '../mcp_config.dart';
 import '../runtime/isolate_executor.dart';
 import '../tools/apollo_tools.dart';
+import '../tools/lsp_tools.dart';
 import '../transport/http_sse_transport.dart';
 import '../transport/stdio_transport.dart';
 
@@ -323,6 +324,18 @@ Examples:
       ..addOption(
         'args',
         help: 'JSON array of positional arguments (apollovm.execute).',
+      )
+      ..addOption(
+        'line',
+        help: 'Zero-based cursor line (apollovm.lsp.* positional tools).',
+      )
+      ..addOption(
+        'character',
+        help: 'Zero-based cursor character (apollovm.lsp.* positional tools).',
+      )
+      ..addOption(
+        'query',
+        help: 'Symbol query (apollovm.lsp.workspaceSymbols).',
       );
   }
 
@@ -352,6 +365,16 @@ Examples:
       args['from'] = argResults!['from'] ?? language;
       args['to'] = argResults!['to'];
       args['source'] = source;
+    } else if (toolName == lspWorkspaceSymbolsToolName) {
+      // The CLI wraps the single provided source as a one-file workspace.
+      args['query'] = argResults!['query'] ?? '';
+      args['files'] = [
+        <String, Object?>{
+          'uri': file ?? 'file:///mcp/source',
+          'source': source,
+          'language': ?language,
+        },
+      ];
     } else {
       args['language'] = language;
       args['source'] = source;
@@ -366,6 +389,10 @@ Examples:
         if (rawArgs != null) {
           args['args'] = jsonDecode(rawArgs) as List;
         }
+      } else if (lspToolNames.contains(toolName)) {
+        args['line'] = int.tryParse(argResults!['line'] as String? ?? '') ?? 0;
+        args['character'] =
+            int.tryParse(argResults!['character'] as String? ?? '') ?? 0;
       }
     }
 

--- a/lib/src/mcp/runtime/lsp_runtime.dart
+++ b/lib/src/mcp/runtime/lsp_runtime.dart
@@ -1,0 +1,222 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'package:apollovm/apollovm_lsp.dart';
+
+import '../mcp_config.dart';
+
+/// In-process façade over the ApolloVM Language Server ([LspService]) used by
+/// the MCP `apollovm.lsp.*` tools, so an AI agent can inspect code the way an
+/// editor does: diagnostics, outline, hover, go-to-definition, references,
+/// completion and workspace-wide symbol search.
+///
+/// Web-safe and stateless: each call spins up an in-process server (no socket,
+/// no `dart:io`), answers the query against the given source, and disposes. The
+/// parser is selected from the source [language] (via a matching document URI),
+/// so results never depend on ambient state.
+class LspRuntime {
+  final McpLimits limits;
+
+  LspRuntime({this.limits = const McpLimits()});
+
+  /// Canonical language name -> file extension, so the LSP analyzer (which
+  /// infers the language from the document URI) selects the right parser.
+  static const _extensions = <String, String>{
+    'dart': 'dart',
+    'java': 'java',
+    'kotlin': 'kt',
+    'go': 'go',
+    'csharp': 'cs',
+    'javascript': 'js',
+    'typescript': 'ts',
+    'lua': 'lua',
+    'python': 'py',
+  };
+
+  /// The languages the LSP tools can analyze (all supported languages except
+  /// `wasm`, which is a compile target rather than a parsed source language).
+  static List<String> get supportedLanguages => _extensions.keys.toList();
+
+  Map<String, Object?> _error(String message) => <String, Object?>{
+    'diagnostics': [
+      <String, Object?>{'severity': 'error', 'message': message},
+    ],
+    'isError': true,
+  };
+
+  /// Validates [language]/[source] and returns the document URI to analyze
+  /// under, or an error map (checked via the `isError` key) when invalid.
+  Object _prepare(String language, String source, {String? uri}) {
+    if (source.length > limits.maxSourceChars) {
+      return _error(
+        'Source exceeds maxSourceChars '
+        '(${source.length} > ${limits.maxSourceChars})',
+      );
+    }
+    final ext = _extensions[language];
+    if (ext == null) {
+      return _error(
+        'Unsupported language: $language '
+        '(LSP languages: ${supportedLanguages.join(', ')})',
+      );
+    }
+    // Honor a caller URI only when its extension already selects this language;
+    // otherwise synthesize one so the parser matches [language].
+    if (uri != null && Analyzer.languageOf(uri) == language) return uri;
+    return 'file:///mcp/source.$ext';
+  }
+
+  /// Runs [query] against a fresh in-process service with [source] open at the
+  /// resolved URI, disposing the service afterwards.
+  Future<Map<String, Object?>> _withDoc(
+    String language,
+    String source,
+    Future<Map<String, Object?>> Function(LspService lsp, String uri) query, {
+    String? uri,
+  }) async {
+    final prepared = _prepare(language, source, uri: uri);
+    if (prepared is Map<String, Object?>) return prepared; // error
+    final docUri = prepared as String;
+
+    final lsp = LspService();
+    try {
+      lsp.open(docUri, source);
+      return await query(lsp, docUri);
+    } finally {
+      await lsp.dispose();
+    }
+  }
+
+  /// Diagnostics (errors/warnings) for [source], with precise LSP ranges.
+  Future<Map<String, Object?>> diagnostics(
+    String language,
+    String source, {
+    String? uri,
+  }) => _withDoc(language, source, uri: uri, (lsp, docUri) async {
+    final diags = await lsp.analyze(docUri, source);
+    return <String, Object?>{
+      'diagnostics': diags.map((d) => d.toJson()).toList(),
+      'ok': diags.every((d) => d.severity != DiagnosticSeverity.error),
+      'isError': false,
+    };
+  });
+
+  /// The document outline: hierarchical symbols with their source ranges.
+  Future<Map<String, Object?>> documentSymbols(
+    String language,
+    String source, {
+    String? uri,
+  }) => _withDoc(language, source, uri: uri, (lsp, docUri) async {
+    final symbols = await lsp.documentSymbols(docUri);
+    return <String, Object?>{
+      'symbols': symbols.map((s) => s.toJson()).toList(),
+      'isError': false,
+    };
+  });
+
+  /// Hover information (signature + documentation) at [line]:[character].
+  Future<Map<String, Object?>> hover(
+    String language,
+    String source,
+    int line,
+    int character, {
+    String? uri,
+  }) => _withDoc(language, source, uri: uri, (lsp, docUri) async {
+    final hover = await lsp.hover(docUri, Position(line, character));
+    return <String, Object?>{'hover': hover?.toJson(), 'isError': false};
+  });
+
+  /// The declaration location for the symbol at [line]:[character].
+  Future<Map<String, Object?>> definition(
+    String language,
+    String source,
+    int line,
+    int character, {
+    String? uri,
+  }) => _withDoc(language, source, uri: uri, (lsp, docUri) async {
+    final def = await lsp.definition(docUri, Position(line, character));
+    return <String, Object?>{'definition': def?.toJson(), 'isError': false};
+  });
+
+  /// All references to the symbol at [line]:[character].
+  Future<Map<String, Object?>> references(
+    String language,
+    String source,
+    int line,
+    int character, {
+    bool includeDeclaration = true,
+    String? uri,
+  }) => _withDoc(language, source, uri: uri, (lsp, docUri) async {
+    final refs = await lsp.references(
+      docUri,
+      Position(line, character),
+      includeDeclaration: includeDeclaration,
+    );
+    return <String, Object?>{
+      'references': refs.map((l) => l.toJson()).toList(),
+      'isError': false,
+    };
+  });
+
+  /// Completion proposals at [line]:[character].
+  Future<Map<String, Object?>> completion(
+    String language,
+    String source,
+    int line,
+    int character, {
+    String? uri,
+  }) => _withDoc(language, source, uri: uri, (lsp, docUri) async {
+    final list = await lsp.completion(docUri, Position(line, character));
+    return <String, Object?>{'completion': list.toJson(), 'isError': false};
+  });
+
+  /// Searches declarations matching [query] across a set of in-memory [files]
+  /// (`{uri, source, language?}`), enabling codebase-wide symbol lookup.
+  Future<Map<String, Object?>> workspaceSymbols(
+    String query,
+    List<Object?> files,
+  ) async {
+    final entries = <({String uri, String source})>[];
+    var totalChars = 0;
+    for (final raw in files) {
+      if (raw is! Map) continue;
+      final source = (raw['source'] as String?) ?? '';
+      totalChars += source.length;
+      if (totalChars > limits.maxSourceChars) {
+        return _error(
+          'Combined sources exceed maxSourceChars '
+          '($totalChars > ${limits.maxSourceChars})',
+        );
+      }
+      final language = raw['language'] as String?;
+      final uri = _fileUri(raw['uri'] as String?, language, entries.length);
+      entries.add((uri: uri, source: source));
+    }
+
+    final lsp = LspService();
+    try {
+      // Analyze each file so its symbols are cached before the query.
+      for (final e in entries) {
+        await lsp.analyze(e.uri, e.source);
+      }
+      final symbols = await lsp.workspaceSymbols(query);
+      return <String, Object?>{
+        'symbols': symbols.map((s) => s.toJson()).toList(),
+        'files': entries.map((e) => e.uri).toList(),
+        'isError': false,
+      };
+    } finally {
+      await lsp.dispose();
+    }
+  }
+
+  /// Resolves a workspace file's URI, synthesizing one from [language] when the
+  /// given [uri] is absent or its extension does not select a known language.
+  String _fileUri(String? uri, String? language, int index) {
+    if (uri != null && Analyzer.languageOf(uri) != null) return uri;
+    final ext = _extensions[language] ?? 'dart';
+    if (uri != null) return 'file:///mcp/$uri.$ext';
+    return 'file:///mcp/file$index.$ext';
+  }
+}

--- a/lib/src/mcp/tools/apollo_tools.dart
+++ b/lib/src/mcp/tools/apollo_tools.dart
@@ -11,6 +11,7 @@ import '../runtime/apollo_runtime.dart';
 import '../serialize/ast_json.dart';
 import '../serialize/symbols.dart';
 import '../serialize/types.dart';
+import 'lsp_tools.dart';
 
 /// Canonical tool names.
 const parseToolName = 'apollovm.parse';
@@ -21,7 +22,8 @@ const symbolsToolName = 'apollovm.symbols';
 const typesToolName = 'apollovm.types';
 const wasmToolName = 'apollovm.wasm';
 
-/// The names of all tools this server exposes, in registration order.
+/// The names of all tools this server exposes, in registration order: the core
+/// VM tools followed by the `apollovm.lsp.*` code-inspection tools.
 const allToolNames = <String>[
   parseToolName,
   executeToolName,
@@ -30,6 +32,7 @@ const allToolNames = <String>[
   symbolsToolName,
   typesToolName,
   wasmToolName,
+  ...lspToolNames,
 ];
 
 /// The source languages the MCP tools accept (canonical names).
@@ -153,6 +156,7 @@ List<Tool> buildTools() => [
       required: ['language', 'source'],
     ),
   ),
+  ...buildLspTools(),
 ];
 
 String _str(Map<String, Object?> args, String key, [String fallback = '']) =>
@@ -168,6 +172,8 @@ Future<Map<String, Object?>> computeTool(
   Map<String, Object?> args,
   McpLimits limits,
 ) async {
+  if (isLspTool(name)) return computeLspTool(name, args, limits);
+
   final rt = ApolloRuntime(limits: limits);
 
   switch (name) {

--- a/lib/src/mcp/tools/lsp_tools.dart
+++ b/lib/src/mcp/tools/lsp_tools.dart
@@ -1,0 +1,246 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'package:dart_mcp/server.dart';
+
+import '../mcp_config.dart';
+import '../runtime/lsp_runtime.dart';
+
+/// Canonical LSP tool names (`apollovm.lsp.*`).
+const lspDiagnosticsToolName = 'apollovm.lsp.diagnostics';
+const lspSymbolsToolName = 'apollovm.lsp.symbols';
+const lspHoverToolName = 'apollovm.lsp.hover';
+const lspDefinitionToolName = 'apollovm.lsp.definition';
+const lspReferencesToolName = 'apollovm.lsp.references';
+const lspCompletionToolName = 'apollovm.lsp.completion';
+const lspWorkspaceSymbolsToolName = 'apollovm.lsp.workspaceSymbols';
+
+/// The LSP inspection tools this server exposes, in registration order.
+const lspToolNames = <String>[
+  lspDiagnosticsToolName,
+  lspSymbolsToolName,
+  lspHoverToolName,
+  lspDefinitionToolName,
+  lspReferencesToolName,
+  lspCompletionToolName,
+  lspWorkspaceSymbolsToolName,
+];
+
+final _languageValues = LspRuntime.supportedLanguages.join(', ');
+
+Schema get _languageSchema =>
+    Schema.string(description: 'Source language ($_languageValues).');
+
+Schema get _sourceSchema =>
+    Schema.string(description: 'The source code to inspect.');
+
+Schema get _uriSchema => Schema.string(
+  description:
+      'Optional document URI (its extension is honored only when it matches '
+      'the language; otherwise one is synthesized).',
+);
+
+Schema get _lineSchema =>
+    Schema.int(description: 'Zero-based line of the cursor position.');
+
+Schema get _characterSchema => Schema.int(
+  description: 'Zero-based character (UTF-16) offset within the line.',
+);
+
+ObjectSchema _positionalSchema({Map<String, Schema> extra = const {}}) =>
+    ObjectSchema(
+      properties: {
+        'language': _languageSchema,
+        'source': _sourceSchema,
+        'line': _lineSchema,
+        'character': _characterSchema,
+        'uri': _uriSchema,
+        ...extra,
+      },
+      required: ['language', 'source', 'line', 'character'],
+    );
+
+ObjectSchema _wholeFileSchema() => ObjectSchema(
+  properties: {
+    'language': _languageSchema,
+    'source': _sourceSchema,
+    'uri': _uriSchema,
+  },
+  required: ['language', 'source'],
+);
+
+/// The [Tool] definitions for the LSP inspection tools. These are the single
+/// source of truth advertised via `tools/list`.
+List<Tool> buildLspTools() => [
+  Tool(
+    name: lspDiagnosticsToolName,
+    description:
+        'Analyze source code and return its diagnostics (errors/warnings) with '
+        'precise LSP line/character ranges.',
+    inputSchema: _wholeFileSchema(),
+  ),
+  Tool(
+    name: lspSymbolsToolName,
+    description:
+        'Return the document outline: a hierarchy of symbols (classes, methods, '
+        'fields, enums, functions, variables) with their source ranges.',
+    inputSchema: _wholeFileSchema(),
+  ),
+  Tool(
+    name: lspHoverToolName,
+    description:
+        'Return hover information (signature, type and documentation) for the '
+        'symbol at a line/character position.',
+    inputSchema: _positionalSchema(),
+  ),
+  Tool(
+    name: lspDefinitionToolName,
+    description:
+        'Return the declaration location (URI + range) of the symbol at a '
+        'line/character position.',
+    inputSchema: _positionalSchema(),
+  ),
+  Tool(
+    name: lspReferencesToolName,
+    description:
+        'Return every reference to the symbol at a line/character position.',
+    inputSchema: _positionalSchema(
+      extra: {
+        'includeDeclaration': Schema.bool(
+          description: 'Include the declaration itself (default true).',
+        ),
+      },
+    ),
+  ),
+  Tool(
+    name: lspCompletionToolName,
+    description:
+        'Return completion proposals (symbols and keywords) at a line/character '
+        'position.',
+    inputSchema: _positionalSchema(),
+  ),
+  Tool(
+    name: lspWorkspaceSymbolsToolName,
+    description:
+        'Search declarations matching a query across a set of in-memory files '
+        '— codebase-wide symbol lookup.',
+    inputSchema: ObjectSchema(
+      properties: {
+        'query': Schema.string(
+          description:
+              'Case-insensitive substring to match (empty matches '
+              'all).',
+        ),
+        'files': Schema.list(
+          description: 'The files that make up the workspace.',
+          items: ObjectSchema(
+            properties: {
+              'uri': Schema.string(description: 'File URI/path.'),
+              'source': _sourceSchema,
+              'language': Schema.string(
+                description:
+                    'Optional language override ($_languageValues); inferred '
+                    'from the URI extension when omitted.',
+              ),
+            },
+            required: ['uri', 'source'],
+          ),
+        ),
+      },
+      required: ['query', 'files'],
+    ),
+  ),
+];
+
+String _str(Map<String, Object?> args, String key, [String fallback = '']) =>
+    (args[key] as String?) ?? fallback;
+
+int _int(Map<String, Object?> args, String key, [int fallback = 0]) {
+  final v = args[key];
+  return v is num ? v.toInt() : fallback;
+}
+
+/// Whether [name] is one of the LSP tools handled by [computeLspTool].
+bool isLspTool(String name) => lspToolNames.contains(name);
+
+/// Runs the LSP tool named [name] with [args] and returns its JSON result map
+/// (always including an `isError` flag). Pure with respect to the host, so it
+/// runs identically in-process or inside a spawned isolate.
+Future<Map<String, Object?>> computeLspTool(
+  String name,
+  Map<String, Object?> args,
+  McpLimits limits,
+) async {
+  final rt = LspRuntime(limits: limits);
+
+  switch (name) {
+    case lspDiagnosticsToolName:
+      return rt.diagnostics(
+        _str(args, 'language'),
+        _str(args, 'source'),
+        uri: args['uri'] as String?,
+      );
+
+    case lspSymbolsToolName:
+      return rt.documentSymbols(
+        _str(args, 'language'),
+        _str(args, 'source'),
+        uri: args['uri'] as String?,
+      );
+
+    case lspHoverToolName:
+      return rt.hover(
+        _str(args, 'language'),
+        _str(args, 'source'),
+        _int(args, 'line'),
+        _int(args, 'character'),
+        uri: args['uri'] as String?,
+      );
+
+    case lspDefinitionToolName:
+      return rt.definition(
+        _str(args, 'language'),
+        _str(args, 'source'),
+        _int(args, 'line'),
+        _int(args, 'character'),
+        uri: args['uri'] as String?,
+      );
+
+    case lspReferencesToolName:
+      return rt.references(
+        _str(args, 'language'),
+        _str(args, 'source'),
+        _int(args, 'line'),
+        _int(args, 'character'),
+        includeDeclaration: (args['includeDeclaration'] as bool?) ?? true,
+        uri: args['uri'] as String?,
+      );
+
+    case lspCompletionToolName:
+      return rt.completion(
+        _str(args, 'language'),
+        _str(args, 'source'),
+        _int(args, 'line'),
+        _int(args, 'character'),
+        uri: args['uri'] as String?,
+      );
+
+    case lspWorkspaceSymbolsToolName:
+      return rt.workspaceSymbols(
+        _str(args, 'query'),
+        (args['files'] as List?)?.cast<Object?>() ?? const [],
+      );
+
+    default:
+      return <String, Object?>{
+        'diagnostics': [
+          <String, Object?>{
+            'severity': 'error',
+            'message': 'Unknown LSP tool: $name',
+          },
+        ],
+        'isError': true,
+      };
+  }
+}

--- a/test/mcp/lsp_tools_test.dart
+++ b/test/mcp/lsp_tools_test.dart
@@ -1,0 +1,250 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'package:apollovm/apollovm_mcp.dart';
+import 'package:test/test.dart';
+
+const _src = '''
+class Foo {
+  /// Doubles [x] and adds [y].
+  static int calc(int x, int y) {
+    var doubled = x * 2;
+    return doubled + y;
+  }
+
+  static int run() {
+    return calc(10, 5);
+  }
+}
+''';
+
+/// `computeTool` with default limits.
+Future<Map<String, Object?>> _call(String name, Map<String, Object?> args) =>
+    computeTool(name, args, const McpLimits());
+
+void main() {
+  group('LSP MCP tools — registration', () {
+    test('all lsp tools are advertised and registered', () {
+      expect(allToolNames, containsAll(lspToolNames));
+      final built = buildLspTools().map((t) => t.name).toSet();
+      expect(built, equals(lspToolNames.toSet()));
+      expect(lspToolNames, hasLength(7));
+      for (final n in lspToolNames) {
+        expect(isLspTool(n), isTrue, reason: n);
+      }
+      expect(isLspTool('apollovm.parse'), isFalse);
+    });
+
+    test('supported languages exclude wasm', () {
+      expect(LspRuntime.supportedLanguages, contains('dart'));
+      expect(LspRuntime.supportedLanguages, contains('python'));
+      expect(LspRuntime.supportedLanguages, isNot(contains('wasm')));
+    });
+  });
+
+  group('apollovm.lsp.diagnostics', () {
+    test('clean source reports no diagnostics', () async {
+      final r = await _call('apollovm.lsp.diagnostics', {
+        'language': 'dart',
+        'source': _src,
+      });
+      expect(r['isError'], isFalse);
+      expect(r['ok'], isTrue);
+      expect(r['diagnostics'], isEmpty);
+    });
+
+    test('broken source reports an error with a range', () async {
+      final r = await _call('apollovm.lsp.diagnostics', {
+        'language': 'dart',
+        'source': 'class Foo {\n  static int calc( {\n}\n',
+      });
+      expect(r['isError'], isFalse);
+      expect(r['ok'], isFalse);
+      final diags = r['diagnostics'] as List;
+      expect(diags, isNotEmpty);
+      expect((diags.first as Map)['severity'], 1); // error
+      expect((diags.first as Map)['range'], isA<Map>());
+    });
+  });
+
+  test('apollovm.lsp.symbols returns a nested outline', () async {
+    final r = await _call('apollovm.lsp.symbols', {
+      'language': 'dart',
+      'source': _src,
+    });
+    final symbols = (r['symbols'] as List).cast<Map>();
+    final foo = symbols.firstWhere((s) => s['name'] == 'Foo');
+    expect(foo['kind'], isNotNull);
+    final children = (foo['children'] as List).cast<Map>();
+    expect(children.map((c) => c['name']), containsAll(['calc', 'run']));
+    expect(foo['range'], isA<Map>());
+  });
+
+  group('apollovm.lsp.hover', () {
+    test('returns markup with signature and doc', () async {
+      // `calc` is the method name on line 2.
+      final r = await _call('apollovm.lsp.hover', {
+        'language': 'dart',
+        'source': _src,
+        'line': 2,
+        'character': 13,
+      });
+      final hover = r['hover'] as Map;
+      final value = (hover['contents'] as Map)['value'] as String;
+      expect(value, contains('calc'));
+      expect(value, contains('Doubles'));
+    });
+
+    test('off an identifier returns null hover', () async {
+      final r = await _call('apollovm.lsp.hover', {
+        'language': 'dart',
+        'source': _src,
+        'line': 6,
+        'character': 0,
+      });
+      expect(r['isError'], isFalse);
+      expect(r['hover'], isNull);
+    });
+  });
+
+  test('apollovm.lsp.definition resolves a call to its declaration', () async {
+    // 2nd `calc` (the call inside `run`) is on line 8.
+    final r = await _call('apollovm.lsp.definition', {
+      'language': 'dart',
+      'source': _src,
+      'line': 8,
+      'character': 11,
+    });
+    final def = r['definition'] as Map;
+    final start = (def['range'] as Map)['start'] as Map;
+    expect(start['line'], 2); // declaration line
+  });
+
+  test('apollovm.lsp.references finds all occurrences', () async {
+    final r = await _call('apollovm.lsp.references', {
+      'language': 'dart',
+      'source': _src,
+      'line': 2,
+      'character': 13,
+    });
+    final refs = r['references'] as List;
+    expect(refs.length, 2); // declaration + call site
+  });
+
+  test('apollovm.lsp.completion proposes symbols and keywords', () async {
+    final r = await _call('apollovm.lsp.completion', {
+      'language': 'dart',
+      'source': _src,
+      'line': 4,
+      'character': 8,
+    });
+    final items = ((r['completion'] as Map)['items'] as List).cast<Map>();
+    final labels = items.map((i) => i['label']).toSet();
+    expect(labels, contains('calc'));
+    expect(labels, contains('return'));
+  });
+
+  group('apollovm.lsp.workspaceSymbols', () {
+    test('searches declarations across multiple files', () async {
+      final r = await _call('apollovm.lsp.workspaceSymbols', {
+        'query': 'calc',
+        'files': [
+          {'uri': 'file:///a.dart', 'source': 'class A { int calc() => 1; }'},
+          {'uri': 'file:///b.dart', 'source': 'int helper() => 0;'},
+        ],
+      });
+      expect(r['isError'], isFalse);
+      final names = (r['symbols'] as List).map((s) => (s as Map)['name']);
+      expect(names, contains('calc'));
+      expect(names, isNot(contains('helper')));
+      expect(r['files'], ['file:///a.dart', 'file:///b.dart']);
+    });
+
+    test('infers a language for a file lacking a known extension', () async {
+      final r = await _call('apollovm.lsp.workspaceSymbols', {
+        'query': '',
+        'files': [
+          {'uri': 'snippet', 'source': 'int total() => 0;', 'language': 'dart'},
+        ],
+      });
+      final names = (r['symbols'] as List).map((s) => (s as Map)['name']);
+      expect(names, contains('total'));
+    });
+
+    test('synthesizes a URI for a file with no uri', () async {
+      final r = await _call('apollovm.lsp.workspaceSymbols', {
+        'query': 'total',
+        'files': [
+          {'source': 'int total() => 0;', 'language': 'dart'},
+        ],
+      });
+      expect(r['isError'], isFalse);
+      expect((r['files'] as List).single, 'file:///mcp/file0.dart');
+      final names = (r['symbols'] as List).map((s) => (s as Map)['name']);
+      expect(names, contains('total'));
+    });
+
+    test('rejects a workspace exceeding maxSourceChars', () async {
+      final r = await computeTool('apollovm.lsp.workspaceSymbols', {
+        'query': '',
+        'files': [
+          {'uri': 'file:///a.dart', 'source': 'class A {}'},
+          {'uri': 'file:///b.dart', 'source': 'class B {}'},
+        ],
+      }, const McpLimits(maxSourceChars: 12));
+      expect(r['isError'], isTrue);
+    });
+  });
+
+  group('language selection & limits', () {
+    test('parser is chosen from the language, not a mismatched URI', () async {
+      // A `.py` URI must not force the Python parser when language is dart.
+      final r = await _call('apollovm.lsp.symbols', {
+        'language': 'dart',
+        'source': _src,
+        'uri': 'file:///thing.py',
+      });
+      final names = (r['symbols'] as List).map((s) => (s as Map)['name']);
+      expect(names, contains('Foo'));
+    });
+
+    test('unsupported language is a tool error', () async {
+      final r = await _call('apollovm.lsp.hover', {
+        'language': 'brainfuck',
+        'source': '++',
+        'line': 0,
+        'character': 0,
+      });
+      expect(r['isError'], isTrue);
+      expect((r['diagnostics'] as List), isNotEmpty);
+    });
+
+    test('source exceeding maxSourceChars is rejected', () async {
+      final r = await computeTool('apollovm.lsp.diagnostics', {
+        'language': 'dart',
+        'source': 'class A {}',
+      }, const McpLimits(maxSourceChars: 4));
+      expect(r['isError'], isTrue);
+    });
+  });
+
+  test('computeLspTool rejects an unknown lsp tool name', () async {
+    final r = await computeLspTool(
+      'apollovm.lsp.bogus',
+      const {},
+      const McpLimits(),
+    );
+    expect(r['isError'], isTrue);
+    expect((r['diagnostics'] as List), isNotEmpty);
+  });
+
+  test('runs identically inside an isolate', () async {
+    final r = await computeToolIsolated('apollovm.lsp.symbols', {
+      'language': 'dart',
+      'source': _src,
+    }, const McpLimits());
+    final names = (r['symbols'] as List).map((s) => (s as Map)['name']);
+    expect(names, contains('Foo'));
+  });
+}

--- a/test/mcp/mcp_command_test.dart
+++ b/test/mcp/mcp_command_test.dart
@@ -109,7 +109,7 @@ void main() {
   group('mcp doctor', () {
     test('runs the capability checks and reports the tool count', () async {
       final output = await runMcp(['doctor']);
-      expect(output, contains('7 tools registered'));
+      expect(output, contains('${allToolNames.length} tools registered'));
       expect(output, contains('apollovm.execute'));
       expect(output, contains('apollovm.wasm'));
     });

--- a/test/mcp/mcp_server_test.dart
+++ b/test/mcp/mcp_server_test.dart
@@ -109,20 +109,15 @@ class Calc {
       expect(serverInfo['version'], ApolloVM.VERSION);
     });
 
-    test('tools/list returns the 7 tools each with an inputSchema', () async {
+    test('tools/list returns all tools each with an inputSchema', () async {
       await client.initialize();
       final resp = await client.request('tools/list');
       final tools = (resp['result'] as Map)['tools'] as List;
       final names = tools.map((t) => (t as Map)['name']).toSet();
-      expect(names, {
-        'apollovm.parse',
-        'apollovm.execute',
-        'apollovm.translate',
-        'apollovm.ast',
-        'apollovm.symbols',
-        'apollovm.types',
-        'apollovm.wasm',
-      });
+      expect(names, allToolNames.toSet());
+      // The core VM tools and the LSP inspection tools are both advertised.
+      expect(names, containsAll(['apollovm.parse', 'apollovm.wasm']));
+      expect(names, containsAll(lspToolNames));
       for (final t in tools) {
         final schema = (t as Map)['inputSchema'] as Map;
         expect(schema['properties'], isNotEmpty);


### PR DESCRIPTION
## Summary

Stacked on #86 (LspService). Adds seven **`apollovm.lsp.*` MCP tools** so an AI agent can inspect a codebase the way an editor does, backed by the in-process `LspService`. Results carry precise LSP line/character ranges.

| Tool | Purpose |
|---|---|
| `apollovm.lsp.diagnostics` | errors/warnings with ranges |
| `apollovm.lsp.symbols` | document outline (nested symbols + ranges) |
| `apollovm.lsp.hover` | signature/type/doc at a position |
| `apollovm.lsp.definition` | declaration location at a position |
| `apollovm.lsp.references` | all references at a position |
| `apollovm.lsp.completion` | proposals at a position |
| `apollovm.lsp.workspaceSymbols` | symbol search across multiple in-memory files |

- Stateless & web-safe (no socket, no `dart:io`), dispatched through the existing `computeTool` pipeline (in-process or isolate), honoring `maxSourceChars`. The parser is chosen from the `language` argument, so a mismatched URI can't switch it.
- New `LspRuntime`; `buildLspTools`/`computeLspTool`/`isLspTool`/`lspToolNames` wired into `allToolNames`/`buildTools`/`computeTool` and exported from `apollovm_mcp.dart`. CLI `mcp call` gains `--line`/`--character`/`--query`.
- New example `example/apollovm_example_mcp_lsp.dart`; both new files at 100% line coverage.

> Note: base is `feat/lsp-in-process-api`; GitHub will retarget this to `master` once that PR merges.

## Testing
- `dart format` / `dart analyze` clean
- New `test/mcp/lsp_tools_test.dart` (19 tests); full suite: 1427 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)