### PR TITLE
v1.6.3 - LSP: body-less constructor/method ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.6.3
+
+### Language Server — body-less constructor/method ranges
+
+- **A member with no `{ ... }` body is now fully covered by its `documentSymbol`
+  range.** A `;`-terminated constructor (`const Foo(this.x);`, a redirecting
+  `Foo.zero() : this(0);`) or an abstract method previously stopped its range at
+  the name, so selecting it excluded the parameters. The range now extends to
+  the terminating `;`, covering the whole signature — parameters and any
+  initializer list. Applies to class and enum constructors alike; bodied and
+  expression-bodied members are unchanged.
+
 ## 1.6.2
 
 ### Language Server — expression-body member ranges

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '1.6.2';
+  static final String VERSION = '1.6.3';
 
   static int _idCount = 0;
 

--- a/lib/src/lsp/analysis/token_index.dart
+++ b/lib/src/lsp/analysis/token_index.dart
@@ -465,8 +465,14 @@ class TokenIndex {
         // A `;` directly in an enum body ends its constant list; everything
         // after it is a regular member.
         if (inEnumBody()) classStack.last.enumConstantsDone = true;
-        // A `;` before the body brace means the member has no body (abstract
-        // method, `=>` expression body, field): drop the pending arm.
+        // A member still pending here has no `{ ... }` body (an abstract method,
+        // or a `;`-terminated constructor such as `const Foo(this.x);` or a
+        // redirecting `Foo.zero() : this(0);`). Extend its range to this `;` so
+        // the whole signature — parameters and any initializer list — is
+        // selectable, then drop the pending arm.
+        if (pendingBody != null) {
+          decls[pendingBody].fullEnd = t.end;
+        }
         pendingBody = null;
         atBoundary = true;
         i++;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 1.6.2
+version: 1.6.3
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/lsp/server_features_test.dart
+++ b/test/lsp/server_features_test.dart
@@ -527,6 +527,71 @@ class Calc {
       },
     );
 
+    test(
+      'documentSymbol range covers a body-less constructor signature',
+      () async {
+        // A constructor with no `{ }` body must still be fully selectable: its
+        // range spans the parameters (and any initializer list), for both class
+        // and enum constructors, as well as abstract methods.
+        const src = '''
+class Foo {
+  final int x;
+  const Foo(this.x);
+  Foo.zero() : this(0);
+  void abstractOne(int a, String b);
+}
+enum Color {
+  red, green;
+  final int code;
+  const Color(this.code);
+}
+''';
+        const uri = 'file:///ws/ctor.dart';
+        final c = _Client();
+        await c.open(uri, src);
+        final resp = await c.request('textDocument/documentSymbol', {
+          'textDocument': _td(uri),
+        });
+        final roots = (resp['result'] as List).cast<Map>();
+
+        Map childOf(String parent, String child) =>
+            ((roots.firstWhere((s) => s['name'] == parent)['children'] as List)
+                    .cast<Map>())
+                .firstWhere((m) => m['name'] == child);
+        Range rangeOf(Map m) =>
+            Range.fromJson((m['range'] as Map).cast<String, Object?>());
+
+        // `const Foo(this.x);` — the range must extend past the parameter list
+        // (well past the end of the name `Foo` at character 13).
+        final ctor = rangeOf(childOf('Foo', 'Foo'));
+        expect(ctor.end.line, 2);
+        expect(
+          ctor.end.character,
+          greaterThan(13),
+          reason: 'body-less constructor must include its parameters',
+        );
+
+        // Redirecting `Foo.zero() : this(0);` includes the initializer list.
+        final zero = rangeOf(childOf('Foo', 'zero'));
+        expect(zero.end.line, 3);
+        expect(zero.end.character, greaterThan(12));
+
+        // Abstract method signature includes its parameters.
+        final abstractOne = rangeOf(childOf('Foo', 'abstractOne'));
+        expect(abstractOne.end.line, 4);
+        expect(abstractOne.end.character, greaterThan(18));
+
+        // Enum body-less constructor includes its parameters too.
+        final enumCtor = rangeOf(childOf('Color', 'Color'));
+        expect(enumCtor.end.line, 9);
+        expect(
+          enumCtor.end.character,
+          greaterThan(14),
+          reason: 'enum constructor must include its parameters',
+        );
+      },
+    );
+
     test('completion maps every present symbol category', () async {
       final c = _Client();
       await c.open(richUri, rich);


### PR DESCRIPTION
## Summary

Makes **body-less constructors** (and abstract methods) fully selectable in `documentSymbol` — their range now includes the parameters/signature.

Before, a member with no `{ }` body stopped its range at the name:
- `const Foo(this.x);` → stopped at `Foo`
- redirecting `Foo.zero() : this(0);` → stopped at `zero`
- enum `const Color(this.code);` → stopped at `Color`
- abstract `void doThing(int a, String b);` → stopped at `doThing`

Now the range extends to the terminating `;`, covering the whole signature (parameters and any initializer list), for **class and enum** constructors alike. Bodied and expression-bodied members are unchanged.

## Tests

Added a regression test (class body-less ctor, redirecting ctor, abstract method, enum body-less ctor). Full LSP suite passes (154). `dart format`, `dart analyze --fatal-infos --fatal-warnings`, and `pub publish --dry-run` clean locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)