### PR TITLE
test(mcp): mark lsp_tools_test as @TestOn('vm') (fix Chrome CI)

### DIFF
--- a/test/mcp/lsp_tools_test.dart
+++ b/test/mcp/lsp_tools_test.dart
@@ -2,6 +2,10 @@
 // This code is governed by the Apache License, Version 2.0.
 // Please refer to the LICENSE and AUTHORS files for details.
 
+@TestOn('vm')
+@Tags(['mcp'])
+library;
+
 import 'package:apollovm/apollovm_mcp.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
## Problem

The `master` CI (`test_chrome` job) went red after #87 merged: **1 test failed** on the web/JS platform.

`test/mcp/lsp_tools_test.dart` exercises isolate execution via `computeToolIsolated` (the "runs identically inside an isolate" case). `dart:isolate` spawning is not available on web, so the case fails only under Chrome — the VM job passes.

## Fix

Add the `@TestOn('vm')` / `@Tags(['mcp'])` library guard that every other `test/mcp/*.dart` file already uses, so the MCP tool suite runs on the VM only. No production code changes; the LSP MCP tools themselves remain web-safe.

Verified locally: `dart test test/mcp/lsp_tools_test.dart` → 19 passing on the VM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)