### PR TITLE
feat(lsp): richer completion + locate missing-';' parse errors (v1.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+## 1.5.0
+
+### Language Server — better completion and parse-error locations
+
+- **Completion now surfaces in-scope identifiers, and works while the buffer does
+  not parse.** Previously `textDocument/completion` only offered AST symbols
+  (top-level/members) plus keywords — so mid-edit, when the parse fails (the
+  common case), it fell back to keywords only. It now also harvests identifiers
+  from the raw token stream, which survives a failed parse and includes local
+  variables and parameters the symbol table omits. Results are de-duplicated and
+  ranked: local-scope symbols, then other symbols, then harvested identifiers,
+  then keywords. The partial token under the cursor is skipped.
+- **Parse-error diagnostics locate a missing `;`.** ApolloVM's PEG parser reports
+  a generic "end of input expected" at offset `0` for most structural mistakes;
+  the LSP layer already recovered the real position for bracket imbalances, and
+  now also for a missing statement terminator in `;`-required languages (Dart,
+  Java, C#). A balanced-but-unterminated statement is pinned to the end of the
+  offending value (with an `expected ';'` hint) instead of defaulting to the top
+  of the file. The heuristic is conservative — it skips continuation shapes
+  (operators, `.`, `?`, `:`, `,`, open brackets, continuation keywords like
+  `return`, and annotations) and does not apply to languages where `;` is
+  optional/absent (Kotlin, JavaScript, Lua, Python).
+
 ## 1.4.2
 
 - Docs: fix the **ApolloVM Web Demo** link — the live playground is served at the

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '1.4.2';
+  static final String VERSION = '1.5.0';
 
   static int _idCount = 0;
 

--- a/lib/src/lsp/analysis/analyzer.dart
+++ b/lib/src/lsp/analysis/analyzer.dart
@@ -115,7 +115,9 @@ class Analyzer {
         symbols = collectSymbols(ast!);
         diagnostics.addAll(_importDiagnostics(ast, text, lineIndex));
       } else {
-        diagnostics.add(_parseErrorDiagnostic(result, lineIndex, text));
+        diagnostics.add(
+          _parseErrorDiagnostic(result, lineIndex, text, language),
+        );
       }
     }
 
@@ -136,13 +138,16 @@ class Analyzer {
     ParseResult<String> result,
     LineIndex lineIndex,
     String text,
+    String language,
   ) {
     // ApolloVM's parser usually reports "end of input expected" at offset 0, so
-    // recover a meaningful location (e.g. the unclosed bracket) in the LSP layer.
+    // recover a meaningful location (e.g. the unclosed bracket, or a missing
+    // `;`) in the LSP layer.
     final loc = locateParseError(
       text,
       parserPosition: result.errorPosition,
       parserMessage: result.errorMessage,
+      language: language,
     );
     final base = (result.errorMessage ?? 'Parse error.')
         .split('\n')

--- a/lib/src/lsp/analysis/parse_error_locator.dart
+++ b/lib/src/lsp/analysis/parse_error_locator.dart
@@ -23,12 +23,19 @@ class ParseErrorLocation {
   });
 }
 
+/// Languages where a statement must end in `;`, so a missing terminator is a
+/// real, locatable error (unlike Kotlin's optional `;`, JavaScript's ASI, or
+/// Lua/Python which have none).
+const _semicolonLanguages = {'dart', 'java', 'java11', 'csharp'};
+
 /// Picks the best error location for [text], given the parser's own
-/// [parserPosition]/[parserMessage] (which may be unreliable).
+/// [parserPosition]/[parserMessage] (which may be unreliable). [language]
+/// enables language-specific recovery (e.g. a missing `;`).
 ParseErrorLocation locateParseError(
   String text, {
   int? parserPosition,
   String? parserMessage,
+  String? language,
 }) {
   final structural = _bracketImbalance(text);
   final msg = (parserMessage ?? '').toLowerCase();
@@ -46,14 +53,25 @@ ParseErrorLocation locateParseError(
   if (parserConcrete) {
     offset = parserPosition;
   } else if (structural != null) {
+    // A bracket imbalance is the most fundamental structural fault — trust it.
     offset = structural.offset;
     hint = structural.hint;
-  } else if (parserPosition != null &&
-      parserPosition > 0 &&
-      parserPosition <= text.length) {
-    offset = parserPosition;
   } else {
-    offset = _firstMeaningfulOffset(text);
+    // Brackets balance but the parse still failed. Try to pin a missing
+    // statement terminator before giving up on a precise location.
+    final missing = (language != null && _semicolonLanguages.contains(language))
+        ? _missingTerminator(text)
+        : null;
+    if (missing != null) {
+      offset = missing.offset;
+      hint = missing.hint;
+    } else if (parserPosition != null &&
+        parserPosition > 0 &&
+        parserPosition <= text.length) {
+      offset = parserPosition;
+    } else {
+      offset = _firstMeaningfulOffset(text);
+    }
   }
 
   final (start, end) = _tokenRange(text, offset);
@@ -64,6 +82,156 @@ ParseErrorLocation locateParseError(
     hint: hint,
   );
 }
+
+/// Finds a likely missing statement terminator (`;`) in [text] for a
+/// `;`-required language, returning where the terminator should go (the end of
+/// the offending value) and a hint, or null when nothing is confidently found.
+///
+/// Deliberately conservative — it only fires when a statement clearly ends in a
+/// value (identifier, number or string literal) on one line and the next
+/// significant token starts a new statement (an identifier or `}`), skipping
+/// every continuation shape (operators, `.`, `?`, `:`, `,`, an open bracket, a
+/// continuation keyword like `return`, or an annotation). A false negative just
+/// falls back to the old behaviour; a false positive would mislocate, so the
+/// guards err toward silence.
+({int offset, String hint})? _missingTerminator(String text) {
+  final n = text.length;
+  var i = 0;
+  var line = 0;
+
+  int? lastSig; // last significant code unit
+  var lastSigOff = -1;
+  var lastSigLine = -1;
+  var lastWord = '';
+  var lastWasAnnotation = false;
+
+  while (i < n) {
+    final c = text.codeUnitAt(i);
+
+    if (c == 0x0a) {
+      line++;
+      i++;
+      continue;
+    }
+    if (c == 0x0d || c == 0x20 || c == 0x09) {
+      i++;
+      continue;
+    }
+
+    // Comments.
+    if (c == 0x2f && i + 1 < n) {
+      final c2 = text.codeUnitAt(i + 1);
+      if (c2 == 0x2f) {
+        i += 2;
+        while (i < n && text.codeUnitAt(i) != 0x0a) {
+          i++;
+        }
+        continue;
+      }
+      if (c2 == 0x2a) {
+        i += 2;
+        while (i + 1 < n &&
+            !(text.codeUnitAt(i) == 0x2a && text.codeUnitAt(i + 1) == 0x2f)) {
+          if (text.codeUnitAt(i) == 0x0a) line++;
+          i++;
+        }
+        i += 2;
+        continue;
+      }
+    }
+
+    // A string literal counts as a value end.
+    if (c == 0x27 || c == 0x22) {
+      final end = _skipString(text, i);
+      for (var k = i; k < end && k < n; k++) {
+        if (text.codeUnitAt(k) == 0x0a) line++;
+      }
+      lastSig = c;
+      lastSigOff = end - 1;
+      lastSigLine = line;
+      lastWord = '';
+      lastWasAnnotation = false;
+      i = end;
+      continue;
+    }
+
+    // A new significant token begins on a later line than the previous one:
+    // decide whether a `;` is missing in between.
+    if (lastSig != null &&
+        line > lastSigLine &&
+        _isValueEnd(lastSig) &&
+        !lastWasAnnotation &&
+        !_continuationKeywords.contains(lastWord) &&
+        _isStatementStart(c)) {
+      return (offset: lastSigOff, hint: "expected ';'");
+    }
+
+    // Advance, recording the new last-significant token.
+    if (_isIdentPart(c)) {
+      final s = i;
+      while (i < n && _isIdentPart(text.codeUnitAt(i))) {
+        i++;
+      }
+      lastWord = text.substring(s, i);
+      lastWasAnnotation = s > 0 && text.codeUnitAt(s - 1) == 0x40; // '@'
+      lastSig = text.codeUnitAt(i - 1);
+      lastSigOff = i - 1;
+      lastSigLine = line;
+      continue;
+    }
+
+    lastSig = c;
+    lastSigOff = i;
+    lastSigLine = line;
+    lastWord = '';
+    lastWasAnnotation = false;
+    i++;
+  }
+
+  return null;
+}
+
+/// Keywords that legitimately end a line with more to follow, so a newline after
+/// them is not a missing terminator.
+const _continuationKeywords = {
+  'return',
+  'throw',
+  'yield',
+  'new',
+  'await',
+  'else',
+  'in',
+  'is',
+  'as',
+  'extends',
+  'implements',
+  'with',
+  'on',
+  'case',
+  'default',
+  'do',
+  'try',
+  'finally',
+  'get',
+  'set',
+  'async',
+  'sync',
+  'operator',
+  'typedef',
+};
+
+/// Whether [c] can end a value/expression (identifier char, digit, or a quote
+/// standing in for a string literal).
+bool _isValueEnd(int c) => _isIdentPart(c) || c == 0x22 || c == 0x27;
+
+/// Whether [c] can start a new statement: an identifier start or a `}` (a value
+/// immediately before a closing brace also wants its `;`).
+bool _isStatementStart(int c) =>
+    (c >= 0x41 && c <= 0x5a) ||
+    (c >= 0x61 && c <= 0x7a) ||
+    c == 0x5f ||
+    c == 0x24 ||
+    c == 0x7d;
 
 /// Scans brackets (`()[]{}`) skipping strings and comments. Returns the first
 /// unexpected/mismatched closer, or the outermost unclosed opener at EOF.

--- a/lib/src/lsp/server/server.dart
+++ b/lib/src/lsp/server/server.dart
@@ -363,28 +363,48 @@ class LspServer {
     if (unit == null) return {'isIncomplete': false, 'items': const []};
     final cur = _resolveCursor(unit, p);
     final container = cur?.container;
+    final cursorOffset = cur?.offset ?? -1;
 
     final items = <CompletionItem>[];
-    for (final s in unit.symbols) {
-      // Rank: local scope (same container) first, then global.
-      final isLocal = container != null && s.container == container;
+    final seen = <String>{};
+
+    void add(String label, int kind, {String? detail, required String rank}) {
+      if (label.isEmpty || !seen.add(label)) return;
       items.add(
         CompletionItem(
-          label: s.name,
-          kind: _completionKind(s.category),
-          detail: s.signature,
-          sortText: '${isLocal ? '0' : '1'}_${s.name}',
+          label: label,
+          kind: kind,
+          detail: detail,
+          sortText: '${rank}_$label',
         ),
       );
     }
-    for (final kw in _keywords) {
-      items.add(
-        CompletionItem(
-          label: kw,
-          kind: CompletionItemKind.keyword,
-          sortText: '2_$kw',
-        ),
+
+    // 1. Declared symbols from the AST (richest: real kind + signature).
+    //    Rank local scope (same container) first, then the rest.
+    for (final s in unit.symbols) {
+      final isLocal = container != null && s.container == container;
+      add(
+        s.name,
+        _completionKind(s.category),
+        detail: s.signature,
+        rank: isLocal ? '0' : '1',
       );
+    }
+
+    // 2. Identifiers harvested from the raw token stream. Unlike the AST
+    //    symbols these survive a *failed* parse — the common case while typing —
+    //    and surface local variables and parameters the symbol table omits.
+    //    Skip the partial token under the cursor (the word being typed).
+    for (final t in unit.tokenIndex.identifiers) {
+      if (cursorOffset >= t.start && cursorOffset <= t.end) continue;
+      if (_keywordSet.contains(t.name)) continue;
+      add(t.name, CompletionItemKind.variable, rank: '2');
+    }
+
+    // 3. Language keywords.
+    for (final kw in _keywords) {
+      add(kw, CompletionItemKind.keyword, rank: '3');
     }
 
     return {
@@ -516,6 +536,8 @@ class LspServer {
     }
     return out;
   }
+
+  static final Set<String> _keywordSet = _keywords.toSet();
 
   static const _keywords = [
     'class',

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 1.4.2
+version: 1.5.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/lsp/parse_error_locator_test.dart
+++ b/test/lsp/parse_error_locator_test.dart
@@ -146,5 +146,58 @@ void main() {
       expect(d.range.start.character, expected.character);
       expect(d.message, contains('never closed'));
     });
+
+    test(
+      'a missing ";" reports on the offending line, not the top of file',
+      () async {
+        const src = 'void main() {\n  var x = 10\n  var y = 20;\n}\n';
+        final unit = await analyzer.analyze('file:///bad.dart', src);
+        expect(unit.ast, isNull);
+        final d = unit.diagnostics.single;
+        // Lands on `10` (line 1) whose statement lacks a `;`, not line 0.
+        final expected = unit.lineIndex.positionAt(src.indexOf('10'));
+        expect(d.range.start.line, 1);
+        expect(d.range.start.character, expected.character);
+        expect(d.message, contains("expected ';'"));
+      },
+    );
+  });
+
+  group('locateParseError — missing terminator (unit)', () {
+    ParseErrorLocation locate(String src, String language) => locateParseError(
+      src,
+      parserPosition: 0,
+      parserMessage: 'end of input expected',
+      language: language,
+    );
+
+    test('locates a missing ";" at the end of the offending value', () {
+      const src = 'void main() {\n  var x = 10\n  var y = 20;\n}\n';
+      final loc = locate(src, 'dart');
+      expect(loc.rangeStart, src.indexOf('10'));
+      expect(loc.hint, contains("expected ';'"));
+    });
+
+    test('locates a missing ";" before a closing brace', () {
+      const src = 'void main() {\n  var x = 1\n}\n';
+      final loc = locate(src, 'dart');
+      expect(loc.rangeStart, src.indexOf('1'));
+      expect(loc.hint, contains("expected ';'"));
+    });
+
+    test('does not invent a ";" for languages that do not require it', () {
+      const src = 'fun main() {\n  val x = 10\n  val y = 20\n}\n';
+      expect(locate(src, 'kotlin').hint, isNull);
+    });
+
+    test('a continuation keyword across lines is not a missing terminator', () {
+      const src = 'int f() {\n  return\n    1 + 2;\n}\n';
+      expect(locate(src, 'dart').hint, isNull);
+    });
+
+    test('an operator-led continuation line is not flagged', () {
+      const src = 'int f() {\n  var a = 1;\n  var b = a\n    + a;\n}\n';
+      expect(locate(src, 'dart').hint, isNull);
+    });
   });
 }

--- a/test/lsp/server_features_test.dart
+++ b/test/lsp/server_features_test.dart
@@ -87,11 +87,39 @@ void main() {
     final result = resp['result'] as Map;
     final items = (result['items'] as List).cast<Map>();
     final labels = items.map((i) => i['label']).toSet();
+    // Declared symbols from the AST.
     expect(labels, containsAll(['User', 'makeId', 'greet']));
+    // Identifiers harvested from the token stream — locals/params the symbol
+    // table omits, e.g. the `name` parameter and `seed`.
+    expect(labels, containsAll(['name', 'seed']));
     expect(labels, contains('class')); // keyword
+    // A harvested identifier is a variable (kind 6), ranked after symbols
+    // (0_/1_) and before keywords.
+    final nameItem = items.firstWhere((i) => i['label'] == 'name');
+    expect(nameItem['kind'], 6);
+    expect((nameItem['sortText'] as String).startsWith('2_'), isTrue);
     // Keywords sort last.
     final kw = items.firstWhere((i) => i['label'] == 'class');
-    expect((kw['sortText'] as String).startsWith('2_'), isTrue);
+    expect((kw['sortText'] as String).startsWith('3_'), isTrue);
+  });
+
+  test('completion still works when the buffer does not parse', () async {
+    final c = _Client();
+    // Missing `;` — the parse fails, so there are no AST symbols; completion
+    // must fall back to identifiers harvested from the raw token stream.
+    const broken =
+        'int run() {\n'
+        '  var greeting = 1;\n'
+        '  var total = greeting\n' // no `;` -> parse error
+        '}\n';
+    await c.open(_uri, broken);
+    final resp = await c.request('textDocument/completion', {
+      'textDocument': _td(_uri),
+      'position': c.pos(2, 22), // end of `greeting`
+    });
+    final items = ((resp['result'] as Map)['items'] as List).cast<Map>();
+    final labels = items.map((i) => i['label']).toSet();
+    expect(labels, containsAll(['greeting', 'total', 'run']));
   });
 
   test('references finds all same-name occurrences in the file', () async {


### PR DESCRIPTION
Two Language Server improvements.

## 1. Completion surfaces in-scope identifiers and survives a failed parse

`textDocument/completion` previously offered only AST symbols (top-level/members) + keywords. Mid-edit the buffer usually **doesn't parse**, so there were no AST symbols and it fell back to keywords only — and it never proposed local variables/parameters even on a clean parse.

It now also harvests identifiers from the raw token stream (`TokenIndex`), which is a scan that survives a failed parse and includes locals/params. Items are de-duplicated and ranked:

`0_` local-scope symbols → `1_` other symbols → `2_` harvested identifiers → `3_` keywords

The partial token under the cursor is skipped. Verified: for a buffer that ends mid-statement (no `;`, parse fails), completion now offers the local `greeting`/`total`/`run` — previously just keywords.

## 2. Parse errors locate a missing `;`

ApolloVM's PEG parser reports a generic `end of input expected` at offset `0` for most structural mistakes. The LSP layer already recovered the real position for bracket imbalances; it now also handles a **missing statement terminator** in `;`-required languages (Dart, Java, C#): a balanced-but-unterminated statement is pinned to the end of the offending value with an `expected ';'` hint, instead of the top of the file.

Example: `var x = 10` (no `;`) followed by another statement now reports at the end of `10` (its line), not `1:1`.

The heuristic is deliberately conservative — it skips continuation shapes (operators, `.`, `?`, `:`, `,`, open brackets), continuation keywords (`return`, `throw`, …), and annotations, and does not apply to languages where `;` is optional/absent (Kotlin, JavaScript, Lua, Python). A false negative just falls back to the previous behaviour.

## Tests

- New: completion works when the buffer does not parse; completion ranks harvested identifiers; missing-`;` locator (unit + integration) incl. negative cases (continuation keyword, operator-led line, `;`-optional language).
- All **222** LSP + MCP tests pass on the VM; `dart analyze` clean; `dart format` clean.

Bumps to **1.5.0** (additive, backward-compatible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)