### PR TITLE
v1.9.2 - Go: field-initializing constructors, reserved words, declaration order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,44 @@
+## 1.9.2
+
+### Go — a class with a field-initializing constructor now survives Dart -> Go
+
+Three defects made `Dart -> Go -> parse -> run` fail (or, worse, silently
+produce the wrong answer) for programs the 1.9.1 fixtures did not cover.
+
+- **A field-initializing constructor parameter was dropped.** Dart's
+  `Point(this.x, this.y)` shorthand generated
+  `func NewPoint(x int, y int) *Point { o := &Point{}; return o }` — the
+  arguments were never assigned, so every field stayed zero-valued and the
+  program ran to a wrong result rather than failing. The factory now emits
+  `o.x = x` for each `this.` parameter, after the field's declared initial
+  value so an explicit argument wins. The long-hand form
+  (`Point(int x, int y) { this.x = x; }`) was already correct.
+- **A source identifier colliding with a Go keyword emitted invalid Go.** A
+  Dart `var map = ...` or a field named `type` became `map := ...` /
+  `o.type`, which does not parse — `map` and `type` are two of Go's 25
+  reserved words. Such a name is now escaped with a trailing `_`
+  (`map_`, `type_`) at every site: declarations, reads, parameters, struct
+  fields, methods and the members written after a `.`.
+- **Structs were emitted after the functions that call them.** ApolloVM's Go
+  parser resolves `NewPoint(...)` against the declarations it has already
+  seen, so a top-level function emitted first could not resolve the struct.
+  `generateASTRoot` now emits structs (and their factories) before the
+  top-level function block.
+
+Supporting change:
+
+- New `ApolloGenerator.normalizeIdentifier(String)` hook, applied by the base
+  generator to the member names written after a `.` (fields, getters, setters
+  and methods). It is the identity for every language except Go, which uses it
+  to escape reserved words, so a declaration and its uses always agree.
+
+#### Known gap
+
+ApolloVM's Go parser remains order-dependent: hand-written Go that calls
+`NewPoint(...)` *before* declaring `type Point struct` still fails to resolve,
+though Go itself is order-independent. The generator no longer produces that
+shape.
+
 ## 1.9.1
 
 ### Core-library, Java 11 and Go fixes found by a coverage pass

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '1.9.1';
+  static final String VERSION = '1.9.2';
 
   static int _idCount = 0;
 

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -425,6 +425,14 @@ abstract class ApolloCodeGenerator
   String normalizeTypeName(String typeName, [String? callingFunction]) =>
       typeName;
 
+  /// Rewrites a member identifier (a field, getter, setter or method name)
+  /// written after a `.` so it is legal in the target language.
+  ///
+  /// Default: unchanged. A language whose reserved words may not be used as
+  /// identifiers (Go) overrides this to escape them, and must apply the same
+  /// rewrite where it emits the matching declaration.
+  String normalizeIdentifier(String name) => name;
+
   @override
   String normalizeTypeFunction(String typeName, String functionName) =>
       functionName;
@@ -1950,6 +1958,8 @@ abstract class ApolloCodeGenerator
     if (expression.variable.isTypeIdentifier) {
       var typeIdentifier = expression.variable.typeIdentifier;
       functionName = normalizeTypeFunction(typeIdentifier!.name, functionName);
+    } else {
+      functionName = normalizeIdentifier(functionName);
     }
 
     generateASTVariable(
@@ -2127,6 +2137,8 @@ abstract class ApolloCodeGenerator
     if (expression.variable.isTypeIdentifier) {
       var typeIdentifier = expression.variable.typeIdentifier;
       getterName = normalizeTypeFunction(typeIdentifier!.name, getterName);
+    } else {
+      getterName = normalizeIdentifier(getterName);
     }
 
     generateASTVariable(
@@ -2162,7 +2174,7 @@ abstract class ApolloCodeGenerator
       headIndented: false,
     );
     out.write('.');
-    out.write(expression.name);
+    out.write(normalizeIdentifier(expression.name));
 
     var op = getASTAssignmentOperatorText(expression.operator);
     out.write(' ');

--- a/lib/src/languages/go/go_generator.dart
+++ b/lib/src/languages/go/go_generator.dart
@@ -25,6 +25,50 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
   /// The fixed receiver name used for struct methods.
   static const String _receiver = 'o';
 
+  /// Go's 25 reserved words. None may be used as an identifier, so a name from
+  /// the source that collides with one (`map`, `type`, `range`, `func`, …) is
+  /// emitted with a trailing `_`.
+  static const Set<String> _goKeywords = {
+    'break',
+    'case',
+    'chan',
+    'const',
+    'continue',
+    'default',
+    'defer',
+    'else',
+    'fallthrough',
+    'for',
+    'func',
+    'go',
+    'goto',
+    'if',
+    'import',
+    'interface',
+    'map',
+    'package',
+    'range',
+    'return',
+    'select',
+    'struct',
+    'switch',
+    'type',
+    'var',
+  };
+
+  /// [name] as a Go identifier: a reserved word gets a trailing `_`.
+  ///
+  /// Applied at every site that writes a value identifier (variables,
+  /// parameters, struct fields, functions and methods), so a declaration and
+  /// its uses always agree.
+  static String _goIdent(String name) =>
+      _goKeywords.contains(name) ? '${name}_' : name;
+
+  /// Member names written after a `.` (`o.type_`, `p.sum()`) are escaped the
+  /// same way as the declarations they refer to.
+  @override
+  String normalizeIdentifier(String name) => _goIdent(name);
+
   /// Field names of the struct currently being generated (for `o.field`).
   Set<String> _currentClassFields = const {};
 
@@ -118,8 +162,10 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
       out.write('\n');
     }
 
-    generateASTBlock(root, out: out, withBrackets: false);
-
+    // Structs (and their factories) are emitted before the top-level functions
+    // that call them. Go itself is order-independent, but ApolloVM's Go parser
+    // resolves a `NewPoint(...)` call against the declarations it has seen so
+    // far, so a caller emitted first could not resolve the struct.
     for (var clazz in root.classes) {
       generateASTClass(clazz, out: out);
     }
@@ -127,6 +173,8 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     for (var extension in root.extensions) {
       generateASTExtension(extension, out: out);
     }
+
+    generateASTBlock(root, out: out, withBrackets: false);
 
     return out;
   }
@@ -175,7 +223,7 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     out.write(' struct {\n');
     for (var field in fields) {
       out.write('  ');
-      out.write(field.name);
+      out.write(_goIdent(field.name));
       out.write(' ');
       generateASTType(field.type, out: out);
       out.write('\n');
@@ -234,7 +282,7 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     out.write(' *');
     out.write(className);
     out.write(') ');
-    out.write(f.name);
+    out.write(_goIdent(f.name));
     out.write('(');
     if (f.parametersSize > 0) {
       generateASTParametersDeclaration(f.parameters, out: out);
@@ -268,10 +316,29 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     out.write('$indent  ');
     out.write('$_receiver := &$className{}\n');
     _writeFieldInits(fieldInits, out, '$indent  ');
+    _writeThisParameterInits(ctor, out, '$indent  ');
     out.write(blockCode);
     out.write('$indent  return $_receiver\n');
     out.write(indent);
     out.write('}\n\n');
+  }
+
+  /// Assigns each field-initializing parameter (Dart's `Point(this.x)`) to its
+  /// field: `o.x = x`. Go has no such shorthand, and without this the factory
+  /// would ignore its arguments and leave the fields zero-valued.
+  ///
+  /// Written after [_writeFieldInits] so an explicit argument wins over the
+  /// field's declared initial value.
+  void _writeThisParameterInits(
+    ASTClassConstructorDeclaration ctor,
+    StringBuffer out,
+    String indent,
+  ) {
+    for (var p in ctor.parameters.allParameters) {
+      if (!p.thisParameter) continue;
+      var name = _goIdent(p.name);
+      out.write('$indent$_receiver.$name = $name\n');
+    }
   }
 
   void _generateDefaultConstructor(
@@ -301,7 +368,7 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     for (var field in fieldInits) {
       out.write(indent);
       out.write('$_receiver.');
-      out.write(field.name);
+      out.write(_goIdent(field.name));
       out.write(' = ');
       generateASTExpression(field.initialValue, out: out, headIndented: false);
       out.write('\n');
@@ -410,7 +477,7 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     out ??= newOutput();
 
     // Go declares the type *after* the name: `a int`.
-    out.write(parameter.name);
+    out.write(_goIdent(parameter.name));
     out.write(' ');
     generateASTType(parameter.type, out: out);
 
@@ -446,7 +513,7 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
 
     if (value != null && type is ASTTypeVar) {
       // Inferred + value: `x := expr`.
-      out.write(statement.name);
+      out.write(_goIdent(statement.name));
       out.write(' := ');
       generateASTExpression(
         value,
@@ -457,7 +524,7 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     } else {
       // `var x Type = expr`, `var x Type`, or `var x = expr`.
       out.write('var ');
-      out.write(statement.name);
+      out.write(_goIdent(statement.name));
       if (type is! ASTTypeVar) {
         out.write(' ');
         generateASTType(type, out: out);
@@ -1052,7 +1119,7 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
       out ??= newOutput();
       if (headIndented) out.write(indent);
       out.write('$_receiver.');
-      out.write(expression.name);
+      out.write(_goIdent(expression.name));
       out.write('(');
       var arguments = expression.arguments;
       for (var i = 0; i < arguments.length; ++i) {
@@ -1092,7 +1159,16 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
       out ??= newOutput();
       if (headIndented) out.write(indent);
       out.write('$_receiver.');
-      out.write(variable.name);
+      out.write(_goIdent(variable.name));
+      return out;
+    }
+
+    // A plain variable read: the base writes the raw name, which would not
+    // agree with the mangled name its declaration emitted.
+    if (!variable.isTypeIdentifier) {
+      out ??= newOutput();
+      if (headIndented) out.write(indent);
+      out.write(_goIdent(variable.name));
       return out;
     }
 
@@ -1119,7 +1195,7 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     if (variable is ASTThisVariable) {
       out.write(_receiver);
     } else {
-      out.write(variable.name);
+      out.write(_goIdent(variable.name));
     }
     return out;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 1.9.1
+version: 1.9.2
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/unit/apollovm_go_constructors_test.dart
+++ b/test/unit/apollovm_go_constructors_test.dart
@@ -136,5 +136,99 @@ void main() {
           );
       expect(result.getValueNoContext(), equals(42));
     });
+
+    test('a field-initializing parameter assigns its field', () async {
+      var vm = await _load(
+        'dart',
+        'class Point { int x; int y; Point(this.x, this.y);\n'
+            '  int sum() { return this.x + this.y; } }\n'
+            'class Foo { int test(int a) { var p = Point(a, 1); return p.sum(); } }',
+      );
+
+      var go = await _generateGo(vm);
+
+      expect(go, contains('o.x = x'));
+      expect(go, contains('o.y = y'));
+
+      var reloaded = await _load('go', go);
+      var result = await reloaded
+          .createRunner('go')!
+          .executeClassMethod(
+            '',
+            'Foo',
+            'test',
+            positionalParameters: [5],
+            classInstanceFields: const {},
+          );
+      expect(
+        result.getValueNoContext(),
+        equals(6),
+        reason: 'Dart `Point(this.x, this.y)` must not drop its arguments',
+      );
+    });
+
+    test('structs are emitted before the functions that call them', () async {
+      var vm = await _load(
+        'dart',
+        'class Point { int x; Point(this.x); }\n'
+            'int run(int a) { var p = Point(a); return p.x; }',
+      );
+
+      var go = await _generateGo(vm);
+
+      expect(
+        go.indexOf('type Point struct'),
+        lessThan(go.indexOf('func run(')),
+        reason:
+            'the Go parser resolves `NewPoint(...)` against what it has '
+            'already seen',
+      );
+
+      var reloaded = await _load('go', go);
+      var result = await reloaded
+          .createRunner('go')!
+          .executeFunction('', 'run', positionalParameters: [7]);
+      expect(result.getValueNoContext(), equals(7));
+    });
+  });
+
+  group('Go reserved words', () {
+    test('an identifier colliding with a Go keyword is escaped', () async {
+      var vm = await _load(
+        'dart',
+        'int run(int a) { var map = a + 1; var type = a + 2; return map + type; }',
+      );
+
+      var go = await _generateGo(vm);
+
+      expect(go, contains('map_ := a + 1'));
+      expect(go, contains('type_ := a + 2'));
+      expect(go, contains('return map_ + type_'));
+
+      var reloaded = await _load('go', go);
+      var result = await reloaded
+          .createRunner('go')!
+          .executeFunction('', 'run', positionalParameters: [5]);
+      expect(result.getValueNoContext(), equals(13));
+    });
+
+    test('a struct field named after a Go keyword is escaped', () async {
+      var vm = await _load(
+        'dart',
+        'class Box { int type; Box(this.type); int get2() { return this.type; } }\n'
+            'int run(int a) { var b = Box(a); return b.get2(); }',
+      );
+
+      var go = await _generateGo(vm);
+
+      expect(go, contains('type_ int'));
+      expect(go, contains('o.type_ = type_'));
+
+      var reloaded = await _load('go', go);
+      var result = await reloaded
+          .createRunner('go')!
+          .executeFunction('', 'run', positionalParameters: [9]);
+      expect(result.getValueNoContext(), equals(9));
+    });
   });
 }


### PR DESCRIPTION
Three defects made `Dart → Go → parse → run` fail — or, in the first case, **silently produce a wrong answer** — for programs the 1.9.1 fixtures did not cover. Found while adding a Go transpile tab to `apollovm_web_example`.

## 1. A field-initializing constructor parameter was dropped

Dart's `Point(this.x, this.y)` shorthand generated:

```go
func NewPoint(x int, y int) *Point {
  o := &Point{}
  return o        // <- arguments never assigned
}
```

The fields stayed zero-valued, so the program *ran* and returned the wrong number rather than failing. The long-hand form (`Point(int x, int y) { this.x = x; }`) was already correct — 1.9.1 fixed the shadowing case for it, which is why this went unnoticed.

The factory now emits `o.x = x` for each `this.` parameter, written after `_writeFieldInits` so an explicit argument beats the field's declared initial value.

## 2. An identifier colliding with a Go keyword emitted invalid Go

A Dart `var map = ...`, or a field named `type`, became `map := ...` / `o.type`. `map` and `type` are 2 of Go's 25 reserved words, so the output did not parse. Such a name is now escaped with a trailing `_` (`map_`, `type_`) at **every** site: declarations, reads, parameters, struct fields, methods, and the members written after a `.`.

To reach that last group without duplicating three base methods, this adds a hook:

```dart
/// Rewrites a member identifier written after a `.` so it is legal in the target language.
String normalizeIdentifier(String name) => name;
```

The base generator applies it to object getter, setter and method-invocation names. It is the identity for every language except Go. Type identifiers keep going through `normalizeTypeFunction`, so `Math.max` is untouched.

## 3. Structs were emitted after the functions that call them

`generateASTRoot` emitted the top-level function block first, then the classes. ApolloVM's Go parser resolves `NewPoint(...)` against declarations it has already seen, so the caller could not resolve the struct. Structs (and their factories) now precede the function block.

## Tests

4 new tests in `test/unit/apollovm_go_constructors_test.dart`, each asserting the generated source *and* running it back through the Go parser:

- a field-initializing parameter assigns its field (runs to `6`, not `0`)
- structs are emitted before the functions that call them
- an identifier colliding with a Go keyword is escaped (runs to `13`)
- a struct field named after a Go keyword is escaped (runs to `9`)

Full suite: **1659 passing** (was 1655). `dart analyze` clean, `dart format` clean.

## Known gap, documented not fixed

ApolloVM's Go parser remains **order-dependent**: hand-written Go calling `NewPoint(...)` before declaring `type Point struct` still fails to resolve, though Go itself is order-independent. Fix 3 means the generator never produces that shape, but a user pasting such Go would still hit it. Worth a follow-up in the parser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)