### PR TITLE
fix(lsp): enum constant range covers its whole entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## 2.0.1
+
+### LSP — an enum constant now selects its whole entry, not just its name
+
+A Dart enum constant is a constructor invocation, but the language server's
+declaration scanner recorded its range as the name alone: `earth(5.97, 6371)`
+selected only `earth`, dropping the arguments. Every other declaration kind has
+its range extended past the name — a class member's covers its parameters and
+body — so enum constants were the one exception, and folding, hover and the
+document outline all saw a truncated span.
+
+- **An enum constant's range now covers the whole entry**: a `.named`
+  constructor, `<T>` type arguments, the argument list, or an `= value`
+  (`Red = 1`). Its *name* span is unchanged, so go-to-definition and rename
+  still target the name alone.
+- **Named arguments are no longer reported as extra constants.** The scan that
+  skipped past a constant stopped at the first `,` even when nested inside the
+  argument list, so scanning resumed mid-arguments and read the argument label
+  as another constant: `earth(mass: 5.97, radius: 6371)` emitted a phantom
+  `radius` enum member into the outline. Entry consumption is now depth-aware —
+  only a `,`/`;`/`}` outside brackets ends an entry — which fixes both the
+  truncated range and the phantom symbols.
+
+Constructors *declared* in an enum body (`const Planet(this.mass);`) were
+already correct and are unchanged.
+
 ## 2.0.0
 
 ### `apollovm` no longer drags a native/FFI toolchain into every consumer

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.0.0';
+  static final String VERSION = '2.0.1';
 
   static int _idCount = 0;
 

--- a/lib/src/lsp/analysis/token_index.dart
+++ b/lib/src/lsp/analysis/token_index.dart
@@ -502,6 +502,7 @@ class TokenIndex {
 
       // Enum constants: identifiers in the enum's constant list (before `;`).
       if (inEnumConstantList() && t.isIdent && atBoundary) {
+        final declIndex = decls.length;
         decls.add(
           DeclSite(
             name: t.value,
@@ -513,13 +514,29 @@ class TokenIndex {
             container: enclosingName(),
           ),
         );
-        // Skip to the next comma/brace.
+        // A constant is a constructor invocation, so consume the rest of the
+        // entry — a `.named` constructor, `<T>` type arguments, the balanced
+        // argument list, or an `= value` — extending `fullEnd` across it. This
+        // mirrors a class member, whose range covers its parameters and body
+        // rather than stopping at the name.
+        //
+        // Only a `,`/`;`/`}` at depth 0 ends the entry: those nested inside an
+        // argument list (`earth(mass: 5.97, radius: 6371)`, a collection
+        // literal) belong to the entry. Consuming them here also keeps their
+        // identifiers from being read as further constants.
         i++;
-        while (i < tokens.length &&
-            !tokens[i].sym(',') &&
-            !tokens[i].sym('}') &&
-            !tokens[i].sym('{') &&
-            !tokens[i].sym(';')) {
+        var depth = 0;
+        while (i < tokens.length) {
+          final u = tokens[i];
+          if (depth == 0 && (u.sym(',') || u.sym(';') || u.sym('}'))) break;
+          if (u.sym('(') || u.sym('[') || u.sym('{')) {
+            depth++;
+          } else if (u.sym(')') || u.sym(']') || u.sym('}')) {
+            // Guarded so an unbalanced closer in malformed source cannot drive
+            // `depth` negative and swallow the rest of the enum body.
+            if (depth > 0) depth--;
+          }
+          decls[declIndex].fullEnd = u.end;
           i++;
         }
         atBoundary = false;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.0.0
+version: 2.0.1
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/lsp/token_index_test.dart
+++ b/test/lsp/token_index_test.dart
@@ -70,6 +70,127 @@ enum Color { red, green, blue }
     expect(members, ['red', 'green', 'blue']);
   });
 
+  group('enum constant ranges', () {
+    // An enum constant is a constructor invocation, so its range must cover the
+    // whole entry — like a class member's range covers its parameters and body.
+    String rangeOf(String src, String name) {
+      final d = TokenIndex.scan(src).declarations.firstWhere(
+        (d) => d.kind == DeclKind.enumMember && d.name == name,
+      );
+      return src.substring(d.fullStart, d.fullEnd);
+    }
+
+    test('covers the argument list', () {
+      const src = '''
+enum Planet {
+  earth(5.97, 6371),
+  mars(0.642, 3389);
+
+  const Planet(this.mass, this.radius);
+  final double mass;
+  final double radius;
+}
+''';
+      expect(rangeOf(src, 'earth'), 'earth(5.97, 6371)');
+      expect(rangeOf(src, 'mars'), 'mars(0.642, 3389)');
+      // The name span stays on the name alone, for selection/definition.
+      final earth = TokenIndex.scan(
+        src,
+      ).declarations.firstWhere((d) => d.name == 'earth');
+      expect(src.substring(earth.nameStart, earth.nameEnd), 'earth');
+    });
+
+    test('covers a named constructor and type arguments', () {
+      const src = '''
+enum Planet {
+  mars.small(0.642, 3389),
+  venus<double>(4.87, 6051);
+
+  const Planet(this.mass, this.radius);
+  const Planet.small(this.mass, this.radius);
+}
+''';
+      expect(rangeOf(src, 'mars'), 'mars.small(0.642, 3389)');
+      expect(rangeOf(src, 'venus'), 'venus<double>(4.87, 6051)');
+    });
+
+    test('covers an `= value` entry', () {
+      const src = 'enum Code { ok = 1, fail = 2 }';
+      expect(rangeOf(src, 'ok'), 'ok = 1');
+      expect(rangeOf(src, 'fail'), 'fail = 2');
+    });
+
+    test('a bare constant is still just its name', () {
+      const src = 'enum Color { red, green, blue }';
+      expect(rangeOf(src, 'red'), 'red');
+      expect(rangeOf(src, 'blue'), 'blue');
+    });
+
+    test('nested commas and braces do not end an entry', () {
+      const src = '''
+enum Group {
+  a(const [1, 2], {'k': 'v'}),
+  b(const [3], {});
+
+  const Group(this.list, this.map);
+}
+''';
+      expect(rangeOf(src, 'a'), "a(const [1, 2], {'k': 'v'})");
+      expect(rangeOf(src, 'b'), 'b(const [3], {})');
+    });
+
+    test('named arguments are not mistaken for constants', () {
+      const src = '''
+enum Planet {
+  earth(mass: 5.97, radius: 6371),
+  mars(mass: 0.642, radius: 3389);
+
+  const Planet({required this.mass, required this.radius});
+  final double mass;
+  final double radius;
+}
+''';
+      final members = TokenIndex.scan(src).declarations
+          .where((d) => d.kind == DeclKind.enumMember)
+          .map((d) => d.name)
+          .toList();
+      expect(members, ['earth', 'mars']);
+      expect(rangeOf(src, 'earth'), 'earth(mass: 5.97, radius: 6371)');
+    });
+
+    test('members after the constant list are recognised normally', () {
+      const src = '''
+enum Planet {
+  earth(5.97, 6371);
+
+  const Planet(this.mass, this.radius);
+
+  final double mass;
+  final double radius;
+
+  double gravity() {
+    return mass / (radius * radius);
+  }
+}
+''';
+      final decls = TokenIndex.scan(src).declarations;
+      final ctor = decls.firstWhere((d) => d.kind == DeclKind.constructor);
+      expect(
+        src.substring(ctor.fullStart, ctor.fullEnd),
+        'const Planet(this.mass, this.radius);',
+      );
+      final gravity = decls.firstWhere((d) => d.name == 'gravity');
+      expect(gravity.kind, DeclKind.method);
+      expect(
+        src.substring(gravity.fullStart, gravity.fullEnd),
+        contains('radius * radius'),
+      );
+      // The enum's own range still closes on its final brace.
+      final planet = decls.firstWhere((d) => d.kind == DeclKind.enumDecl);
+      expect(src.substring(planet.fullStart, planet.fullEnd), src.trim());
+    });
+  });
+
   test('recognises top-level variables (var / final) and class fields', () {
     final idx = TokenIndex.scan('''
 var count = 0;


### PR DESCRIPTION
## Summary

A Dart enum constant is a constructor invocation, but the LSP's declaration scanner recorded its range as the name alone: `earth(5.97, 6371)` selected only `earth`, dropping the arguments. Every other declaration kind has its range extended past the name — a class member's covers its parameters and body — so enum constants were the one exception, and folding, hover and the document outline all saw a truncated span.

The skip past a constant was also not depth-aware: it stopped at the first `,` even when nested inside the argument list, so scanning resumed mid-arguments and read the argument label as another constant. `earth(mass: 5.97, radius: 6371)` emitted a **phantom `radius` enum member** into the outline.

## Fix

`lib/src/lsp/analysis/token_index.dart` now consumes the whole entry with bracket balancing, extending `fullEnd` across a `.named` constructor, `<T>` type arguments, the argument list, or an `= value`. Only a `,`/`;`/`}` at depth 0 ends an entry. Consuming the arguments rather than re-scanning them is what removes the phantom symbols. The name span is untouched, so go-to-definition and rename still target the name alone.

`<`/`>` are deliberately not balanced: a `>` used as comparison in a const expression would drive the depth negative and swallow the rest of the enum body. The cost is that a multi-argument type argument (`venus<String, int>(...)`) ends its range early at the inner comma — rare, and it fails short rather than catastrophically.

Constructors *declared* in an enum body (`const Planet(this.mass);`) were already correct and are unchanged — they share the class member path.

## Release

Bumps `2.0.0` → `2.0.1` (pubspec, `ApolloVM.VERSION`, CHANGELOG).

## Test plan

- 7 new regression tests in `test/lsp/token_index_test.dart`: argument lists, named/type-argument constructors, `= value` entries, bare constants, nested commas/braces, named-argument phantoms, and members after the constant list.
- Full VM suite: 1680 tests pass.
- `dart format`, `dart analyze --fatal-infos --fatal-warnings`, `dart pub publish --dry-run` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)