### PR TITLE
feat: support static class fields (read/write, qualified + bare)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## 2.1.1
 
+### `static` class fields are now supported
+
+`static` fields previously had no class-level storage — they were initialized
+onto every instance, and reading one (`ClassName.field`, or a bare reference
+inside a `static` method) threw at runtime. Now each class has a lazily
+initialized static-field store, shared by qualified `ClassName.field` access and
+bare references inside the class's own `static` methods, for read, write and
+compound assignment. The Java and C# grammars also now record the `static` field
+modifier (they were dropping it), so this works across those languages too.
+
 ### Correctness fixes (parser & interpreter)
 
 - **Compound assignment `~/=` no longer crashes the parser.** `~/=` (Dart) and

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -1874,6 +1874,15 @@ class ASTExpressionVariableAssignment extends ASTExpression {
   Iterable<ASTNode> get children => [variable, expression];
 
   @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+    // Resolve the assignment target so a bare `static` field reference (whose
+    // resolution depends on the AST identifier) works on both read and write.
+    variable.resolveNode(this);
+    expression.resolveNode(this);
+  }
+
+  @override
   FutureOr<ASTType> resolveType(VMContext? context) =>
       expression.resolveType(context);
 
@@ -3100,6 +3109,17 @@ class ASTExpressionObjectGetterAccess extends ASTExpressionGetterAccess
     return node is ASTClassEnum ? node : null;
   }
 
+  /// If [variable] names a class that declares a `static` field [name] (i.e.
+  /// this is a `ClassName.staticField` access), returns that class; otherwise
+  /// `null`.
+  ASTClassNormal? _staticFieldClass() {
+    final v = variable;
+    if (v is! ASTScopeVariable) return null;
+    var node = getNodeIdentifier(v.name);
+    if (node is ASTClassNormal && node.hasStaticField(name)) return node;
+    return null;
+  }
+
   /// Resolves an enum static access (`EnumType.entry` or `EnumType.values`):
   /// an entry yields its cached `const` instance (a singleton, so `==` is
   /// identity); `values` yields the list of all instances in declaration order.
@@ -3168,6 +3188,9 @@ class ASTExpressionObjectGetterAccess extends ASTExpressionGetterAccess
       if (enumClass.entries.any((e) => e.name == name)) return enumClass.type;
     }
 
+    var staticFieldType = _staticFieldClass()?.getField(name)?.type;
+    if (staticFieldType != null) return staticFieldType;
+
     if (context == null) {
       return super.resolveType(context);
     }
@@ -3198,6 +3221,9 @@ class ASTExpressionObjectGetterAccess extends ASTExpressionGetterAccess
       if (enumClass.entries.any((e) => e.name == name)) return enumClass.type;
     }
 
+    var staticFieldType = _staticFieldClass()?.getField(name)?.type;
+    if (staticFieldType != null) return staticFieldType;
+
     return _getVariableValue(context).resolveMapped((obj) {
       if (obj is ASTClassInstance) {
         var classContext = obj.createContext(context);
@@ -3220,6 +3246,20 @@ class ASTExpressionObjectGetterAccess extends ASTExpressionGetterAccess
       return enumEntry.resolveMapped(
         (ret) => _callChainFunction(parentContext, runStatus, ret),
       );
+    }
+
+    // `ClassName.staticField` read.
+    var staticClass = _staticFieldClass();
+    if (staticClass != null) {
+      return staticClass
+          .getStaticFieldValue(parentContext, name)
+          .resolveMapped(
+            (v) => _callChainFunction(
+              parentContext,
+              runStatus,
+              v ?? ASTValueNull.instance,
+            ),
+          );
     }
 
     return _getVariableValue(parentContext).resolveMapped((obj) {
@@ -3294,12 +3334,56 @@ class ASTExpressionObjectSetterAssignment extends ASTExpression {
   FutureOr<ASTType> resolveType(VMContext? context) =>
       expression.resolveType(context);
 
+  /// If [variable] names a class that declares a `static` field [name], returns
+  /// that class (i.e. this is a `ClassName.staticField = …` assignment).
+  ASTClassNormal? _staticFieldClass() {
+    final v = variable;
+    if (v is! ASTScopeVariable) return null;
+    var node = getNodeIdentifier(v.name);
+    if (node is ASTClassNormal && node.hasStaticField(name)) return node;
+    return null;
+  }
+
+  FutureOr<ASTValue> _applyOperator(ASTValue current, ASTValue value) {
+    switch (operator) {
+      case ASTAssignmentOperator.set:
+        return value;
+      case ASTAssignmentOperator.sum:
+        return current + value;
+      case ASTAssignmentOperator.subtract:
+        return current - value;
+      case ASTAssignmentOperator.multiply:
+        return current * value;
+      case ASTAssignmentOperator.divide:
+        return current / value;
+      case ASTAssignmentOperator.divideAsInt:
+        return current ~/ value;
+    }
+  }
+
   @override
   FutureOr<ASTValue> run(
     VMContext parentContext,
     ASTRunStatus runStatus,
   ) async {
     var context = defineRunContext(parentContext);
+
+    // `ClassName.staticField = value` (and compound ops).
+    var staticClass = _staticFieldClass();
+    if (staticClass != null) {
+      var value = await expression.run(context, runStatus);
+      ASTValue resultValue;
+      if (operator == ASTAssignmentOperator.set) {
+        resultValue = value;
+      } else {
+        var current =
+            await staticClass.getStaticFieldValue(context, name) ??
+            ASTValueNull.instance;
+        resultValue = await _applyOperator(current, value);
+      }
+      await staticClass.setStaticFieldValue(context, name, resultValue);
+      return resultValue;
+    }
 
     var obj = await variable.getValue(context);
     if (obj is! ASTClassInstance) {
@@ -3311,23 +3395,8 @@ class ASTExpressionObjectSetterAssignment extends ASTExpression {
     var classContext = obj.createContext(context);
     var value = await expression.run(context, runStatus);
 
-    FutureOr<ASTValue> result;
-    switch (operator) {
-      case ASTAssignmentOperator.set:
-        result = value;
-      case ASTAssignmentOperator.sum:
-        result = (await _currentField(classContext, obj)) + value;
-      case ASTAssignmentOperator.subtract:
-        result = (await _currentField(classContext, obj)) - value;
-      case ASTAssignmentOperator.multiply:
-        result = (await _currentField(classContext, obj)) * value;
-      case ASTAssignmentOperator.divide:
-        result = (await _currentField(classContext, obj)) / value;
-      case ASTAssignmentOperator.divideAsInt:
-        result = (await _currentField(classContext, obj)) ~/ value;
-    }
-
-    var resultValue = await result;
+    var current = await _currentField(classContext, obj);
+    var resultValue = await _applyOperator(current, value);
     await obj.setField(classContext, name, resultValue);
     return resultValue;
   }

--- a/lib/src/ast/apollovm_ast_toplevel.dart
+++ b/lib/src/ast/apollovm_ast_toplevel.dart
@@ -821,6 +821,71 @@ class ASTClassNormal extends ASTClass<VMObject> {
     return field;
   }
 
+  /// Per-class storage for `static` field values, lazily initialized on first
+  /// access. Static fields belong to the class, not to each instance.
+  Map<String, ASTValue>? _staticFieldValues;
+
+  /// Whether [name] is a `static` field declared on this class.
+  bool hasStaticField(String name, {bool caseInsensitive = false}) {
+    var f = getField(name, caseInsensitive: caseInsensitive);
+    return f != null && f.modifiers.isStatic;
+  }
+
+  Future<Map<String, ASTValue>> _ensureStaticFields(
+    VMContext context,
+    ASTRunStatus runStatus,
+  ) async {
+    var store = _staticFieldValues;
+    if (store != null) return store;
+    store = _staticFieldValues = <String, ASTValue>{};
+    for (var field in _fields.values) {
+      if (!field.modifiers.isStatic) continue;
+      if (field is ASTClassFieldWithInitialValue) {
+        store[field.name] = await field.getInitialValue(context, runStatus);
+      } else {
+        store[field.name] = ASTValueNull.instance;
+      }
+    }
+    return store;
+  }
+
+  String _resolveStaticFieldName(
+    Map<String, ASTValue> store,
+    String name,
+    bool caseInsensitive,
+  ) {
+    if (caseInsensitive && !store.containsKey(name)) {
+      for (var k in store.keys) {
+        if (equalsIgnoreAsciiCase(k, name)) return k;
+      }
+    }
+    return name;
+  }
+
+  /// Reads a `static` field value (initializing static fields on first use).
+  Future<ASTValue?> getStaticFieldValue(
+    VMContext context,
+    String name, {
+    bool caseInsensitive = false,
+  }) async {
+    var store = await _ensureStaticFields(context, ASTRunStatus.dummy);
+    return store[_resolveStaticFieldName(store, name, caseInsensitive)];
+  }
+
+  /// Writes a `static` field value; returns the previous value.
+  Future<ASTValue?> setStaticFieldValue(
+    VMContext context,
+    String name,
+    ASTValue value, {
+    bool caseInsensitive = false,
+  }) async {
+    var store = await _ensureStaticFields(context, ASTRunStatus.dummy);
+    var key = _resolveStaticFieldName(store, name, caseInsensitive);
+    var prev = store[key];
+    store[key] = value;
+    return prev;
+  }
+
   @override
   FutureOr<ASTClassInstance<VMObject>?> createInstance(
     VMClassContext context,
@@ -844,6 +909,9 @@ class ASTClassNormal extends ASTClass<VMObject> {
     }
 
     for (var field in _fields.values) {
+      // `static` fields belong to the class, not the instance (see
+      // `getStaticFieldValue`/`setStaticFieldValue`).
+      if (field.modifiers.isStatic) continue;
       if (field is ASTClassFieldWithInitialValue) {
         var value = await field.getInitialValue(context, runStatus);
         instance.vmObject.setFieldValue(field.name, value);

--- a/lib/src/ast/apollovm_ast_variable.dart
+++ b/lib/src/ast/apollovm_ast_variable.dart
@@ -293,6 +293,18 @@ class ASTScopeVariable<T> extends ASTVariable {
 
     return variable.resolveMapped((v) {
       if (v == null) {
+        // A bare reference to a `static` field of the enclosing class (e.g.
+        // `count` inside a `static` method of the class that declares it). The
+        // AST identifier resolves to the field declaration; route reads/writes
+        // to the class's static-field store.
+        var idNode = resolvedIdentifier;
+        if (idNode is ASTClassField && idNode.modifiers.isStatic) {
+          var clazz = idNode.parentNode;
+          if (clazz is ASTClassNormal) {
+            return ASTStaticFieldVariable(clazz, name);
+          }
+        }
+
         var typeResolver = context.typeResolver;
         var resolveType = typeResolver.resolveType(name);
         return resolveType.resolveMapped((t) {
@@ -392,4 +404,33 @@ class ASTStaticClassAccessorVariable<T> extends ASTVariable {
   FutureOr<ASTValue> getValue(VMContext context) {
     return staticAccessor;
   }
+}
+
+/// [ASTVariable] for a bare reference to a `static` field of [clazz], e.g.
+/// `count` used inside a `static` method of the class that declares it. Reads
+/// and writes go to the class's static-field store (shared by all instances and
+/// by qualified `ClassName.field` access).
+class ASTStaticFieldVariable<T> extends ASTVariable {
+  final ASTClassNormal clazz;
+
+  ASTStaticFieldVariable(this.clazz, super.name);
+
+  @override
+  Iterable<ASTNode> get children => [];
+
+  @override
+  FutureOr<ASTType> resolveType(VMContext? context) =>
+      clazz.getField(name)?.type ?? ASTTypeDynamic.instance;
+
+  @override
+  ASTVariable resolveVariable(VMContext context) => this;
+
+  @override
+  FutureOr<ASTValue> getValue(VMContext context) => clazz
+      .getStaticFieldValue(context, name)
+      .resolveMapped((v) => v ?? ASTValueNull.instance);
+
+  @override
+  FutureOr<void> setValue(VMContext context, ASTValue value) =>
+      clazz.setStaticFieldValue(context, name, value).resolveMapped((_) {});
 }

--- a/lib/src/languages/csharp/csharp_grammar.dart
+++ b/lib/src/languages/csharp/csharp_grammar.dart
@@ -322,7 +322,12 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
                 (v[0] as ASTModifiers?) ?? ASTModifiers.modifiersNone;
             var type = v[1];
             var name = v[2];
-            return ASTClassField(type, name, modifiers.isFinal);
+            return ASTClassField(
+              type,
+              name,
+              modifiers.isFinal,
+              modifiers: modifiers,
+            );
           });
 
   Parser<ASTClassField> classFieldDeclarationWithValue() =>
@@ -343,6 +348,7 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
               name,
               expression,
               modifiers.isFinal,
+              modifiers: modifiers,
             );
           });
 

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -208,7 +208,12 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
                 (v[0] as ASTModifiers?) ?? ASTModifiers.modifiersNone;
             var type = v[1];
             var name = v[2];
-            return ASTClassField(type, name, modifiers.isFinal);
+            return ASTClassField(
+              type,
+              name,
+              modifiers.isFinal,
+              modifiers: modifiers,
+            );
           });
 
   Parser<ASTClassField> classFieldDeclarationWithValue() =>
@@ -229,6 +234,7 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
               name,
               expression,
               modifiers.isFinal,
+              modifiers: modifiers,
             );
           });
 

--- a/test/features/apollovm_static_fields_test.dart
+++ b/test/features/apollovm_static_fields_test.dart
@@ -1,0 +1,177 @@
+@TestOn('vm')
+@Tags(['dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Runs `[className].[method]` (a `static` method) and returns its value.
+Future<Object?> _runStatic(
+  String language,
+  String source,
+  String className,
+  String method,
+) async {
+  var vm = ApolloVM();
+  expect(
+    await vm.loadCodeUnit(SourceCodeUnit(language, source, id: 'test')),
+    isTrue,
+    reason: '$language: cannot parse',
+  );
+  var r = await vm
+      .createRunner(language)!
+      .executeClassMethod(
+        '',
+        className,
+        method,
+        positionalParameters: const [[]],
+        classInstanceFields: const {},
+      );
+  return r.getValueNoContext();
+}
+
+void main() {
+  group('Dart static fields', () {
+    test('bare read inside a static method', () async {
+      expect(
+        await _runStatic(
+          'dart',
+          'class C { static int count = 7; static int run() { return count; } }',
+          'C',
+          'run',
+        ),
+        equals(7),
+      );
+    });
+
+    test('bare write inside a static method persists', () async {
+      expect(
+        await _runStatic(
+          'dart',
+          'class C { static int count = 7;'
+              ' static int run() { count = count + 5; return count; } }',
+          'C',
+          'run',
+        ),
+        equals(12),
+      );
+    });
+
+    test('qualified read (ClassName.field) from another class', () async {
+      expect(
+        await _runStatic(
+          'dart',
+          'class C { static int count = 7; }'
+              ' class M { static int run() { return C.count; } }',
+          'M',
+          'run',
+        ),
+        equals(7),
+      );
+    });
+
+    test('qualified write (ClassName.field = v)', () async {
+      expect(
+        await _runStatic(
+          'dart',
+          'class C { static int count = 7; }'
+              ' class M { static int run() { C.count = 20; return C.count; } }',
+          'M',
+          'run',
+        ),
+        equals(20),
+      );
+    });
+
+    test('qualified compound assignment (ClassName.field += v)', () async {
+      expect(
+        await _runStatic(
+          'dart',
+          'class C { static int count = 7; }'
+              ' class M { static int run() { C.count += 5; return C.count; } }',
+          'M',
+          'run',
+        ),
+        equals(12),
+      );
+    });
+
+    test('a static field without an initializer defaults to null', () async {
+      expect(
+        await _runStatic(
+          'dart',
+          'class C { static int x; static bool run() { return x == null; } }',
+          'C',
+          'run',
+        ),
+        isTrue,
+      );
+    });
+
+    test('static and instance fields of the same class coexist', () async {
+      // The instance field `n` is per-instance; the static `total` is shared.
+      var r = await _runStatic(
+        'dart',
+        'class C {'
+            ' int n = 3;'
+            ' static int total = 100;'
+            ' static int run() { C.total = C.total + 1; return C.total; }'
+            ' }',
+        'C',
+        'run',
+      );
+      expect(r, equals(101));
+    });
+
+    test(
+      'static writes are visible across qualified and bare access',
+      () async {
+        expect(
+          await _runStatic(
+            'dart',
+            'class C {'
+                ' static int v = 1;'
+                ' static int bump() { v = v + 10; return v; }'
+                ' static int run() { bump(); return C.v; }'
+                ' }',
+            'C',
+            'run',
+          ),
+          equals(11),
+        );
+      },
+    );
+  });
+
+  group('Cross-language static fields', () {
+    test('Java: static field read/write', () async {
+      expect(
+        await _runStatic(
+          'java11',
+          'class C {'
+              ' static int count = 7;'
+              ' static int run() { count = count + 5; return count; }'
+              ' }',
+          'C',
+          'run',
+        ),
+        equals(12),
+      );
+    });
+
+    test('C#: static field read/write', () async {
+      expect(
+        await _runStatic(
+          'csharp',
+          'class C {'
+              ' static int count = 7;'
+              ' static int run() { count = count + 5; return count; }'
+              ' }',
+          'C',
+          'run',
+        ),
+        equals(12),
+      );
+    });
+  });
+}

--- a/test/features/apollovm_static_fields_test.dart
+++ b/test/features/apollovm_static_fields_test.dart
@@ -141,6 +141,107 @@ void main() {
         );
       },
     );
+
+    test('qualified read of a null-default static field', () async {
+      expect(
+        await _runStatic(
+          'dart',
+          'class C { static int x; }'
+              ' class M { static bool run() { return C.x == null; } }',
+          'M',
+          'run',
+        ),
+        isTrue,
+      );
+    });
+
+    test('every qualified compound operator on a static field', () async {
+      Future<Object?> op(String stmt) => _runStatic(
+        'dart',
+        'class C { static int v = 12; }'
+            ' class M { static int run() { $stmt; return C.v; } }',
+        'M',
+        'run',
+      );
+      expect(await op('C.v -= 2'), equals(10));
+      expect(await op('C.v *= 3'), equals(36));
+      expect(await op('C.v ~/= 5'), equals(2));
+
+      // `/=` yields a double, so use a double-typed static field.
+      expect(
+        await _runStatic(
+          'dart',
+          'class C { static double v = 12.0; }'
+              ' class M { static double run() { C.v /= 5; return C.v; } }',
+          'M',
+          'run',
+        ),
+        equals(2.4),
+      );
+    });
+
+    test('a static field carries its declared type', () async {
+      // Assigning `C.v` to a typed local exercises static-field type resolution.
+      expect(
+        await _runStatic(
+          'dart',
+          'class C { static int v = 42; }'
+              ' class M { static int run() { int y = C.v; return y; } }',
+          'M',
+          'run',
+        ),
+        equals(42),
+      );
+    });
+  });
+
+  group('Static-field internals (direct)', () {
+    Future<ASTClassNormal> loadClass(String src) async {
+      var vm = ApolloVM();
+      expect(
+        await vm.loadCodeUnit(SourceCodeUnit('dart', src, id: 't')),
+        isTrue,
+      );
+      return vm
+          .getNamespaceWithClass('C', language: 'dart')
+          .first
+          .getClass('C')!;
+    }
+
+    test(
+      'ASTStaticFieldVariable read/write/resolveType/resolveVariable',
+      () async {
+        var clazz = await loadClass('class C { static int count = 7; }');
+        var v = ASTStaticFieldVariable(clazz, 'count');
+        var ctx = VMScopeContext(ASTBlock(null));
+
+        expect(v.resolveVariable(ctx), same(v));
+        expect(await v.resolveType(ctx), isA<ASTTypeInt>());
+        var read = await v.getValue(ctx);
+        expect(read.getValueNoContext(), equals(7));
+        await v.setValue(ctx, ASTValueInt(99));
+        expect((await v.getValue(ctx)).getValueNoContext(), equals(99));
+      },
+    );
+
+    test('resolveType of an unknown field falls back to dynamic', () async {
+      var clazz = await loadClass('class C { static int count = 7; }');
+      var v = ASTStaticFieldVariable(clazz, 'missing');
+      var ctx = VMScopeContext(ASTBlock(null));
+      expect(await v.resolveType(ctx), isA<ASTTypeDynamic>());
+    });
+
+    test('getStaticFieldValue resolves a name case-insensitively', () async {
+      var clazz = await loadClass('class C { static int count = 7; }');
+      var ctx = VMScopeContext(ASTBlock(null));
+      expect(clazz.hasStaticField('COUNT', caseInsensitive: true), isTrue);
+      var v = await clazz.getStaticFieldValue(
+        ctx,
+        'COUNT',
+        caseInsensitive: true,
+      );
+      expect(v?.getValueNoContext(), equals(7));
+    });
   });
 
   group('Cross-language static fields', () {


### PR DESCRIPTION
PR 2 from the bug/missing-feature sweep — implements **static class fields** (Tier 2 of the analysis). Part of the **2.1.1** release (no version bump; CHANGELOG appended). Full VM suite green (2179 tests, `-x wasm-gc`), analyze + format clean.

## Problem
`static` fields had no class-level storage: they were initialized onto *every instance*, and reading one threw at runtime — `ClassName.field` ("getter not found") and a bare reference inside a `static` method ("Can't find variable"). Static *methods* already worked.

## Changes
- **Per-class static store** on `ASTClassNormal` — lazily initialized `getStaticFieldValue`/`setStaticFieldValue`; `static` fields are no longer initialized onto instances.
- **Qualified `ClassName.staticField`** read/write/compound resolved to the store in the getter/setter expression nodes (parallel to the existing enum-static handling).
- **Bare `staticField`** inside the class's own `static` methods resolved via a new `ASTStaticFieldVariable`; the assignment node now also resolves its target so the bare-write path sees the static identifier.
- **Java & C# grammars** now pass field `modifiers` to `ASTClassField` (they were dropping `static`), so static fields work in those languages too.

## Tests
`apollovm_static_fields_test.dart`: bare + qualified read/write, compound assignment, default-null, static/instance coexistence, cross-visibility writes, and Java + C# cases.

## Notes
- Interpreter-level (the Wasm backend's separate static-field gap is tracked in `WASM_BACKEND_PLAN.md`).
- Follow-ups from the analysis (inheritance/`super`, nested indexing) remain for subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)