### PR TITLE
Improve coverage; core-library, Java 11 and Go fixes it surfaced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+## 1.9.1
+
+### Core-library and generator fixes found by a coverage pass
+
+Line coverage of `lib/` went from 83.4% to 84.6%. The tests written to get there
+surfaced three real defects:
+
+- **`String.length`, `String.isEmpty`, `String.isNotEmpty` and `int`/`double`
+  `sign` only worked when *called*** (`s.length()`), not when read as the
+  properties they are in Dart, Kotlin and C# (`s.length`). `List` and `Map`
+  already exposed theirs correctly. They are now getters as well as methods, so
+  Java-style `s.length()` keeps working.
+- **The Java 11 grammar crashed on the diamond form of a collection literal.**
+  `new HashMap<>(){{ put("a", 1); }}` — which the Java generator itself emits —
+  handed the `'>'` character to a cast expecting an `ASTType` and threw a raw
+  `TypeError`. A separate typo made the map literal's diamond alternative match
+  `<<` instead of `<>`. A Dart map literal now round-trips through Java.
+- **`ApolloGenerator` carried ~140 lines of dead dispatch** (`generateASTNode`,
+  `generateASTRoot`, `generateASTType`, `generateASTStatement`,
+  `generateASTBranch`, `generateASTExpression`, `generateASTValue`), shadowed by
+  every subclass and already drifting from them — the base `generateASTRoot`
+  never learned to emit extensions. The dispatchers are now abstract or removed.
+
+New tests: the core runtime library (`dart:math`, and every `String`, `int`,
+`double`, `List` and `Map` member), and a generator matrix asserting that a
+program exercising most AST node kinds generates in all nine languages and that
+the generated source parses back.
+
+Known gaps this pass documented but did not fix: several grammars parse only a
+subset of what their own generator emits (Lua has no `for`/`while` rule and
+emits `+` for string concatenation; Python cannot parse the lambda it generates;
+Go has no `&T{}` composite literal, so it cannot read back the constructor
+factory it emits). See `test/unit/apollovm_generator_matrix_test.dart`.
+
 ## 1.9.0
 
 ### Extensions — add methods and getters to an existing type

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## 1.9.1
 
-### Core-library and generator fixes found by a coverage pass
+### Core-library, Go and generator fixes found by a coverage pass
 
-Line coverage of `lib/` went from 83.4% to 84.6%. The tests written to get there
-surfaced three real defects:
+Line coverage of `lib/` went from 83.4% to 84.7%. The tests written to get there
+surfaced six real defects:
 
 - **`String.length`, `String.isEmpty`, `String.isNotEmpty` and `int`/`double`
   `sign` only worked when *called*** (`s.length()`), not when read as the
@@ -21,16 +21,34 @@ surfaced three real defects:
   every subclass and already drifting from them — the base `generateASTRoot`
   never learned to emit extensions. The dispatchers are now abstract or removed.
 
+**Go constructors did not work at all.** Three defects compounded:
+
+- The grammar had no `&T{}` composite literal, so *any* Go source containing a
+  `func NewFoo() *Foo { o := &Foo{} ... }` factory — the shape the Go generator
+  itself emits — failed to parse. `&T{}` (the zero-valued form) now parses as
+  the struct's no-argument constructor.
+- A `NewFoo(...)` call site resolved to a top-level function that no longer
+  existed, because the declaration had already been folded into the struct's
+  constructor. It now resolves to the constructor, and inside a factory the
+  local `o` binds to the instance under construction.
+- The generator emitted `p := Point(a, 1)`, which is not Go. Instantiation now
+  emits the factory call `NewPoint(a, 1)`, and every struct gets a factory so
+  the call always resolves.
+
+**The Go generator rewrote a shadowing parameter as a field.**
+`Point(int x) { this.x = x; }` generated `o.x = o.x`, silently assigning the
+field to itself. A parameter now shadows a same-named field.
+
 New tests: the core runtime library (`dart:math`, and every `String`, `int`,
-`double`, `List` and `Map` member), and a generator matrix asserting that a
-program exercising most AST node kinds generates in all nine languages and that
-the generated source parses back.
+`double`, `List` and `Map` member); Go constructors end-to-end; and a generator
+matrix asserting that a program exercising most AST node kinds generates in all
+nine languages and that the generated source parses back.
 
 Known gaps this pass documented but did not fix: several grammars parse only a
 subset of what their own generator emits (Lua has no `for`/`while` rule and
-emits `+` for string concatenation; Python cannot parse the lambda it generates;
-Go has no `&T{}` composite literal, so it cannot read back the constructor
-factory it emits). See `test/unit/apollovm_generator_matrix_test.dart`.
+emits `+` for string concatenation and `s.m()` for method calls; Python cannot
+parse the lambda it generates; JS/TS cannot parse the map literal they
+generate). See `test/unit/apollovm_generator_matrix_test.dart`.
 
 ## 1.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,54 +1,81 @@
 ## 1.9.1
 
-### Core-library, Go and generator fixes found by a coverage pass
+### Core-library, Java 11 and Go fixes found by a coverage pass
 
-Line coverage of `lib/` went from 83.4% to 84.7%. The tests written to get there
-surfaced six real defects:
+Line coverage of `lib/` went from 83.4% to 84.7%. The number is the least
+interesting part: writing the tests surfaced seven real defects, all fixed here.
 
-- **`String.length`, `String.isEmpty`, `String.isNotEmpty` and `int`/`double`
-  `sign` only worked when *called*** (`s.length()`), not when read as the
-  properties they are in Dart, Kotlin and C# (`s.length`). `List` and `Map`
-  already exposed theirs correctly. They are now getters as well as methods, so
+#### Core library
+
+- **`String.length`, `String.isEmpty`, `String.isNotEmpty` and the `sign` of
+  `int`/`double` only worked when *called*.** `s.length()` worked and `s.length`
+  threw — the opposite of how Dart, Kotlin and C# source reads. `List` and `Map`
+  already exposed theirs as getters. They are now getters *and* methods, so
   Java-style `s.length()` keeps working.
-- **The Java 11 grammar crashed on the diamond form of a collection literal.**
-  `new HashMap<>(){{ put("a", 1); }}` — which the Java generator itself emits —
-  handed the `'>'` character to a cast expecting an `ASTType` and threw a raw
-  `TypeError`. A separate typo made the map literal's diamond alternative match
-  `<<` instead of `<>`. A Dart map literal now round-trips through Java.
+
+#### Java 11
+
+- **The grammar crashed on the diamond form of a collection literal.**
+  `new HashMap<>(){{ put("a", 1); }}` — exactly what the Java generator emits for
+  a Dart map literal — handed the `'>'` character to a cast expecting an
+  `ASTType` and threw a raw `TypeError`. A separate typo made the map literal's
+  diamond alternative match `<<` instead of `<>`. Generic type arguments are now
+  picked out by type rather than by position, in all four list/map literal rules.
+  A Dart map literal now round-trips through Java.
+
+#### Go — constructors did not work at all, in either direction
+
+- **The grammar had no `&T{}` composite literal**, so *any* Go source containing
+  a `func NewFoo() *Foo { o := &Foo{} ... }` factory — the exact shape the Go
+  generator emits — failed to parse. The zero-valued form now parses as the
+  struct's no-argument constructor. Field-initializing literals (`&Foo{x: 1}`)
+  remain unsupported.
+- **A `NewFoo(...)` call site resolved to a top-level function that no longer
+  existed**, since the declaration had already been folded into the struct's
+  constructor. It now resolves to the constructor.
+- **Inside a factory, `o` was a plain local**, so `o.x = x` failed with "Can't
+  find variable: 'o'". It is now bound as the receiver before the body parses,
+  which the factory-to-constructor conversion already assumed.
+- **The generator rewrote a shadowing parameter as a field.**
+  `Point(int x) { this.x = x; }` emitted `o.x = o.x`, silently assigning the
+  field to itself. A parameter now shadows a same-named field.
+- **The generator emitted `p := Point(a, 1)`, which is not Go.** Instantiation
+  now emits the factory call `p := NewPoint(a, 1)`, and every struct gets a
+  factory (a field-less struct used to get none) so the call always resolves.
+  This is the only change to the expected output of the `go_*.test.xml`
+  fixtures.
+
+Dart -> Go -> parse -> run now works end to end.
+
+#### Cleanup
+
 - **`ApolloGenerator` carried ~140 lines of dead dispatch** (`generateASTNode`,
   `generateASTRoot`, `generateASTType`, `generateASTStatement`,
-  `generateASTBranch`, `generateASTExpression`, `generateASTValue`), shadowed by
-  every subclass and already drifting from them — the base `generateASTRoot`
-  never learned to emit extensions. The dispatchers are now abstract or removed.
+  `generateASTBranch`, `generateASTExpression`, `generateASTValue`). Every one
+  was shadowed by both subclasses, and they had already drifted: the base
+  `generateASTRoot` never learned to emit extensions, so a future third
+  generator would have silently dropped them. They are now abstract, or removed
+  where nothing dispatches through the base.
 
-**Go constructors did not work at all.** Three defects compounded:
+#### Tests
 
-- The grammar had no `&T{}` composite literal, so *any* Go source containing a
-  `func NewFoo() *Foo { o := &Foo{} ... }` factory — the shape the Go generator
-  itself emits — failed to parse. `&T{}` (the zero-valued form) now parses as
-  the struct's no-argument constructor.
-- A `NewFoo(...)` call site resolved to a top-level function that no longer
-  existed, because the declaration had already been folded into the struct's
-  constructor. It now resolves to the constructor, and inside a factory the
-  local `o` binds to the instance under construction.
-- The generator emitted `p := Point(a, 1)`, which is not Go. Instantiation now
-  emits the factory call `NewPoint(a, 1)`, and every struct gets a factory so
-  the call always resolves.
+- The core runtime library: `dart:math`, and every `String`, `int`, `double`,
+  `List` and `Map` member, in both getter and method form where both exist.
+- Go constructors: the factory and its composite literal, running a factory, the
+  shadowing fix, and a full Dart -> Go -> parse -> run round-trip.
+- A generator matrix asserting that a program exercising most AST node kinds
+  generates in all nine languages and that the generated source parses back.
+  This is what found the Java 11 and Go defects.
 
-**The Go generator rewrote a shadowing parameter as a field.**
-`Point(int x) { this.x = x; }` generated `o.x = o.x`, silently assigning the
-field to itself. A parameter now shadows a same-named field.
+#### Known gaps, documented but not fixed
 
-New tests: the core runtime library (`dart:math`, and every `String`, `int`,
-`double`, `List` and `Map` member); Go constructors end-to-end; and a generator
-matrix asserting that a program exercising most AST node kinds generates in all
-nine languages and that the generated source parses back.
-
-Known gaps this pass documented but did not fix: several grammars parse only a
-subset of what their own generator emits (Lua has no `for`/`while` rule and
-emits `+` for string concatenation and `s.m()` for method calls; Python cannot
-parse the lambda it generates; JS/TS cannot parse the map literal they
-generate). See `test/unit/apollovm_generator_matrix_test.dart`.
+Several grammars parse only a subset of what their own generator emits: the Lua
+generator emits `a + b` for string concatenation and `s.m()` for method calls,
+where Lua wants `a .. b` and `s:m()` (Lua classes are already marked unsupported
+in the README matrix, so that generator is outside the stated contract); Python
+cannot parse the lambda it generates; JS and TS cannot parse the map literal
+they generate. Each is listed in
+`test/unit/apollovm_generator_matrix_test.dart`.
 
 ## 1.9.0
 

--- a/README.md
+++ b/README.md
@@ -147,8 +147,10 @@ Generics are `🚫` for JS/Lua/Python: no static type syntax to parameterize. &n
 methods `func (o *Name) m(...)` (the same idiom Lua uses for tables). &nbsp;
 ⁸ Go struct types can't carry inline field initializers, so initializers are moved into the
 generated `NewName` factory. &nbsp;
-⁹ Go constructors/instantiation use a `func NewName(...) *Name` factory (and `Name(...)`
-call sites), since Go has no `new`. &nbsp;
+⁹ Go constructors/instantiation use a `func NewName(...) *Name` factory (built around the
+zero-valued composite literal `&Name{}`), and call sites read `NewName(...)`, since Go has
+no `new`. Every struct gets a factory, so instantiation always resolves. Only the empty-brace
+composite literal is parsed; field-initializing literals (`&Name{x: 1}`) are not. &nbsp;
 ¹⁰ Go has no `static`/visibility keywords: static methods become package-level `func`s and
 visibility follows identifier capitalization. Inheritance, rich enums and generics
 (Go embedding/`iota`/`[T any]`) are `🚧` — not implemented for Go yet. &nbsp;

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '1.9.0';
+  static final String VERSION = '1.9.1';
 
   static int _idCount = 0;
 

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -26,7 +26,8 @@ abstract class ApolloCodeGenerator
   @override
   StringBuffer newOutput() => StringBuffer();
 
-  @override
+  /// Emits any [ASTNode]. Declared here rather than on [ApolloGenerator]:
+  /// only a source-code generator can render an arbitrary node standalone.
   StringBuffer generateASTNode(
     ASTNode node, {
     StringBuffer? out,
@@ -367,7 +368,7 @@ abstract class ApolloCodeGenerator
     );
   }
 
-  @override
+  /// Emits a type, dispatching on its array rank.
   StringBuffer generateASTType(
     ASTType type, {
     StringBuffer? out,

--- a/lib/src/apollovm_generator.dart
+++ b/lib/src/apollovm_generator.dart
@@ -3,7 +3,6 @@
 // Please refer to the LICENSE and AUTHORS files for details.
 
 import 'apollovm_code_storage.dart';
-import 'ast/apollovm_ast_base.dart';
 import 'ast/apollovm_ast_expression.dart';
 import 'ast/apollovm_ast_statement.dart';
 import 'ast/apollovm_ast_toplevel.dart';
@@ -32,43 +31,7 @@ abstract class ApolloGenerator<
 
   O newOutput();
 
-  O generateASTNode(ASTNode node, {O? out}) {
-    if (node is ASTValue) {
-      return generateASTValue(node, out: out);
-    } else if (node is ASTExpression) {
-      return generateASTExpression(node, out: out);
-    } else if (node is ASTRoot) {
-      return generateASTRoot(node, out: out);
-    } else if (node is ASTStatementImport) {
-      return generateASTStatementImport(node, out: out);
-    } else if (node is ASTClassNormal) {
-      return generateASTClass(node, out: out);
-    } else if (node is ASTSingleLineStatementBlock) {
-      return generateASTSingleLineStatementBlock(node, out: out);
-    } else if (node is ASTBlock) {
-      return generateASTBlock(node, out: out);
-    } else if (node is ASTStatement) {
-      return generateASTStatement(node, out: out);
-    } else if (node is ASTClassFunctionDeclaration) {
-      return generateASTClassFunctionDeclaration(node, out: out);
-    } else if (node is ASTFunctionDeclaration) {
-      return generateASTFunctionDeclaration(node, out: out);
-    }
-
-    throw UnsupportedError("Can't handle ASTNode: $node");
-  }
-
-  O generateASTRoot(ASTRoot root, {O? out}) {
-    out ??= newOutput();
-
-    generateASTBlock(root, out: out);
-
-    for (var clazz in root.classes) {
-      generateASTClass(clazz, out: out);
-    }
-
-    return out;
-  }
+  O generateASTRoot(ASTRoot root, {O? out});
 
   O generateASTBlock(ASTBlock block, {O? out});
 
@@ -110,18 +73,6 @@ abstract class ApolloGenerator<
     O? out,
   });
 
-  O generateASTType(ASTType type, {O? out}) {
-    if (type is ASTTypeArray) {
-      return generateASTTypeArray(type, out: out);
-    } else if (type is ASTTypeArray2D) {
-      return generateASTTypeArray2D(type, out: out);
-    } else if (type is ASTTypeArray3D) {
-      return generateASTTypeArray3D(type, out: out);
-    }
-
-    return generateASTTypeDefault(type, out: out);
-  }
-
   O generateASTTypeArray(ASTTypeArray type, {O? out});
 
   O generateASTTypeArray2D(ASTTypeArray2D type, {O? out});
@@ -136,49 +87,9 @@ abstract class ApolloGenerator<
 
   O generateASTTypeDefault(ASTType type, {O? out});
 
-  O generateASTStatement(ASTStatement statement, {O? out}) {
-    if (statement is ASTStatementExpression) {
-      return generateASTStatementExpression(statement, out: out);
-    } else if (statement is ASTStatementVariableDeclaration) {
-      return generateASTStatementVariableDeclaration(statement, out: out);
-    } else if (statement is ASTBranch) {
-      return generateASTBranch(statement, out: out);
-    } else if (statement is ASTStatementForLoop) {
-      return generateASTStatementForLoop(statement, out: out);
-    } else if (statement is ASTStatementForEach) {
-      return generateASTStatementForEach(statement, out: out);
-    } else if (statement is ASTStatementWhileLoop) {
-      return generateASTStatementWhileLoop(statement, out: out);
-    } else if (statement is ASTStatementBlock) {
-      return generateASTStatementBlock(statement, out: out);
-    } else if (statement is ASTStatementFunctionDeclaration) {
-      return generateASTStatementFunctionDeclaration(statement, out: out);
-    } else if (statement is ASTStatementReturnNull) {
-      return generateASTStatementReturnNull(statement, out: out);
-    } else if (statement is ASTStatementReturnValue) {
-      return generateASTStatementReturnValue(statement, out: out);
-    } else if (statement is ASTStatementReturnVariable) {
-      return generateASTStatementReturnVariable(statement, out: out);
-    } else if (statement is ASTStatementReturnWithExpression) {
-      return generateASTStatementReturnWithExpression(statement, out: out);
-    } else if (statement is ASTStatementReturn) {
-      return generateASTStatementReturn(statement, out: out);
-    }
+  O generateASTStatement(ASTStatement statement, {O? out});
 
-    throw UnsupportedError("Can't handle statement: $statement");
-  }
-
-  O generateASTBranch(ASTBranch branch, {O? out}) {
-    if (branch is ASTBranchIfBlock) {
-      return generateASTBranchIfBlock(branch, out: out);
-    } else if (branch is ASTBranchIfElseBlock) {
-      return generateASTBranchIfElseBlock(branch, out: out);
-    } else if (branch is ASTBranchIfElseIfsElseBlock) {
-      return generateASTBranchIfElseIfsElseBlock(branch, out: out);
-    }
-
-    throw UnsupportedError("Can't handle branch: $branch");
-  }
+  O generateASTBranch(ASTBranch branch, {O? out});
 
   O generateASTStatementForLoop(ASTStatementForLoop forLoop, {O? out});
 
@@ -243,45 +154,7 @@ abstract class ApolloGenerator<
     O? out,
   });
 
-  O generateASTExpression(ASTExpression expression, {O? out}) {
-    if (expression is ASTExpressionNullValue) {
-      return generateASTExpressionNullValue(expression, out: out);
-    } else if (expression is ASTExpressionVariableAccess) {
-      return generateASTExpressionVariableAccess(expression, out: out);
-    } else if (expression is ASTExpressionVariableAssignment) {
-      return generateASTExpressionVariableAssignment(expression, out: out);
-    } else if (expression is ASTExpressionVariableEntryAssignment) {
-      return generateASTExpressionVariableEntryAssignment(expression, out: out);
-    } else if (expression is ASTExpressionVariableEntryAccess) {
-      return generateASTExpressionVariableEntryAccess(expression, out: out);
-    } else if (expression is ASTExpressionLiteral) {
-      return generateASTExpressionLiteral(expression, out: out);
-    } else if (expression is ASTExpressionListLiteral) {
-      return generateASTExpressionListLiteral(expression, out: out);
-    } else if (expression is ASTExpressionMapLiteral) {
-      return generateASTExpressionMapLiteral(expression, out: out);
-    } else if (expression is ASTExpressionNegation) {
-      return generateASTExpressionNegation(expression, out: out);
-    } else if (expression is ASTExpressionNegative) {
-      return generateASTExpressionNegative(expression, out: out);
-    } else if (expression is ASTExpressionAwait) {
-      return generateASTExpressionAwait(expression, out: out);
-    } else if (expression is ASTExpressionLocalFunctionInvocation) {
-      return generateASTExpressionLocalFunctionInvocation(expression, out: out);
-    } else if (expression is ASTExpressionObjectFunctionInvocation) {
-      return generateASTExpressionFunctionInvocation(expression, out: out);
-    } else if (expression is ASTExpressionGroupFunctionInvocation) {
-      return generateASTExpressionGroupFunctionInvocation(expression, out: out);
-    } else if (expression is ASTExpressionOperation) {
-      return generateASTExpressionOperation(expression, out: out);
-    } else if (expression is ASTExpressionConditional) {
-      return generateASTExpressionConditional(expression, out: out);
-    } else if (expression is ASTExpressionLiteralFunction) {
-      return generateASTExpressionLiteralFunction(expression, out: out);
-    }
-
-    throw UnsupportedError("Can't generate expression: $expression");
-  }
+  O generateASTExpression(ASTExpression expression, {O? out});
 
   O generateASTExpressionOperation(ASTExpressionOperation expression, {O? out});
 
@@ -383,37 +256,7 @@ abstract class ApolloGenerator<
     O? out,
   });
 
-  O generateASTValue(ASTValue value, {O? out}) {
-    if (value is ASTValueString) {
-      return generateASTValueString(value, out: out);
-    } else if (value is ASTValueInt) {
-      return generateASTValueInt(value, out: out);
-    } else if (value is ASTValueDouble) {
-      return generateASTValueDouble(value, out: out);
-    } else if (value is ASTValueNull) {
-      return generateASTValueNull(value, out: out);
-    } else if (value is ASTValueVar) {
-      return generateASTValueVar(value, out: out);
-    } else if (value is ASTValueObject) {
-      return generateASTValueObject(value, out: out);
-    } else if (value is ASTValueStatic) {
-      return generateASTValueStatic(value, out: out);
-    } else if (value is ASTValueStringVariable) {
-      return generateASTValueStringVariable(value, out: out);
-    } else if (value is ASTValueStringConcatenation) {
-      return generateASTValueStringConcatenation(value, out: out);
-    } else if (value is ASTValueStringExpression) {
-      return generateASTValueStringExpression(value, out: out);
-    } else if (value is ASTValueArray) {
-      return generateASTValueArray(value, out: out);
-    } else if (value is ASTValueArray2D) {
-      return generateASTValueArray2D(value, out: out);
-    } else if (value is ASTValueArray3D) {
-      return generateASTValueArray3D(value, out: out);
-    }
-
-    throw UnsupportedError("Can't generate value: $value");
-  }
+  O generateASTValue(ASTValue value, {O? out});
 
   O generateASTValueStringConcatenation(
     ASTValueStringConcatenation value, {

--- a/lib/src/core/apollovm_core_base.dart
+++ b/lib/src/core/apollovm_core_base.dart
@@ -410,6 +410,12 @@ class CoreClassString extends CoreClassPrimitive<String> {
   late final ASTExternalClassFunction _functionIsEmpty;
   late final ASTExternalClassFunction _functionIsNotEmpty;
 
+  // `length`/`isEmpty`/`isNotEmpty` are properties in Dart/Kotlin/C# and
+  // methods in Java (`s.length()`), so they are exposed both ways.
+  late final ASTExternalClassGetter _getterLength;
+  late final ASTExternalClassGetter _getterIsEmpty;
+  late final ASTExternalClassGetter _getterIsNotEmpty;
+
   late final ASTExternalClassFunction _functionSubstring;
   late final ASTExternalClassFunction _functionIndexOf;
   late final ASTExternalClassFunction _functionStartsWith;
@@ -474,6 +480,24 @@ class CoreClassString extends CoreClassPrimitive<String> {
       'isNotEmpty',
       ASTTypeBool.instance,
       (String o) => o.isNotEmpty,
+    );
+
+    _getterLength = _externalClassGetter(
+      'length',
+      ASTTypeInt.instance,
+      (Object? o) => o is String ? o.length : null,
+    );
+
+    _getterIsEmpty = _externalClassGetter(
+      'isEmpty',
+      ASTTypeBool.instance,
+      (Object? o) => o is String ? o.isEmpty : null,
+    );
+
+    _getterIsNotEmpty = _externalClassGetter(
+      'isNotEmpty',
+      ASTTypeBool.instance,
+      (Object? o) => o is String ? o.isNotEmpty : null,
     );
 
     _functionSubstring = _externalClassFunctionArgs2(
@@ -644,6 +668,24 @@ class CoreClassString extends CoreClassPrimitive<String> {
   }
 
   @override
+  ASTGetterDeclaration? getGetter(
+    String fName,
+    VMContext context, {
+    bool caseInsensitive = false,
+  }) {
+    switch (fName) {
+      case 'length':
+        return _getterLength;
+      case 'isEmpty':
+        return _getterIsEmpty;
+      case 'isNotEmpty':
+        return _getterIsNotEmpty;
+    }
+
+    throw StateError("Can't find core getter: $coreName.$fName");
+  }
+
+  @override
   ASTFunctionDeclaration? getFunction(
     String fName,
     ASTFunctionSignature parametersSignature,
@@ -734,6 +776,9 @@ class CoreClassInt extends CoreClassPrimitive<int> {
   late final ASTExternalClassFunction _functionClamp;
   late final ASTExternalClassFunction _functionRemainder;
   late final ASTExternalClassFunction _functionToRadixString;
+
+  /// `sign` is a property in Dart; also kept as a method for Java-style calls.
+  late final ASTExternalClassGetter _getterSign;
   late final ASTExternalClassFunction _functionToDouble;
 
   CoreClassInt._() : super(ASTTypeInt.instance, 'int') {
@@ -783,6 +828,12 @@ class CoreClassInt extends CoreClassPrimitive<int> {
       (int self) => self.sign,
     );
 
+    _getterSign = _externalClassGetter(
+      'sign',
+      ASTTypeInt.instance,
+      (Object? o) => o is int ? o.sign : null,
+    );
+
     _functionClamp = _externalClassFunctionArgs2(
       'clamp',
       ASTTypeInt.instance,
@@ -810,6 +861,20 @@ class CoreClassInt extends CoreClassPrimitive<int> {
       ASTTypeDouble.instance,
       (int self) => self.toDouble(),
     );
+  }
+
+  @override
+  ASTGetterDeclaration? getGetter(
+    String fName,
+    VMContext context, {
+    bool caseInsensitive = false,
+  }) {
+    switch (fName) {
+      case 'sign':
+        return _getterSign;
+    }
+
+    throw StateError("Can't find core getter: $coreName.$fName");
   }
 
   @override
@@ -872,6 +937,9 @@ class CoreClassDouble extends CoreClassPrimitive<double> {
   late final ASTExternalClassFunction _functionClamp;
   late final ASTExternalClassFunction _functionRemainder;
   late final ASTExternalClassFunction _functionToStringAsFixed;
+
+  /// `sign` is a property in Dart; also kept as a method for Java-style calls.
+  late final ASTExternalClassGetter _getterSign;
   late final ASTExternalClassFunction _functionToStringAsExponential;
   late final ASTExternalClassFunction _functionToStringAsPrecision;
   late final ASTExternalClassFunction _functionToInt;
@@ -939,6 +1007,12 @@ class CoreClassDouble extends CoreClassPrimitive<double> {
       'sign',
       ASTTypeDouble.instance,
       (double self) => self.sign,
+    );
+
+    _getterSign = _externalClassGetter(
+      'sign',
+      ASTTypeDouble.instance,
+      (Object? o) => o is double ? o.sign : null,
     );
 
     _functionClamp = _externalClassFunctionArgs2(
@@ -1036,6 +1110,20 @@ class CoreClassDouble extends CoreClassPrimitive<double> {
       ASTTypeInt.instance,
       (double self) => self.truncate(),
     );
+  }
+
+  @override
+  ASTGetterDeclaration? getGetter(
+    String fName,
+    VMContext context, {
+    bool caseInsensitive = false,
+  }) {
+    switch (fName) {
+      case 'sign':
+        return _getterSign;
+    }
+
+    throw StateError("Can't find core getter: $coreName.$fName");
   }
 
   @override

--- a/lib/src/languages/go/go_generator.dart
+++ b/lib/src/languages/go/go_generator.dart
@@ -31,6 +31,29 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
   /// Method names of the struct currently being generated (for `o.method()`).
   Set<String> _currentClassMethods = const {};
 
+  /// Names of every struct (class) in the program being generated. Go has no
+  /// `new`, so instantiating `Point(...)` is emitted as its factory
+  /// `NewPoint(...)`.
+  Set<String> _programStructNames = const {};
+
+  /// Parameter names of the member currently being generated. A parameter
+  /// shadows a same-named field, so `Point(int x) { this.x = x; }` must emit
+  /// `o.x = x`, not `o.x = o.x`.
+  Set<String> _currentMemberParameters = const {};
+
+  /// Generates [f]'s body with its parameters registered as shadowing names.
+  StringBuffer _generateMemberBlock(ASTInvocableDeclaration f, String indent) {
+    var previous = _currentMemberParameters;
+    _currentMemberParameters = f.parameters.allParameters
+        .map((p) => p.name)
+        .toSet();
+    try {
+      return generateASTBlock(f, indent: indent, withBrackets: false);
+    } finally {
+      _currentMemberParameters = previous;
+    }
+  }
+
   /// Name of the struct currently being generated (for the receiver type).
   String? _currentClassName;
 
@@ -77,6 +100,8 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     bool withBrackets = true,
   }) {
     out ??= newOutput();
+
+    _programStructNames = root.classes.map((c) => c.name).toSet();
 
     out.write('package main\n\n');
 
@@ -169,13 +194,15 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     var fieldInits = fields.whereType<ASTClassFieldWithInitialValue>().toList();
     var constructors = clazz.constructors.toList();
 
+    // Every struct gets a factory, so `Point(...)` always has a `NewPoint(...)`
+    // to call — see [generateASTExpressionLocalFunctionInvocation].
     if (constructors.isNotEmpty) {
       for (var c in constructors) {
         for (var ctor in c.functions) {
           _generateConstructor(ctor, name, fieldInits, out, indent);
         }
       }
-    } else if (fieldInits.isNotEmpty) {
+    } else {
       _generateDefaultConstructor(name, fieldInits, out, indent);
     }
 
@@ -189,6 +216,7 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     _currentClassName = null;
     _currentClassFields = const {};
     _currentClassMethods = const {};
+    _currentMemberParameters = const {};
 
     return out;
   }
@@ -199,7 +227,7 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     StringBuffer out,
     String indent,
   ) {
-    var blockCode = generateASTBlock(f, indent: indent, withBrackets: false);
+    var blockCode = _generateMemberBlock(f, indent);
 
     out.write('func (');
     out.write(_receiver);
@@ -226,7 +254,7 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     StringBuffer out,
     String indent,
   ) {
-    var blockCode = generateASTBlock(ctor, indent: indent, withBrackets: false);
+    var blockCode = _generateMemberBlock(ctor, indent);
 
     out.write('func New');
     out.write(className);
@@ -998,6 +1026,27 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
       return out;
     }
 
+    // Instantiating a struct calls its factory: `Point(...)` -> `NewPoint(...)`.
+    if (_programStructNames.contains(expression.name)) {
+      out ??= newOutput();
+      if (headIndented) out.write(indent);
+      out.write('New');
+      out.write(expression.name);
+      out.write('(');
+      var arguments = expression.arguments;
+      for (var i = 0; i < arguments.length; ++i) {
+        if (i > 0) out.write(', ');
+        generateASTExpression(
+          arguments[i],
+          out: out,
+          indent: '$indent  ',
+          headIndented: false,
+        );
+      }
+      out.write(')');
+      return out;
+    }
+
     // Sibling-method calls inside a struct method become `o.method(...)`.
     if (_currentClassMethods.contains(expression.name)) {
       out ??= newOutput();
@@ -1035,9 +1084,11 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     String indent = '',
     bool headIndented = true,
   }) {
-    // Field reads inside a struct method become `o.field`.
+    // Field reads inside a struct method become `o.field`, unless a parameter
+    // of the same name shadows the field.
     if (!variable.isTypeIdentifier &&
-        _currentClassFields.contains(variable.name)) {
+        _currentClassFields.contains(variable.name) &&
+        !_currentMemberParameters.contains(variable.name)) {
       out ??= newOutput();
       if (headIndented) out.write(indent);
       out.write('$_receiver.');

--- a/lib/src/languages/go/go_grammar.dart
+++ b/lib/src/languages/go/go_grammar.dart
@@ -69,6 +69,16 @@ class GoGrammarDefinition extends GoGrammarLexer {
   /// `_classTypeParameters`), cleared afterwards.
   String? _currentReceiver;
 
+  /// Struct names declared so far in the compilation unit. Go's own generated
+  /// code always declares a struct before its factory and before any use, so
+  /// tracking them as they are parsed is enough to recognize `&Name{}` and to
+  /// map a `NewName(...)` call onto the struct's constructor.
+  final Set<String> _structNames = <String>{};
+
+  /// The local name the Go generator gives the instance under construction in a
+  /// factory: `o := &Foo{}`.
+  static const String _constructorReceiverName = 'o';
+
   @override
   Parser start() => ref0(compilationUnit).trim().end();
 
@@ -155,6 +165,15 @@ class GoGrammarDefinition extends GoGrammarLexer {
             return root;
           });
 
+  /// `NewFoo` names the factory constructor of the struct `Foo`; the shared AST
+  /// invokes a constructor by its class name, so the call site is rewritten.
+  /// Returns `null` when [name] is an ordinary function.
+  String? _structConstructorName(String name) {
+    if (!name.startsWith('New') || name.length <= 3) return null;
+    var owner = name.substring(3);
+    return _structNames.contains(owner) ? owner : null;
+  }
+
   /// A top-level function is a constructor when it is named `New<Struct>` and
   /// `<Struct>` is a declared struct.
   static String? _constructorOwner(
@@ -176,9 +195,14 @@ class GoGrammarDefinition extends GoGrammarLexer {
   ) {
     var statements = f.statements.toList();
     statements.removeWhere((s) {
-      if (s is ASTStatementVariableDeclaration && s.name == 'o') return true;
-      if (s is ASTStatementReturnVariable && s.variable.name == 'o') {
+      if (s is ASTStatementVariableDeclaration &&
+          s.name == _constructorReceiverName) {
         return true;
+      }
+      // `return o` parses as `return this`, since `o` is bound as the receiver.
+      if (s is ASTStatementReturnVariable) {
+        var v = s.variable;
+        return v is ASTThisVariable || v.name == _constructorReceiverName;
       }
       return false;
     });
@@ -262,6 +286,7 @@ class GoGrammarDefinition extends GoGrammarLexer {
           .map((v) {
             var name = v[1] as String;
             var fields = (v[4] as List).cast<ASTClassField>().toList();
+            _structNames.add(name);
             return _StructDecl(name, fields);
           });
 
@@ -313,7 +338,16 @@ class GoGrammarDefinition extends GoGrammarLexer {
   /// `func name(params) ret { body }` — a top-level function.
   Parser<ASTFunctionDeclaration> functionDeclaration() =>
       (funcToken().trimHidden() &
-              identifier() &
+              identifier().map((name) {
+                // Inside a `func NewFoo(...) *Foo` factory the local `o` of the
+                // `o := &Foo{}` scaffolding *is* the instance under
+                // construction, so bind it as the receiver before the body
+                // parses. `_toConstructor` strips the scaffolding afterwards.
+                _currentReceiver = _structConstructorName(name) != null
+                    ? _constructorReceiverName
+                    : null;
+                return name;
+              }) &
               functionParametersDeclaration() &
               type().optional() &
               codeBlock())
@@ -322,6 +356,7 @@ class GoGrammarDefinition extends GoGrammarLexer {
             var parameters = v[2] as ASTFunctionParametersDeclaration;
             var returnType = (v[3] as ASTType?) ?? ASTTypeVoid.instance;
             var block = v[4] as ASTBlock;
+            _currentReceiver = null;
             return ASTFunctionDeclaration(
               name,
               parameters,
@@ -721,6 +756,7 @@ class GoGrammarDefinition extends GoGrammarLexer {
               expressionVariableDirectOperation() |
               expressionObjectFieldAssignment() |
               expressionVariableAssigment() |
+              expressionStructLiteral() |
               expressionFunctionInvocation() |
               expressionObjectEntryFunctionInvocation() |
               expressionVariableEntryAccess() |
@@ -787,6 +823,22 @@ class GoGrammarDefinition extends GoGrammarLexer {
         (v) => v[1] as ASTExpression,
       );
 
+  /// The zero-valued composite literal of a declared struct: `&Foo{}`.
+  ///
+  /// Go has no `new`; this is how an instance is created, and it is what the Go
+  /// generator emits inside a `func NewFoo() *Foo` factory. It maps to the
+  /// struct's no-argument constructor. Only the empty-brace form is supported;
+  /// field-initializing literals (`&Foo{x: 1}`) are not.
+  Parser<ASTExpression> expressionStructLiteral() =>
+      (char('&').trimHidden() &
+              identifier() &
+              char('{').trimHidden() &
+              char('}').trimHidden())
+          .map((v) {
+            var name = v[1] as String;
+            return ASTExpressionLocalFunctionInvocation(name, []);
+          });
+
   Parser<ASTExpressionGroupFunctionInvocation>
   expressionGroupFunctionInvocation() =>
       (ref0(expressionGroup) &
@@ -850,7 +902,9 @@ class GoGrammarDefinition extends GoGrammarLexer {
               );
             }
 
-            var name = normalizeFunctionName(rawName);
+            var name =
+                _structConstructorName(rawName) ??
+                normalizeFunctionName(rawName);
 
             if (obj != null && obj != 'this' && obj != _currentReceiver) {
               var variable = ASTScopeVariable(obj);

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -925,6 +925,17 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
             );
           });
 
+  /// The [index]th declared type argument of a matched generic clause.
+  ///
+  /// The clause is either `<K, V>` (types present) or the diamond `<>` (only
+  /// the two angle-bracket characters), so the types are picked out by type
+  /// rather than by position.
+  static ASTType _genericTypeAt(Object? genericsMatch, int index) {
+    if (genericsMatch is! List) return ASTTypeDynamic.instance;
+    var types = genericsMatch.whereType<ASTType>().toList();
+    return index < types.length ? types[index] : ASTTypeDynamic.instance;
+  }
+
   Parser<ASTExpressionListLiteral> expressionListEmptyLiteral() =>
       (string('new').trimHidden() &
               string('ArrayList').trimHidden() &
@@ -935,7 +946,7 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
               char('(').trimHidden() &
               char(')').trimHidden())
           .map((v) {
-            var type = (v[2]?[1] as ASTType?) ?? ASTTypeDynamic.instance;
+            var type = _genericTypeAt(v[2], 0);
             return ASTExpressionListLiteral(type, []);
           });
 
@@ -960,7 +971,7 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
                   .star() &
               string('}}').trimHidden())
           .map((v) {
-            var type = (v[2]?[1] as ASTType?) ?? ASTTypeDynamic.instance;
+            var type = _genericTypeAt(v[2], 0);
             var v0 = (v[6] as List).whereType<ASTExpression>().first;
             var tail =
                 (v[7] as List?)
@@ -984,8 +995,8 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
               char('(').trimHidden() &
               char(')').trimHidden())
           .map((v) {
-            var keyType = (v[2]?[1] as ASTType?) ?? ASTTypeDynamic.instance;
-            var valueType = (v[2]?[3] as ASTType?) ?? ASTTypeDynamic.instance;
+            var keyType = _genericTypeAt(v[2], 0);
+            var valueType = _genericTypeAt(v[2], 1);
             return ASTExpressionMapLiteral(keyType, valueType, []);
           });
 
@@ -997,7 +1008,7 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
                       char(',').trimHidden() &
                       simpleType() &
                       char('>').trimHidden()) |
-                  (char('<').trimHidden() & char('<').trimHidden())) &
+                  (char('<').trimHidden() & char('>').trimHidden())) &
               char('(').trimHidden() &
               char(')').trimHidden() &
               string('{{').trimHidden() &
@@ -1016,8 +1027,8 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
                   .star() &
               string('}}').trimHidden())
           .map((v) {
-            var keyType = (v[2]?[1] as ASTType?) ?? ASTTypeDynamic.instance;
-            var valueType = (v[2]?[3] as ASTType?) ?? ASTTypeDynamic.instance;
+            var keyType = _genericTypeAt(v[2], 0);
+            var valueType = _genericTypeAt(v[2], 1);
             var entry0 = (v[6] as List).whereType<ASTExpression>().toList();
             var entriesTail = (v[7] as List?)
                 ?.whereType<List>()

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 1.9.0
+version: 1.9.1
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/tests_definitions/go_basic_class_function.test.xml
+++ b/test/tests_definitions/go_basic_class_function.test.xml
@@ -30,6 +30,11 @@ import "fmt"
 type Calc struct {
 }
 
+func NewCalc() *Calc {
+  o := &Calc{}
+  return o
+}
+
 func (o *Calc) sum(title string, a int, b int) int {
   total := a + b
   msg := "sum " + title + " = " + total

--- a/test/tests_definitions/go_basic_for_loop.test.xml
+++ b/test/tests_definitions/go_basic_for_loop.test.xml
@@ -29,6 +29,11 @@ package main
 type C struct {
 }
 
+func NewC() *C {
+  o := &C{}
+  return o
+}
+
 func (o *C) run(n int) int {
   total := 0
   for i := 0; i < n; i = i + 1 {

--- a/test/tests_definitions/go_basic_foreach.test.xml
+++ b/test/tests_definitions/go_basic_foreach.test.xml
@@ -30,6 +30,11 @@ package main
 type C struct {
 }
 
+func NewC() *C {
+  o := &C{}
+  return o
+}
+
 func (o *C) run() int {
   xs := []int{2, 4, 6}
   total := 0

--- a/test/tests_definitions/go_bitwise.test.xml
+++ b/test/tests_definitions/go_bitwise.test.xml
@@ -25,6 +25,11 @@ package main
 type C struct {
 }
 
+func NewC() *C {
+  o := &C{}
+  return o
+}
+
 func (o *C) run(a int, b int) int {
   return (((a & b) | (a ^ b)) + (a << 1)) + (a >> 1)
 }

--- a/test/tests_definitions/go_control_flow.test.xml
+++ b/test/tests_definitions/go_control_flow.test.xml
@@ -51,6 +51,11 @@ package main
 type C struct {
 }
 
+func NewC() *C {
+  o := &C{}
+  return o
+}
+
 func (o *C) run() int {
   sum := 0
   i := 0

--- a/test/tests_definitions/go_lambda_input.test.xml
+++ b/test/tests_definitions/go_lambda_input.test.xml
@@ -28,6 +28,11 @@ package main
 type C struct {
 }
 
+func NewC() *C {
+  o := &C{}
+  return o
+}
+
 func (o *C) run(a int) int {
   triple := func(x int) int {
     return x * 3

--- a/test/unit/apollovm_core_library_test.dart
+++ b/test/unit/apollovm_core_library_test.dart
@@ -1,0 +1,268 @@
+@Tags(['dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Runs the top-level `run()` of [body] and returns its value.
+///
+/// [body] is the *body* of `run()`, so each case reads as the expression under
+/// test rather than as a whole program.
+Future<Object?> _run(String body, {bool math = false}) async {
+  var src = 'dynamic run() { $body }';
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', src, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source: $src");
+
+  var runner = vm.createRunner('dart', importCorePackageMath: math)!;
+  var value = await runner.executeFunction('', 'run');
+  return value.getValueNoContext();
+}
+
+void main() {
+  group('dart:math package', () {
+    test('pow, sqrt, exp and log', () async {
+      expect(await _run('return pow(2, 10);', math: true), equals(1024));
+      expect(await _run('return sqrt(16);', math: true), equals(4.0));
+      expect(await _run('return exp(0);', math: true), equals(1.0));
+      expect(await _run('return log(1);', math: true), equals(0.0));
+    });
+
+    test('trigonometric functions', () async {
+      expect(await _run('return sin(0);', math: true), equals(0.0));
+      expect(await _run('return cos(0);', math: true), equals(1.0));
+      expect(await _run('return tan(0);', math: true), equals(0.0));
+      expect(await _run('return asin(0);', math: true), equals(0.0));
+      expect(await _run('return atan(0);', math: true), equals(0.0));
+      expect(await _run('return atan2(0, 1);', math: true), equals(0.0));
+
+      // acos(1) == 0, avoiding a float literal comparison for acos(0) == pi/2.
+      expect(await _run('return acos(1);', math: true), equals(0.0));
+    });
+
+    test('abs, min and max', () async {
+      expect(await _run('return abs(-3);', math: true), equals(3));
+      expect(await _run('return min(2, 7);', math: true), equals(2));
+      expect(await _run('return max(2, 7);', math: true), equals(7));
+    });
+
+    test('an unknown math function is an error', () async {
+      expect(
+        () => _run('return nope(1);', math: true),
+        throwsA(isA<ApolloVMRuntimeError>()),
+      );
+    });
+  });
+
+  group('core String', () {
+    test('length, isEmpty and isNotEmpty as getters', () async {
+      expect(await _run("var s = 'abc'; return s.length;"), equals(3));
+      expect(await _run("var s = ''; return s.isEmpty;"), isTrue);
+      expect(await _run("var s = 'a'; return s.isNotEmpty;"), isTrue);
+    });
+
+    test('length, isEmpty and isNotEmpty as methods', () async {
+      // Java-style `s.length()` must keep working alongside the getter form.
+      expect(await _run("var s = 'abc'; return s.length();"), equals(3));
+      expect(await _run("var s = ''; return s.isEmpty();"), isTrue);
+      expect(await _run("var s = 'a'; return s.isNotEmpty();"), isTrue);
+    });
+
+    test('case conversion and contains', () async {
+      expect(await _run("var s = 'aB'; return s.toUpperCase();"), equals('AB'));
+      expect(await _run("var s = 'aB'; return s.toLowerCase();"), equals('ab'));
+      expect(await _run("var s = 'abc'; return s.contains('b');"), isTrue);
+    });
+
+    test('substring, indexOf, lastIndexOf and codeUnitAt', () async {
+      expect(await _run("var s = 'abcd'; return s.substring(1, 3);"), 'bc');
+      expect(await _run("var s = 'aba'; return s.indexOf('a');"), equals(0));
+      expect(
+        await _run("var s = 'aba'; return s.lastIndexOf('a');"),
+        equals(2),
+      );
+      expect(await _run("var s = 'A'; return s.codeUnitAt(0);"), equals(65));
+    });
+
+    test('startsWith and endsWith', () async {
+      expect(await _run("var s = 'abc'; return s.startsWith('ab');"), isTrue);
+      expect(await _run("var s = 'abc'; return s.endsWith('bc');"), isTrue);
+    });
+
+    test('trim, trimLeft and trimRight', () async {
+      expect(await _run("var s = ' a '; return s.trim();"), equals('a'));
+      expect(await _run("var s = ' a '; return s.trimLeft();"), equals('a '));
+      expect(await _run("var s = ' a '; return s.trimRight();"), equals(' a'));
+    });
+
+    test('split, replaceAll and replaceFirst', () async {
+      expect(await _run("var s = 'a,b'; return s.split(',');"), ['a', 'b']);
+      expect(await _run("var s = 'aa'; return s.replaceAll('a', 'b');"), 'bb');
+      expect(
+        await _run("var s = 'aa'; return s.replaceFirst('a', 'b');"),
+        'ba',
+      );
+    });
+
+    test('toString', () async {
+      expect(await _run("var s = 'a'; return s.toString();"), equals('a'));
+    });
+
+    test('an unknown String member is an error', () async {
+      expect(
+        () => _run("var s = 'a'; return s.nope();"),
+        throwsA(isA<Error>()),
+      );
+      expect(() => _run("var s = 'a'; return s.nope;"), throwsA(isA<Error>()));
+    });
+  });
+
+  group('core int', () {
+    test('parse, tryParse and valueOf', () async {
+      expect(await _run("return int.parse('42');"), equals(42));
+      expect(await _run("return int.tryParse('42');"), equals(42));
+      expect(await _run("return int.tryParse('x');"), isNull);
+    });
+
+    test('sign as a getter and as a method', () async {
+      expect(await _run('var a = -5; return a.sign;'), equals(-1));
+      expect(await _run('var a = -5; return a.sign();'), equals(-1));
+    });
+
+    test('abs, compareTo and remainder', () async {
+      expect(await _run('var a = -5; return a.abs();'), equals(5));
+      expect(await _run('var a = 1; return a.compareTo(2);'), equals(-1));
+      expect(await _run('var a = 10; return a.remainder(3);'), equals(1));
+    });
+
+    test('clamp, toRadixString and toDouble', () async {
+      expect(await _run('var a = 10; return a.clamp(1, 5);'), equals(5));
+      expect(await _run('var a = 255; return a.toRadixString(16);'), 'ff');
+      expect(await _run('var a = 3; return a.toDouble();'), equals(3.0));
+    });
+
+    test('toString', () async {
+      expect(await _run('var a = 7; return a.toString();'), equals('7'));
+    });
+
+    test('an unknown int member is an error', () async {
+      expect(() => _run('var a = 1; return a.nope();'), throwsA(isA<Error>()));
+      expect(() => _run('var a = 1; return a.nope;'), throwsA(isA<Error>()));
+    });
+  });
+
+  group('core double', () {
+    test('parse, tryParse and valueOf', () async {
+      expect(await _run("return double.parse('1.5');"), equals(1.5));
+      expect(await _run("return double.tryParse('1.5');"), equals(1.5));
+      expect(await _run("return double.tryParse('x');"), isNull);
+    });
+
+    test('sign as a getter and as a method', () async {
+      expect(await _run('var d = -1.5; return d.sign;'), equals(-1.0));
+      expect(await _run('var d = -1.5; return d.sign();'), equals(-1.0));
+    });
+
+    test('abs, compareTo and remainder', () async {
+      expect(await _run('var d = -1.5; return d.abs();'), equals(1.5));
+      expect(await _run('var d = 1.0; return d.compareTo(2.0);'), equals(-1));
+      expect(await _run('var d = 5.5; return d.remainder(2.0);'), equals(1.5));
+    });
+
+    test('rounding: round, floor, ceil, truncate and toInt', () async {
+      expect(await _run('var d = 2.6; return d.round();'), equals(3));
+      expect(await _run('var d = 2.6; return d.floor();'), equals(2));
+      expect(await _run('var d = 2.1; return d.ceil();'), equals(3));
+      expect(await _run('var d = 2.9; return d.truncate();'), equals(2));
+      expect(await _run('var d = 2.9; return d.toInt();'), equals(2));
+    });
+
+    test('string formatting', () async {
+      expect(await _run('var d = 1.5; return d.toStringAsFixed(2);'), '1.50');
+      expect(
+        await _run('var d = 1.23456; return d.toStringAsPrecision(3);'),
+        equals('1.23'),
+      );
+      expect(
+        await _run('var d = 1000.0; return d.toStringAsExponential(1);'),
+        equals('1.0e+3'),
+      );
+    });
+
+    test('clamp and toString', () async {
+      expect(await _run('var d = 9.0; return d.clamp(1.0, 5.0);'), equals(5.0));
+      expect(await _run('var d = 1.5; return d.toString();'), equals('1.5'));
+    });
+  });
+
+  group('core List', () {
+    test('length, isEmpty, isNotEmpty, first and last as getters', () async {
+      expect(await _run('var l = [1, 2]; return l.length;'), equals(2));
+      expect(await _run('var l = []; return l.isEmpty;'), isTrue);
+      expect(await _run('var l = [1]; return l.isNotEmpty;'), isTrue);
+      expect(await _run('var l = [7, 8]; return l.first;'), equals(7));
+      expect(await _run('var l = [7, 8]; return l.last;'), equals(8));
+    });
+
+    test('add, addAll and insert', () async {
+      expect(await _run('var l = [1]; l.add(2); return l;'), [1, 2]);
+      expect(await _run('var l = [1]; l.addAll([2, 3]); return l;'), [1, 2, 3]);
+      expect(await _run('var l = [1, 3]; l.insert(1, 2); return l;'), [
+        1,
+        2,
+        3,
+      ]);
+    });
+
+    test('remove, removeAt and clear', () async {
+      expect(await _run('var l = [1, 2]; return l.remove(2);'), isTrue);
+      expect(await _run('var l = [1, 2]; l.removeAt(0); return l;'), [2]);
+      expect(await _run('var l = [1, 2]; l.clear(); return l;'), isEmpty);
+    });
+
+    test('contains, indexOf and sublist', () async {
+      expect(await _run('var l = [1, 2]; return l.contains(2);'), isTrue);
+      expect(await _run('var l = [1, 2]; return l.indexOf(2);'), equals(1));
+      expect(await _run('var l = [1, 2, 3]; return l.sublist(1);'), [2, 3]);
+      expect(await _run('var l = [1, 2, 3]; return l.sublist(0, 2);'), [1, 2]);
+    });
+
+    test('an unknown List member is an error', () async {
+      expect(() => _run('var l = []; return l.nope();'), throwsA(isA<Error>()));
+      expect(() => _run('var l = []; return l.nope;'), throwsA(isA<Error>()));
+    });
+  });
+
+  group('core Map', () {
+    test('length, isEmpty and isNotEmpty as getters', () async {
+      expect(await _run("var m = {'a': 1}; return m.length;"), equals(1));
+      expect(await _run('var m = {}; return m.isEmpty;'), isTrue);
+      expect(await _run("var m = {'a': 1}; return m.isNotEmpty;"), isTrue);
+    });
+
+    test('keys and values as getters', () async {
+      expect(await _run("var m = {'a': 1}; return m.keys;"), ['a']);
+      expect(await _run("var m = {'a': 1}; return m.values;"), [1]);
+    });
+
+    test('containsKey, remove and clear', () async {
+      expect(
+        await _run("var m = {'a': 1}; return m.containsKey('a');"),
+        isTrue,
+      );
+      expect(
+        await _run("var m = {'a': 1}; m.remove('a'); return m.length;"),
+        0,
+      );
+      expect(
+        await _run("var m = {'a': 1}; m.clear(); return m.isEmpty;"),
+        true,
+      );
+    });
+
+    test('an unknown Map member is an error', () async {
+      expect(() => _run('var m = {}; return m.nope();'), throwsA(isA<Error>()));
+      expect(() => _run('var m = {}; return m.nope;'), throwsA(isA<Error>()));
+    });
+  });
+}

--- a/test/unit/apollovm_generator_matrix_test.dart
+++ b/test/unit/apollovm_generator_matrix_test.dart
@@ -70,12 +70,12 @@ class Calc {
 ///    and Go no `for` loop.
 ///  - Python cannot parse the lambda it generates; JS and TS cannot parse the
 ///    map literal they generate.
-///  - A class with a field makes Go emit a `func NewC() *C { o := &C{} … }`
-///    factory, and the Go grammar has no `&T{}` composite literal.
 ///  - The Lua generator emits `a + b` for string concatenation and `s.m()` for
 ///    a method call, where Lua wants `a .. b` and `s:m()`.
 const _roundTripSource = r'''
 class Calc {
+
+  int base = 10;
 
   int branches(int a) {
     if (a > 10) { return 1; } else if (a > 5) { return 2; } else { return 3; }

--- a/test/unit/apollovm_generator_matrix_test.dart
+++ b/test/unit/apollovm_generator_matrix_test.dart
@@ -1,0 +1,193 @@
+@Tags(['dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Every source language ApolloVM can both parse and generate.
+const _languages = [
+  'dart',
+  'java11',
+  'javascript',
+  'typescript',
+  'kotlin',
+  'csharp',
+  'python',
+  'go',
+  'lua',
+];
+
+/// A program exercising a wide spread of AST node kinds: fields, loops of every
+/// shape, branches, the ternary, unary and bitwise operators, string
+/// interpolation, collection literals and a lambda.
+const _richSource = r'''
+class Calc {
+
+  int base = 10;
+
+  int loops(int n) {
+    var total = 0;
+    for (var i = 0; i < n; ++i) { total += i; }
+    var j = 0;
+    while (j < 2) { j++; }
+    do { j--; } while (j > 0);
+    for (var e in [1, 2]) { total += e; }
+    return total;
+  }
+
+  int branches(int a) {
+    if (a > 10) { return 1; } else if (a > 5) { return 2; } else { return 3; }
+  }
+
+  int ops(int a) {
+    var b = a * 2 + 1 - 3;
+    var c = a > 1 ? 1 : 0;
+    var neg = -a;
+    var not = !(a > 1);
+    var bits = (a & 3) | (a ^ 1);
+    return b + c + neg + bits;
+  }
+
+  String strings(String s) {
+    var t = 'x: $s';
+    return t + s.toUpperCase();
+  }
+
+  int lambdas(int a) {
+    var f = (int x) { return x * 2; };
+    return f(a);
+  }
+}
+''';
+
+/// Constructs every language both generates *and* parses back, so the generated
+/// source can be re-loaded.
+///
+/// Deliberately narrower than [_richSource]: several grammars parse only a
+/// subset of what their own generator emits. Known gaps, each reproducible by
+/// moving the construct into this source:
+///  - Loops: Lua has no `for`/`while` rule, Python no `do`/`while`, and Kotlin
+///    and Go no `for` loop.
+///  - Python cannot parse the lambda it generates; JS and TS cannot parse the
+///    map literal they generate.
+///  - A class with a field makes Go emit a `func NewC() *C { o := &C{} … }`
+///    factory, and the Go grammar has no `&T{}` composite literal.
+///  - The Lua generator emits `a + b` for string concatenation and `s.m()` for
+///    a method call, where Lua wants `a .. b` and `s:m()`.
+const _roundTripSource = r'''
+class Calc {
+
+  int branches(int a) {
+    if (a > 10) { return 1; } else if (a > 5) { return 2; } else { return 3; }
+  }
+
+  int ops(int a) {
+    var c = a > 1 ? 1 : 0;
+    var neg = -a;
+    var bits = (a & 3) | (a ^ 1);
+    return c + neg + bits;
+  }
+
+  List lists() {
+    return [1, 2];
+  }
+}
+''';
+
+Future<ApolloVM> _loadDart(String src) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', src, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source");
+  return vm;
+}
+
+/// Generates [vm]'s AST as [language] and returns each generated code unit.
+Future<List<String>> _generate(ApolloVM vm, String language) async {
+  var storage = vm.generateAllCodeIn(language);
+  await storage.writeAllSources();
+
+  var sources = <String>[];
+  for (var ns in await storage.getNamespaces()) {
+    for (var id in await storage.getNamespaceCodeUnitsIDs(ns)) {
+      sources.add((await storage.getNamespaceCodeUnit(ns, id))!);
+    }
+  }
+  return sources;
+}
+
+void main() {
+  group('code generation across every language', () {
+    test('a rich program generates without error in every language', () async {
+      var vm = await _loadDart(_richSource);
+
+      for (var language in _languages) {
+        var sources = await _generate(vm, language);
+        expect(sources, isNotEmpty, reason: '$language generated nothing');
+        expect(
+          sources.single,
+          contains('class Calc'.split(' ').last),
+          reason: '$language should name the generated class',
+        );
+      }
+    });
+
+    test('generated source parses back in its own language', () async {
+      var vm = await _loadDart(_roundTripSource);
+
+      for (var language in _languages) {
+        for (var source in await _generate(vm, language)) {
+          var reloaded = ApolloVM();
+          var ok = await reloaded.loadCodeUnit(
+            SourceCodeUnit(language, source, id: 'test'),
+          );
+          expect(
+            ok,
+            isTrue,
+            reason: '$language generated source it cannot parse:\n$source',
+          );
+        }
+      }
+    });
+  });
+
+  group('Java 11 collection literals', () {
+    Future<bool> parseJava(String body) async {
+      var src = 'class C {\n  Object m() {\n    return $body;\n  }\n}\n';
+      return ApolloVM().loadCodeUnit(SourceCodeUnit('java11', src, id: 'test'));
+    }
+
+    // The diamond alternative used to hand the `'>'` character to a cast
+    // expecting an `ASTType`, throwing a raw `TypeError` instead of parsing.
+    test('the diamond form of a list literal parses', () async {
+      expect(await parseJava('new ArrayList<>()'), isTrue);
+      expect(await parseJava('new ArrayList<>(){{ add(1); }}'), isTrue);
+    });
+
+    test('the diamond form of a map literal parses', () async {
+      expect(await parseJava('new HashMap<>()'), isTrue);
+      expect(await parseJava('new HashMap<>(){{ put("a", 1); }}'), isTrue);
+    });
+
+    test('the explicitly typed forms still parse', () async {
+      expect(await parseJava('new ArrayList<Integer>(){{ add(1); }}'), isTrue);
+      expect(
+        await parseJava('new HashMap<String, Integer>(){{ put("a", 1); }}'),
+        isTrue,
+      );
+    });
+
+    test('a Dart map literal round-trips through Java', () async {
+      var vm = await _loadDart(
+        "class C { Map m() { return {'a': 1, 'b': 2}; } }",
+      );
+      var java = (await _generate(vm, 'java11')).single;
+      expect(java, contains('new HashMap<'));
+
+      var reloaded = ApolloVM();
+      expect(
+        await reloaded.loadCodeUnit(SourceCodeUnit('java11', java, id: 'test')),
+        isTrue,
+      );
+    });
+  });
+}

--- a/test/unit/apollovm_go_constructors_test.dart
+++ b/test/unit/apollovm_go_constructors_test.dart
@@ -1,0 +1,140 @@
+@Tags(['dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+Future<ApolloVM> _load(String language, String src) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit(language, src, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load $language source");
+  return vm;
+}
+
+Future<String> _generateGo(ApolloVM vm) async {
+  var storage = vm.generateAllCodeIn('go');
+  await storage.writeAllSources();
+  for (var ns in await storage.getNamespaces()) {
+    for (var id in await storage.getNamespaceCodeUnitsIDs(ns)) {
+      return (await storage.getNamespaceCodeUnit(ns, id))!;
+    }
+  }
+  throw StateError('no generated source');
+}
+
+/// Go has no classes: a class is a `type X struct` plus receiver methods and a
+/// `func NewX(...) *X` factory. None of that could previously be parsed back.
+const _goSource = '''
+package main
+
+type Point struct {
+  x int
+  y int
+}
+
+func NewPoint(x int, y int) *Point {
+  o := &Point{}
+  o.x = x
+  o.y = y
+  return o
+}
+
+func (o *Point) sum() int {
+  return o.x + o.y
+}
+
+func run() int {
+  p := NewPoint(40, 2)
+  return p.sum()
+}
+''';
+
+void main() {
+  group('Go constructors', () {
+    test('a factory and its `&T{}` composite literal parse', () async {
+      var vm = await _load('go', _goSource);
+      var point = vm.getLanguageNamespaces('go').getClass('Point');
+      expect(point, isNotNull);
+      expect(point!.constructors, isNotEmpty);
+    });
+
+    test('a factory runs, binding `o` to the instance', () async {
+      var vm = await _load('go', _goSource);
+      var result = await vm.createRunner('go')!.executeFunction('', 'run');
+      expect(result.getValueNoContext(), equals(42));
+    });
+
+    test('a struct literal with fields is not supported', () async {
+      // Only the zero-valued `&T{}` form is parsed.
+      expect(
+        () => _load(
+          'go',
+          'package main\n\ntype P struct {\n  x int\n}\n\n'
+              'func NewP() *P {\n  o := &P{x: 1}\n  return o\n}\n',
+        ),
+        throwsA(anything),
+      );
+    });
+  });
+
+  group('Go code generation', () {
+    test('every struct gets a factory, and instantiation calls it', () async {
+      var vm = await _load(
+        'dart',
+        'class Point { int x; Point(int x) { this.x = x; } int get2() { return this.x; } }\n'
+            'class Foo { int test() { var p = Point(7); return p.get2(); } }',
+      );
+
+      var go = await _generateGo(vm);
+
+      expect(go, contains('func NewPoint(x int) *Point {'));
+      // A field-less struct still gets a factory, so `NewFoo()` always exists.
+      expect(go, contains('func NewFoo() *Foo {'));
+      // Go has no `new`: instantiation goes through the factory.
+      expect(go, contains('p := NewPoint(7)'));
+      expect(go, isNot(contains('p := Point(7)')));
+    });
+
+    test(
+      'a parameter shadowing a field is not rewritten to `o.field`',
+      () async {
+        var vm = await _load(
+          'dart',
+          'class Point { int x; Point(int x) { this.x = x; } }',
+        );
+
+        var go = await _generateGo(vm);
+
+        expect(go, contains('o.x = x'));
+        expect(
+          go,
+          isNot(contains('o.x = o.x')),
+          reason: 'the constructor parameter `x` shadows the field `x`',
+        );
+      },
+    );
+
+    test('generated Go parses back and runs', () async {
+      var vm = await _load(
+        'dart',
+        'class Point { int x; int y; Point(int x, int y) { this.x = x; this.y = y; }\n'
+            '  int sum() { return this.x + this.y; } }\n'
+            'class Foo { int test(int a) { var p = Point(a, 2); return p.sum(); } }',
+      );
+
+      var go = await _generateGo(vm);
+
+      var reloaded = await _load('go', go);
+      var result = await reloaded
+          .createRunner('go')!
+          .executeClassMethod(
+            '',
+            'Foo',
+            'test',
+            positionalParameters: [40],
+            classInstanceFields: const {},
+          );
+      expect(result.getValueNoContext(), equals(42));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Line coverage of `lib/` goes from **83.41% to 84.73%**. The number is the least interesting part — writing the tests surfaced **six real defects**, all fixed here.

Two commits: a coverage pass (`v1.9.1`), and a Go constructor fix that the first commit's round-trip matrix exposed.

## Fixes

**`s.length` didn't work.** `String.length`, `String.isEmpty`, `String.isNotEmpty` and the `sign` of `int`/`double` were registered only as *methods*, so `s.length()` worked and `s.length` threw — the opposite of how Dart, Kotlin and C# source actually reads. `List` and `Map` already exposed theirs as getters. They are now getters *and* methods, so Java-style `s.length()` keeps working.

**The Java 11 grammar crashed on its own output.** `new HashMap<>(){{ put("a", 1); }}` — exactly what the Java generator emits for a Dart map literal — passed the `'>'` character into a cast expecting an `ASTType` and threw a raw `TypeError`. A second typo made the map literal's diamond alternative match `<<` instead of `<>`. Generic type arguments are now picked out by type rather than by position, in all four list/map literal rules.

**`ApolloGenerator` carried ~140 lines of dead dispatch.** `generateASTNode`, `generateASTRoot`, `generateASTType`, `generateASTStatement`, `generateASTBranch`, `generateASTExpression` and `generateASTValue` were each shadowed by both subclasses — and had already drifted: the base `generateASTRoot` never learned to emit extensions, so a future third generator would have silently dropped them. Now abstract, or removed where nothing dispatches through the base. The file went from 141 instrumented lines to 6.

**Go constructors did not work at all**, in either direction:

- *Parser*: no `&T{}` composite literal, so **any** Go source containing a `func NewFoo() *Foo { o := &Foo{} … }` factory — the exact shape the Go generator emits — failed to parse. The zero-valued form now parses as the struct's no-argument constructor.
- *Parser*: a `NewFoo(...)` call site resolved to a top-level function that no longer existed, since `compilationUnit` had already folded the declaration into the struct's constructor.
- *Parser*: inside a factory, `o` was a plain local, so `o.x = x` failed with `Can't find variable: 'o'` — though `_toConstructor` already assumed `o` was the instance when stripping the scaffolding.
- *Generator*: `Point(int x) { this.x = x; }` emitted `o.x = o.x` — a parameter shadowing a same-named field was rewritten as a field read, silently assigning the field to itself.
- *Generator*: instantiation emitted `p := Point(a, 1)`, which is not Go. It now emits `p := NewPoint(a, 1)`, and every struct gets a factory (a field-less struct used to get none) so the call always resolves.

Dart → Go → parse → run now works end to end.

## New tests

- `test/unit/apollovm_core_library_test.dart` (34 tests) — the core runtime library: `dart:math`, and every `String`, `int`, `double`, `List` and `Map` member, in both getter and method form where both exist.
- `test/unit/apollovm_generator_matrix_test.dart` — a program exercising most AST node kinds generates in all nine languages, and the generated source parses back. This is what found the Java 11 and Go bugs.
- `test/unit/apollovm_go_constructors_test.dart` — the factory and its composite literal, running a factory, the shadowing fix, and a full Dart → Go → parse → run round-trip.

The six `go_*.test.xml` fixtures change only by gaining the now-always-emitted factory.

## Documented, not fixed

The matrix test made a pattern visible: several grammars parse only a subset of what their own generator emits. The Lua generator emits `t + s.toUpperCase()` where Lua wants `t .. s:upper()` (Lua classes are already `🚫` in the README matrix, so that generator is outside the stated contract); Python cannot parse the lambda it generates; JS/TS cannot parse the map literal they generate. Each is listed in the matrix test rather than silently tolerated.

## Verification

`dart analyze` clean, `dart format` clean, **1655 tests pass** (up from 1609).

🤖 Generated with [Claude Code](https://claude.com/claude-code)