### PR TITLE
v1.4.2 — fix ApolloVM Web Demo URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.4.2
+
+- Docs: fix the **ApolloVM Web Demo** link — the live playground is served at the
+  site root (`https://apollovm.github.io/apollovm_web_example/`), not the old
+  `/www/` path.
+
 ## 1.4.1
 
 ### MCP — web compatibility

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ ApolloVM is a portable VM (native, JS/Web, Flutter) that can parse, translate, a
 
 Experience ApolloVM in action right from your browser:
 
-- Explore the [ApolloVM Web Demo](https://apollovm.github.io/apollovm_web_example/www/)
+- Explore the [ApolloVM Web Demo](https://apollovm.github.io/apollovm_web_example/)
 
 If you prefer to run the demo on your local machine:
 - Follow the step-by-step instructions available in the [GitHub Repository](https://github.com/ApolloVM/apollovm_web_example).

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '1.4.1';
+  static final String VERSION = '1.4.2';
 
   static int _idCount = 0;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 1.4.1
+version: 1.4.2
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 


### PR DESCRIPTION
Docs-only patch. The live playground moved from `…/apollovm_web_example/www/` to the site root `…/apollovm_web_example/` (the `/www/` path now 404s). Updates the README link and bumps to 1.4.2 so the corrected link reaches the pub.dev package page (which only refreshes on publish).

- `README.md`: fix the ApolloVM Web Demo link.
- `pubspec.yaml` + `ApolloVM.VERSION`: 1.4.1 → 1.4.2.
- CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)