### PR TITLE
feat: class inheritance (extends) — inherited methods/fields + super

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,20 @@ were invisible and `super` was unresolved. Now:
   override still wins over the inherited method.
 - **Inherited fields** are initialized onto instances (superclass-first) and are
   readable/writable from a subclass.
-- **`super.method()`** dispatches to the parent's (overridden) method, resolved
-  relative to the class where the call is written (correct for multi-level
-  hierarchies).
+- **Inherited getters** resolve through the superclass chain (a subclass getter
+  override still wins), and **inherited `static` fields** read/write the base
+  class that declares them (`Sub.staticField`).
+- **`super`** dispatches to the parent: `super.method()` calls the overridden
+  parent method (resolved relative to the class where the call is written, so it
+  is correct for multi-level hierarchies), `super.getter` reads the parent
+  getter, and `super.field` reads/writes the inherited field.
 - The **Java** (`extends`) and **C#** (`: Base`) grammars now record the
   superclass they were previously dropping, so inheritance works across those
   languages too.
+
+Not yet supported: constructor initializer lists with an explicit
+super-constructor call (`B(v) : super(v)`) — inherited fields are still set from
+a constructor body or a `this.param`.
 
 ## 2.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 2.2.0
+
+### Class inheritance (`extends`) is now functional
+
+`extends` was parsed but had no runtime effect — inherited methods and fields
+were invisible and `super` was unresolved. Now:
+
+- **Inherited methods** resolve through the superclass chain, for both bare calls
+  (`base()` inside a subclass) and receiver calls (`obj.base()`); a subclass
+  override still wins over the inherited method.
+- **Inherited fields** are initialized onto instances (superclass-first) and are
+  readable/writable from a subclass.
+- **`super.method()`** dispatches to the parent's (overridden) method, resolved
+  relative to the class where the call is written (correct for multi-level
+  hierarchies).
+- The **Java** (`extends`) and **C#** (`: Base`) grammars now record the
+  superclass they were previously dropping, so inheritance works across those
+  languages too.
+
 ## 2.1.1
 
 ### `static` class fields are now supported

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.1.1';
+  static final String VERSION = '2.2.0';
 
   static int _idCount = 0;
 

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -2630,11 +2630,46 @@ class ASTExpressionObjectFunctionInvocation
     variable.resolveNode(this);
   }
 
+  /// Whether this is a `super.method(...)` call (the receiver is `super`).
+  bool get _isSuper => variable.name == 'super';
+
+  /// The class whose body textually contains this invocation (the *static*
+  /// enclosing class, used to resolve `super` relative to where it is written,
+  /// not the runtime instance's class — important for multi-level hierarchies).
+  ASTClass? _enclosingClass() {
+    for (ASTNode? n = parentNode; n != null; n = n.parentNode) {
+      if (n is ASTClass) return n;
+    }
+    return null;
+  }
+
   FutureOr<ASTValue> _getVariableValue(VMContext parentContext) {
+    if (_isSuper) {
+      // `super` is the current instance; the superclass drives method dispatch
+      // (see `_getObjectClass`).
+      var obj = parentContext.getClassInstance();
+      if (obj == null) {
+        throw ApolloVMRuntimeError(
+          "Can't resolve `super`: no class instance in scope.",
+        );
+      }
+      return obj;
+    }
     return variable.getValue(parentContext);
   }
 
   FutureOr<ASTClass> _getObjectClass(VMContext parentContext) {
+    if (_isSuper) {
+      var enclosing = _enclosingClass();
+      var superClass = enclosing?.superClass;
+      if (superClass == null) {
+        throw ApolloVMRuntimeError(
+          "Can't resolve `super`: class `${enclosing?.name}` has no superclass.",
+        );
+      }
+      return superClass;
+    }
+
     var retObj = _getVariableValue(parentContext);
 
     return retObj.resolveMapped((obj) {

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -3119,11 +3119,43 @@ class ASTExpressionObjectGetterAccess extends ASTExpressionGetterAccess
     variable.resolveNode(this);
   }
 
+  /// Whether the receiver is `super` (`super.field` / `super.getter`).
+  bool get _isSuper => variable.name == 'super';
+
+  /// The class whose body textually contains this access, for resolving `super`
+  /// relative to where it is written (not the runtime instance's class).
+  ASTClass? _enclosingClass() {
+    for (ASTNode? n = parentNode; n != null; n = n.parentNode) {
+      if (n is ASTClass) return n;
+    }
+    return null;
+  }
+
   FutureOr<ASTValue> _getVariableValue(VMContext parentContext) {
+    if (_isSuper) {
+      var obj = parentContext.getClassInstance();
+      if (obj == null) {
+        throw ApolloVMRuntimeError(
+          "Can't resolve `super`: no class instance in scope.",
+        );
+      }
+      return obj;
+    }
     return variable.getValue(parentContext);
   }
 
   FutureOr<ASTClass> _getObjectClass(VMContext parentContext) {
+    if (_isSuper) {
+      var superClass = _enclosingClass()?.superClass;
+      if (superClass == null) {
+        throw ApolloVMRuntimeError(
+          "Can't resolve `super`: class "
+          "`${_enclosingClass()?.name}` has no superclass.",
+        );
+      }
+      return superClass;
+    }
+
     var retObj = _getVariableValue(parentContext);
 
     return retObj.resolveMapped((obj) {
@@ -3420,7 +3452,11 @@ class ASTExpressionObjectSetterAssignment extends ASTExpression {
       return resultValue;
     }
 
-    var obj = await variable.getValue(context);
+    // `super.field = value`: a field is not polymorphic, so `super.field`
+    // refers to the same instance field as `this.field`.
+    var obj = variable.name == 'super'
+        ? context.getClassInstance()
+        : await variable.getValue(context);
     if (obj is! ASTClassInstance) {
       throw ApolloVMRuntimeError(
         "Can't set field `$name`: target is not a class instance: $obj",

--- a/lib/src/ast/apollovm_ast_toplevel.dart
+++ b/lib/src/ast/apollovm_ast_toplevel.dart
@@ -333,6 +333,24 @@ abstract class ASTClass<T> extends ASTEntryPointBlock {
     return null;
   }
 
+  /// Resolves a getter visible from this class: own getters first, then the
+  /// superclass chain (inherited getters).
+  @override
+  ASTGetterDeclaration? getGetter(
+    String fName,
+    VMContext context, {
+    bool caseInsensitive = false,
+  }) {
+    var g = super.getGetter(fName, context, caseInsensitive: caseInsensitive);
+    if (g != null) return g;
+
+    return superClass?.getGetter(
+      fName,
+      context,
+      caseInsensitive: caseInsensitive,
+    );
+  }
+
   List<ASTConstructorSet> get constructors;
 
   void resolveNodeConstructors(ASTNode? parentNode);
@@ -902,23 +920,65 @@ class ASTClassNormal extends ASTClass<VMObject> {
     return name;
   }
 
-  /// Reads a `static` field value (initializing static fields on first use).
+  /// Whether this class itself declares a `static` field [name] (not inherited).
+  bool _declaresStaticFieldLocally(String name, bool caseInsensitive) {
+    var f = _fields[name];
+    if (f == null && caseInsensitive) {
+      for (var entry in _fields.entries) {
+        if (equalsIgnoreAsciiCase(entry.key, name)) {
+          f = entry.value;
+          break;
+        }
+      }
+    }
+    return f != null && f.modifiers.isStatic;
+  }
+
+  /// The superclass as an [ASTClassNormal], if it declares static-field storage.
+  ASTClassNormal? get _superClassNormal =>
+      superClass is ASTClassNormal ? superClass as ASTClassNormal : null;
+
+  /// Reads a `static` field value (initializing static fields on first use). A
+  /// field inherited from the superclass is read from the class that declares
+  /// it (static storage is per-declaring-class).
   Future<ASTValue?> getStaticFieldValue(
     VMContext context,
     String name, {
     bool caseInsensitive = false,
   }) async {
+    if (!_declaresStaticFieldLocally(name, caseInsensitive)) {
+      var sc = _superClassNormal;
+      if (sc != null) {
+        return sc.getStaticFieldValue(
+          context,
+          name,
+          caseInsensitive: caseInsensitive,
+        );
+      }
+    }
     var store = await _ensureStaticFields(context, ASTRunStatus.dummy);
     return store[_resolveStaticFieldName(store, name, caseInsensitive)];
   }
 
-  /// Writes a `static` field value; returns the previous value.
+  /// Writes a `static` field value; returns the previous value. An inherited
+  /// static field is written through to its declaring class.
   Future<ASTValue?> setStaticFieldValue(
     VMContext context,
     String name,
     ASTValue value, {
     bool caseInsensitive = false,
   }) async {
+    if (!_declaresStaticFieldLocally(name, caseInsensitive)) {
+      var sc = _superClassNormal;
+      if (sc != null) {
+        return sc.setStaticFieldValue(
+          context,
+          name,
+          value,
+          caseInsensitive: caseInsensitive,
+        );
+      }
+    }
     var store = await _ensureStaticFields(context, ASTRunStatus.dummy);
     var key = _resolveStaticFieldName(store, name, caseInsensitive);
     var prev = store[key];

--- a/lib/src/ast/apollovm_ast_toplevel.dart
+++ b/lib/src/ast/apollovm_ast_toplevel.dart
@@ -286,11 +286,16 @@ abstract class ASTClass<T> extends ASTEntryPointBlock {
     VMContext? parentContext,
   ]) => VMClassContext(this, parent: parentContext, typeResolver: typeResolver);
 
-  /// Resolves a function/constructor visible from inside this class. Falls back
-  /// to the enclosing [ASTRoot] (reached via the `parentNode` chain set by
-  /// `ASTRoot.resolveNode`) so a method can instantiate sibling classes (their
-  /// constructors) and call top-level functions — the class-method execution
-  /// context is rooted at the class, not the program root.
+  /// The resolved superclass this class `extends`, or `null` if none. Overridden
+  /// by [ASTClassNormal] (which carries the `extends` name).
+  ASTClass? get superClass => null;
+
+  /// Resolves a function/constructor visible from inside this class. Checks this
+  /// class's own functions, then the superclass chain (inherited methods), then
+  /// falls back to the enclosing [ASTRoot] (reached via the `parentNode` chain
+  /// set by `ASTRoot.resolveNode`) so a method can instantiate sibling classes
+  /// (their constructors) and call top-level functions — the class-method
+  /// execution context is rooted at the class, not the program root.
   @override
   ASTInvocableDeclaration? getFunction(
     String fName,
@@ -305,6 +310,15 @@ abstract class ASTClass<T> extends ASTEntryPointBlock {
       caseInsensitive: caseInsensitive,
     );
     if (f != null) return f;
+
+    // Inherited method from the superclass chain.
+    var sf = superClass?.getFunction(
+      fName,
+      parametersSignature,
+      context,
+      caseInsensitive: caseInsensitive,
+    );
+    if (sf != null) return sf;
 
     for (ASTNode? node = parentNode; node != null; node = node.parentNode) {
       if (node is ASTRoot) {
@@ -617,6 +631,24 @@ class ASTClassNormal extends ASTClass<VMObject> {
   /// Returns `true` if this class is `abstract`.
   bool get isAbstract => kind == ASTClassKind.abstractClass;
 
+  ASTClass? _superClass;
+  bool _superClassResolved = false;
+
+  /// The resolved superclass named by [superClassName] (via the enclosing
+  /// [ASTRoot]), or `null` if there is no `extends` or it can't be resolved.
+  @override
+  ASTClass? get superClass {
+    if (!_superClassResolved) {
+      _superClassResolved = true;
+      var name = superClassName;
+      if (name != null && name != this.name) {
+        var node = getNodeIdentifier(name);
+        if (node is ASTClass) _superClass = node;
+      }
+    }
+    return _superClass;
+  }
+
   @override
   void set(ASTBlock? other) {
     if (other == null) return;
@@ -818,6 +850,14 @@ class ASTClassNormal extends ASTClass<VMObject> {
       }
     }
 
+    // Fall back to an inherited field from the superclass chain.
+    field ??= superClass is ASTClassNormal
+        ? (superClass as ASTClassNormal).getField(
+            name,
+            caseInsensitive: caseInsensitive,
+          )
+        : null;
+
     return field;
   }
 
@@ -906,6 +946,13 @@ class ASTClassNormal extends ASTClass<VMObject> {
   ) async {
     if (instance is! ASTClassInstance<VMObject>) {
       throw _exceptionNotClassInstance(instance);
+    }
+
+    // Initialize inherited fields first (superclass chain), so a subclass's
+    // own fields are applied last.
+    var superClass = this.superClass;
+    if (superClass is ASTClassNormal) {
+      await superClass.initializeInstance(context, runStatus, instance);
     }
 
     for (var field in _fields.values) {

--- a/lib/src/languages/csharp/csharp_grammar.dart
+++ b/lib/src/languages/csharp/csharp_grammar.dart
@@ -250,8 +250,21 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
               classCodeBlock())
           .map((v) {
             var name = v[2] as String;
+            var baseList = v[4];
             var block = v[5];
-            var clazz = ASTClassNormal(name, ASTType<VMObject>(name), null);
+            // The first entry of a C# base list (`: Base, IFace, …`) is the
+            // base class; record it as the superclass.
+            String? superName;
+            if (baseList is List && baseList.length > 1) {
+              var firstBase = baseList[1];
+              if (firstBase is ASTType) superName = firstBase.name;
+            }
+            var clazz = ASTClassNormal(
+              name,
+              ASTType<VMObject>(name),
+              null,
+              superClassName: superName,
+            );
             clazz.set(block);
             _classTypeParameters.clear();
             return clazz;

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -144,11 +144,28 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
               }) &
               identifier() &
               typeParameters().optional() &
+              (string('extends').trimHidden() & ref0(type)).optional() &
+              (string('implements').trimHidden() &
+                      ref0(type) &
+                      (char(',').trimHidden() & ref0(type)).star())
+                  .optional() &
               classCodeBlock())
           .map((v) {
             var name = v[1] as String;
-            var block = v[3];
-            var clazz = ASTClassNormal(name, ASTType<VMObject>(name), null);
+            var ext = v[3];
+            var block = v[5];
+            // `extends Base` records the superclass name.
+            String? superName;
+            if (ext is List) {
+              var t = ext[1];
+              if (t is ASTType) superName = t.name;
+            }
+            var clazz = ASTClassNormal(
+              name,
+              ASTType<VMObject>(name),
+              null,
+              superClassName: superName,
+            );
             clazz.set(block);
             _classTypeParameters.clear();
             return clazz;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.1.1
+version: 2.2.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/features/apollovm_inheritance_test.dart
+++ b/test/features/apollovm_inheritance_test.dart
@@ -185,6 +185,213 @@ void main() {
     });
   });
 
+  group('super fields', () {
+    test('super.field reads the inherited instance field', () async {
+      expect(
+        await _run(
+          'dart',
+          'class A { int x = 7; }'
+              ' class B extends A { int g() { return super.x; } }'
+              ' class M { static int run() { var b = B(); return b.g(); } }',
+          'M',
+          'run',
+        ),
+        equals(7),
+      );
+    });
+
+    test('super.field = value writes the inherited instance field', () async {
+      expect(
+        await _run(
+          'dart',
+          'class A { int x = 7; }'
+              ' class B extends A { int g() { super.x = 20; return x; } }'
+              ' class M { static int run() { var b = B(); return b.g(); } }',
+          'M',
+          'run',
+        ),
+        equals(20),
+      );
+    });
+
+    test('super.getter in a class with no superclass errors clearly', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(
+        SourceCodeUnit(
+          'dart',
+          'class A { int get v { return super.v; } }'
+              ' class M { static int run() { var a = A(); return a.v; } }',
+          id: 'test',
+        ),
+      );
+      await expectLater(
+        vm
+            .createRunner('dart')!
+            .executeClassMethod(
+              '',
+              'M',
+              'run',
+              positionalParameters: const [[]],
+              classInstanceFields: const {},
+            ),
+        throwsA(isA<ApolloVMRuntimeError>()),
+      );
+    });
+
+    test('super.getter dispatches to the parent (overridden) getter', () async {
+      expect(
+        await _run(
+          'dart',
+          'class A { int get v { return 1; } }'
+              ' class B extends A { int get v { return 2; }'
+              ' int g() { return super.v; } }'
+              ' class M { static int run() { var b = B(); return b.g(); } }',
+          'M',
+          'run',
+        ),
+        equals(1),
+      );
+    });
+  });
+
+  group('Inherited getters', () {
+    test('an inherited getter is readable on an instance', () async {
+      expect(
+        await _run(
+          'dart',
+          'class A { int _x = 4; int get gx { return _x; } }'
+              ' class B extends A {}'
+              ' class M { static int run() { var b = B(); return b.gx; } }',
+          'M',
+          'run',
+        ),
+        equals(4),
+      );
+    });
+
+    test('a getter override wins over the inherited getter', () async {
+      expect(
+        await _run(
+          'dart',
+          'class A { int get gx { return 1; } }'
+              ' class B extends A { int get gx { return 2; } }'
+              ' class M { static int run() { var b = B(); return b.gx; } }',
+          'M',
+          'run',
+        ),
+        equals(2),
+      );
+    });
+  });
+
+  group('Inherited static fields', () {
+    test('a subclass reads an inherited static field (qualified)', () async {
+      expect(
+        await _run(
+          'dart',
+          'class A { static int c = 9; }'
+              ' class B extends A {}'
+              ' class M { static int run() { return B.c; } }',
+          'M',
+          'run',
+        ),
+        equals(9),
+      );
+    });
+
+    test(
+      'writing an inherited static field goes to the declaring class',
+      () async {
+        // `B.c = 20` writes through to `A.c` (static storage is per-declaring
+        // class), so reading `A.c` back sees the new value.
+        expect(
+          await _run(
+            'dart',
+            'class A { static int c = 9; }'
+                ' class B extends A {}'
+                ' class M { static int run() { B.c = 20; return A.c; } }',
+            'M',
+            'run',
+          ),
+          equals(20),
+        );
+      },
+    );
+  });
+
+  group('Constructors with inheritance', () {
+    test(
+      'a subclass constructor sets an inherited field by bare name',
+      () async {
+        expect(
+          await _run(
+            'dart',
+            'class A { int x = 0; }'
+                ' class B extends A { B(int v) { x = v; } }'
+                ' class M { static int run() { var b = B(9); return b.x; } }',
+            'M',
+            'run',
+          ),
+          equals(9),
+        );
+      },
+    );
+
+    test('a subclass `this.param` binds an inherited field', () async {
+      expect(
+        await _run(
+          'dart',
+          'class A { int x = 0; }'
+              ' class B extends A { B(this.x); }'
+              ' class M { static int run() { var b = B(13); return b.x; } }',
+          'M',
+          'run',
+        ),
+        equals(13),
+      );
+    });
+
+    test(
+      'the default constructor initializes inherited field values',
+      () async {
+        expect(
+          await _run(
+            'dart',
+            'class A { int x = 42; }'
+                ' class B extends A {}'
+                ' class M { static int run() { var b = B(); return b.x; } }',
+            'M',
+            'run',
+          ),
+          equals(42),
+        );
+      },
+    );
+  });
+
+  group('Known limitations', () {
+    test(
+      'a constructor initializer list (`: super(v)`) does not parse yet',
+      () async {
+        // Documents a current parser gap: explicit super-constructor calls in an
+        // initializer list are not supported. Inherited fields are still set via
+        // the constructor body or `this.param`.
+        var vm = ApolloVM();
+        await expectLater(
+          vm.loadCodeUnit(
+            SourceCodeUnit(
+              'dart',
+              'class A { int x = 0; A(int v) { x = v; } }'
+                  ' class B extends A { B(int v) : super(v); }',
+              id: 'test',
+            ),
+          ),
+          throwsA(isA<SyntaxError>()),
+        );
+      },
+    );
+  });
+
   group('Cross-language inheritance', () {
     test('Java: inherited method + override', () async {
       expect(

--- a/test/features/apollovm_inheritance_test.dart
+++ b/test/features/apollovm_inheritance_test.dart
@@ -1,0 +1,216 @@
+@TestOn('vm')
+@Tags(['dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+Future<Object?> _run(
+  String language,
+  String source,
+  String className,
+  String method,
+) async {
+  var vm = ApolloVM();
+  expect(
+    await vm.loadCodeUnit(SourceCodeUnit(language, source, id: 'test')),
+    isTrue,
+    reason: '$language: cannot parse',
+  );
+  var r = await vm
+      .createRunner(language)!
+      .executeClassMethod(
+        '',
+        className,
+        method,
+        positionalParameters: const [[]],
+        classInstanceFields: const {},
+      );
+  return r.getValueNoContext();
+}
+
+void main() {
+  group('Inherited methods', () {
+    test('a subclass calls an inherited method by bare name', () async {
+      expect(
+        await _run(
+          'dart',
+          'class A { int base() { return 1; } }'
+              ' class B extends A { int run() { return base() + 2; } }',
+          'B',
+          'run',
+        ),
+        equals(3),
+      );
+    });
+
+    test('an inherited method is callable on an instance', () async {
+      expect(
+        await _run(
+          'dart',
+          'class A { int base() { return 5; } }'
+              ' class B extends A {}'
+              ' class M { static int run() { var b = B(); return b.base(); } }',
+          'M',
+          'run',
+        ),
+        equals(5),
+      );
+    });
+
+    test('a method override wins over the inherited method', () async {
+      expect(
+        await _run(
+          'dart',
+          'class A { int f() { return 1; } }'
+              ' class B extends A { int f() { return 2; } }'
+              ' class M { static int run() { var b = B(); return b.f(); } }',
+          'M',
+          'run',
+        ),
+        equals(2),
+      );
+    });
+
+    test('a method inherited across two levels', () async {
+      expect(
+        await _run(
+          'dart',
+          'class A { int base() { return 9; } }'
+              ' class B extends A {}'
+              ' class C extends B {}'
+              ' class M { static int run() { var c = C(); return c.base(); } }',
+          'M',
+          'run',
+        ),
+        equals(9),
+      );
+    });
+  });
+
+  group('Inherited fields', () {
+    test('a subclass reads an inherited field', () async {
+      expect(
+        await _run(
+          'dart',
+          'class A { int x = 7; }'
+              ' class B extends A { int run() { return x; } }',
+          'B',
+          'run',
+        ),
+        equals(7),
+      );
+    });
+
+    test('a subclass writes an inherited field', () async {
+      expect(
+        await _run(
+          'dart',
+          'class A { int x = 7; }'
+              ' class B extends A { int run() { x = x + 3; return x; } }',
+          'B',
+          'run',
+        ),
+        equals(10),
+      );
+    });
+
+    test('inherited and own fields coexist', () async {
+      expect(
+        await _run(
+          'dart',
+          'class A { int a = 1; }'
+              ' class B extends A { int b = 2; int run() { return a + b; } }',
+          'B',
+          'run',
+        ),
+        equals(3),
+      );
+    });
+  });
+
+  group('super', () {
+    test('super.method() calls the overridden parent method', () async {
+      expect(
+        await _run(
+          'dart',
+          'class A { int f() { return 10; } }'
+              ' class B extends A { int f() { return super.f() + 5; }'
+              ' int run() { return f(); } }',
+          'B',
+          'run',
+        ),
+        equals(15),
+      );
+    });
+
+    test('super in a class with no superclass errors clearly', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnit(
+        SourceCodeUnit(
+          'dart',
+          'class A { int f() { return super.f(); } int run() { return f(); } }',
+          id: 'test',
+        ),
+      );
+      await expectLater(
+        vm
+            .createRunner('dart')!
+            .executeClassMethod(
+              '',
+              'A',
+              'run',
+              positionalParameters: const [[]],
+              classInstanceFields: const {},
+            ),
+        throwsA(isA<ApolloVMRuntimeError>()),
+      );
+    });
+
+    test('super resolves relative to the textual class (multi-level)', () async {
+      // C inherits B.f; B.f's `super` is A.f (not C's parent B), so the result
+      // is A.f() + 10 = 11.
+      expect(
+        await _run(
+          'dart',
+          'class A { int f() { return 1; } }'
+              ' class B extends A { int f() { return super.f() + 10; } }'
+              ' class C extends B {'
+              ' static int run() { var c = C(); return c.f(); } }',
+          'C',
+          'run',
+        ),
+        equals(11),
+      );
+    });
+  });
+
+  group('Cross-language inheritance', () {
+    test('Java: inherited method + override', () async {
+      expect(
+        await _run(
+          'java11',
+          'class A { int f() { return 1; } int base() { return 100; } }'
+              ' class B extends A { int f() { return 2; }'
+              ' int run() { return f() + base(); } }',
+          'B',
+          'run',
+        ),
+        equals(102),
+      );
+    });
+
+    test('C#: inherited field', () async {
+      expect(
+        await _run(
+          'csharp',
+          'class A { int x = 7; }'
+              ' class B : A { int run() { return x + 1; } }',
+          'B',
+          'run',
+        ),
+        equals(8),
+      );
+    });
+  });
+}


### PR DESCRIPTION
PR 3 from the bug/missing-feature sweep — implements **class inheritance** (Tier 2 of the analysis). Bumps to **2.2.0**. Full VM suite green (2208 tests, `-x wasm-gc`), analyze + format clean, ~97% patch coverage.

## Problem
`extends` was parsed but had **no runtime effect** — inherited members threw and `super` was unresolved.

## Changes
- **Superclass resolution** — `ASTClass.superClass` resolves `superClassName` via the enclosing root; `getFunction`, `getGetter`, and `getField` chain through the superclass; static-field storage chains to the declaring class. Subclass overrides still win.
- **Inherited fields** — `initializeInstance` inits the superclass chain first, so inherited fields exist on instances (read/write).
- **Inherited getters** and **inherited static fields** (`Sub.staticField`).
- **`super`** — `super.method()` dispatches to the parent's overridden method (resolved from the *textual* enclosing class → correct for multi-level); `super.getter` and `super.field` (read/write).
- **Java / C# grammars** now record the base class they were dropping (Java `extends`, C# `: Base`).

## Tests (`apollovm_inheritance_test.dart`, 24 cases)
Inherited methods (bare, receiver, override, 2-level); inherited fields (read/write/coexist); `super` method/field/getter (incl. multi-level + no-superclass errors); inherited getters (+override wins); inherited static (read/write); constructors with inheritance (bare, `this.param`, default init); and a documented parser limitation for `: super(v)` initializer lists. Java + C# cases.

## Known limitation (documented, follow-up)
Constructor initializer lists with an explicit `: super(v)` call are a parser gap; inherited fields are set from the constructor body or `this.param` in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)