### PR TITLE
Extension methods and getters (Dart, Kotlin, C#)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,35 @@
+## 1.9.0
+
+### Extensions — add methods and getters to an existing type
+
+Three of the supported languages have a native extension construct, and they now
+share one: parse in any of them, run, and translate to the others.
+
+- **Dart**: `extension NumExt on int { int doubled() { return this * 2; } int get twice { … } }`
+  (the name is optional).
+- **Kotlin**: top-level `fun Int.doubled(): Int { … }` and `val Int.twice: Int get() = …`;
+  members are grouped by receiver into one extension.
+- **C#**: `static class NumExt { public static int Doubled(this int self) { … } }`; the
+  self-parameter and `this` are translated in both directions. C# has no extension property,
+  so an extension with a getter cannot be emitted as C#.
+
+Extensions apply to core types (`int`, `String`, …) as well as user classes, support
+overloads, and may call one another (`this.doubled()` or plain `doubled()`). A class member
+always wins over an extension member. Extensions are module-local: they are not carried across
+`import`. Java, JavaScript, TypeScript, Python, Go and Lua have no equivalent construct, so
+asking for one throws `UnsupportedSyntaxError` instead of emitting a shim that would mean
+something else.
+
+Supporting changes:
+
+- Dart now parses **instance getters** (`int get x { … }` / `=> …`) in class bodies too; the
+  `ASTClassGetterDeclaration` node existed but no grammar reached it.
+- New `ASTExtension` node and `ASTRoot.extensions` registry, consulted as a fallback when a
+  receiver's own class lookup misses.
+- Fixed: expressions interpolated into a string (`'${a.doubled()}'`) were never linked into the
+  AST `parentNode` chain, so they could not resolve anything reached through it.
+- Extensions appear in LSP document symbols and in the MCP AST serialization.
+
 ## 1.8.0
 
 ### Remote repository backend — edit and version-control a project from the browser

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ Supporting changes:
 - Fixed: expressions interpolated into a string (`'${a.doubled()}'`) were never linked into the
   AST `parentNode` chain, so they could not resolve anything reached through it.
 - Extensions appear in LSP document symbols and in the MCP AST serialization.
+- MCP: an `ASTGetterDeclaration` now serializes its name, return type and
+  modifiers instead of appearing as an anonymous node.
 
 ## 1.8.0
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Same legend and **Wasm** column semantics as the table above.
 | Enums (rich: ctor args, fields, methods)⁶                     | ✅ | ✅ | ✅ | 🚧 | ✅ | 🚫  | ✅ | 🚫  | ✅ | ✅⁶ |
 | Generics (generic classes + instantiation + type erasure)    | ✅ | ✅ | ✅ | 🚧 | ✅ | 🚫  | ✅ | 🚫  | 🚫  | 🚧 |
 | Type inference (`var` / `val` / `auto`)                       | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚫  | 🚫  | ✅⁵ |
+| Extensions (methods + getters)¹¹                              | ✅ | 🚫  | ✅ | 🚫  | 🧩¹² | 🚫  | 🚫  | 🚫  | 🚫  | 🚧 |
 
 ¹ Lua is table-based: "fields" are table entries (`obj.x`), "constructors" are factory/`setmetatable`
 idioms, methods are `function Obj:method`. &nbsp;
@@ -150,7 +151,16 @@ generated `NewName` factory. &nbsp;
 call sites), since Go has no `new`. &nbsp;
 ¹⁰ Go has no `static`/visibility keywords: static methods become package-level `func`s and
 visibility follows identifier capitalization. Inheritance, rich enums and generics
-(Go embedding/`iota`/`[T any]`) are `🚧` — not implemented for Go yet.
+(Go embedding/`iota`/`[T any]`) are `🚧` — not implemented for Go yet. &nbsp;
+¹¹ Members added to an existing type (a core type like `int`/`String`, or a user class) from
+outside its declaration: Dart `extension E on T { ... }`, Kotlin top-level `fun T.m()` and
+`val T.g: R get()`, C# `static class E { static R M(this T self) }`. A class member always wins
+over an extension member, and an extension is visible only within its own module (not carried
+across `import`). The languages marked `🚫` have no equivalent construct — prototype patching,
+monkey patching and metatables are not the same thing — so generating an extension for them
+throws `UnsupportedSyntaxError` rather than emitting a semantically different shim. &nbsp;
+¹² C# has no extension *property*, so an extension declaring a getter cannot be emitted as C#;
+its methods round-trip, with `this`/`self` translated both ways.
 
 > Per-language behavior is normalized to a shared AST, so types and constructs map
 > cleanly when translating between languages (e.g. C# `string` ⇄ Dart `String`,

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '1.8.0';
+  static final String VERSION = '1.9.0';
 
   static int _idCount = 0;
 

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -4,6 +4,7 @@
 
 import 'apollovm_code_storage.dart';
 import 'apollovm_generator.dart';
+import 'apollovm_parser.dart';
 import 'ast/apollovm_ast_base.dart';
 import 'ast/apollovm_ast_expression.dart';
 import 'ast/apollovm_ast_statement.dart';
@@ -50,6 +51,8 @@ abstract class ApolloCodeGenerator
       return generateASTRoot(node, out: out, indent: indent);
     } else if (node is ASTClassNormal) {
       return generateASTClass(node, out: out, indent: indent);
+    } else if (node is ASTExtension) {
+      return generateASTExtension(node, out: out, indent: indent);
     } else if (node is ASTSingleLineStatementBlock) {
       return generateASTSingleLineStatementBlock(
         node,
@@ -117,7 +120,43 @@ abstract class ApolloCodeGenerator
       generateASTClass(clazz, out: out);
     }
 
+    for (var extension in root.extensions) {
+      generateASTExtension(extension, out: out);
+    }
+
     return out;
+  }
+
+  /// Emits an extension declaration.
+  ///
+  /// Only Dart, Kotlin and C# have a native extension construct; every other
+  /// language rejects it rather than emit something that does not mean the same
+  /// thing (a monkey-patched prototype or a free-standing static helper would
+  /// silently change the program's semantics at the call sites).
+  StringBuffer generateASTExtension(
+    ASTExtension extension, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    throw UnsupportedSyntaxError(
+      "Language '$language' has no extension declaration: $extension",
+    );
+  }
+
+  /// Emits an instance getter (`int get twice => …`). Default: unsupported.
+  ///
+  /// [receiver] is set only when the getter belongs to an extension *and* the
+  /// target language qualifies the declaration by the extended type (Kotlin:
+  /// `val Int.twice: Int get()`).
+  StringBuffer generateASTClassGetterDeclaration(
+    ASTClassGetterDeclaration getter, {
+    StringBuffer? out,
+    String indent = '',
+    String? receiver,
+  }) {
+    throw UnsupportedSyntaxError(
+      "Language '$language' has no getter declaration: ${getter.name}",
+    );
   }
 
   @override
@@ -177,6 +216,12 @@ abstract class ApolloCodeGenerator
         } else {
           generateASTFunctionDeclaration(f, out: out, indent: indent2);
         }
+      }
+    }
+
+    for (var g in block.getter) {
+      if (g is ASTClassGetterDeclaration) {
+        generateASTClassGetterDeclaration(g, out: out, indent: indent2);
       }
     }
 

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -13,6 +13,128 @@ import 'apollovm_ast_type.dart';
 import 'apollovm_ast_value.dart';
 import 'apollovm_ast_variable.dart';
 
+/// The [ASTRoot] enclosing [node], reached through the `parentNode` chain set
+/// by `ASTRoot.resolveNode`, or `null` for a detached node.
+///
+/// Used by the invocation expressions to reach the module's extension registry.
+ASTRoot? _resolveASTRoot(ASTNode node) {
+  for (ASTNode? n = node; n != null; n = n.parentNode) {
+    if (n is ASTRoot) return n;
+  }
+  return null;
+}
+
+/// Resolves the method [name] on the receiver's class [clazz], falling back to
+/// an extension method declared by the enclosing module. A class member always
+/// wins over an extension member.
+///
+/// The core classes (`CoreClassInt`, `CoreClassString`, …) signal an unknown
+/// member by throwing rather than returning `null`, so that throw is captured
+/// and rethrown unchanged when no extension applies — a program without
+/// extensions fails exactly as it did before.
+ASTInvocableDeclaration? _resolveFunctionOrExtension(
+  ASTNode node,
+  ASTClass clazz,
+  String name,
+  ASTFunctionSignature parametersSignature,
+  VMContext context,
+) {
+  ASTInvocableDeclaration? f;
+  StateError? classLookupError;
+
+  try {
+    f = clazz.getFunction(name, parametersSignature, context);
+  } on StateError catch (e) {
+    classLookupError = e;
+  }
+
+  if (f != null) return f;
+
+  var extensionFunction = _resolveASTRoot(
+    node,
+  )?.getExtensionFunction(clazz, name, parametersSignature);
+  if (extensionFunction != null) return extensionFunction;
+
+  if (classLookupError != null) throw classLookupError;
+  return null;
+}
+
+/// The class of the `this` instance reachable from [context], or `null` outside
+/// a class/extension member.
+ASTClass? _receiverClass(VMContext context) {
+  var instance = context.getClassInstance();
+  if (instance == null) return null;
+  if (instance is ASTClassInstance) return instance.clazz;
+
+  try {
+    return instance.type.getClass();
+  } on StateError {
+    return null;
+  }
+}
+
+/// Resolves an unqualified call — `doubled()` or, in the languages that desugar
+/// it that way, `this.doubled()` — against the scope chain, falling back to an
+/// extension method on the receiver's class. This is what lets one extension
+/// member call another.
+///
+/// See [_resolveFunctionOrExtension] on why the class lookup's throw is
+/// captured rather than treated as an error.
+ASTInvocableDeclaration? _resolveLocalFunctionOrExtension(
+  ASTNode node,
+  VMContext context,
+  String name,
+  ASTFunctionSignature parametersSignature,
+) {
+  ASTInvocableDeclaration? f;
+  StateError? contextLookupError;
+
+  try {
+    f = context.getFunction(name, parametersSignature);
+  } on StateError catch (e) {
+    contextLookupError = e;
+  }
+
+  if (f != null) return f;
+
+  var receiverClass = _receiverClass(context);
+  if (receiverClass != null) {
+    var extensionFunction = _resolveASTRoot(
+      node,
+    )?.getExtensionFunction(receiverClass, name, parametersSignature);
+    if (extensionFunction != null) return extensionFunction;
+  }
+
+  if (contextLookupError != null) throw contextLookupError;
+  return null;
+}
+
+/// Resolves the getter [name] on the receiver's class [clazz], falling back to
+/// an extension getter. See [_resolveFunctionOrExtension].
+ASTGetterDeclaration? _resolveGetterOrExtension(
+  ASTNode node,
+  ASTClass clazz,
+  String name,
+  VMContext context,
+) {
+  ASTGetterDeclaration? g;
+  StateError? classLookupError;
+
+  try {
+    g = clazz.getGetter(name, context);
+  } on StateError catch (e) {
+    classLookupError = e;
+  }
+
+  if (g != null) return g;
+
+  var extensionGetter = _resolveASTRoot(node)?.getExtensionGetter(clazz, name);
+  if (extensionGetter != null) return extensionGetter;
+
+  if (classLookupError != null) throw classLookupError;
+  return null;
+}
+
 /// Base for AST expressions.
 abstract class ASTExpression with ASTNode implements ASTCodeRunner {
   static FutureOr<ASTType> typeFromExpressions(
@@ -267,6 +389,14 @@ class ASTExpressionLiteral extends ASTExpression {
 
   @override
   Iterable<ASTNode> get children => [value];
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+    // A string literal can hold interpolated expressions; resolving the value
+    // links them into the `parentNode` chain up to the `ASTRoot`.
+    value.resolveNode(this);
+  }
 
   @override
   FutureOr<ASTType> resolveType(VMContext? context) =>
@@ -2284,7 +2414,12 @@ class ASTExpressionLocalFunctionInvocation
   FutureOr<ASTValue> run(VMContext parentContext, ASTRunStatus runStatus) {
     // A declared function (including named arrow functions) takes precedence.
     var fSignature = _getASTFunctionSignature();
-    var declared = parentContext.getFunction(name, fSignature);
+    var declared = _resolveLocalFunctionOrExtension(
+      this,
+      parentContext,
+      name,
+      fSignature,
+    );
     if (declared != null) {
       return super.run(parentContext, runStatus);
     }
@@ -2336,7 +2471,12 @@ class ASTExpressionLocalFunctionInvocation
   @override
   ASTInvocableDeclaration _getFunction(VMContext parentContext) {
     var fSignature = _getASTFunctionSignature();
-    var f = parentContext.getFunction(name, fSignature);
+    var f = _resolveLocalFunctionOrExtension(
+      this,
+      parentContext,
+      name,
+      fSignature,
+    );
 
     if (f == null) {
       throw ApolloVMRuntimeError(
@@ -2391,7 +2531,13 @@ class ASTExpressionChainFunctionInvocation
     return _getFunctionClass(previousValue).resolveMapped((clazz) {
       var fSignature = _getASTFunctionSignature();
 
-      var f = clazz.getFunction(name, fSignature, parentContext);
+      var f = _resolveFunctionOrExtension(
+        this,
+        clazz,
+        name,
+        fSignature,
+        parentContext,
+      );
 
       if (f == null) {
         throw ApolloVMRuntimeError(
@@ -2538,7 +2684,16 @@ class ASTExpressionObjectFunctionInvocation
     return _getFunctionClass(parentContext).resolveMapped((clazz) {
       var fSignature = _getASTFunctionSignature();
 
-      var f = clazz.getFunction(name, fSignature, parentContext);
+      // This is the path for `x.doubled()` and for `this.doubled()` from inside
+      // an extension body.
+      var f = _resolveFunctionOrExtension(
+        this,
+        clazz,
+        name,
+        fSignature,
+        parentContext,
+      );
+
       if (f == null) {
         throw ApolloVMRuntimeError(
           "Can't find class[${clazz.name}] function[$name( $fSignature )] for object!",
@@ -2987,7 +3142,8 @@ class ASTExpressionObjectGetterAccess extends ASTExpressionGetterAccess
   @override
   FutureOr<ASTGetterDeclaration> _getGetter(VMContext parentContext) {
     return _getGetterClass(parentContext).resolveMapped((clazz) {
-      var g = clazz.getGetter(name, parentContext);
+      var g = _resolveGetterOrExtension(this, clazz, name, parentContext);
+
       if (g == null) {
         return _getVariableValue(parentContext).resolveMapped((obj) {
           throw ApolloVMRuntimeError(

--- a/lib/src/ast/apollovm_ast_statement.dart
+++ b/lib/src/ast/apollovm_ast_statement.dart
@@ -317,6 +317,10 @@ class ASTBlock extends ASTStatement {
     for (var e in _functions.values) {
       e.resolveNode(this);
     }
+
+    for (var e in _getters.values) {
+      e.resolveNode(this);
+    }
   }
 
   @override
@@ -472,6 +476,9 @@ class ASTBlock extends ASTStatement {
 
     _functions.clear();
     addAllFunctions(other._functions.values.expand((e) => e.functions));
+
+    _getters.clear();
+    addAllGetters(other._getters.values);
 
     _statements.clear();
     addAllStatements(other._statements);

--- a/lib/src/ast/apollovm_ast_toplevel.dart
+++ b/lib/src/ast/apollovm_ast_toplevel.dart
@@ -798,6 +798,14 @@ class ASTClassNormal extends ASTClass<VMObject> {
   }
 
   @override
+  void addGetter(ASTGetterDeclaration g) {
+    if (g is ASTClassGetterDeclaration) {
+      g.clazz = this;
+    }
+    super.addGetter(g);
+  }
+
+  @override
   ASTClassField? getField(String name, {bool caseInsensitive = false}) {
     var field = _fields[name];
 
@@ -1167,6 +1175,122 @@ class ASTTypeAlias with ASTNode implements ASTTypedNode {
   String toString() => 'typedef $name = $targetType';
 }
 
+/// AST of an extension: members declared for an existing type from outside its
+/// declaration. Sources: Dart `extension E on T {}`, Kotlin `fun T.m()` /
+/// `val T.g: R get()`, C# `static class E { static R M(this T self) }`.
+///
+/// Deliberately **not** an [ASTClass]: the [ASTClass] constructor calls
+/// `type.setClass(this)`, which would either throw (the target type already has
+/// a class) or hijack the target's type. For the same reason the members are
+/// never added onto the target [ASTClass] — the core classes (`CoreClassInt`,
+/// `CoreClassString`, …) are process-wide singletons, so injecting `int.doubled`
+/// there would leak the extension into every other module. Instead extensions
+/// are registered on the declaring [ASTRoot] and consulted only as a *fallback*
+/// when normal member lookup misses. See [ASTRoot.getExtensionFunction].
+///
+/// Members are stored in the inherited [ASTBlock] maps, so overload resolution
+/// (via [ASTFunctionSet]) and getter lookup come for free.
+///
+/// Scope: instance methods and getters. Not static members, operators or
+/// setters. Extensions are visible only within their own module (they are not
+/// carried across `import`).
+class ASTExtension extends ASTBlock {
+  /// The extension name. Optional: Dart allows unnamed extensions, and Kotlin
+  /// has no name at all (one is synthesized when grouping by receiver).
+  final String? name;
+
+  /// The extended type (the `on` clause / the receiver).
+  final ASTType targetType;
+
+  ASTClass? _targetClass;
+
+  /// The [ASTClass] of [targetType], resolved by [resolveNode].
+  ASTClass? get targetClass => _targetClass;
+
+  ASTExtension(this.name, this.targetType) : super(null);
+
+  @override
+  Iterable<ASTNode> get children => [...super.children, ...getter];
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+
+    _targetClass ??= _resolveTargetClass();
+    var targetClass = _targetClass;
+
+    // Binding each member's `clazz` to the *target* class is what makes the
+    // existing dispatch work unchanged: `objectCall` builds a
+    // `VMClassContext(clazz!)` and `setClassInstance(receiver)`, so `this`
+    // resolves to the receiver — including a primitive one.
+    for (var set in functions) {
+      for (var f in set.functions) {
+        if (f is ASTClassFunctionDeclaration) {
+          f.clazz = targetClass;
+        }
+      }
+    }
+
+    for (var g in getter) {
+      if (g is ASTClassGetterDeclaration) {
+        g.clazz = targetClass;
+      }
+    }
+  }
+
+  ASTRoot? get _root {
+    for (ASTNode? node = parentNode; node != null; node = node.parentNode) {
+      if (node is ASTRoot) return node;
+    }
+    return null;
+  }
+
+  /// A user class comes from the enclosing [ASTRoot]; a core type (`int`,
+  /// `String`, …) from [ASTType.getClass], which delegates to [ApolloVMCore].
+  ASTClass? _resolveTargetClass() {
+    var userClass = _root?.getClass(targetType.name);
+    if (userClass != null) return userClass;
+
+    try {
+      return targetType.getClass();
+    } on StateError {
+      // An unknown target type: the extension is simply never applicable.
+      return null;
+    }
+  }
+
+  /// Whether this extension extends [clazz].
+  ///
+  /// Subtype matching (an `on num` extension applying to an `int` receiver) is
+  /// not implemented.
+  bool matchesReceiver(ASTClass clazz) =>
+      identical(clazz, _targetClass) || clazz.name == targetType.name;
+
+  /// The extension method [name] matching [parametersSignature], or `null`.
+  ASTInvocableDeclaration? findFunction(
+    String name,
+    ASTFunctionSignature parametersSignature,
+  ) {
+    var set = getFunctionWithName(name);
+    if (set == null) return null;
+
+    try {
+      return set.get(parametersSignature, false);
+    } on StateError {
+      // Name declared, but no overload accepts this signature.
+      return null;
+    } on ApolloVMRuntimeError {
+      return null;
+    }
+  }
+
+  /// The extension getter [name], or `null`.
+  ASTGetterDeclaration? findGetter(String name) => getGetterWithName(name);
+
+  @override
+  String toString() => 'ASTExtension[${name ?? ''}]on[$targetType]';
+}
+
 /// An AST Root.
 ///
 /// A parse of a [CodeUnit] generates an [ASTRoot].
@@ -1184,6 +1308,48 @@ class ASTRoot extends ASTEntryPointBlock {
     for (var e in _typeAliases.values) {
       e.resolveNode(this);
     }
+
+    for (var e in _extensions) {
+      e.resolveNode(this);
+    }
+  }
+
+  final List<ASTExtension> _extensions = <ASTExtension>[];
+
+  /// The extensions declared by this module, in declaration order.
+  List<ASTExtension> get extensions => UnmodifiableListView(_extensions);
+
+  void addExtension(ASTExtension extension) {
+    _extensions.add(extension);
+    _exportedSymbolNames = null;
+  }
+
+  /// Resolves an extension method [name] for a receiver of class [receiver].
+  ///
+  /// Called by the invocation expressions only after the receiver's own class
+  /// lookup has missed, so a class member always wins over an extension member.
+  ASTInvocableDeclaration? getExtensionFunction(
+    ASTClass receiver,
+    String name,
+    ASTFunctionSignature parametersSignature,
+  ) {
+    for (var extension in _extensions) {
+      if (!extension.matchesReceiver(receiver)) continue;
+      var f = extension.findFunction(name, parametersSignature);
+      if (f != null) return f;
+    }
+    return null;
+  }
+
+  /// Resolves an extension getter [name] for a receiver of class [receiver].
+  /// See [getExtensionFunction].
+  ASTGetterDeclaration? getExtensionGetter(ASTClass receiver, String name) {
+    for (var extension in _extensions) {
+      if (!extension.matchesReceiver(receiver)) continue;
+      var g = extension.findGetter(name);
+      if (g != null) return g;
+    }
+    return null;
   }
 
   @override
@@ -1260,11 +1426,7 @@ class ASTRoot extends ASTEntryPointBlock {
     var cached = _exportedSymbolNames;
     if (cached != null) return cached;
 
-    var all = <String>{
-      ...functions.map((f) => f.name),
-      ..._classes.keys,
-      ..._typeAliases.keys,
-    };
+    var all = _ownSymbolNames();
 
     var explicit = _exports
         .where((e) => e.path == null && e.symbols.isNotEmpty)
@@ -1282,14 +1444,19 @@ class ASTRoot extends ASTEntryPointBlock {
     return _exportedSymbolNames = UnmodifiableSetView(result);
   }
 
+  /// Every top-level symbol name declared by this module. Unnamed extensions
+  /// (Dart allows them) contribute nothing, as they cannot be referenced.
+  Set<String> _ownSymbolNames() => <String>{
+    ...functions.map((f) => f.name),
+    ..._classes.keys,
+    ..._typeAliases.keys,
+    ..._extensions.map((e) => e.name).nonNulls,
+  };
+
   /// Own top-level symbol names that are NOT declared (used by the resolver to
   /// flag invalid exports).
   Set<String> exportNamesNotDeclared() {
-    var all = <String>{
-      ...functions.map((f) => f.name),
-      ..._classes.keys,
-      ..._typeAliases.keys,
-    };
+    var all = _ownSymbolNames();
     return _exports
         .where((e) => e.path == null)
         .expand((e) => e.symbols.map((s) => s.name))

--- a/lib/src/ast/apollovm_ast_toplevel.dart
+++ b/lib/src/ast/apollovm_ast_toplevel.dart
@@ -1277,9 +1277,9 @@ class ASTExtension extends ASTBlock {
     try {
       return set.get(parametersSignature, false);
     } on StateError {
-      // Name declared, but no overload accepts this signature.
-      return null;
-    } on ApolloVMRuntimeError {
+      // Name declared, but the single declaration rejects this signature.
+      // (With several overloads the set falls back to the first one, as it
+      // does for class methods.)
       return null;
     }
   }

--- a/lib/src/ast/apollovm_ast_value.dart
+++ b/lib/src/ast/apollovm_ast_value.dart
@@ -1064,12 +1064,6 @@ class ASTValueAsString<T> extends ASTValue<String> {
   Iterable<ASTNode> get children => [value];
 
   @override
-  void resolveNode(ASTNode? parentNode) {
-    super.resolveNode(parentNode);
-    value.resolveNode(this);
-  }
-
-  @override
   FutureOr<String> getValue(VMContext context) {
     return value
         .getValue(context)
@@ -1104,14 +1098,6 @@ class ASTValuesListAsString extends ASTValue<String> {
 
   @override
   Iterable<ASTNode> get children => [...values];
-
-  @override
-  void resolveNode(ASTNode? parentNode) {
-    super.resolveNode(parentNode);
-    for (var v in values) {
-      v.resolveNode(this);
-    }
-  }
 
   @override
   FutureOr<String> getValue(VMContext context) {

--- a/lib/src/ast/apollovm_ast_value.dart
+++ b/lib/src/ast/apollovm_ast_value.dart
@@ -1064,6 +1064,12 @@ class ASTValueAsString<T> extends ASTValue<String> {
   Iterable<ASTNode> get children => [value];
 
   @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+    value.resolveNode(this);
+  }
+
+  @override
   FutureOr<String> getValue(VMContext context) {
     return value
         .getValue(context)
@@ -1098,6 +1104,14 @@ class ASTValuesListAsString extends ASTValue<String> {
 
   @override
   Iterable<ASTNode> get children => [...values];
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+    for (var v in values) {
+      v.resolveNode(this);
+    }
+  }
 
   @override
   FutureOr<String> getValue(VMContext context) {
@@ -1140,6 +1154,15 @@ class ASTValueStringExpression<T> extends ASTValue<String> {
 
   @override
   Iterable<ASTNode> get children => [expression];
+
+  /// Resolves the interpolated expression against this node, so that it reaches
+  /// the enclosing [ASTRoot] (and its extensions) through the `parentNode`
+  /// chain, exactly as an expression in statement position does.
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+    expression.resolveNode(this);
+  }
 
   @override
   FutureOr<String> getValue(VMContext context) {
@@ -1226,6 +1249,14 @@ class ASTValueStringConcatenation extends ASTValue<String> {
 
   @override
   Iterable<ASTNode> get children => [...values];
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+    for (var v in values) {
+      v.resolveNode(this);
+    }
+  }
 
   @override
   FutureOr<String> getValue(VMContext context) {

--- a/lib/src/languages/csharp/csharp_generator.dart
+++ b/lib/src/languages/csharp/csharp_generator.dart
@@ -100,6 +100,113 @@ class ApolloCodeGeneratorCSharp extends ApolloCodeGenerator {
     return out;
   }
 
+  /// The name of the self-parameter of the extension method being generated.
+  /// While set, `this` is rendered as that identifier — C# extension methods
+  /// receive the instance as a parameter, not as `this`.
+  String? _extensionSelfName;
+
+  /// C# has no extension *block*: an extension is a `static class` whose
+  /// methods take a `this`-qualified first parameter.
+  ///
+  /// C# has no extension properties, so an extension declaring getters (from
+  /// Dart or Kotlin) cannot be expressed.
+  @override
+  StringBuffer generateASTExtension(
+    ASTExtension extension, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    if (extension.getter.isNotEmpty) {
+      throw UnsupportedSyntaxError(
+        'C# has no extension property: ${extension.getter.map((g) => g.name).join(', ')}',
+      );
+    }
+
+    var name = extension.name ?? '${extension.targetType.name}Extension';
+    var indent2 = '$indent  ';
+
+    out.write(indent);
+    out.write('static class ');
+    out.write(name);
+    out.write(' {\n\n');
+
+    for (var set in extension.functions) {
+      for (var f in set.functions) {
+        if (f is ASTClassFunctionDeclaration) {
+          _generateExtensionMethod(f, extension.targetType, out, indent2);
+        }
+      }
+    }
+
+    out.write(indent);
+    out.write('}\n');
+
+    return out;
+  }
+
+  void _generateExtensionMethod(
+    ASTClassFunctionDeclaration f,
+    ASTType targetType,
+    StringBuffer out,
+    String indent,
+  ) {
+    const selfName = 'self';
+
+    _extensionSelfName = selfName;
+    StringBuffer blockCode;
+    try {
+      blockCode = generateASTBlock(f, indent: indent, withBrackets: false);
+    } finally {
+      _extensionSelfName = null;
+    }
+
+    out.write(indent);
+    out.write('public static ');
+    if (f.modifiers.isAsync) out.write('async ');
+    out.write(generateASTType(f.returnType));
+    out.write(' ');
+    out.write(f.name);
+
+    out.write('(this ');
+    out.write(generateASTType(targetType));
+    out.write(' $selfName');
+    if (f.parametersSize > 0) {
+      out.write(', ');
+      generateASTParametersDeclaration(f.parameters, out: out);
+    }
+    out.write(') {\n');
+    out.write(blockCode);
+    out.write(indent);
+    out.write('}\n\n');
+  }
+
+  @override
+  StringBuffer generateASTVariable(
+    ASTVariable variable, {
+    String? callingFunction,
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    var selfName = _extensionSelfName;
+    if (selfName != null && variable is ASTThisVariable) {
+      out ??= newOutput();
+      if (headIndented) out.write(indent);
+      out.write(selfName);
+      return out;
+    }
+
+    return super.generateASTVariable(
+      variable,
+      callingFunction: callingFunction,
+      out: out,
+      indent: indent,
+      headIndented: headIndented,
+    );
+  }
+
   @override
   StringBuffer generateASTClass(
     ASTClassNormal clazz, {

--- a/lib/src/languages/csharp/csharp_grammar.dart
+++ b/lib/src/languages/csharp/csharp_grammar.dart
@@ -63,13 +63,17 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
 
   Parser<ASTRoot> compilationUnit() =>
       (ref0(usingDirective).star() & ref0(topLevelDefinition).star()).map((v) {
-        var topDef = v[1];
-
-        var classes = topDef as List;
+        var topDef = v[1] as List;
 
         var root = ASTRoot();
 
-        root.addAllClasses(classes.cast());
+        for (var def in topDef) {
+          if (def is ASTExtension) {
+            root.addExtension(def);
+          } else if (def is ASTClassNormal) {
+            root.addClass(def);
+          }
+        }
 
         root.resolveNode(null);
 
@@ -83,7 +87,115 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
       (char('.').trimHidden() & identifier()).star() &
       char(';').trimHidden());
 
-  Parser topLevelDefinition() => (enumDeclaration() | classDeclaration());
+  Parser topLevelDefinition() =>
+      (enumDeclaration() | extensionClassDeclaration() | classDeclaration());
+
+  /// The name of the `this`-parameter of the extension method being parsed.
+  /// Inside the body that identifier denotes the receiver, so it is parsed as
+  /// [ASTThisVariable] — the shared AST has no notion of a self-parameter.
+  String? _extensionSelfName;
+
+  /// `this` (any language) or the current extension method's self-parameter.
+  ASTVariable _variableForName(String name) =>
+      name == 'this' || name == _extensionSelfName
+      ? ASTThisVariable()
+      : ASTScopeVariable(name);
+
+  /// A C# extension class: a `static class` whose methods all take a
+  /// `this`-qualified first parameter, e.g.
+  /// `static class NumExt { public static int Doubled(this int self) { … } }`.
+  ///
+  /// Tried before [classDeclaration], which rejects the `this` parameter.
+  Parser<ASTExtension> extensionClassDeclaration() =>
+      (classVisibilityModifier().star() &
+              string('class').trimHidden() &
+              identifier() &
+              char('{').trimHidden() &
+              ref0(extensionMethodDeclaration).plus() &
+              char('}').trimHidden())
+          .map((v) {
+            // `classVisibilityModifier` flattens the trimmed range, so each
+            // matched keyword carries the surrounding whitespace.
+            var classModifiers = (v[0] as List)
+                .map((e) => (e as String).trim())
+                .toList();
+            var name = v[2] as String;
+            var methods = (v[4] as List).cast<_ExtensionMethod>();
+
+            if (!classModifiers.contains('static')) {
+              throw SyntaxError(
+                'An extension class must be `static`: class $name',
+              );
+            }
+
+            // The shared AST models one extension per extended type, while C#
+            // lets a single static class extend several types.
+            var receiverType = methods.first.receiverType;
+            for (var m in methods) {
+              if (m.receiverType.name != receiverType.name) {
+                throw SyntaxError(
+                  'Extension class `$name` extends multiple types '
+                  '(${receiverType.name}, ${m.receiverType.name}): not supported.',
+                );
+              }
+            }
+
+            var extension = ASTExtension(name, receiverType);
+            for (var m in methods) {
+              extension.addFunction(m.function);
+            }
+            return extension;
+          });
+
+  /// `public static int Doubled(this int self, int by) { … }`.
+  Parser extensionMethodDeclaration() =>
+      (modifiers().optional() &
+              type() &
+              identifier() &
+              char('(').trimHidden() &
+              ref0(extensionSelfParameter) &
+              (char(',').trimHidden() & parameterDeclaration()).star() &
+              char(')').trimHidden() &
+              codeBlock())
+          .map((v) {
+            var modifiers =
+                (v[0] as ASTModifiers?) ?? ASTModifiers.modifiersNone;
+            var returnType = v[1] as ASTType;
+            var name = v[2] as String;
+            var self = v[4] as _ExtensionSelf;
+            var block = v[7] as ASTBlock;
+
+            var parameters = (v[5] as List)
+                .map((e) => (e as List)[1] as ASTFunctionParameterDeclaration)
+                .toList();
+
+            _extensionSelfName = null;
+
+            // `static` is C#'s carrier syntax for the receiver; the AST models
+            // an extension method as an instance method bound to the receiver.
+            return _ExtensionMethod(
+              self.receiverType,
+              ASTClassFunctionDeclaration(
+                null,
+                name,
+                ASTFunctionParametersDeclaration(parameters, null, null),
+                returnType,
+                block: block,
+                modifiers: modifiers.copyWith(isStatic: false),
+              ),
+            );
+          });
+
+  /// The receiver parameter of an extension method: `this int self`. Registers
+  /// [_extensionSelfName] so the body's `self` parses as `this`; the sequence
+  /// is parsed left-to-right, so this runs before the method body.
+  Parser extensionSelfParameter() =>
+      (token('this') & type() & identifier()).map((v) {
+        var receiverType = v[1] as ASTType;
+        var selfName = v[2] as String;
+        _extensionSelfName = selfName;
+        return _ExtensionSelf(receiverType, selfName);
+      });
 
   Parser<ASTClassEnum> enumDeclaration() =>
       (classVisibilityModifier().star() &
@@ -127,6 +239,9 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
       (classVisibilityModifier().star() &
               string('class').trimHidden().map((v) {
                 _classTypeParameters.clear();
+                // A failed `extensionClassDeclaration` attempt (tried first)
+                // may have left a self-name behind; a plain class has none.
+                _extensionSelfName = null;
                 return v;
               }) &
               identifier() &
@@ -831,7 +946,7 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
                 .toList();
 
             if (obj != null && obj != 'this') {
-              var variable = ASTScopeVariable(obj);
+              var variable = _variableForName(obj);
               return ASTExpressionObjectFunctionInvocation(
                 variable,
                 name,
@@ -859,9 +974,7 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
                 .whereType<ASTExpressionChainFunctionInvocation>()
                 .toList();
 
-            ASTVariable variable = obj == 'this'
-                ? ASTThisVariable()
-                : ASTScopeVariable(obj!);
+            var variable = _variableForName(obj!);
             return ASTExpressionObjectGetterAccess(
               variable,
               name,
@@ -1113,9 +1226,7 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
             var name = v[2] as String;
             var op = v[3] as ASTAssignmentOperator;
             var valueExpr = v[4] as ASTExpression;
-            ASTVariable variable = obj == 'this'
-                ? ASTThisVariable()
-                : ASTScopeVariable(obj);
+            var variable = _variableForName(obj);
             return ASTExpressionObjectSetterAssignment(
               variable,
               name,
@@ -1138,9 +1249,10 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
     return ASTThisVariable();
   });
 
-  Parser<ASTScopeVariable> scopeVariable() => (identifier()).map((v) {
-    return ASTScopeVariable(v);
-  });
+  /// A bare identifier. Inside an extension method the self-parameter denotes
+  /// the receiver, so it yields [ASTThisVariable] instead.
+  Parser<ASTVariable> scopeVariable() =>
+      (identifier()).map((v) => _variableForName(v));
 
   /// C# lambda used as an expression (a closure): `(a, b) => expr`,
   /// `(int a) => { ... }`, `x => x * 2`, `() => 0`. Captures the enclosing scope.
@@ -1353,4 +1465,20 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
 
     return l.expand((e) => e is List ? _expandListDeeply(e) : [e]).toList();
   }
+}
+
+/// The `this int self` receiver parameter of a C# extension method.
+class _ExtensionSelf {
+  final ASTType receiverType;
+  final String name;
+
+  _ExtensionSelf(this.receiverType, this.name);
+}
+
+/// A parsed C# extension method tagged with the type it extends.
+class _ExtensionMethod {
+  final ASTType receiverType;
+  final ASTClassFunctionDeclaration function;
+
+  _ExtensionMethod(this.receiverType, this.function);
 }

--- a/lib/src/languages/dart/dart_generator.dart
+++ b/lib/src/languages/dart/dart_generator.dart
@@ -165,6 +165,64 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
     return out;
   }
 
+  @override
+  StringBuffer generateASTExtension(
+    ASTExtension extension, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    var code = generateASTBlock(
+      extension,
+      withBrackets: true,
+      withBlankHeadLine: true,
+    );
+
+    out.write(indent);
+    out.write('extension ');
+
+    var name = extension.name;
+    if (name != null) {
+      out.write(name);
+      out.write(' ');
+    }
+
+    out.write('on ');
+    out.write(generateASTType(extension.targetType));
+    out.write(' ');
+    out.write(code);
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTClassGetterDeclaration(
+    ASTClassGetterDeclaration getter, {
+    StringBuffer? out,
+    String indent = '',
+    String? receiver,
+  }) {
+    out ??= newOutput();
+
+    var blockCode = generateASTBlock(
+      getter,
+      indent: indent,
+      withBrackets: false,
+    );
+
+    out.write(indent);
+    out.write(generateASTType(getter.returnType));
+    out.write(' get ');
+    out.write(getter.name);
+    out.write(' {\n');
+    out.write(blockCode);
+    out.write(indent);
+    out.write('}\n\n');
+
+    return out;
+  }
+
   /// Generates a Dart `enum` declaration (simple or enhanced/rich).
   StringBuffer generateASTClassEnum(
     ASTClassEnum clazz, {

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -76,6 +76,8 @@ class DartGrammarDefinition extends DartGrammarLexer {
                   root.addFunction(def);
                 } else if (def is ASTClassNormal) {
                   root.addClass(def);
+                } else if (def is ASTExtension) {
+                  root.addExtension(def);
                 } else if (def is ASTTypeAlias) {
                   root.addTypeAlias(def);
                 } else if (def is ASTStatementVariableDeclaration) {
@@ -96,6 +98,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
   Parser topLevelDefinition() =>
       (typeAliasDeclaration() |
               enumDeclaration() |
+              extensionDeclaration() |
               classDeclaration() |
               functionDeclaration() |
               statementVariableDeclaration())
@@ -198,6 +201,64 @@ class DartGrammarDefinition extends DartGrammarLexer {
               type() &
               char(';').trimHidden())
           .map((v) => ASTTypeAlias(v[1] as String, v[3] as ASTType));
+
+  /// `extension [Name] on Type { <methods and getters> }`.
+  ///
+  /// The name is optional (Dart allows unnamed extensions). Members reuse the
+  /// class-member parsers, so an extension method is an ordinary
+  /// [ASTClassFunctionDeclaration] whose `clazz` is bound to the extended class
+  /// by [ASTExtension.resolveNode].
+  Parser<ASTExtension> extensionDeclaration() =>
+      (extensionToken().trimHidden() &
+              extensionName() &
+              onToken().trimHidden() &
+              type() &
+              char('{').trimHidden() &
+              (ref0(classFunctionDeclaration) | ref0(getterDeclaration))
+                  .star() &
+              char('}').trimHidden())
+          .map((v) {
+            var name = v[1] as String?;
+            var targetType = v[3] as ASTType;
+
+            var extension = ASTExtension(name, targetType);
+
+            for (var member in (v[5] as List)) {
+              if (member is ASTClassGetterDeclaration) {
+                extension.addGetter(member);
+              } else if (member is ASTFunctionDeclaration) {
+                extension.addFunction(member);
+              }
+            }
+
+            return extension;
+          });
+
+  /// The optional name of an extension. Only consumed when followed by `on`,
+  /// otherwise `extension on int {}` would read `on` as the name.
+  Parser<String?> extensionName() =>
+      (identifier().trimHidden() & onToken().and())
+          .map((v) => v[0] as String)
+          .optional();
+
+  /// An instance getter: `int get twice => this * 2;` or `int get twice { … }`.
+  /// Valid in a class body and in an extension body. Setters are not supported.
+  Parser<ASTClassGetterDeclaration> getterDeclaration() =>
+      (type().optional() &
+              getToken().trimHidden() &
+              identifier() &
+              (arrowBody() | codeBlock()))
+          .map((v) {
+            var returnType = v[0] as ASTType? ?? ASTTypeDynamic.instance;
+            var name = v[2] as String;
+            var block = v[3] as ASTBlock;
+            return ASTClassGetterDeclaration(
+              null,
+              name,
+              returnType,
+              block: block,
+            );
+          });
 
   /// Type-parameter names of the class currently being parsed (e.g. `T` in
   /// `class Wrapper<T>`). Used by [simpleType] to erase them to `dynamic`.
@@ -362,6 +423,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
       (char('{').trimHidden() &
               (ref0(classConstructorDefaultDeclaration) |
                       ref0(classFunctionDeclaration) |
+                      ref0(getterDeclaration) |
                       ref0(classFieldDeclaration) |
                       ref0(classFieldDeclarationWithValue))
                   .star() &
@@ -372,6 +434,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
             var constructors = list
                 .whereType<ASTClassConstructorDeclaration>()
                 .toList();
+            var getters = list.whereType<ASTClassGetterDeclaration>().toList();
             var functions = list.whereType<ASTFunctionDeclaration>().toList();
 
             var block = ASTClassNormal('?', ASTType<VMObject>('?'), null);
@@ -379,6 +442,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
             block.addAllFields(fields);
             block.addAllConstructors(constructors);
             block.addAllFunctions(functions);
+            block.addAllGetters(getters);
 
             return block;
           });

--- a/lib/src/languages/dart/dart_grammar_lexer.dart
+++ b/lib/src/languages/dart/dart_grammar_lexer.dart
@@ -87,7 +87,9 @@ abstract class DartGrammarLexer extends BaseGrammarLexer {
 
   Parser factoryToken() => ref1(token, 'factory');
 
-  Parser getToken() => ref1(token, 'get');
+  Parser extensionToken() => _keywordToken('extension');
+
+  Parser getToken() => _keywordToken('get');
 
   Parser hideToken() => ref1(token, 'hide');
 
@@ -104,6 +106,8 @@ abstract class DartGrammarLexer extends BaseGrammarLexer {
   Parser negateToken() => ref1(token, 'negate');
 
   Parser ofToken() => ref1(token, 'of');
+
+  Parser onToken() => _keywordToken('on');
 
   Parser operatorToken() => ref1(token, 'operator');
 

--- a/lib/src/languages/go/go_generator.dart
+++ b/lib/src/languages/go/go_generator.dart
@@ -99,6 +99,10 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
       generateASTClass(clazz, out: out);
     }
 
+    for (var extension in root.extensions) {
+      generateASTExtension(extension, out: out);
+    }
+
     return out;
   }
 

--- a/lib/src/languages/kotlin/kotlin_generator.dart
+++ b/lib/src/languages/kotlin/kotlin_generator.dart
@@ -152,6 +152,71 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
     return out;
   }
 
+  /// Kotlin has no extension *block*: each member is emitted as a top-level
+  /// declaration qualified by the receiver type — `fun Int.doubled(): Int` and
+  /// `val Int.twice: Int get()`. The extension's name is therefore dropped.
+  @override
+  StringBuffer generateASTExtension(
+    ASTExtension extension, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    var receiver = generateASTType(extension.targetType).toString();
+
+    for (var set in extension.functions) {
+      for (var f in set.functions) {
+        _generateASTFunctionDeclarationImpl(f, out, indent, receiver);
+      }
+    }
+
+    for (var g in extension.getter) {
+      if (g is ASTClassGetterDeclaration) {
+        generateASTClassGetterDeclaration(
+          g,
+          out: out,
+          indent: indent,
+          receiver: receiver,
+        );
+      }
+    }
+
+    return out;
+  }
+
+  @override
+  StringBuffer generateASTClassGetterDeclaration(
+    ASTClassGetterDeclaration getter, {
+    StringBuffer? out,
+    String indent = '',
+    String? receiver,
+  }) {
+    out ??= newOutput();
+
+    var blockCode = generateASTBlock(
+      getter,
+      indent: indent,
+      withBrackets: false,
+    );
+
+    out.write(indent);
+    out.write('val ');
+    if (receiver != null) {
+      out.write(receiver);
+      out.write('.');
+    }
+    out.write(getter.name);
+    out.write(': ');
+    generateASTType(getter.returnType, out: out);
+    out.write(' get() {\n');
+    out.write(blockCode);
+    out.write(indent);
+    out.write('}\n\n');
+
+    return out;
+  }
+
   @override
   StringBuffer generateASTClass(
     ASTClassNormal clazz, {
@@ -345,11 +410,14 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
     return _generateASTFunctionDeclarationImpl(f, out, indent);
   }
 
+  /// [receiver] is set only for extension functions, where the name is
+  /// qualified by the extended type: `fun Int.doubled()`.
   StringBuffer _generateASTFunctionDeclarationImpl(
     ASTFunctionDeclaration f,
     StringBuffer? out,
-    String indent,
-  ) {
+    String indent, [
+    String? receiver,
+  ]) {
     out ??= newOutput();
 
     var blockCode = generateASTBlock(f, indent: indent, withBrackets: false);
@@ -374,6 +442,10 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
     }
 
     out.write('fun ');
+    if (receiver != null) {
+      out.write(receiver);
+      out.write('.');
+    }
     out.write(f.name);
     _generateFunctionParamsAndBlock(f, blockCode, out, indent, returnType);
 

--- a/lib/src/languages/kotlin/kotlin_grammar.dart
+++ b/lib/src/languages/kotlin/kotlin_grammar.dart
@@ -73,9 +73,33 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
           }
         }
 
+        // Kotlin declares extension members one at a time (`fun Int.a()`,
+        // `val Int.b`), so they are grouped by receiver into one ASTExtension
+        // each — the same shape the Go grammar builds from receiver methods.
+        var extensionsByReceiver = <String, ASTExtension>{};
+
         for (var defList in topDef) {
           for (var def in defList) {
-            if (def is ASTFunctionDeclaration) {
+            if (def is _ExtensionMember) {
+              var extension = extensionsByReceiver.putIfAbsent(
+                def.receiverType.name,
+                () {
+                  var e = ASTExtension(
+                    '${def.receiverType.name}Ext',
+                    def.receiverType,
+                  );
+                  root.addExtension(e);
+                  return e;
+                },
+              );
+
+              var member = def.member;
+              if (member is ASTClassGetterDeclaration) {
+                extension.addGetter(member);
+              } else if (member is ASTFunctionDeclaration) {
+                extension.addFunction(member);
+              }
+            } else if (def is ASTFunctionDeclaration) {
               root.addFunction(def);
             } else if (def is ASTClassNormal) {
               root.addClass(def);
@@ -103,10 +127,89 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
 
   Parser topLevelDefinition() =>
       (enumDeclaration() |
+              extensionFunctionDeclaration() |
+              extensionPropertyDeclaration() |
               functionDeclaration() |
               classDeclaration() |
               statementVariableDeclaration())
           .plus();
+
+  /// An extension function: `fun Int.doubled(): Int { return this * 2 }`.
+  ///
+  /// Yields a receiver-tagged member; [compilationUnit] groups the members of
+  /// each receiver into a single [ASTExtension].
+  Parser extensionFunctionDeclaration() =>
+      (memberModifiers() &
+              funToken().trimHidden() &
+              type() &
+              char('.') &
+              identifier() &
+              functionParametersDeclaration() &
+              (char(':').trimHidden() & type()).optional() &
+              codeBlock())
+          .map((v) {
+            var modifiers = v[0] as ASTModifiers;
+            var receiverType = v[2] as ASTType;
+            var name = v[4] as String;
+            var parameters = v[5] as ASTFunctionParametersDeclaration;
+            var returnType = (v[6]?[1] as ASTType?) ?? ASTTypeVoid.instance;
+            var block = v[7] as ASTBlock;
+
+            // Not `static`: an extension function has a receiver (`this`).
+            return _ExtensionMember(
+              receiverType,
+              ASTClassFunctionDeclaration(
+                null,
+                name,
+                parameters,
+                returnType,
+                block: block,
+                modifiers: modifiers,
+              ),
+            );
+          });
+
+  /// An extension property (read-only): `val Int.twice: Int get() = this * 2`,
+  /// or with a block body `get() { return this * 2 }`. `var` extension
+  /// properties (with a setter) are not supported.
+  Parser extensionPropertyDeclaration() =>
+      (memberModifiers() &
+              valToken().trimHidden() &
+              type() &
+              char('.') &
+              identifier() &
+              char(':').trimHidden() &
+              type() &
+              getToken().trimHidden() &
+              char('(').trimHidden() &
+              char(')').trimHidden() &
+              (getterAssignedBody() | codeBlock()))
+          .map((v) {
+            var modifiers = v[0] as ASTModifiers;
+            var receiverType = v[2] as ASTType;
+            var name = v[4] as String;
+            var returnType = v[6] as ASTType;
+            var block = v[10] as ASTBlock;
+
+            return _ExtensionMember(
+              receiverType,
+              ASTClassGetterDeclaration(
+                null,
+                name,
+                returnType,
+                block: block,
+                modifiers: modifiers,
+              ),
+            );
+          });
+
+  /// Expression-bodied getter: `get() = <expr>` desugars to `{ return <expr> }`.
+  Parser<ASTBlock> getterAssignedBody() =>
+      (char('=').trimHidden() & ref0(expression)).map((v) {
+        var value = v[1] as ASTExpression;
+        return ASTBlock(null)
+          ..addAllStatements([ASTStatementReturnWithExpression(value)]);
+      });
 
   /// Kotlin enum class:
   /// `enum class Name[(val p: T, ...)] { A[(args)], B; members }`.
@@ -1416,4 +1519,15 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
       }
     }
   }
+}
+
+/// A parsed extension member tagged with its receiver type, produced by
+/// [KotlinGrammarDefinition.extensionFunctionDeclaration] and
+/// [KotlinGrammarDefinition.extensionPropertyDeclaration]. Kotlin has no
+/// extension *block*, so members are grouped by receiver in `compilationUnit`.
+class _ExtensionMember {
+  final ASTType receiverType;
+  final ASTNode member;
+
+  _ExtensionMember(this.receiverType, this.member);
 }

--- a/lib/src/languages/kotlin/kotlin_grammar_lexer.dart
+++ b/lib/src/languages/kotlin/kotlin_grammar_lexer.dart
@@ -45,6 +45,8 @@ abstract class KotlinGrammarLexer extends BaseGrammarLexer {
 
   // Whole-word match so identifiers like `value`/`variant` are not read as
   // `val`/`var` followed by the rest (which mangled constructor/field names).
+  Parser getToken() => _wordKeyword('get');
+
   Parser valToken() => _wordKeyword('val');
 
   Parser varToken() => _wordKeyword('var');

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -13,6 +13,7 @@ import '../../apollovm_base.dart';
 import '../../apollovm_code_storage.dart';
 import '../../apollovm_generated_output.dart';
 import '../../apollovm_generator.dart';
+import '../../apollovm_parser.dart';
 import '../../ast/apollovm_ast_base.dart';
 import '../../ast/apollovm_ast_expression.dart';
 import '../../ast/apollovm_ast_statement.dart';
@@ -61,6 +62,13 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   @override
   BytesOutput generateASTRoot(ASTRoot root, {BytesOutput? out}) {
     out ??= newOutput();
+
+    if (root.extensions.isNotEmpty) {
+      throw UnsupportedSyntaxError(
+        'Wasm compilation of extensions is not implemented: '
+        '${root.extensions.join(', ')}',
+      );
+    }
 
     out.write(Wasm.magicModuleHeader, description: "Wasm Magic");
     out.write(Wasm.moduleVersion, description: "Version 1");

--- a/lib/src/lsp/analysis/symbols.dart
+++ b/lib/src/lsp/analysis/symbols.dart
@@ -129,6 +129,45 @@ List<SymbolInfo> collectSymbols(ASTRoot root) {
     }
   }
 
+  // Extensions and their members. An unnamed extension has no symbol of its
+  // own, but its members are still listed, contained by the extended type.
+  for (final extension in root.extensions) {
+    final targetName = extension.targetType.name;
+    final container = extension.name ?? targetName;
+
+    if (extension.name != null) {
+      out.add(
+        SymbolInfo(
+          name: extension.name!,
+          category: SymbolCategory.classSym,
+          signature: 'extension ${extension.name} on $targetName',
+          typeName: targetName,
+        ),
+      );
+    }
+
+    for (final set in extension.functions) {
+      for (final m in set.functions) {
+        out.add(
+          _invocable(m, container: container, category: SymbolCategory.method),
+        );
+      }
+    }
+
+    for (final g in extension.getter) {
+      out.add(
+        SymbolInfo(
+          name: g.name,
+          category: SymbolCategory.getter,
+          container: container,
+          signature: '${_typeName(g.returnType)} get ${g.name}',
+          typeName: _typeName(g.returnType),
+          modifiers: g.modifiers.modifiers,
+        ),
+      );
+    }
+  }
+
   return out;
 }
 

--- a/lib/src/mcp/serialize/ast_json.dart
+++ b/lib/src/mcp/serialize/ast_json.dart
@@ -77,6 +77,14 @@ Map<String, Object?> astNodeToJson(
       json['classes'] = node.classesNames;
       json['functions'] = node.functions.map((f) => f.name).toList();
       json['imports'] = node.imports.map((i) => i.path).toList();
+      if (node.extensions.isNotEmpty) {
+        json['extensions'] = node.extensions
+            .map((e) => e.name ?? 'on ${e.targetType.name}')
+            .toList();
+      }
+    case ASTExtension():
+      if (node.name != null) json['name'] = node.name;
+      json['on'] = typeToJson(node.targetType);
     case ASTClassNormal():
       json['name'] = node.name;
       json['kind'] = node.kind.name;
@@ -117,7 +125,8 @@ Map<String, Object?> astNodeToJson(
     final children = <ASTNode>[
       ...node.children,
       ...switch (node) {
-        ASTRoot() => [...node.imports, ...node.classes],
+        // `ASTExtension.children` already lists its own methods and getters.
+        ASTRoot() => [...node.imports, ...node.classes, ...node.extensions],
         ASTClassNormal() => [
           ...node.fields,
           for (final set in node.constructors) ...set.functions,

--- a/lib/src/mcp/serialize/ast_json.dart
+++ b/lib/src/mcp/serialize/ast_json.dart
@@ -98,6 +98,10 @@ Map<String, Object?> astNodeToJson(
       json['constructors'] = node.constructorsNames;
     case ASTInvocableDeclaration():
       json.addAll(invocableToJson(node));
+    case ASTGetterDeclaration():
+      json['name'] = node.name;
+      json['returnType'] = typeToJson(node.returnType);
+      json['modifiers'] = modifiersToJson(node.modifiers);
     case ASTClassField():
       json['name'] = node.name;
       json['type'] = typeToJson(node.type);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 1.8.0
+version: 1.9.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/lsp/symbols_test.dart
+++ b/test/lsp/symbols_test.dart
@@ -14,6 +14,16 @@ enum Color { red, green, blue }
 int makeAge(int seed) { return seed; }
 ''';
 
+const _srcExtensions = '''
+extension NumExt on int {
+  int doubled() { return this * 2; }
+  int get twice { return this * 2; }
+}
+extension on String {
+  String shout() { return this; }
+}
+''';
+
 void main() {
   test(
     'collectSymbols captures classes, members, enum and functions',
@@ -69,5 +79,28 @@ void main() {
     );
     // Unknown name resolves to null.
     expect(unit.symbolFor('doesNotExist'), isNull);
+  });
+
+  test('collectSymbols captures extensions and their members', () async {
+    final unit = await Analyzer().analyze('file:///e.dart', _srcExtensions);
+    final byName = {
+      for (final s in unit.symbols) '${s.container}:${s.name}': s,
+    };
+
+    final ext = byName['null:NumExt']!;
+    expect(ext.category, SymbolCategory.classSym);
+    expect(ext.signature, 'extension NumExt on int');
+    expect(ext.typeName, 'int');
+
+    expect(byName['NumExt:doubled']!.category, SymbolCategory.method);
+    expect(byName['NumExt:doubled']!.signature, 'int doubled()');
+
+    expect(byName['NumExt:twice']!.category, SymbolCategory.getter);
+    expect(byName['NumExt:twice']!.signature, 'int get twice');
+
+    // An unnamed extension contributes no symbol of its own; its members are
+    // contained by the extended type.
+    expect(byName.keys.where((k) => k.endsWith(':')), isEmpty);
+    expect(byName['String:shout']!.category, SymbolCategory.method);
   });
 }

--- a/test/mcp/serialize_test.dart
+++ b/test/mcp/serialize_test.dart
@@ -60,6 +60,18 @@ Set<String> _nodeTypes(Map<String, Object?> json) {
   return types;
 }
 
+/// Every `name` in a serialized AST tree.
+Set<String> _names(Map<String, Object?> json) {
+  final names = <String>{if (json['name'] is String) json['name'] as String};
+  final children = json['children'] as List?;
+  if (children != null) {
+    for (final c in children) {
+      names.addAll(_names(c as Map<String, Object?>));
+    }
+  }
+  return names;
+}
+
 void main() {
   group('valueToJson', () {
     test('passes primitives through', () {
@@ -176,6 +188,41 @@ void main() {
       final root = await _parse(_richSource);
       final shallow = astNodeToJson(root, maxDepth: 0);
       expect(shallow.containsKey('children'), isFalse);
+    });
+
+    test('serializes extensions, their methods and getters', () async {
+      final root = await _parse('''
+        extension NumExt on int {
+          int doubled() { return this * 2; }
+          int get twice { return this * 2; }
+        }
+        extension on String { String shout() { return this; } }
+      ''');
+
+      final json = astNodeToJson(root, maxDepth: 500);
+      expect(json['extensions'], equals(['NumExt', 'on String']));
+
+      final extensions = (json['children'] as List)
+          .cast<Map<String, Object?>>()
+          .where((c) => c['node'] == 'ASTExtension')
+          .toList();
+      expect(extensions, hasLength(2));
+
+      final numExt = extensions.first;
+      expect(numExt['name'], 'NumExt');
+      expect((numExt['on'] as Map)['name'], 'int');
+
+      // The unnamed extension carries no `name`, only its extended type.
+      expect(extensions.last.containsKey('name'), isFalse);
+      expect((extensions.last['on'] as Map)['name'], 'String');
+
+      // Both the method and the getter are walked (methods sit inside an
+      // `ASTFunctionSet`, so look at the whole subtree).
+      expect(
+        _nodeTypes(numExt),
+        anyElement(startsWith('ASTClassGetterDeclaration')),
+      );
+      expect(_names(numExt), containsAll(['doubled', 'twice']));
     });
 
     test('serializes generic types recursively', () async {

--- a/test/tests_definitions/csharp_extension_method.test.xml
+++ b/test/tests_definitions/csharp_extension_method.test.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Extension methods (static class with `this` parameter)">
+    <source language="csharp">
+        <![CDATA[
+
+            static class NumExt {
+
+              public static int Doubled(this int self) {
+                return self * 2;
+              }
+
+              public static int Plus(this int self, int by) {
+                return self + by;
+              }
+
+            }
+
+            class Foo {
+
+              void test(int a) {
+                var b = a.Doubled();
+                var c = a.Plus(1);
+                print("b: " + b + " ; c: " + c);
+              }
+            }
+
+        ]]>
+    </source>
+    <call class="Foo" function="test">
+        [ 21 ]
+    </call>
+    <output>
+        ["b: 42 ; c: 22"]
+    </output>
+    <source-generated language="csharp"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  void test(int a) {
+    var b = a.Doubled();
+    var c = a.Plus(1);
+    print("b: " + b + " ; c: " + c);
+  }
+
+}
+static class NumExt {
+
+  public static int Doubled(this int self) {
+    return self * 2;
+  }
+
+  public static int Plus(this int self, int by) {
+    return self + by;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  void test(int a) {
+    var b = a.Doubled();
+    var c = a.Plus(1);
+    print('b: $b ; c: $c');
+  }
+
+}
+extension NumExt on int {
+
+  int Doubled() {
+    return this * 2;
+  }
+
+  int Plus(int by) {
+    return this + by;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="kotlin"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  fun test(a: Int) {
+    var b = a.Doubled()
+    var c = a.Plus(1)
+    print("b: " + b + " ; c: " + c)
+  }
+
+}
+public fun Int.Doubled(): Int {
+  return this * 2
+}
+
+public fun Int.Plus(by: Int): Int {
+  return this + by
+}
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/dart_extension_getter.test.xml
+++ b/test/tests_definitions/dart_extension_getter.test.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Extension getter">
+    <source language="dart">
+        <![CDATA[
+
+            extension NumExt on int {
+
+              int doubled() {
+                return this * 2;
+              }
+
+              int get twice {
+                return doubled();
+              }
+
+            }
+
+            class Foo {
+
+              void test(int a) {
+                var b = a.twice;
+                print('b: $b');
+              }
+            }
+
+        ]]>
+    </source>
+    <call class="Foo" function="test">
+        [ 21 ]
+    </call>
+    <output>
+        ["b: 42"]
+    </output>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  void test(int a) {
+    var b = a.twice;
+    print('b: $b');
+  }
+
+}
+extension NumExt on int {
+
+  int doubled() {
+    return this * 2;
+  }
+
+  int get twice {
+    return doubled();
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="kotlin"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  fun test(a: Int) {
+    var b = a.twice
+    print("b: $b")
+  }
+
+}
+fun Int.doubled(): Int {
+  return this * 2
+}
+
+val Int.twice: Int get() {
+  return doubled()
+}
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/dart_extension_method.test.xml
+++ b/test/tests_definitions/dart_extension_method.test.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Extension methods">
+    <source language="dart">
+        <![CDATA[
+
+            extension NumExt on int {
+
+              int doubled() {
+                return this * 2;
+              }
+
+              int plus(int a) {
+                return this + a;
+              }
+
+            }
+
+            class Foo {
+
+              void test(int a) {
+                var b = a.doubled();
+                var c = a.plus(1);
+                print('b: $b ; c: $c');
+              }
+            }
+
+        ]]>
+    </source>
+    <call class="Foo" function="test">
+        [ 21 ]
+    </call>
+    <output>
+        ["b: 42 ; c: 22"]
+    </output>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  void test(int a) {
+    var b = a.doubled();
+    var c = a.plus(1);
+    print('b: $b ; c: $c');
+  }
+
+}
+extension NumExt on int {
+
+  int doubled() {
+    return this * 2;
+  }
+
+  int plus(int a) {
+    return this + a;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="kotlin"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  fun test(a: Int) {
+    var b = a.doubled()
+    var c = a.plus(1)
+    print("b: $b ; c: $c")
+  }
+
+}
+fun Int.doubled(): Int {
+  return this * 2
+}
+
+fun Int.plus(a: Int): Int {
+  return this + a
+}
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="csharp"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  void test(int a) {
+    var b = a.doubled();
+    var c = a.plus(1);
+    print("b: " + b + " ; c: " + c);
+  }
+
+}
+static class NumExt {
+
+  public static int doubled(this int self) {
+    return self * 2;
+  }
+
+  public static int plus(this int self, int a) {
+    return self + a;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/dart_extension_on_class.test.xml
+++ b/test/tests_definitions/dart_extension_on_class.test.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Extension on a user class">
+    <source language="dart">
+        <![CDATA[
+
+            class Point {
+
+              int x;
+              int y;
+
+              Point(int x, int y) {
+                this.x = x;
+                this.y = y;
+              }
+
+              int sum() {
+                return this.x + this.y;
+              }
+            }
+
+            extension PointExt on Point {
+
+              int scaled(int by) {
+                return this.sum() * by;
+              }
+
+              int get doubledSum {
+                return this.scaled(2);
+              }
+
+            }
+
+            class Foo {
+
+              void test(int a) {
+                var p = Point(a, 1);
+                print('scaled: ${p.scaled(3)}');
+                print('doubledSum: ${p.doubledSum}');
+              }
+            }
+
+        ]]>
+    </source>
+    <call class="Foo" function="test">
+        [ 10 ]
+    </call>
+    <output>
+        ["scaled: 33", "doubledSum: 22"]
+    </output>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Point {
+
+  int x;
+  int y;
+
+  Point(int x, int y) {
+    this.x = x;
+    this.y = y;
+  }
+
+  int sum() {
+    return this.x + this.y;
+  }
+
+}
+class Foo {
+
+  void test(int a) {
+    var p = Point(a, 1);
+    print('scaled: ${p.scaled(3)}');
+    print('doubledSum: ${p.doubledSum}');
+  }
+
+}
+extension PointExt on Point {
+
+  int scaled(int by) {
+    return sum() * by;
+  }
+
+  int get doubledSum {
+    return scaled(2);
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="kotlin"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Point {
+
+  var x: Int
+  var y: Int
+
+  constructor(x: Int, y: Int) {
+    this.x = x
+    this.y = y
+  }
+
+  fun sum(): Int {
+    return this.x + this.y
+  }
+
+}
+class Foo {
+
+  fun test(a: Int) {
+    var p = Point(a, 1)
+    print("scaled: ${p.scaled(3)}")
+    print("doubledSum: ${p.doubledSum}")
+  }
+
+}
+fun Point.scaled(by: Int): Int {
+  return sum() * by
+}
+
+val Point.doubledSum: Int get() {
+  return scaled(2)
+}
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/dart_extension_overload.test.xml
+++ b/test/tests_definitions/dart_extension_overload.test.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Overloaded extension methods">
+    <source language="dart">
+        <![CDATA[
+
+            extension NumExt on int {
+
+              int plus(int a) {
+                return this + a;
+              }
+
+              int plus(int a, int b) {
+                return this + a + b;
+              }
+
+            }
+
+            class Foo {
+
+              void test(int a) {
+                var b = a.plus(1);
+                var c = a.plus(1, 2);
+                print('b: $b ; c: $c');
+              }
+            }
+
+        ]]>
+    </source>
+    <call class="Foo" function="test">
+        [ 10 ]
+    </call>
+    <output>
+        ["b: 11 ; c: 13"]
+    </output>
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  void test(int a) {
+    var b = a.plus(1);
+    var c = a.plus(1, 2);
+    print('b: $b ; c: $c');
+  }
+
+}
+extension NumExt on int {
+
+  int plus(int a) {
+    return this + a;
+  }
+
+  int plus(int a, int b) {
+    return (this + a) + b;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="kotlin"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  fun test(a: Int) {
+    var b = a.plus(1)
+    var c = a.plus(1, 2)
+    print("b: $b ; c: $c")
+  }
+
+}
+fun Int.plus(a: Int): Int {
+  return this + a
+}
+
+fun Int.plus(a: Int, b: Int): Int {
+  return (this + a) + b
+}
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="csharp"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  void test(int a) {
+    var b = a.plus(1);
+    var c = a.plus(1, 2);
+    print("b: " + b + " ; c: " + c);
+  }
+
+}
+static class NumExt {
+
+  public static int plus(this int self, int a) {
+    return self + a;
+  }
+
+  public static int plus(this int self, int a, int b) {
+    return (self + a) + b;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/kotlin_extension_method.test.xml
+++ b/test/tests_definitions/kotlin_extension_method.test.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Extension function and property">
+    <source language="kotlin">
+        <![CDATA[
+
+            fun Int.doubled(): Int {
+              return this * 2
+            }
+
+            val Int.twice: Int get() = this * 2
+
+            class Foo {
+
+              fun test(a: Int) {
+                var b = a.doubled()
+                var c = a.twice
+                println("b: $b ; c: $c")
+              }
+            }
+
+        ]]>
+    </source>
+    <call class="Foo" function="test">
+        [ 21 ]
+    </call>
+    <output>
+        ["b: 42 ; c: 42"]
+    </output>
+    <source-generated language="kotlin"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  fun test(a: Int) {
+    var b = a.doubled()
+    var c = a.twice
+    print("b: $b ; c: $c")
+  }
+
+}
+fun Int.doubled(): Int {
+  return this * 2
+}
+
+val Int.twice: Int get() {
+  return this * 2
+}
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Foo {
+
+  void test(int a) {
+    var b = a.doubled();
+    var c = a.twice;
+    print('b: $b ; c: $c');
+  }
+
+}
+extension intExt on int {
+
+  int doubled() {
+    return this * 2;
+  }
+
+  int get twice {
+    return this * 2;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/unit/apollovm_extension_test.dart
+++ b/test/unit/apollovm_extension_test.dart
@@ -1,0 +1,247 @@
+@Tags(['dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+Future<ApolloVM> _load(String src, {String language = 'dart'}) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit(language, src, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load $language source");
+  return vm;
+}
+
+/// Runs the top-level `run()` of [src] and returns its value.
+Future<Object?> _run(String src) async {
+  var vm = await _load(src);
+  var res = await vm.createRunner('dart')!.executeFunction('', 'run');
+  return res.getValueNoContext();
+}
+
+/// Parses [src] and returns its resolved [ASTRoot].
+Future<ASTRoot> _parseRoot(String src, {String language = 'dart'}) async {
+  var vm = ApolloVM();
+  var result = await vm
+      .getParser<String>(language)!
+      .parse(SourceCodeUnit(language, src, id: 'test'));
+  expect(result.isOK, isTrue, reason: 'should parse: ${result.errorMessage}');
+  return result.root!;
+}
+
+void main() {
+  group('ASTExtension resolution', () {
+    test('binds members to the extended core class', () async {
+      var root = await _parseRoot(
+        'extension NumExt on int { int doubled() { return this * 2; } }',
+      );
+
+      var extension = root.extensions.single;
+      expect(extension.name, equals('NumExt'));
+
+      var targetClass = extension.targetClass;
+      expect(targetClass, isNotNull);
+      expect(targetClass!.name, equals('int'));
+      expect(extension.matchesReceiver(targetClass), isTrue);
+
+      // Dispatch relies on each member's `clazz` pointing at the extended
+      // class, so `objectCall` binds `this` to the receiver.
+      var doubled = extension.functions.single.functions.single;
+      expect(doubled, isA<ASTClassFunctionDeclaration>());
+      expect(
+        identical((doubled as ASTClassFunctionDeclaration).clazz, targetClass),
+        isTrue,
+      );
+    });
+
+    test('binds members to the extended user class', () async {
+      var root = await _parseRoot('''
+        class Point { int x; Point(int x) { this.x = x; } }
+        extension PointExt on Point { int twiceX() { return this.x * 2; } }
+      ''');
+
+      var extension = root.extensions.single;
+      expect(identical(extension.targetClass, root.getClass('Point')), isTrue);
+    });
+
+    test('an unknown extended type resolves to no class', () async {
+      var root = await _parseRoot(
+        'extension E on Missing { int m() { return 1; } }',
+      );
+      expect(root.extensions.single.targetClass, isNull);
+    });
+
+    test(
+      'a named extension is an exported symbol; an unnamed one is not',
+      () async {
+        var named = await _parseRoot(
+          'extension NumExt on int { int m() { return 1; } }',
+        );
+        expect(named.exportedSymbolNames, contains('NumExt'));
+
+        var unnamed = await _parseRoot(
+          'extension on int { int m() { return 1; } }',
+        );
+        expect(unnamed.extensions.single.name, isNull);
+        expect(unnamed.exportedSymbolNames, isEmpty);
+      },
+    );
+
+    test(
+      'two modules extending `int` do not pollute the shared core class',
+      () async {
+        var a = await _parseRoot(
+          'extension A on int { int m() { return 1; } }',
+        );
+        var b = await _parseRoot(
+          'extension B on int { int m() { return 2; } }',
+        );
+
+        // Both resolve to the same `CoreClassInt` singleton, but neither injected
+        // `m` into it: the core class knows no member named `m`.
+        var classA = a.extensions.single.targetClass!;
+        var classB = b.extensions.single.targetClass!;
+        expect(identical(classA, classB), isTrue);
+        expect(classA.getFunctionWithName('m'), isNull);
+      },
+    );
+  });
+
+  group('Extension dispatch', () {
+    test('method on a primitive receiver', () async {
+      expect(
+        await _run(
+          'extension NumExt on int { int doubled() { return this * 2; } }\n'
+          'int run() { var a = 21; return a.doubled(); }',
+        ),
+        equals(42),
+      );
+    });
+
+    test('method on a String receiver', () async {
+      expect(
+        await _run(
+          "extension StrExt on String { String twice() { return this + this; } }\n"
+          "String run() { var s = 'ab'; return s.twice(); }",
+        ),
+        equals('abab'),
+      );
+    });
+
+    test('getter on a primitive receiver', () async {
+      expect(
+        await _run(
+          'extension NumExt on int { int get twice { return this * 2; } }\n'
+          'int run() { var a = 21; return a.twice; }',
+        ),
+        equals(42),
+      );
+    });
+
+    test('method on a user class instance', () async {
+      expect(
+        await _run('''
+          class Point { int x; Point(int x) { this.x = x; } }
+          extension PointExt on Point { int twiceX() { return this.x * 2; } }
+          int run() { var p = Point(21); return p.twiceX(); }
+        '''),
+        equals(42),
+      );
+    });
+
+    test('overload resolution picks by signature', () async {
+      expect(
+        await _run('''
+          extension NumExt on int {
+            int plus(int a) { return this + a; }
+            int plus(int a, int b) { return this + a + b; }
+          }
+          int run() { var a = 10; return a.plus(1) + a.plus(1, 2); }
+        '''),
+        equals(11 + 13),
+      );
+    });
+
+    test(
+      'a class member wins over an extension member of the same name',
+      () async {
+        expect(
+          await _run('''
+          class Point { int x; Point(int x) { this.x = x; } int get v { return 1; } }
+          extension PointExt on Point { int get v { return 2; } }
+          int run() { var p = Point(0); return p.v; }
+        '''),
+          equals(1),
+        );
+      },
+    );
+
+    test(
+      'an extension member can call another, qualified and unqualified',
+      () async {
+        expect(
+          await _run('''
+          extension NumExt on int {
+            int doubled() { return this * 2; }
+            int quad() { return this.doubled() * 2; }
+            int get octo { return quad() * 2; }
+          }
+          int run() { var a = 2; return a.octo; }
+        '''),
+          equals(16),
+        );
+      },
+    );
+
+    test(
+      'an unknown member of a core type still reports the original error',
+      () async {
+        expect(
+          () => _run(
+            'extension NumExt on int { int doubled() { return this * 2; } }\n'
+            'int run() { var a = 1; return a.nope(); }',
+          ),
+          throwsA(isA<StateError>()),
+        );
+      },
+    );
+
+    test('an extension does not apply to an unrelated receiver', () async {
+      expect(
+        () => _run(
+          'extension NumExt on int { int doubled() { return this * 2; } }\n'
+          "int run() { var s = 'a'; return s.doubled(); }",
+        ),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+
+  group('Extension code generation', () {
+    test('a language without extensions rejects them', () async {
+      var vm = await _load(
+        'extension NumExt on int { int doubled() { return this * 2; } }',
+      );
+
+      for (var language in ['java11', 'javascript', 'python', 'go', 'lua']) {
+        expect(
+          () => vm.generateAllCodeIn(language).writeAllSources(),
+          throwsA(isA<UnsupportedSyntaxError>()),
+          reason: '$language should not silently emit an extension',
+        );
+      }
+    });
+
+    test(
+      'C# rejects an extension getter (it has no extension property)',
+      () async {
+        var vm = await _load(
+          'extension NumExt on int { int get twice { return this * 2; } }',
+        );
+        expect(
+          () => vm.generateAllCodeIn('csharp').writeAllSources(),
+          throwsA(isA<UnsupportedSyntaxError>()),
+        );
+      },
+    );
+  });
+}

--- a/test/unit/apollovm_extension_test.dart
+++ b/test/unit/apollovm_extension_test.dart
@@ -2,6 +2,7 @@
 library;
 
 import 'package:apollovm/apollovm.dart';
+import 'package:apollovm/src/apollovm_code_storage.dart';
 import 'package:test/test.dart';
 
 Future<ApolloVM> _load(String src, {String language = 'dart'}) async {
@@ -214,6 +215,51 @@ void main() {
         throwsA(isA<StateError>()),
       );
     });
+
+    test(
+      'a call no extension overload accepts reports the original error',
+      () async {
+        // The sole `plus(int)` declaration rejects a `String` argument, so the
+        // receiver's own class-lookup error surfaces instead.
+        expect(
+          () => _run(
+            'extension NumExt on int { int plus(int a) { return this + a; } }\n'
+            "int run() { var a = 1; return a.plus('x'); }",
+          ),
+          throwsA(isA<StateError>()),
+        );
+      },
+    );
+
+    test(
+      'getter on a receiver whose core class throws on unknown getters',
+      () async {
+        // `CoreClassList.getGetter` throws (rather than returning null) for an
+        // unknown getter; the extension must still be found.
+        expect(
+          await _run('''
+          extension ListExt on List {
+            int get doubledLength { return this.length * 2; }
+          }
+          int run() { var l = [1, 2, 3]; return l.doubledLength; }
+        '''),
+          equals(6),
+        );
+      },
+    );
+
+    test(
+      'an unknown getter on such a receiver reports the original error',
+      () async {
+        expect(
+          () => _run(
+            'extension ListExt on List { int get doubledLength { return 1; } }\n'
+            'int run() { var l = [1]; return l.nope; }',
+          ),
+          throwsA(isA<StateError>()),
+        );
+      },
+    );
   });
 
   group('Extension code generation', () {
@@ -231,6 +277,58 @@ void main() {
       }
     });
 
+    test('Wasm rejects an extension', () async {
+      var vm = await _load(
+        'extension NumExt on int { int doubled() { return this * 2; } }',
+      );
+      expect(
+        () => vm.generateAllIn<BytesOutput>('wasm'),
+        throwsA(isA<UnsupportedSyntaxError>()),
+      );
+    });
+
+    test('a language without getters rejects a class getter', () async {
+      var vm = await _load('class C { int get x { return 1; } }');
+      expect(
+        () => vm.generateAllCodeIn('java11').writeAllSources(),
+        throwsA(isA<UnsupportedSyntaxError>()),
+      );
+    });
+
+    test('an unnamed extension round-trips and is named for C#', () async {
+      var vm = await _load(
+        'extension on int { int doubled() { return this * 2; } }',
+      );
+
+      var dart = (await vm.generateAllCodeIn('dart').writeAllSources())
+          .toString();
+      expect(dart, contains('extension on int {'));
+
+      var kotlin = (await vm.generateAllCodeIn('kotlin').writeAllSources())
+          .toString();
+      expect(kotlin, contains('fun Int.doubled(): Int {'));
+
+      // C# needs a class name; one is synthesized from the extended type.
+      var csharp = (await vm.generateAllCodeIn('csharp').writeAllSources())
+          .toString();
+      expect(csharp, contains('static class intExtension {'));
+      expect(csharp, contains('public static int doubled(this int self) {'));
+    });
+
+    test('generateASTNode dispatches an ASTExtension', () async {
+      var root = await _parseRoot(
+        'extension NumExt on int { int doubled() { return this * 2; } }',
+      );
+      var generator = ApolloVM().createCodeGenerator(
+        'dart',
+        ApolloSourceCodeStorageMemory(),
+      )!;
+
+      // No `out` buffer: the generator must create one.
+      var code = generator.generateASTNode(root.extensions.single).toString();
+      expect(code, startsWith('extension NumExt on int {'));
+    });
+
     test(
       'C# rejects an extension getter (it has no extension property)',
       () async {
@@ -241,6 +339,85 @@ void main() {
           () => vm.generateAllCodeIn('csharp').writeAllSources(),
           throwsA(isA<UnsupportedSyntaxError>()),
         );
+      },
+    );
+  });
+
+  group('C# extension class', () {
+    Future<ParseResult<String>> parseCSharp(String src) => ApolloVM()
+        .getParser<String>('csharp')!
+        .parse(SourceCodeUnit('csharp', src, id: 'test'));
+
+    // A malformed extension aborts the parse (as `modifiers()` already does for
+    // duplicated modifiers) rather than silently falling back to a plain class.
+    test('a `this` parameter requires a `static` class', () async {
+      expect(
+        () => parseCSharp('''
+          class NumExt {
+            public static int Doubled(this int self) { return self * 2; }
+          }
+        '''),
+        throwsA(
+          isA<SyntaxError>().having(
+            (e) => e.toString(),
+            'message',
+            contains('must be `static`'),
+          ),
+        ),
+      );
+    });
+
+    test('one static class may not extend several types', () async {
+      expect(
+        () => parseCSharp('''
+          static class Ext {
+            public static int Doubled(this int self) { return self * 2; }
+            public static string Shout(this string self) { return self; }
+          }
+        '''),
+        throwsA(
+          isA<SyntaxError>().having(
+            (e) => e.toString(),
+            'message',
+            contains('extends multiple types'),
+          ),
+        ),
+      );
+    });
+
+    test('a plain static class is still a class, not an extension', () async {
+      var result = await parseCSharp('''
+        static class Util {
+          public static int Twice(int a) { return a * 2; }
+        }
+      ''');
+      expect(result.isOK, isTrue, reason: result.errorMessage);
+      expect(result.root!.extensions, isEmpty);
+      expect(result.root!.classesNames, equals(['Util']));
+    });
+
+    test(
+      'a local named `self` outside an extension is a normal variable',
+      () async {
+        var vm = await _load('''
+        static class Ext {
+          public static int Doubled(this int self) { return self * 2; }
+        }
+        class Foo {
+          int test(int a) { var self = a; return self + 1; }
+        }
+      ''', language: 'csharp');
+
+        var res = await vm
+            .createRunner('csharp')!
+            .executeClassMethod(
+              '',
+              'Foo',
+              'test',
+              positionalParameters: [41],
+              classInstanceFields: const {},
+            );
+        expect(res.getValueNoContext(), equals(42));
       },
     );
   });


### PR DESCRIPTION
## Summary

Adds a shared `ASTExtension` node so members can be declared for an existing type from outside its declaration, in the three supported languages that have a native extension construct:

| Language | Syntax |
|---|---|
| Dart | `extension NumExt on int { int doubled() {...} int get twice {...} }` (name optional) |
| Kotlin | top-level `fun Int.doubled(): Int {...}` and `val Int.twice: Int get() = ...` |
| C# | `static class NumExt { public static int Doubled(this int self) {...} }` |

Extensions apply to core types (`int`, `String`, …) as well as user classes, support overloads, and may call one another (`this.doubled()` or plain `doubled()`). A class member always wins over an extension member. Extensions are module-local — they are not carried across `import`.

Java, JavaScript, TypeScript, Python, Go and Lua have no equivalent construct (prototype patching, monkey patching and metatables are not the same thing), so generating an extension for them throws `UnsupportedSyntaxError` rather than emitting a shim that would mean something else. C# has no extension *property*, so an extension declaring a getter cannot be emitted as C#; its methods round-trip, with `this`/`self` translated both ways.

## Design

An extension is deliberately **not** an `ASTClass`, and its members are never injected into the target class. `ASTType.setClass` throws when re-set, and the core classes (`CoreClassInt`, `CoreClassString`, …) are process-wide singletons — injecting there would leak `int.doubled` into every other module. Instead extensions are registered on the declaring `ASTRoot` and consulted only as a *fallback* when the receiver's own member lookup misses, which gives class-member precedence for free.

The runtime needed almost no new machinery: binding each member's `clazz` to the *extended* class lets the existing `objectCall` build a `VMClassContext` and bind `this` to the receiver, including a primitive one.

## Supporting changes

- Dart now parses **instance getters** (`int get x { ... }` / `=> ...`) in class bodies too. `ASTClassGetterDeclaration` and its dispatch path already existed, but no grammar reached it.
- **Fix**: expressions interpolated into a string (`'${a.doubled()}'`) were never linked into the AST `parentNode` chain — `ASTExpressionLiteral.resolveNode` and the string-value nodes set their own parent but never descended. Anything resolved through that chain was unreachable from inside an interpolation.
- `this.method()` desugars to a *local* invocation in Dart and C#, so the fallback also hooks that path. This additionally makes unqualified calls between extension members work.
- Extensions surface in LSP document symbols and in the MCP AST serialization; Go's `generateASTRoot` override and the Wasm generator now reject them explicitly instead of silently dropping them.

## Testing

`dart analyze` clean, `dart format` clean, **1596 tests pass** (22 new, up from 1574):

- 6 cross-language fixtures in `test/tests_definitions/` that parse, run, **and** round-trip translate (e.g. C# `self` ⇄ Dart `this`): extension methods, extension getter, extension on a user class, overloads, plus Kotlin- and C#-sourced variants.
- 16 unit tests in `test/unit/apollovm_extension_test.dart` covering target-class resolution, dispatch precedence, overload matching, core-singleton isolation across modules, and the unsupported-language rejections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)