### PR TITLE
chore: release 2.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 2.1.1
+
+### Correctness fixes (parser & interpreter)
+
+- **Compound assignment `~/=` no longer crashes the parser.** `~/=` (Dart) and
+  `//=` (Python) matched the grammar but had no handler, so parsing threw an
+  uncaught error out of `loadCodeUnit` instead of building the AST. `~/=`/`//=`
+  are now fully supported, and any *other* still-unsupported compound operator
+  (e.g. JavaScript/TypeScript `%=`) now surfaces as a clean `SyntaxError`
+  instead of an uncaught crash.
+- **`Enum.values` can be assigned to a typed or inferred list.** It was built
+  with a `dynamic` element type while its declared type is `List<Enum>`, so
+  `var v = Color.values;` / `List<Color> v = Color.values;` failed the
+  declaration cast. It now carries the enum's own element type.
+- **`ASTValue.fromValue<int>` on a non-whole double** now throws a clean
+  `ApolloVMCastException` instead of a raw Dart `TypeError`.
+
+Division semantics are unchanged and remain intentionally per-language
+(Dart/JS/TS/Python `/` yields a `double`; Java/C#/Go/Kotlin `/` on ints is
+truncating integer division); regression guards now pin both.
+
 ## 2.1.0
 
 ### Wasm backend — loop increment fix and initial String methods

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.1.0';
+  static final String VERSION = '2.1.1';
 
   static int _idCount = 0;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.1.0
+version: 2.1.1
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 


### PR DESCRIPTION
Version bump + CHANGELOG for the correctness fixes merged in #104 (which should have carried the bump).

**2.1.0 → 2.1.1** (patch — bug fixes only), in both `pubspec.yaml` and the `VERSION` constant.

## Changelog (2.1.1)
- Compound `~/=` (Dart) / `//=` (Python) parse crash fixed — now fully supported; other unsupported compound ops (`%=`) surface as a clean `SyntaxError` instead of an uncaught crash.
- `Enum.values` carries the enum element type, so it can be assigned to `List<Enum>` / `var`.
- `ASTValue.fromValue<int>` on a non-whole double throws `ApolloVMCastException` instead of a raw `TypeError`.
- Division semantics unchanged (intentionally per-language), now pinned by regression guards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)