### PR TITLE
v1.6.1 - LSP: enum members after the constant list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.6.1
+
+### Language Server — enum members after the constant list
+
+- **Enum members declared after the constant list are now recognized as real
+  members.** Everything after the `;` that ends an enum's constant list (fields,
+  constructors, methods) was being swallowed as bogus enum constants (named
+  `int`, `const`, `final`, …), so `documentSymbol` gave enum methods no body
+  range and did not recognize enum constructors at all. The token indexer now
+  tracks the constant-list terminator per enum: after it, identifiers in the
+  enum body are parsed like class members — real kinds and full-body ranges.
+  Pure-constant enums (`enum E { a, b, c }`) are unaffected; class constructors
+  were already handled correctly.
+
 ## 1.6.0
 
 ### Language Server — member-aware completion and full-body symbol ranges

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '1.6.0';
+  static final String VERSION = '1.6.1';
 
   static int _idCount = 0;
 

--- a/lib/src/lsp/analysis/token_index.dart
+++ b/lib/src/lsp/analysis/token_index.dart
@@ -333,6 +333,11 @@ class TokenIndex {
         classStack.isNotEmpty &&
         classStack.last.isEnum &&
         braceDepth == classStack.last.bodyDepth;
+    // True only while scanning the enum's constant list (before the `;` that
+    // ends it). After that `;`, an enum body holds ordinary members (fields,
+    // constructors, methods) that must be recognised like class members.
+    bool inEnumConstantList() =>
+        inEnumBody() && !classStack.last.enumConstantsDone;
 
     _ClassScope? pendingClass;
     // Index of a member whose body brace is expected next (armed once its
@@ -405,6 +410,9 @@ class TokenIndex {
         continue;
       }
       if (t.sym(';')) {
+        // A `;` directly in an enum body ends its constant list; everything
+        // after it is a regular member.
+        if (inEnumBody()) classStack.last.enumConstantsDone = true;
         // A `;` before the body brace means the member has no body (abstract
         // method, `=>` expression body, field): drop the pending arm.
         pendingBody = null;
@@ -413,15 +421,15 @@ class TokenIndex {
         continue;
       }
       if (t.sym(',')) {
-        // Commas separate entries only inside an enum body; elsewhere (e.g.
-        // parameter lists) they must not open a new declaration boundary.
-        atBoundary = inEnumBody();
+        // Commas separate entries only within an enum's constant list;
+        // elsewhere (e.g. parameter lists) they must not open a new boundary.
+        atBoundary = inEnumConstantList();
         i++;
         continue;
       }
 
-      // Enum members: identifiers directly in an enum body.
-      if (inEnumBody() && t.isIdent && atBoundary) {
+      // Enum constants: identifiers in the enum's constant list (before `;`).
+      if (inEnumConstantList() && t.isIdent && atBoundary) {
         decls.add(
           DeclSite(
             name: t.value,
@@ -637,6 +645,9 @@ class _ClassScope {
   final bool isEnum;
   final int declIndex;
   int bodyDepth = -1;
+  // For enums: set once the constant list's terminating `;` is seen, after
+  // which members are parsed like class members rather than enum constants.
+  bool enumConstantsDone = false;
   _ClassScope(this.name, this.isEnum, this.declIndex);
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 1.6.0
+version: 1.6.1
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/lsp/server_features_test.dart
+++ b/test/lsp/server_features_test.dart
@@ -413,6 +413,57 @@ class Box {
       },
     );
 
+    test(
+      'enum members after the constant list are parsed as real members',
+      () async {
+        // Everything after the `;` that ends the constant list — fields,
+        // constructors, methods — must be recognized like class members (with
+        // real kinds and full-body ranges), not swallowed as enum constants.
+        const src = '''
+enum Color {
+  red, green, blue;
+
+  final int code;
+  const Color(this.code);
+
+  int doubled() {
+    return code * 2;
+  }
+}
+''';
+        const uri = 'file:///ws/enum.dart';
+        final c = _Client();
+        await c.open(uri, src);
+        final resp = await c.request('textDocument/documentSymbol', {
+          'textDocument': _td(uri),
+        });
+        final color = (resp['result'] as List).cast<Map>().firstWhere(
+          (s) => s['name'] == 'Color',
+        );
+        final children = (color['children'] as List).cast<Map>();
+        final byName = {for (final m in children) m['name']: m};
+
+        // The three constants stay enum members.
+        for (final name in ['red', 'green', 'blue']) {
+          expect(byName[name]?['kind'], SymbolKind.enumMember);
+        }
+        // The trailing members get their real kinds — not enumMember.
+        expect(byName['code']?['kind'], SymbolKind.field);
+        expect(byName['Color']?['kind'], SymbolKind.constructor);
+        expect(byName['doubled']?['kind'], SymbolKind.method);
+
+        // The method's range spans its body (line 7 is the closing `  }`).
+        final doubled = Range.fromJson(
+          (byName['doubled']!['range'] as Map).cast<String, Object?>(),
+        );
+        expect(
+          doubled.end.line,
+          8,
+          reason: 'enum method range must include its body',
+        );
+      },
+    );
+
     test('completion maps every present symbol category', () async {
       final c = _Client();
       await c.open(richUri, rich);


### PR DESCRIPTION
## Summary

Fixes `documentSymbol` for members declared after an enum's constant list.

Everything after the `;` that ends an enum's constant list (fields, constructors, methods) was being swallowed as bogus enum constants (named `int`, `const`, `final`, …). As a result enum methods got no body range and enum constructors weren't recognized at all.

The token indexer now tracks the constant-list terminator per enum scope: after that `;`, identifiers in the enum body are parsed like class members, getting their real kinds and full-body ranges.

```
enum Color { red, green, blue; final int code; const Color(this.code); int doubled() {...} }
  red/green/blue → enumMember
  code           → field
  Color          → constructor
  doubled        → method   (range spans the body)
```

Pure-constant enums (`enum E { a, b, c }`) are unaffected. Class constructors were already handled correctly.

## Tests

Added a regression test in `test/lsp/server_features_test.dart` (kinds + method body range). Full LSP suite passes (152). `dart format`, `dart analyze --fatal-infos --fatal-warnings`, and `pub publish --dry-run` all clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)