### PR TITLE
Make the MCP tools + LSP web-compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,26 @@
 - New example
   [`example/apollovm_example_mcp_lsp.dart`](example/apollovm_example_mcp_lsp.dart).
 
+### MCP — web compatibility
+
+- **`package:apollovm/apollovm_mcp.dart` is now fully web-safe** — it imports no
+  `dart:io` and no `dart:isolate`, so the MCP server and every `apollovm.*` /
+  `apollovm.lsp.*` tool compile and run in a browser (dart2js / DDC). Construct
+  `ApolloMcpServer` on any `StreamChannel<String>` (e.g. a web `MessageChannel`)
+  and drive all tools in-process.
+- The `dart:io`-only pieces moved to a new **`package:apollovm/apollovm_mcp_io.dart`**
+  (which re-exports `apollovm_mcp.dart`): `serveStdio`, `HttpSseTransport` and
+  the `CommandMcp` CLI group. Native embedders and the `apollovm` CLI import
+  this; nothing else changes for them.
+- The per-tool timeout executor is now platform-selected (mirroring
+  `wasm_runtime.dart`): a killable-isolate executor on native, and an in-process
+  executor with a cooperative timeout on the web (no `dart:isolate`). Tools in
+  `McpLimits.isolateTools` therefore still run, degrading to a soft timeout on
+  the web.
+- New cross-platform test `test/mcp/web_compat_test.dart` runs the tools, the
+  in-process `LspClient` and the server under `dart test --platform chrome`,
+  guarding the web-safe surface against future `dart:io`/`dart:isolate` leaks.
+
 ### Language Server Protocol — in-process API (no socket)
 
 - **New `LspService`** in `package:apollovm/apollovm_lsp.dart`: a

--- a/bin/apollovm.dart
+++ b/bin/apollovm.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 
 import 'package:apollovm/apollovm.dart';
 import 'package:apollovm/apollovm_lsp.dart';
-import 'package:apollovm/apollovm_mcp.dart';
+import 'package:apollovm/apollovm_mcp_io.dart';
 import 'package:apollovm/apollovm_pub.dart';
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';

--- a/lib/apollovm_mcp.dart
+++ b/lib/apollovm_mcp.dart
@@ -9,13 +9,20 @@
 /// `apollovm.translate`, `apollovm.ast`, `apollovm.symbols`, `apollovm.types`,
 /// `apollovm.wasm`), plus a set of `apollovm.lsp.*` tools that let an agent
 /// inspect code the way an editor does (diagnostics, outline, hover,
-/// definition, references, completion and workspace-wide symbol search) — all
-/// over stdio or HTTP/SSE, with a configurable security model (per-tool isolate
-/// execution, timeout, and input/output limits).
+/// definition, references, completion and workspace-wide symbol search).
+///
+/// This library is **web-safe**: it imports no `dart:io` and no `dart:isolate`,
+/// so a browser IDE or an embedded agent can run the server and all tools
+/// in-process. Construct an [ApolloMcpServer] on any `StreamChannel<String>`.
+/// On native, tools flagged by [McpLimits.isolateTools] run in a killable
+/// isolate for a hard timeout; on the web they run in-process with a
+/// cooperative timeout (see `isolate_executor.dart`).
+///
+/// The native-only transports and CLI (stdio, HTTP/SSE, the `mcp` command)
+/// live in `package:apollovm/apollovm_mcp_io.dart`, which requires `dart:io`.
 library;
 
 export 'src/mcp/apollo_mcp_server.dart';
-export 'src/mcp/cli/mcp_command.dart';
 export 'src/mcp/mcp_config.dart';
 export 'src/mcp/runtime/isolate_executor.dart'
     show computeToolIsolated, runToolInIsolate;
@@ -23,5 +30,3 @@ export 'src/mcp/runtime/lsp_runtime.dart' show LspRuntime;
 export 'src/mcp/tools/apollo_tools.dart' show allToolNames, computeTool;
 export 'src/mcp/tools/lsp_tools.dart'
     show buildLspTools, computeLspTool, isLspTool, lspToolNames;
-export 'src/mcp/transport/http_sse_transport.dart';
-export 'src/mcp/transport/stdio_transport.dart';

--- a/lib/apollovm_mcp_io.dart
+++ b/lib/apollovm_mcp_io.dart
@@ -1,0 +1,23 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+/// Native (`dart:io`) MCP server extras for ApolloVM.
+///
+/// Re-exports the web-safe [`apollovm_mcp`](apollovm_mcp.dart) surface (server,
+/// config, tools) and adds the transports and CLI that need `dart:io`:
+///
+/// * `serveStdio` — run the server over stdio (the standard local MCP
+///   transport).
+/// * `HttpSseTransport` — serve over HTTP/SSE for networked use.
+/// * `CommandMcp` — the `apollovm mcp …` command group for the CLI.
+///
+/// Import this on the Dart VM / native. For the web (dart2js / DDC), import
+/// `package:apollovm/apollovm_mcp.dart` and drive [ApolloMcpServer] over an
+/// in-process `StreamChannel<String>` instead.
+library;
+
+export 'apollovm_mcp.dart';
+export 'src/mcp/cli/mcp_command.dart';
+export 'src/mcp/transport/http_sse_transport.dart';
+export 'src/mcp/transport/stdio_transport.dart';

--- a/lib/src/mcp/runtime/isolate_executor.dart
+++ b/lib/src/mcp/runtime/isolate_executor.dart
@@ -2,119 +2,12 @@
 // This code is governed by the Apache License, Version 2.0.
 // Please refer to the LICENSE and AUTHORS files for details.
 
-import 'dart:async';
-import 'dart:isolate';
-
-import '../mcp_config.dart';
-import '../tools/apollo_tools.dart';
-
-/// A sendable description of a tool computation to run inside an isolate.
-class _IsolateJob {
-  final String toolName;
-  final Map<String, Object?> args;
-  final McpLimits limits;
-  final SendPort replyPort;
-
-  _IsolateJob(this.toolName, this.args, this.limits, this.replyPort);
-}
-
-/// Runs the tool named [toolName] inside an isolate, using
-/// [McpLimits.timeoutMs] (or an override in `args['timeoutMs']`) as the hard
-/// timeout. Convenience wrapper over [runToolInIsolate].
-Future<Map<String, Object?>> computeToolIsolated(
-  String toolName,
-  Map<String, Object?> args,
-  McpLimits limits,
-) {
-  final timeoutMs = (args['timeoutMs'] as int?) ?? limits.timeoutMs;
-  return runToolInIsolate(
-    toolName,
-    args,
-    limits,
-    Duration(milliseconds: timeoutMs),
-  );
-}
-
-/// Runs [computeTool] for [toolName] inside a spawned [Isolate], enforcing a
-/// hard [timeout] via `Timer` + `Isolate.kill`.
-///
-/// This is the only reliable way to bound CPU/wall-clock in Dart: a runaway
-/// loop that ignores the event loop cannot be stopped in-process, but the
-/// isolate running it can be killed. On timeout (or isolate error/premature
-/// exit) an error result map is returned; captured output produced before the
-/// kill is not recovered.
-Future<Map<String, Object?>> runToolInIsolate(
-  String toolName,
-  Map<String, Object?> args,
-  McpLimits limits,
-  Duration timeout,
-) async {
-  final replyPort = ReceivePort();
-  final errorPort = ReceivePort();
-  final exitPort = ReceivePort();
-  final completer = Completer<Map<String, Object?>>();
-
-  Isolate? isolate;
-  Timer? timer;
-
-  void complete(Map<String, Object?> result) {
-    if (!completer.isCompleted) completer.complete(result);
-  }
-
-  try {
-    isolate = await Isolate.spawn(
-      _isolateEntry,
-      _IsolateJob(toolName, args, limits, replyPort.sendPort),
-      onError: errorPort.sendPort,
-      onExit: exitPort.sendPort,
-      errorsAreFatal: true,
-    );
-
-    timer = Timer(timeout, () {
-      isolate?.kill(priority: Isolate.immediate);
-      complete(
-        _errorResult('Execution timed out after ${timeout.inMilliseconds}ms'),
-      );
-    });
-
-    replyPort.listen((message) {
-      complete((message as Map).cast<String, Object?>());
-    });
-
-    errorPort.listen((message) {
-      // message is [errorString, stackTraceString].
-      final error = (message is List && message.isNotEmpty)
-          ? '${message.first}'
-          : '$message';
-      complete(_errorResult('Isolate error: $error'));
-    });
-
-    exitPort.listen((_) {
-      complete(_errorResult('Isolate exited before returning a result'));
-    });
-
-    return await completer.future;
-  } finally {
-    timer?.cancel();
-    replyPort.close();
-    errorPort.close();
-    exitPort.close();
-    isolate?.kill(priority: Isolate.immediate);
-  }
-}
-
-Future<void> _isolateEntry(_IsolateJob job) async {
-  try {
-    final result = await computeTool(job.toolName, job.args, job.limits);
-    job.replyPort.send(result);
-  } catch (e) {
-    job.replyPort.send(_errorResult('$e'));
-  }
-}
-
-Map<String, Object?> _errorResult(String message) => <String, Object?>{
-  'diagnostics': [
-    <String, Object?>{'severity': 'error', 'message': message},
-  ],
-  'isError': true,
-};
+// Platform-selected tool executor for `computeToolIsolated` /
+// `runToolInIsolate`.
+//
+// On native (`dart:isolate` present) each tool runs in a spawned isolate that a
+// hard timeout can kill; on the web it runs in-process with a cooperative
+// timeout. Both variants expose the same API, so callers (the MCP server) are
+// platform-agnostic. Mirrors the `wasm_runtime.dart` conditional-import idiom.
+export 'isolate_executor_generic.dart'
+    if (dart.library.io) 'isolate_executor_io.dart';

--- a/lib/src/mcp/runtime/isolate_executor_generic.dart
+++ b/lib/src/mcp/runtime/isolate_executor_generic.dart
@@ -1,0 +1,58 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+// The platform-generic (web/JS) tool executor. Selected by
+// `isolate_executor.dart` when `dart:isolate` is unavailable (e.g. dart2js /
+// DDC), where it is the only option.
+import 'dart:async';
+
+import '../mcp_config.dart';
+import '../tools/apollo_tools.dart';
+
+/// Runs the tool named [toolName] with the configured timeout. Convenience
+/// wrapper over [runToolInIsolate], mirroring the native executor's API.
+Future<Map<String, Object?>> computeToolIsolated(
+  String toolName,
+  Map<String, Object?> args,
+  McpLimits limits,
+) {
+  final timeoutMs = (args['timeoutMs'] as int?) ?? limits.timeoutMs;
+  return runToolInIsolate(
+    toolName,
+    args,
+    limits,
+    Duration(milliseconds: timeoutMs),
+  );
+}
+
+/// Runs [computeTool] for [toolName] **in-process**, bounding it with a
+/// cooperative [timeout] (`Future.timeout`).
+///
+/// This platform has no `dart:isolate`, so — unlike the native executor — the
+/// timeout cannot forcibly kill CPU-bound code that never yields to the event
+/// loop; it only stops awaiting the result. Same signature and error-result
+/// shape as the native `runToolInIsolate` so callers are platform-agnostic.
+Future<Map<String, Object?>> runToolInIsolate(
+  String toolName,
+  Map<String, Object?> args,
+  McpLimits limits,
+  Duration timeout,
+) async {
+  try {
+    return await computeTool(toolName, args, limits).timeout(
+      timeout,
+      onTimeout: () =>
+          _errorResult('Execution timed out after ${timeout.inMilliseconds}ms'),
+    );
+  } catch (e) {
+    return _errorResult('$e');
+  }
+}
+
+Map<String, Object?> _errorResult(String message) => <String, Object?>{
+  'diagnostics': [
+    <String, Object?>{'severity': 'error', 'message': message},
+  ],
+  'isError': true,
+};

--- a/lib/src/mcp/runtime/isolate_executor_io.dart
+++ b/lib/src/mcp/runtime/isolate_executor_io.dart
@@ -1,0 +1,124 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+// The native tool executor. Selected by `isolate_executor.dart` when
+// `dart:isolate` is available; runs each tool in a spawned isolate so a hard
+// timeout can kill runaway code. See `isolate_executor_generic.dart` for the
+// in-process web variant.
+import 'dart:async';
+import 'dart:isolate';
+
+import '../mcp_config.dart';
+import '../tools/apollo_tools.dart';
+
+/// A sendable description of a tool computation to run inside an isolate.
+class _IsolateJob {
+  final String toolName;
+  final Map<String, Object?> args;
+  final McpLimits limits;
+  final SendPort replyPort;
+
+  _IsolateJob(this.toolName, this.args, this.limits, this.replyPort);
+}
+
+/// Runs the tool named [toolName] inside an isolate, using
+/// [McpLimits.timeoutMs] (or an override in `args['timeoutMs']`) as the hard
+/// timeout. Convenience wrapper over [runToolInIsolate].
+Future<Map<String, Object?>> computeToolIsolated(
+  String toolName,
+  Map<String, Object?> args,
+  McpLimits limits,
+) {
+  final timeoutMs = (args['timeoutMs'] as int?) ?? limits.timeoutMs;
+  return runToolInIsolate(
+    toolName,
+    args,
+    limits,
+    Duration(milliseconds: timeoutMs),
+  );
+}
+
+/// Runs [computeTool] for [toolName] inside a spawned [Isolate], enforcing a
+/// hard [timeout] via `Timer` + `Isolate.kill`.
+///
+/// This is the only reliable way to bound CPU/wall-clock in Dart: a runaway
+/// loop that ignores the event loop cannot be stopped in-process, but the
+/// isolate running it can be killed. On timeout (or isolate error/premature
+/// exit) an error result map is returned; captured output produced before the
+/// kill is not recovered.
+Future<Map<String, Object?>> runToolInIsolate(
+  String toolName,
+  Map<String, Object?> args,
+  McpLimits limits,
+  Duration timeout,
+) async {
+  final replyPort = ReceivePort();
+  final errorPort = ReceivePort();
+  final exitPort = ReceivePort();
+  final completer = Completer<Map<String, Object?>>();
+
+  Isolate? isolate;
+  Timer? timer;
+
+  void complete(Map<String, Object?> result) {
+    if (!completer.isCompleted) completer.complete(result);
+  }
+
+  try {
+    isolate = await Isolate.spawn(
+      _isolateEntry,
+      _IsolateJob(toolName, args, limits, replyPort.sendPort),
+      onError: errorPort.sendPort,
+      onExit: exitPort.sendPort,
+      errorsAreFatal: true,
+    );
+
+    timer = Timer(timeout, () {
+      isolate?.kill(priority: Isolate.immediate);
+      complete(
+        _errorResult('Execution timed out after ${timeout.inMilliseconds}ms'),
+      );
+    });
+
+    replyPort.listen((message) {
+      complete((message as Map).cast<String, Object?>());
+    });
+
+    errorPort.listen((message) {
+      // message is [errorString, stackTraceString].
+      final error = (message is List && message.isNotEmpty)
+          ? '${message.first}'
+          : '$message';
+      complete(_errorResult('Isolate error: $error'));
+    });
+
+    exitPort.listen((_) {
+      complete(_errorResult('Isolate exited before returning a result'));
+    });
+
+    return await completer.future;
+  } finally {
+    timer?.cancel();
+    replyPort.close();
+    errorPort.close();
+    exitPort.close();
+    isolate?.kill(priority: Isolate.immediate);
+  }
+}
+
+Future<void> _isolateEntry(_IsolateJob job) async {
+  try {
+    final result = await computeTool(job.toolName, job.args, job.limits);
+    job.replyPort.send(result);
+  } catch (e) {
+    job.replyPort.send(_errorResult('$e'));
+  }
+}
+
+Map<String, Object?> _errorResult(String message) => <String, Object?>{
+  'diagnostics': [
+    <String, Object?>{'severity': 'error', 'message': message},
+  ],
+  'isError': true,
+};

--- a/test/mcp/http_sse_transport_test.dart
+++ b/test/mcp/http_sse_transport_test.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:apollovm/apollovm_mcp.dart';
+import 'package:apollovm/apollovm_mcp_io.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/mcp/mcp_command_test.dart
+++ b/test/mcp/mcp_command_test.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:apollovm/apollovm.dart' show ApolloVM;
-import 'package:apollovm/apollovm_mcp.dart';
+import 'package:apollovm/apollovm_mcp_io.dart';
 import 'package:args/command_runner.dart';
 import 'package:test/test.dart';
 

--- a/test/mcp/stdio_transport_test.dart
+++ b/test/mcp/stdio_transport_test.dart
@@ -6,7 +6,7 @@ import 'dart:async';
 import 'dart:convert';
 
 import 'package:apollovm/apollovm.dart' show ApolloVM;
-import 'package:apollovm/apollovm_mcp.dart';
+import 'package:apollovm/apollovm_mcp_io.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/mcp/web_compat_test.dart
+++ b/test/mcp/web_compat_test.dart
@@ -1,0 +1,85 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+// Cross-platform (VM + browser) test: the MCP tools and the LSP run entirely
+// in-process on the web. Deliberately NOT `@TestOn('vm')` — it runs under
+// `dart test --platform chrome` in CI, so a `dart:io` / `dart:isolate` leak
+// into the web-safe surface (`apollovm_mcp.dart` / `apollovm_lsp.dart`) fails
+// compilation here. The native transports/CLI live in `apollovm_mcp_io.dart`.
+@Tags(['mcp'])
+library;
+
+import 'package:apollovm/apollovm_lsp.dart';
+import 'package:apollovm/apollovm_mcp.dart';
+import 'package:stream_channel/stream_channel.dart';
+import 'package:test/test.dart';
+
+const _src =
+    'class Greeter {\n'
+    '  final String name;\n'
+    '  Greeter(this.name);\n'
+    '  String greet() => \'Hello, \$name!\';\n'
+    '}\n';
+
+void main() {
+  group('web-safe MCP surface', () {
+    const limits = McpLimits();
+
+    test('core tool (apollovm.parse) runs in-process', () async {
+      final result = await computeTool('apollovm.parse', {
+        'language': 'dart',
+        'source': _src,
+      }, limits);
+      expect(result['isError'], isFalse);
+    });
+
+    test('the isolate-flagged tool degrades to in-process execution', () async {
+      // `apollovm.execute` is in `limits.isolateTools`; on the web there is no
+      // `dart:isolate`, so the generic executor runs it in-process.
+      final result = await computeToolIsolated('apollovm.execute', {
+        'language': 'dart',
+        'source': 'int main() { return 21 + 21; }',
+      }, limits);
+      expect(result['isError'], isFalse);
+      expect(result['result'], 42);
+    });
+
+    test(
+      'LSP tool (apollovm.lsp.diagnostics) runs the in-process server',
+      () async {
+        expect(isLspTool('apollovm.lsp.diagnostics'), isTrue);
+        final result = await computeLspTool('apollovm.lsp.diagnostics', {
+          'language': 'dart',
+          'source': _src,
+        }, limits);
+        expect(result['isError'], isFalse);
+        expect(result['diagnostics'], isEmpty);
+      },
+    );
+
+    test('all tool schemas build', () {
+      expect(allToolNames, isNotEmpty);
+      expect(lspToolNames, isNotEmpty);
+      expect(buildLspTools().map((t) => t.name), containsAll(lspToolNames));
+    });
+  });
+
+  test('LspClient.inProcess drives the server in one isolate', () async {
+    final client = LspClient.inProcess();
+    await client.initialize();
+    client.initialized();
+    client.didOpen('file:///main.dart', _src);
+
+    final symbols = await client.documentSymbol('file:///main.dart');
+    expect(symbols.map((s) => s.name), contains('Greeter'));
+
+    await client.dispose();
+  });
+
+  test('ApolloMcpServer binds to a StreamChannel<String>', () {
+    final controller = StreamChannelController<String>();
+    final server = ApolloMcpServer(controller.local);
+    expect(server, isNotNull);
+  });
+}


### PR DESCRIPTION
## Summary

`package:apollovm/apollovm_mcp.dart` is now free of `dart:io` and `dart:isolate`, so the MCP server and every `apollovm.*` / `apollovm.lsp.*` tool compile and run in a browser (dart2js / DDC). Construct `ApolloMcpServer` on any `StreamChannel<String>` (e.g. a web `MessageChannel`) and drive the tools in-process.

Previously the 1.4.0 CHANGELOG described the `apollovm.lsp.*` tools as "web-safe … no `dart:io`", but `apollovm_mcp.dart` still re-exported the stdio/HTTP transports (`dart:io`) and the isolate executor (`dart:isolate`) — so any web build importing it failed to compile (hence every MCP test was pinned `@TestOn('vm')`). This PR makes the claim actually true.

## Changes

Follows the repo's existing `wasm_runtime.dart` conditional-import idiom.

- **Library split.** `apollovm_mcp.dart` stays web-safe (server, config, tools, LSP tools). The `dart:io`-only pieces — `serveStdio`, `HttpSseTransport`, `CommandMcp` — moved to a new native-only **`apollovm_mcp_io.dart`** that re-exports `apollovm_mcp.dart`. `bin/apollovm.dart` and the transport/CLI tests import it; nothing else changes for native embedders.
- **Platform-selected timeout executor.** `isolate_executor.dart` is now a conditional-export facade → `isolate_executor_io.dart` (killable isolate, native) / `isolate_executor_generic.dart` (in-process cooperative timeout, web). Tools in `McpLimits.isolateTools` still run everywhere, degrading to a soft timeout on the web (no `dart:isolate`).
- **Regression guard.** New cross-platform `test/mcp/web_compat_test.dart` (not `@TestOn('vm')`) runs under the existing `test_chrome` job.
- CHANGELOG's 1.4.0 entry updated with an "MCP — web compatibility" subsection.

## Verification

- `dart compile js` compiles the full MCP + LSP surface (~4.3 MB JS) with no `dart:io` / `dart:isolate` errors.
- **6 web-compat tests pass in real Chrome** (`dart test --platform chrome`): core tool in-process, isolate-flagged tool degrading in-process, LSP diagnostics via the in-process server, `LspClient.inProcess` document symbols, and `ApolloMcpServer` binding to a `StreamChannel`.
- All **75 MCP tests pass on the VM**; `dart analyze` clean; `dart format` clean; CLI (`apollovm mcp info`) still works; `pub publish --dry-run` clean.

## Compatibility

Native consumers of `serveStdio` / `HttpSseTransport` / `CommandMcp` via `apollovm_mcp.dart` must switch their import to `apollovm_mcp_io.dart` (a one-line change). This is pre-release (1.4.0 unpublished).

🤖 Generated with [Claude Code](https://claude.com/claude-code)