### PR TITLE
v1.6.0 - LSP: member-aware completion + full-body symbol ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 1.6.0
+
+### Language Server — member-aware completion and full-body symbol ranges
+
+- **`documentSymbol` ranges now span a member's whole body, not just its
+  signature.** Previously only class/enum declarations had their `range`
+  extended to the closing `}`; a function/method/constructor stopped at the end
+  of its name, so an editor "select symbol" or outline action only highlighted
+  the signature. The token indexer now tracks member bodies too — skipping the
+  parameter list first, so Dart named-parameter braces (`{ ... }`) are not
+  mistaken for the body — and extends `fullEnd` to the body's closing `}`.
+  Bodyless members (abstract/`;`-terminated) are left unchanged. The narrower
+  `selectionRange` (the name) is untouched.
+- **Completion on `this.` / `super.` proposes the enclosing type's members.**
+  A member-access position is now recognized and answered with just that type's
+  fields and methods (with their real kinds), instead of the full grab-bag of
+  every identifier plus keywords.
+- **Completion keeps real symbol kinds even when the buffer does not parse.**
+  The `this.` case leaves the source unparseable, which had emptied the AST
+  symbol table and degraded every proposal to a plain identifier. Completion now
+  also draws on the token-index declarations (which survive a failed parse), so
+  methods and fields keep their proper kinds mid-edit. Local variables and
+  parameters continue to be surfaced from the raw token stream.
+
 ## 1.5.0
 
 ### Language Server — better completion and parse-error locations

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '1.5.0';
+  static final String VERSION = '1.6.0';
 
   static int _idCount = 0;
 

--- a/lib/src/lsp/analysis/token_index.dart
+++ b/lib/src/lsp/analysis/token_index.dart
@@ -319,6 +319,10 @@ class TokenIndex {
     final decls = <DeclSite>[];
     // Stack of open class/enum bodies: (name, bodyDepth, isEnum, declIndex).
     final classStack = <_ClassScope>[];
+    // Stack of open function/method/constructor bodies: (declIndex, bodyDepth).
+    // Lets a member's `fullEnd` be extended to its body's closing `}` (so the
+    // declaration range covers the whole method, not just its signature).
+    final bodyStack = <_BodyScope>[];
     var braceDepth = 0;
     var atBoundary = true;
 
@@ -331,6 +335,9 @@ class TokenIndex {
         braceDepth == classStack.last.bodyDepth;
 
     _ClassScope? pendingClass;
+    // Index of a member whose body brace is expected next (armed once its
+    // parameter list has been consumed); `null` when no body is pending.
+    int? pendingBody;
 
     var i = 0;
     while (i < tokens.length) {
@@ -371,24 +378,36 @@ class TokenIndex {
           pc.bodyDepth = braceDepth;
           classStack.add(pc);
           pendingClass = null;
+        } else if (pendingBody != null) {
+          bodyStack.add(_BodyScope(pendingBody, braceDepth));
+          pendingBody = null;
         }
         atBoundary = true;
         i++;
         continue;
       }
       if (t.sym('}')) {
+        // Close any function/method bodies ending at this depth.
+        while (bodyStack.isNotEmpty && bodyStack.last.bodyDepth == braceDepth) {
+          final closed = bodyStack.removeLast();
+          decls[closed.declIndex].fullEnd = t.end;
+        }
         // Close any class bodies at this depth.
         while (classStack.isNotEmpty &&
             classStack.last.bodyDepth == braceDepth) {
           final closed = classStack.removeLast();
           decls[closed.declIndex].fullEnd = t.end;
         }
+        pendingBody = null;
         braceDepth--;
         atBoundary = true;
         i++;
         continue;
       }
       if (t.sym(';')) {
+        // A `;` before the body brace means the member has no body (abstract
+        // method, `=>` expression body, field): drop the pending arm.
+        pendingBody = null;
         atBoundary = true;
         i++;
         continue;
@@ -442,6 +461,31 @@ class TokenIndex {
         if (consumed > 0) {
           i += consumed;
           atBoundary = false;
+          // For a function/method/constructor, `_tryDeclaration` stops before
+          // the parameter list. Skip its balanced `( ... )` here (so nested
+          // named-parameter braces aren't mistaken for the body) and arm body
+          // tracking so the next `{` is recorded as this member's body.
+          pendingBody = null;
+          final added = decls.last;
+          if (added.kind == DeclKind.function ||
+              added.kind == DeclKind.method ||
+              added.kind == DeclKind.constructor) {
+            if (i < tokens.length && tokens[i].sym('(')) {
+              var depth = 0;
+              while (i < tokens.length) {
+                if (tokens[i].sym('(')) {
+                  depth++;
+                } else if (tokens[i].sym(')')) {
+                  depth--;
+                  i++;
+                  if (depth == 0) break;
+                  continue;
+                }
+                i++;
+              }
+            }
+            pendingBody = decls.length - 1;
+          }
           continue;
         }
       }
@@ -594,4 +638,10 @@ class _ClassScope {
   final int declIndex;
   int bodyDepth = -1;
   _ClassScope(this.name, this.isEnum, this.declIndex);
+}
+
+class _BodyScope {
+  final int declIndex;
+  final int bodyDepth;
+  _BodyScope(this.declIndex, this.bodyDepth);
 }

--- a/lib/src/lsp/server/server.dart
+++ b/lib/src/lsp/server/server.dart
@@ -365,6 +365,8 @@ class LspServer {
     final container = cur?.container;
     final cursorOffset = cur?.offset ?? -1;
 
+    final decls = unit.tokenIndex.declarations;
+
     final items = <CompletionItem>[];
     final seen = <String>{};
 
@@ -380,6 +382,31 @@ class LspServer {
       );
     }
 
+    Map<String, Object?> result() => {
+      'isIncomplete': false,
+      'items': items.map((i) => i.toJson()).toList(),
+    };
+
+    // Member access `<receiver>.<partial>`: for `this`/`super`, propose only
+    // the enclosing type's members (with their real kinds) — never keywords or
+    // unrelated globals. This works even while the buffer does not parse (the
+    // usual state right after typing `.`), because it reads the token-index
+    // declarations rather than the AST.
+    final receiver = _memberAccessReceiver(unit.text, cursorOffset);
+    if (receiver == 'this' || receiver == 'super') {
+      for (final d in decls) {
+        if (d.kind == DeclKind.constructor) continue; // not reached via `this.`
+        final isMember = container != null
+            ? d.container == container
+            : d.container != null;
+        if (!isMember) continue;
+        add(d.name, _declCompletionKind(d.kind), rank: '0');
+      }
+      // Only commit to member-only results if we actually found members;
+      // otherwise fall through to the general proposals below.
+      if (items.isNotEmpty) return result();
+    }
+
     // 1. Declared symbols from the AST (richest: real kind + signature).
     //    Rank local scope (same container) first, then the rest.
     for (final s in unit.symbols) {
@@ -392,25 +419,86 @@ class LspServer {
       );
     }
 
-    // 2. Identifiers harvested from the raw token stream. Unlike the AST
-    //    symbols these survive a *failed* parse — the common case while typing —
-    //    and surface local variables and parameters the symbol table omits.
-    //    Skip the partial token under the cursor (the word being typed).
+    // 2. Token-index declarations. Unlike the AST symbols these survive a
+    //    *failed* parse — the common case while typing — so methods and fields
+    //    keep their real kinds instead of degrading to plain identifiers.
+    for (final d in decls) {
+      final isLocal = container != null && d.container == container;
+      add(d.name, _declCompletionKind(d.kind), rank: isLocal ? '0' : '1');
+    }
+
+    // 3. Identifiers harvested from the raw token stream: local variables and
+    //    parameters the symbol table omits. Skip the partial token under the
+    //    cursor (the word being typed).
     for (final t in unit.tokenIndex.identifiers) {
       if (cursorOffset >= t.start && cursorOffset <= t.end) continue;
       if (_keywordSet.contains(t.name)) continue;
       add(t.name, CompletionItemKind.variable, rank: '2');
     }
 
-    // 3. Language keywords.
+    // 4. Language keywords.
     for (final kw in _keywords) {
       add(kw, CompletionItemKind.keyword, rank: '3');
     }
 
-    return {
-      'isIncomplete': false,
-      'items': items.map((i) => i.toJson()).toList(),
-    };
+    return result();
+  }
+
+  /// If the caret sits in a member-access position `<receiver>.<partial>`,
+  /// returns the receiver identifier (e.g. `this`, `super`, a variable name, or
+  /// `''` for a non-identifier receiver). Returns `null` when the caret is not
+  /// after a `.`.
+  static String? _memberAccessReceiver(String text, int offset) {
+    if (offset < 0 || offset > text.length) return null;
+    var i = offset;
+    // Skip the partial member identifier being typed.
+    while (i > 0 && _isIdentChar(text.codeUnitAt(i - 1))) {
+      i--;
+    }
+    // Require a '.' (possibly after inline spaces) immediately to the left.
+    var j = i;
+    while (j > 0 && _isInlineSpace(text.codeUnitAt(j - 1))) {
+      j--;
+    }
+    if (j == 0 || text.codeUnitAt(j - 1) != 0x2e /* . */ ) return null;
+    j--; // consume the '.'
+    while (j > 0 && _isInlineSpace(text.codeUnitAt(j - 1))) {
+      j--;
+    }
+    final end = j;
+    while (j > 0 && _isIdentChar(text.codeUnitAt(j - 1))) {
+      j--;
+    }
+    return text.substring(j, end);
+  }
+
+  static bool _isIdentChar(int c) =>
+      c == 0x5f || // _
+      (c >= 0x30 && c <= 0x39) || // 0-9
+      (c >= 0x41 && c <= 0x5a) || // A-Z
+      (c >= 0x61 && c <= 0x7a); // a-z
+
+  static bool _isInlineSpace(int c) => c == 0x20 || c == 0x09;
+
+  int _declCompletionKind(DeclKind k) {
+    switch (k) {
+      case DeclKind.classDecl:
+        return CompletionItemKind.classKind;
+      case DeclKind.enumDecl:
+        return CompletionItemKind.enumKind;
+      case DeclKind.function:
+        return CompletionItemKind.function;
+      case DeclKind.method:
+        return CompletionItemKind.method;
+      case DeclKind.constructor:
+        return CompletionItemKind.constructor;
+      case DeclKind.field:
+        return CompletionItemKind.field;
+      case DeclKind.variable:
+        return CompletionItemKind.variable;
+      case DeclKind.enumMember:
+        return CompletionItemKind.enumMember;
+    }
   }
 
   int _completionKind(SymbolCategory c) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 1.5.0
+version: 1.6.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/lsp/server_features_test.dart
+++ b/test/lsp/server_features_test.dart
@@ -338,6 +338,81 @@ int makeAge(int seed) { return seed; }
       expect(members.first['kind'], SymbolKind.enumMember);
     });
 
+    test(
+      'documentSymbol range spans a member body, not just its signature',
+      () async {
+        final c = _Client();
+        await c.open(richUri, rich);
+        final resp = await c.request('textDocument/documentSymbol', {
+          'textDocument': _td(richUri),
+        });
+        final roots = (resp['result'] as List).cast<Map>();
+        final byName = {for (final s in roots) s['name']: s};
+
+        Range rangeOf(Map sym) =>
+            Range.fromJson((sym['range'] as Map).cast<String, Object?>());
+        Range selOf(Map sym) => Range.fromJson(
+          (sym['selectionRange'] as Map).cast<String, Object?>(),
+        );
+
+        // Top-level function: the range must reach the closing brace on its line,
+        // well past the name in `selectionRange`.
+        final makeAge = byName['makeAge']!;
+        expect(rangeOf(makeAge).end.line, selOf(makeAge).end.line);
+        expect(
+          rangeOf(makeAge).end.character,
+          greaterThan(selOf(makeAge).end.character),
+          reason: 'range should include the { return seed; } body',
+        );
+
+        // Method inside a class: same expectation for `bark`.
+        final dog = byName['Dog']!;
+        final bark = (dog['children'] as List).cast<Map>().firstWhere(
+          (m) => m['name'] == 'bark',
+        );
+        expect(
+          rangeOf(bark).end.character,
+          greaterThan(selOf(bark).end.character),
+          reason: 'method range should include its body',
+        );
+      },
+    );
+
+    test(
+      'documentSymbol range skips named-parameter braces to reach the body',
+      () async {
+        // The `{ ... }` of Dart named parameters must not be mistaken for the
+        // method body; the range should extend to the real body's closing brace.
+        const named = '''
+class Box {
+  int add({int a = 1, int b = 2}) {
+    return a + b;
+  }
+}
+''';
+        const namedUri = 'file:///ws/named.dart';
+        final c = _Client();
+        await c.open(namedUri, named);
+        final resp = await c.request('textDocument/documentSymbol', {
+          'textDocument': _td(namedUri),
+        });
+        final roots = (resp['result'] as List).cast<Map>();
+        final box = roots.firstWhere((s) => s['name'] == 'Box');
+        final add = (box['children'] as List).cast<Map>().firstWhere(
+          (m) => m['name'] == 'add',
+        );
+        final range = Range.fromJson(
+          (add['range'] as Map).cast<String, Object?>(),
+        );
+        // `named` line 3 (0-based) is the method's closing `  }`.
+        expect(
+          range.end.line,
+          3,
+          reason: 'range must reach the body brace, not the params brace',
+        );
+      },
+    );
+
     test('completion maps every present symbol category', () async {
       final c = _Client();
       await c.open(richUri, rich);
@@ -358,6 +433,60 @@ int makeAge(int seed) { return seed; }
           CompletionItemKind.function,
         ]),
       );
+    });
+
+    test('completion after `this.` proposes only the class members', () async {
+      // `this.` leaves the buffer unparseable; completion must still surface
+      // the enclosing class's members (with real kinds) and nothing else.
+      const memberSrc = '''
+class Dog {
+  int age = 0;
+  int legs = 4;
+  int bark(int n) {
+    this.
+    return n;
+  }
+}
+''';
+      const memberUri = 'file:///ws/member.dart';
+      final c = _Client();
+      await c.open(memberUri, memberSrc);
+      final resp = await c.request('textDocument/completion', {
+        'textDocument': _td(memberUri),
+        'position': {'line': 4, 'character': 9}, // right after `this.`
+      });
+      final items = ((resp['result'] as Map)['items'] as List).cast<Map>();
+      final byName = {for (final i in items) i['label']: i['kind']};
+
+      // Exactly the members of Dog, with their real kinds — no keywords, no
+      // unrelated globals.
+      expect(byName.keys, unorderedEquals(['age', 'legs', 'bark']));
+      expect(byName['age'], CompletionItemKind.field);
+      expect(byName['legs'], CompletionItemKind.field);
+      expect(byName['bark'], CompletionItemKind.method);
+    });
+
+    test('completion offers local variables and parameters', () async {
+      const localSrc = '''
+class Dog {
+  int bark(int n) {
+    var local = 1;
+    var x = 0;
+    return n;
+  }
+}
+''';
+      const localUri = 'file:///ws/local.dart';
+      final c = _Client();
+      await c.open(localUri, localSrc);
+      final resp = await c.request('textDocument/completion', {
+        'textDocument': _td(localUri),
+        'position': {'line': 4, 'character': 4}, // start of the `return` line
+      });
+      final items = ((resp['result'] as Map)['items'] as List).cast<Map>();
+      final labels = items.map((i) => i['label']).toSet();
+      // The local variable, a second local, and the parameter are all offered.
+      expect(labels, containsAll(['local', 'x', 'n']));
     });
 
     test('hover labels a field and an enum member', () async {


### PR DESCRIPTION
## Summary

Language Server improvements (v1.6.0):

- **`documentSymbol` ranges now span a member's whole body**, not just its signature. The token indexer tracks function/method/constructor bodies (skipping the parameter list first, so Dart named-parameter `{ ... }` isn't mistaken for the body) and extends `fullEnd` to the body's closing `}`. Enables editor/outline "select whole method". Bodyless members and the `selectionRange` (name) are unchanged.
- **Completion on `this.` / `super.`** now proposes the enclosing type's members (with their real kinds), instead of every identifier plus keywords.
- **Completion keeps real symbol kinds even when the buffer does not parse** (the `this.` case leaves the source unparseable). It now also draws on the token-index declarations, which survive a failed parse; local variables and parameters are still surfaced from the raw token stream.

## Tests

Added to `test/lsp/server_features_test.dart`:
- member-body symbol ranges (top-level function + class method), incl. the Dart named-parameter edge case;
- `this.` proposes only class members with correct kinds;
- local variables/parameters are offered.

Full LSP suite passes (151 tests). `dart format`, `dart analyze --fatal-infos --fatal-warnings`, `dependency_validator`, and `pub publish --dry-run` all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)