### PR TITLE
v1.6.2 - LSP: expression-body member ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 1.6.2
+
+### Language Server — expression-body member ranges
+
+- **Members with an expression body are now fully covered by their
+  `documentSymbol` range.** A `=> expr;` member (Dart/C#) previously stopped at
+  its name, and a brace-less `= expr` member (Kotlin) even swallowed the next
+  member because the scanner never recovered. The token indexer now consumes the
+  expression: the `=>` form extends to its terminating `;`, and the brace-less
+  `=` form is bounded to the end of its line (so the following member is still
+  recognized). Balanced `()`/`[]`/`{}` inside the expression (e.g. a map literal
+  body `=> {1: 2}`) are handled without corrupting brace tracking. Works for
+  both class and enum members.
+
 ## 1.6.1
 
 ### Language Server — enum members after the constant list

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '1.6.1';
+  static final String VERSION = '1.6.2';
 
   static int _idCount = 0;
 

--- a/lib/src/lsp/analysis/token_index.dart
+++ b/lib/src/lsp/analysis/token_index.dart
@@ -122,7 +122,10 @@ class _Tok {
   final String value;
   final int start;
   final int end;
-  const _Tok(this.type, this.value, this.start, this.end);
+  // Whether a newline separates this token from the previous one. Used to
+  // bound brace-less expression bodies (Kotlin `fun f() = expr`) to their line.
+  bool nlBefore = false;
+  _Tok(this.type, this.value, this.start, this.end);
   bool get isIdent => type == 0;
   bool sym(String s) => type == 1 && value == s;
 }
@@ -181,6 +184,16 @@ class TokenIndex {
     final n = text.length;
     var i = 0;
 
+    // Set when a newline has been skipped since the previous token; stamped on
+    // the next emitted token (and then cleared).
+    var pendingNl = false;
+    void add(int type, String value, int start, int end) {
+      final t = _Tok(type, value, start, end);
+      t.nlBefore = pendingNl;
+      pendingNl = false;
+      tokens.add(t);
+    }
+
     bool isIdentStart(int c) =>
         (c >= 0x41 && c <= 0x5a) ||
         (c >= 0x61 && c <= 0x7a) ||
@@ -194,6 +207,7 @@ class TokenIndex {
 
       // Whitespace.
       if (c == 0x20 || c == 0x09 || c == 0x0a || c == 0x0d) {
+        if (c == 0x0a) pendingNl = true;
         i++;
         continue;
       }
@@ -212,6 +226,7 @@ class TokenIndex {
           i += 2;
           var depth = 1;
           while (i < n && depth > 0) {
+            if (text.codeUnitAt(i) == 0x0a) pendingNl = true;
             if (i + 1 < n &&
                 text.codeUnitAt(i) == 0x2f &&
                 text.codeUnitAt(i + 1) == 0x2a) {
@@ -234,7 +249,7 @@ class TokenIndex {
       if (c == 0x27 || c == 0x22) {
         final start = i;
         i = _skipString(text, i);
-        tokens.add(_Tok(2, text.substring(start, i), start, i));
+        add(2, text.substring(start, i), start, i);
         continue;
       }
 
@@ -245,7 +260,7 @@ class TokenIndex {
         while (i < n && isIdentPart(text.codeUnitAt(i))) {
           i++;
         }
-        tokens.add(_Tok(0, text.substring(start, i), start, i));
+        add(0, text.substring(start, i), start, i);
         continue;
       }
 
@@ -264,12 +279,12 @@ class TokenIndex {
             break;
           }
         }
-        tokens.add(_Tok(3, text.substring(start, i), start, i));
+        add(3, text.substring(start, i), start, i);
         continue;
       }
 
       // Single-character symbol.
-      tokens.add(_Tok(1, text[i], i, i + 1));
+      add(1, text[i], i, i + 1);
       i++;
     }
     return tokens;
@@ -344,9 +359,46 @@ class TokenIndex {
     // parameter list has been consumed); `null` when no body is pending.
     int? pendingBody;
 
+    // Expression-body tracking (`=> expr;` in Dart/C#, `= expr` in Kotlin). When
+    // a member has an expression body instead of a `{ ... }` block, we extend
+    // its `fullEnd` across the whole expression so the declaration is fully
+    // selectable. `exprMember` is the member's decl index; `exprArrow` marks the
+    // `=>` form (terminated by `;`) vs. the brace-less `=` form (bounded by the
+    // end of its line); `exprDepth` balances `()[]{}` opened inside the
+    // expression so the terminator/enclosing `}` is only honoured at depth 0.
+    int? exprMember;
+    var exprArrow = false;
+    var exprDepth = 0;
+
     var i = 0;
     while (i < tokens.length) {
       final t = tokens[i];
+
+      // Consume an in-progress expression body.
+      if (exprMember != null) {
+        if (exprDepth == 0 && (t.sym('}') || (!exprArrow && t.nlBefore))) {
+          // The enclosing block's `}` or a new line (brace-less form) ends the
+          // expression; do not consume this token — fall through to reprocess
+          // it as the start of the next declaration.
+          exprMember = null;
+          atBoundary = true;
+        } else if (exprDepth == 0 && t.sym(';')) {
+          decls[exprMember].fullEnd = t.end;
+          exprMember = null;
+          atBoundary = true;
+          i++;
+          continue;
+        } else {
+          if (t.sym('(') || t.sym('[') || t.sym('{')) {
+            exprDepth++;
+          } else if (t.sym(')') || t.sym(']') || t.sym('}')) {
+            exprDepth--;
+          }
+          decls[exprMember].fullEnd = t.end;
+          i++;
+          continue;
+        }
+      }
 
       // Annotations/metadata (`@Override`, `@Deprecated("x")`) precede a
       // declaration and must not clear the boundary flag.
@@ -425,6 +477,20 @@ class TokenIndex {
         // elsewhere (e.g. parameter lists) they must not open a new boundary.
         atBoundary = inEnumConstantList();
         i++;
+        continue;
+      }
+
+      // A pending member with an expression body: `=> expr` (Dart/C#) or a
+      // brace-less `= expr` (Kotlin). Start consuming the expression so the
+      // member's range covers it (handled at the top of the loop).
+      if (pendingBody != null && t.sym('=')) {
+        final arrow = i + 1 < tokens.length && tokens[i + 1].sym('>');
+        exprMember = pendingBody;
+        exprArrow = arrow;
+        exprDepth = 0;
+        pendingBody = null;
+        atBoundary = false;
+        i += arrow ? 2 : 1; // consume '=' (and '>' of '=>')
         continue;
       }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 1.6.1
+version: 1.6.2
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/lsp/server_features_test.dart
+++ b/test/lsp/server_features_test.dart
@@ -464,6 +464,69 @@ enum Color {
       },
     );
 
+    test(
+      'documentSymbol range covers expression bodies (class and enum)',
+      () async {
+        // `=> expr;` and Kotlin's brace-less `= expr` members must be fully
+        // selectable: the range spans the expression, not just the signature.
+        const src = '''
+class Foo {
+  int square(int n) => n * n;
+  Map<int, int> pairs() => {1: 2, 3: 4};
+}
+enum Sign {
+  pos, neg;
+  int doubled() => index * 2;
+}
+class Calc {
+  fun sum(a: Int, b: Int) = a + b
+  fun run() {
+    print(sum(1, 2));
+  }
+}
+''';
+        const uri = 'file:///ws/expr.dart';
+        final c = _Client();
+        await c.open(uri, src);
+        final resp = await c.request('textDocument/documentSymbol', {
+          'textDocument': _td(uri),
+        });
+        final roots = (resp['result'] as List).cast<Map>();
+
+        Map childOf(String parent, String child) =>
+            ((roots.firstWhere((s) => s['name'] == parent)['children'] as List)
+                    .cast<Map>())
+                .firstWhere((m) => m['name'] == child);
+        Range rangeOf(Map m) =>
+            Range.fromJson((m['range'] as Map).cast<String, Object?>());
+
+        // Class `=> expr;` reaches past the `;` (line 1 ends at `;`).
+        final square = rangeOf(childOf('Foo', 'square'));
+        expect(square.end.line, 1);
+        expect(square.end.character, greaterThan(28));
+
+        // Map-literal body: balanced braces don't corrupt the following member.
+        final pairs = rangeOf(childOf('Foo', 'pairs'));
+        expect(pairs.end.line, 2);
+
+        // Enum expression-body method includes its expression.
+        final doubled = rangeOf(childOf('Sign', 'doubled'));
+        expect(doubled.end.line, 6);
+        expect(doubled.end.character, greaterThan(18));
+
+        // Kotlin brace-less `= expr` is bounded to its own line and does not
+        // swallow the next member — `run` is recognized with its own block body.
+        final sum = rangeOf(childOf('Calc', 'sum'));
+        expect(
+          sum.end.line,
+          9,
+          reason: 'brace-less body must stop at its line',
+        );
+        final run = rangeOf(childOf('Calc', 'run'));
+        expect(run.end.line, 12, reason: 'run keeps its own block body');
+      },
+    );
+
     test('completion maps every present symbol category', () async {
       final c = _Client();
       await c.open(richUri, rich);


### PR DESCRIPTION
## Summary

Makes members with an **expression body** fully covered by their `documentSymbol` range (so an editor "select symbol" / Outline click selects the whole member). Works for **class and enum** members.

Before:
- `int square(int n) => n * n;` (Dart/C#) → range stopped at the name `square`.
- `fun sum(a, b) = a + b` (Kotlin, brace-less) → even worse: it *swallowed* the next member because with no terminator the scanner never recovered.

Now the token indexer consumes the expression:
- the `=>` form extends to its terminating `;`;
- the brace-less `=` form is bounded to the end of its line (the following member is recognized again);
- balanced `()`/`[]`/`{}` inside the expression (e.g. a map-literal body `=> {1: 2}`) are handled without corrupting brace tracking.

Implementation: the lexer now records whether a newline precedes each token (used to bound brace-less bodies), and `_extractDeclarations` tracks an in-progress expression body with a small local depth counter.

## Tests

Added a regression test (class `=>`, map-literal body, enum `=>`, and the Kotlin no-swallow case). Full LSP suite passes (153). `dart format`, `dart analyze --fatal-infos --fatal-warnings`, and `pub publish --dry-run` clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)