### PR TITLE
v1.4.1 — MCP tools + LSP web-compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## 1.4.1
+
+### MCP — web compatibility
+
+- **`package:apollovm/apollovm_mcp.dart` is now fully web-safe** — it imports no
+  `dart:io` and no `dart:isolate`, so the MCP server and every `apollovm.*` /
+  `apollovm.lsp.*` tool compile and run in a browser (dart2js / DDC). Construct
+  `ApolloMcpServer` on any `StreamChannel<String>` (e.g. a web `MessageChannel`)
+  and drive all tools in-process. (In 1.4.0 the `apollovm.lsp.*` tools were
+  documented as web-safe, but `apollovm_mcp.dart` still transitively imported
+  `dart:io`/`dart:isolate`, so a web build failed to compile.)
+- The `dart:io`-only pieces moved to a new **`package:apollovm/apollovm_mcp_io.dart`**
+  (which re-exports `apollovm_mcp.dart`): `serveStdio`, `HttpSseTransport` and
+  the `CommandMcp` CLI group. Native embedders and the `apollovm` CLI import
+  this. **Migration:** if you imported `serveStdio` / `HttpSseTransport` /
+  `CommandMcp` from `apollovm_mcp.dart`, switch that import to
+  `apollovm_mcp_io.dart` (a one-line change).
+- The per-tool timeout executor is now platform-selected (mirroring
+  `wasm_runtime.dart`): a killable-isolate executor on native, and an in-process
+  executor with a cooperative timeout on the web (no `dart:isolate`). Tools in
+  `McpLimits.isolateTools` therefore still run, degrading to a soft timeout on
+  the web.
+- New cross-platform test `test/mcp/web_compat_test.dart` runs the tools, the
+  in-process `LspClient` and the server under `dart test --platform chrome`,
+  guarding the web-safe surface against future `dart:io`/`dart:isolate` leaks.
+
 ## 1.4.0
 
 ### MCP — code-inspection tools (LSP)
@@ -22,26 +48,6 @@
   `apollovm mcp call` gained `--line`, `--character` and `--query` flags.
 - New example
   [`example/apollovm_example_mcp_lsp.dart`](example/apollovm_example_mcp_lsp.dart).
-
-### MCP — web compatibility
-
-- **`package:apollovm/apollovm_mcp.dart` is now fully web-safe** — it imports no
-  `dart:io` and no `dart:isolate`, so the MCP server and every `apollovm.*` /
-  `apollovm.lsp.*` tool compile and run in a browser (dart2js / DDC). Construct
-  `ApolloMcpServer` on any `StreamChannel<String>` (e.g. a web `MessageChannel`)
-  and drive all tools in-process.
-- The `dart:io`-only pieces moved to a new **`package:apollovm/apollovm_mcp_io.dart`**
-  (which re-exports `apollovm_mcp.dart`): `serveStdio`, `HttpSseTransport` and
-  the `CommandMcp` CLI group. Native embedders and the `apollovm` CLI import
-  this; nothing else changes for them.
-- The per-tool timeout executor is now platform-selected (mirroring
-  `wasm_runtime.dart`): a killable-isolate executor on native, and an in-process
-  executor with a cooperative timeout on the web (no `dart:isolate`). Tools in
-  `McpLimits.isolateTools` therefore still run, degrading to a soft timeout on
-  the web.
-- New cross-platform test `test/mcp/web_compat_test.dart` runs the tools, the
-  in-process `LspClient` and the server under `dart test --platform chrome`,
-  guarding the web-safe surface against future `dart:io`/`dart:isolate` leaks.
 
 ### Language Server Protocol — in-process API (no socket)
 

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '1.4.0';
+  static final String VERSION = '1.4.1';
 
   static int _idCount = 0;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 1.4.0
+version: 1.4.1
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 


### PR DESCRIPTION
Version bump to **1.4.1** for the web-compatibility work merged in #89.

1.4.0 was already published to pub.dev (before #89 landed) and pub.dev versions are immutable, so the web-compat fix ships as 1.4.1. This PR only bumps `pubspec.yaml` and moves the web-compat notes into their own `## 1.4.1` CHANGELOG section.

Follow-up to #89 · release + publish to pub.dev after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)