### PR TITLE
feat(wasm): compile static class fields to module globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.3.0
+
+### Wasm: `static` class fields
+
+The on-the-fly WebAssembly compiler now supports `static` class fields (bringing
+it toward parity with the interpreter, which gained them in 2.1.1). Each static
+field becomes a typed, mutable module **global** seeded with its literal
+`int`/`double`/`bool` initializer; a bare reference inside a `static` method
+reads and writes it (including compound assignment like `c += 1`), and values
+persist across calls. Qualified `Class.field` from another class, inherited
+static fields, and non-literal initializers remain follow-ups.
+
 ## 2.2.0
 
 ### Nested / chained index access (`m[0][1]`)

--- a/WASM_BACKEND_PLAN.md
+++ b/WASM_BACKEND_PLAN.md
@@ -132,25 +132,19 @@ test('instance getter', () => _testWasm(
 
 ---
 
-## GAP D — `static` fields (INTERPRETER-SUPPORTED since 2.1.1)
+## GAP D — `static` fields — DONE (bare access)
 
-> The AST interpreter fully supports `static` fields (read/write, qualified and
-> bare, incl. inherited) as of 2.1.1. Wasm is the only backend that can't compile
-> them, so this is now a straight interpret-works / Wasm-doesn't gap.
+Static fields now compile to typed, mutable module **globals** (one per field,
+placed after the heap pointer and before the enum-entry caches), seeded with
+their literal `int`/`double`/`bool` initializer. A bare reference inside a
+`static` method reads/writes the global (`global.get`/`global.set`), including
+compound assignment; values persist across calls. See
+`apollovm_wasm_static_field_test.dart`.
 
-- **Error** (compile): `Bad state: Can't find local variable \`count\` in
-  context.`
-- **Trigger**: reading/writing a `static` field (`return count;`, `C.count`,
-  `C.count = v`). Static *methods* work; static *fields* don't resolve.
-- **Fix direction**: give static fields module-level storage (a global or a
-  fixed memory slot, per declaring class) and resolve a bare/`Class.`-qualified
-  static-field name to a load/store from it.
-
-```dart
-test('static field read', () => _testWasm(
-  'class C { static int count = 7; static int run() { return count; } }',
-  'C.run', {[]: 7}));
-```
+**Remaining (follow-up):** qualified `C.field` from *another* class (goes through
+the getter path, not the bare-variable path), inherited static fields (walk the
+superclass chain), and non-literal initializers (need a start function). Bare
+same-class access — the common case — is covered.
 
 ---
 

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.2.0';
+  static final String VERSION = '2.3.0';
 
   static int _idCount = 0;
 

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -96,6 +96,21 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
     var functions = [...baseFunctions, ...anonClosures.map((c) => c.function)];
     var module = WasmModuleContext(functions, classLayouts: classLayouts);
+
+    // Register a module global for each `static` field, up front (before any
+    // enum-entry global) so global indices are stable. Only literal `int`/
+    // `double`/`bool` initializers are seeded; others start at 0.
+    for (var clazz in root.classes) {
+      for (var field in clazz.fields) {
+        if (!field.modifiers.isStatic) continue;
+        module.registerStaticFieldGlobal(
+          '${clazz.name}.${field.name}',
+          field.type,
+          _staticFieldInitNum(field),
+        );
+      }
+    }
+
     for (var c in anonClosures) {
       module.registerClosure(c);
     }
@@ -207,6 +222,40 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     }
     return WasmClassLayout(clazz.name, offsets, types, offset);
   }
+
+  /// The seed value for a `static` field global: the field's literal `int` /
+  /// `double` / `bool` initializer (bool as `0`/`1`), or `0` when there is no
+  /// initializer or it is not a compile-time literal.
+  num _staticFieldInitNum(ASTClassField field) {
+    if (field is ASTClassFieldWithInitialValue) {
+      try {
+        var v = field.getInitialValueNoContext();
+        if (v is ASTValue) {
+          var raw = v.getValueNoContext();
+          if (raw is bool) return raw ? 1 : 0;
+          if (raw is num) return raw;
+        }
+      } catch (_) {
+        // Non-literal initializer: leave the global at 0.
+      }
+    }
+    return 0;
+  }
+
+  /// The `"Class.field"` key of a bare `static` field [name] of the current
+  /// class (via `context.classLayout`), or `null` if it isn't a static field.
+  String? _staticFieldKey(WasmContext context, String name) {
+    var module = context.module;
+    var className = context.classLayout?.className;
+    if (module == null || className == null) return null;
+    var key = '$className.$name';
+    return module.staticFieldGlobalIndexOf(key) != null ? key : null;
+  }
+
+  /// The virtual-stack type used for a value of [type]: a `bool` is an i32,
+  /// otherwise the type itself (`int`↔i64 / `double`↔f64, as elsewhere).
+  ASTType _wasmStackTypeFor(ASTType type) =>
+      type is ASTTypeBool ? _astTypeInt32 : type;
 
   /// Synthesizes the module functions for a class: one per constructor (Wasm
   /// signature = the constructor's value params, returns an i32 object pointer)
@@ -1176,6 +1225,37 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         description: "Global \$hp",
       ),
     ];
+
+    // Static-field globals (mutable, typed by the field): one per `static`
+    // field, seeded with its literal initializer. Placed right after `$hp`.
+    for (var sf in module.staticFieldGlobals) {
+      final int typeByte;
+      final List<int> initConst;
+      if (sf.type is ASTTypeInt) {
+        typeByte = WasmType.i64Type.value;
+        initConst = Wasm64.i64Const(sf.init.toInt());
+      } else if (sf.type is ASTTypeDouble) {
+        typeByte = WasmType.f64Type.value;
+        initConst = Wasm64.f64Const(sf.init.toDouble());
+      } else {
+        // `bool` and reference/other types use an i32 global (0 by default).
+        typeByte = WasmType.i32Type.value;
+        initConst = Wasm32.i32Const(sf.init.toInt());
+      }
+      entries.add(
+        BytesOutput(
+          data: [
+            BytesOutput(data: typeByte, description: "Global type"),
+            BytesOutput(data: Wasm.globalMutable, description: "Mutable"),
+            BytesOutput(
+              data: [...initConst, Wasm.end],
+              description: "Init (${sf.key} = ${sf.init})",
+            ),
+          ],
+          description: "Static field global `${sf.key}`",
+        ),
+      );
+    }
 
     // Globals 1..N (mutable i32, init 0): one per enum entry, caching its
     // lazily-built `const` instance pointer (0 = not yet built).
@@ -4024,6 +4104,20 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       return _generateFieldGet(out, context, name);
     }
 
+    // A bare `static` field of the current class reads its module global.
+    var staticKey = _staticFieldKey(context, name);
+    if (staticKey != null) {
+      final s0 = context.stackLength;
+      var type = context.module!.staticFieldTypeOf(staticKey)!;
+      out.write(
+        Wasm.globalGet(context.module!.staticFieldGlobalIndexOf(staticKey)!),
+        description: "[OP] static field get `$staticKey`",
+      );
+      context.stackPush(_wasmStackTypeFor(type), "static field `$name`");
+      context.assertStackLength(s0 + 1, "After static field get `$name`");
+      return out;
+    }
+
     var localVar = _getLocalVariable(context, name);
 
     final stackLng0 = context.stackLength;
@@ -4066,6 +4160,39 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     // `this + offset`.
     if (context.isFieldAccess(name)) {
       return _generateFieldSet(expression, out: out, context: context);
+    }
+
+    // A bare `static` field of the current class stores to its module global.
+    var staticKey = _staticFieldKey(context, name);
+    if (staticKey != null) {
+      final s0 = context.stackLength;
+      if (op == ASTAssignmentOperator.set) {
+        generateASTExpression(
+          expression.expression,
+          out: out,
+          context: context,
+        );
+      } else {
+        // Compound op: read the current value (`ASTExpressionVariableAccess`
+        // resolves to the static global), apply the operator with the RHS.
+        generateASTExpressionOperation(
+          ASTExpressionOperation(
+            ASTExpressionVariableAccess(variable),
+            op.asASTExpressionOperator!,
+            expression.expression,
+          ),
+          out: out,
+          context: context,
+        );
+      }
+      context.assertStackLength(s0 + 1, "After static assign value `$name`");
+      out.write(
+        Wasm.globalSet(context.module!.staticFieldGlobalIndexOf(staticKey)!),
+        description: "[OP] static field set `$staticKey`",
+      );
+      // Keep the phantom virtual entry (the real stack is balanced by
+      // `global.set`), matching the local-assignment contract.
+      return out;
     }
 
     var localVar = _getLocalVariable(context, name);
@@ -8446,6 +8573,17 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       context.stackPush(_elemStackType(type), 'boxed `$name` (return)');
     } else if (context.isFieldAccess(name)) {
       _generateFieldGet(out, context, name);
+    } else if (_staticFieldKey(context, name) != null) {
+      var key = _staticFieldKey(context, name)!;
+      var type = context.module!.staticFieldTypeOf(key)!;
+      out.write(
+        Wasm.globalGet(context.module!.staticFieldGlobalIndexOf(key)!),
+        description: "[OP] static field get `$key` (return)",
+      );
+      context.stackPush(
+        _wasmStackTypeFor(type),
+        'static field `$name` (return)',
+      );
     } else {
       var localVar = _getLocalVariable(context, name);
       _localVariableGet(out, context, localVar.index, name, '(return)');
@@ -10532,14 +10670,53 @@ class WasmModuleContext {
   int get enumEntryGlobalCount => _enumEntryGlobals.length;
 
   /// Registers (or reuses) the cache global for enum-entry [key], returning its
-  /// Wasm global index.
+  /// Wasm global index. Enum globals follow the heap pointer (index 0) and the
+  /// static-field globals (see [registerStaticFieldGlobal]).
   int enumEntryGlobalIndex(String key) {
+    var base = 1 + staticFieldGlobalCount;
     var i = _enumEntryGlobals.indexOf(key);
-    if (i >= 0) return 1 + i;
+    if (i >= 0) return base + i;
     _enumEntryGlobals.add(key);
     requiresMemory = true;
     requiresHeapGlobal = true; // ensures the Global section is emitted
-    return _enumEntryGlobals.length; // 1 + (length-1)
+    return base + (_enumEntryGlobals.length - 1);
+  }
+
+  // --- Static field globals (one typed mutable global per `static` field) ---
+
+  /// Static-field globals in index order: each holds the field's value. Placed
+  /// right after the heap-pointer global `$hp` (index 0), so a field's global
+  /// index is `1 + its position` here. Registered up front at module build
+  /// (before any enum globals), so indices are stable.
+  final List<({String key, ASTType type, num init})> _staticFieldGlobals = [];
+  final Map<String, int> _staticFieldGlobalIndex = {};
+
+  /// Number of static-field globals (emitted after `$hp`, before enum globals).
+  int get staticFieldGlobalCount => _staticFieldGlobals.length;
+
+  /// The registered static-field globals, in index order.
+  List<({String key, ASTType type, num init})> get staticFieldGlobals =>
+      List.unmodifiable(_staticFieldGlobals);
+
+  /// Registers a `static` field global for [key] (`"Class.field"`), returning
+  /// its Wasm global index. Idempotent per key.
+  int registerStaticFieldGlobal(String key, ASTType type, num init) {
+    var existing = _staticFieldGlobalIndex[key];
+    if (existing != null) return existing;
+    var index = 1 + _staticFieldGlobals.length; // after `$hp` (index 0)
+    _staticFieldGlobals.add((key: key, type: type, init: init));
+    _staticFieldGlobalIndex[key] = index;
+    requiresHeapGlobal = true; // ensures the Global section is emitted
+    return index;
+  }
+
+  /// The global index of static field [key] (`"Class.field"`), or `null`.
+  int? staticFieldGlobalIndexOf(String key) => _staticFieldGlobalIndex[key];
+
+  /// The declared type of static field [key] (`"Class.field"`), or `null`.
+  ASTType? staticFieldTypeOf(String key) {
+    var idx = _staticFieldGlobalIndex[key];
+    return idx == null ? null : _staticFieldGlobals[idx - 1].type;
   }
 
   /// Ensures the exported `__alloc(i32 size) -> i32 ptr` bump-allocator function

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.2.0
+version: 2.3.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/wasm/apollovm_wasm_static_field_test.dart
+++ b/test/wasm/apollovm_wasm_static_field_test.dart
@@ -1,0 +1,179 @@
+@TestOn('vm')
+@Tags(['wasm', 'dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+import 'wasm_runtime_setup.dart';
+
+/// Compiles [code] to Wasm and runs [functionName] through both the AST
+/// interpreter and the compiled+executed module, asserting every entry in
+/// [executions].
+Future<void> _testWasm(
+  String code,
+  String functionName,
+  Map<List, Object?> executions,
+) async {
+  var vm = ApolloVM();
+  expect(
+    await vm.loadCodeUnit(SourceCodeUnit('dart', code, id: 'test')),
+    isTrue,
+    reason: "Can't load Dart source",
+  );
+
+  // A `Class.method` entry point is a `static` method: the interpreter runs it
+  // via `executeClassMethod` (the compiled Wasm exports it under the same
+  // `Class.method` name, called with `executeFunction` below).
+  var dotAt = functionName.indexOf('.');
+  var className = dotAt < 0 ? null : functionName.substring(0, dotAt);
+  var methodName = dotAt < 0 ? functionName : functionName.substring(dotAt + 1);
+
+  var astRunner = vm.createRunner('dart')!;
+  for (var e in executions.entries) {
+    var r = className == null
+        ? await astRunner.executeFunction(
+            '',
+            methodName,
+            positionalParameters: e.key,
+          )
+        : await astRunner.executeClassMethod(
+            '',
+            className,
+            methodName,
+            positionalParameters: [e.key],
+            classInstanceFields: const {},
+          );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'AST $functionName(${e.key})',
+    );
+  }
+
+  var storage = vm.generateAllIn<BytesOutput>('wasm');
+  BytesOutput? compiled;
+  for (var ns in (await storage.allEntries()).values) {
+    for (var m in ns.values) {
+      compiled ??= m;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var vmWasm = ApolloVM();
+  expect(
+    await vmWasm.loadCodeUnit(
+      BinaryCodeUnit(
+        'wasm',
+        compiled!.output(),
+        id: 'test.wasm',
+        namespace: '',
+      ),
+    ),
+    isTrue,
+    reason: 'Compiled Wasm failed to load',
+  );
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  for (var e in executions.entries) {
+    var r = await wasmRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'WASM $functionName(${e.key})',
+    );
+  }
+}
+
+void main() {
+  setUpWasmRuntime();
+
+  // `static` fields compile to typed module globals (seeded with their literal
+  // initializer), read/written by a bare reference inside a `static` method.
+  group('Wasm static fields', () {
+    test('int read', () async {
+      await _testWasm(
+        'class C { static int c = 7; static int run() { return c; } }',
+        'C.run',
+        {[]: 7},
+      );
+    });
+
+    test('double read', () async {
+      await _testWasm(
+        'class C { static double c = 2.5; static double run() { return c; } }',
+        'C.run',
+        {[]: 2.5},
+      );
+    });
+
+    test('bool read/write', () async {
+      await _testWasm(
+        'class C { static bool on = true;'
+            ' static bool run() { on = false; return on; } }',
+        'C.run',
+        {[]: false},
+      );
+    });
+
+    test('used in an expression', () async {
+      await _testWasm(
+        'class C { static int a = 3; static int b = 4;'
+            ' static int run() { return a + b; } }',
+        'C.run',
+        {[]: 7},
+      );
+    });
+
+    test('write (set)', () async {
+      await _testWasm(
+        'class C { static int c = 7; static int run() { c = 20; return c; } }',
+        'C.run',
+        {[]: 20},
+      );
+    });
+
+    test('compound assignment (`+=`)', () async {
+      await _testWasm(
+        'class C { static int c = 7; static int run() { c += 5; return c; } }',
+        'C.run',
+        {[]: 12},
+      );
+    });
+
+    test('a static field persists across calls', () async {
+      await _testWasm(
+        'class C {'
+            ' static int c = 0;'
+            ' static int bump() { c += 1; return c; }'
+            ' static int run() { bump(); bump(); return c; } }',
+        'C.run',
+        {[]: 2},
+      );
+    });
+
+    test('static fields of two classes have independent storage', () async {
+      await _testWasm(
+        'class A { static int v = 10; static int run() { return v; } }'
+            ' class B { static int v = 20; }',
+        'A.run',
+        {[]: 10},
+      );
+    });
+
+    // The static-field globals share the module global space with the enum
+    // entry caches; this guards the global-index layout for a module using both.
+    test('static fields coexist with an enum', () async {
+      await _testWasm(
+        'enum Color { red, green, blue }'
+            ' class C { static int c = 5;'
+            ' static int run() { var g = Color.green; return c + g.index; } }',
+        'C.run',
+        {[]: 6},
+      );
+    });
+  });
+}


### PR DESCRIPTION
First of the Wasm-backend catch-up gaps (**GAP D** in `WASM_BACKEND_PLAN.md`). Bumps to **2.3.0**. Full VM suite green (2234 tests, `-x wasm-gc`), full Wasm suite green (424), analyze/format clean, ~99% patch coverage.

## Problem
`static` fields are fully interpreter-supported (2.1.1), but the Wasm compiler couldn't compile them — `return count` / `count = v` threw "can't find local variable".

## Changes
- Each `static` field → a typed, mutable **module global** (i64 int / f64 double / i32 bool·other), seeded with its literal initializer. Placed after the heap-pointer global and before the enum-entry caches; registered up front at module build so indices are stable (enum-entry index offset past them).
- A bare reference in a `static` method reads/writes the global (`global.get`/`global.set`) — in variable access, assignment (incl. compound `+=`), and the `return <var>` path. Values persist across calls.

## Tests
`apollovm_wasm_static_field_test.dart`: int/double/bool read+write, compound, cross-call persistence, two-class independence, and **enum coexistence** (guards the shared global-index layout).

## Follow-ups (documented, GAP D)
Qualified `C.field` from another class (getter path), inherited static fields (superclass chain), non-literal initializers (start function). Bare same-class access — the common case — is covered.

Next: GAP E (inheritance) and GAP G (nested collections) — the other interpreter-supported Wasm gaps, accumulating into 2.3.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)