### PR TITLE
feat(wasm): compile class inheritance (extends / super) — GAP E

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+## 2.4.0
+
+### Wasm: class inheritance (`extends` / `super`)
+
+The on-the-fly WebAssembly compiler now supports single inheritance, matching the
+interpreter. A subclass instance carries its superclass's fields **first** in its
+heap layout, so an inherited field sits at the same offset as on the superclass —
+a superclass method, compiled once, reads/writes the correct slot when invoked on
+a subclass instance. Method resolution walks the `extends` chain (an override on
+the subclass wins, otherwise the inherited superclass method), the subclass
+constructor runs inherited field initializers, and `super.method(args)` keeps the
+current instance as the receiver while dispatching to the superclass (skipping the
+override). Covers inherited method calls (bare and via a receiver, with
+arguments), inherited field read/write (including `double`), own+inherited fields
+at distinct offsets, override-wins, `super.method()`/`super.method(args)`, and
+multi-level `extends` chains.
+
+Dispatch is static (by the receiver's declared type); virtual dispatch through an
+upcast receiver, `super.field`/`super.getter`, and inherited user-getters remain
+follow-ups. Static members are intentionally not inherited (matching Dart).
+
 ## 2.3.0
 
 ### Wasm: `static` class fields

--- a/WASM_BACKEND_PLAN.md
+++ b/WASM_BACKEND_PLAN.md
@@ -148,26 +148,37 @@ same-class access — the common case — is covered.
 
 ---
 
-## GAP E — inheritance: methods, fields, getters, `static`, `super` (INTERPRETER-SUPPORTED since 2.2.0)
+## GAP E — inheritance: methods, fields, `super` — DONE
 
-> The AST interpreter fully implements inheritance as of 2.2.0: inherited
-> methods (override wins), inherited fields, inherited getters, inherited static
-> fields, and `super.method()` / `super.getter` / `super.field`. The Wasm
-> backend compiles none of it yet.
+A subclass instance now carries its superclass's fields **first** in the heap
+layout ([`_allInstanceFields`], superclass-first), so an inherited field sits at
+the same offset on a subclass instance as on the superclass — a superclass method
+compiled once against the superclass layout reads/writes the correct slot when
+invoked on a subclass instance. Method resolution (`methodIndex` /
+`methodIndexForCall`) walks the `extends` chain: the most-derived class that
+declares the method wins (an override), otherwise the inherited superclass method.
+`super.m(args)` keeps the current instance as the receiver but starts dispatch at
+the enclosing class's superclass (skipping the override). The subclass constructor
+also runs inherited field initializers (superclass-first). See
+`apollovm_wasm_inheritance_test.dart`. Covered: inherited method (bare and via a
+receiver, with args), inherited field read/write (incl. `double`), own+inherited
+fields at distinct offsets, override-wins, `super.m()` / `super.m(args)`, and a
+two-level `extends` chain.
 
-- **Errors** (compile): `Can't call non-static method 'A.base' without an
-  instance.` (inherited method); `Can't find local variable \`x\`` (inherited
-  field); `Can't find local variable \`super\`` (`super.*`).
-- **Trigger**: any access to a member declared on a superclass, or `super`.
-- **Fix direction**: resolve the superclass chain when laying out object fields
-  and the method/function index table (vtable), so inherited members are
-  reachable on a subclass instance; model `super` as the current instance with
-  dispatch starting at the enclosing class's superclass.
+**Remaining (follow-up):** dispatch is *static* (by the receiver's declared type),
+not virtual — an upcast receiver (`A a = B();`) calls the declared type's method,
+not the runtime type's; a true vtable would be needed for polymorphic dispatch.
+`super.field` / `super.getter` and inherited user-getters are not wired (GAP C is
+still open for getters generally). Static members are intentionally **not**
+inherited (matching Dart). The `: super(...)` constructor-initializer syntax is a
+separate **parser** gap (the Dart grammar doesn't parse it yet).
 
 ```dart
 test('inherited superclass method', () => _testWasm(
-  'class A { int base() { return 1; } }'
-  ' class B extends A { int run() { return base() + 2; } }', 'B.run', {[]: 3}));
+  'class A { int base() { return 9; } }'
+  ' class B extends A { int run() { return base(); } }'
+  ' class M { static int go() { var b = B(); return b.run(); } }',
+  'M.go', {[]: 9}));
 ```
 
 ---
@@ -209,19 +220,17 @@ test('return a List', () => _testWasm(
 
 ## Suggested order
 
-GAPs D, E and G below are **already implemented in the AST interpreter** (2.1.1 /
-2.2.0), so closing them brings the Wasm backend to parity with what source
-already runs — good candidates to prioritize.
+GAP G below is **already implemented in the AST interpreter** (2.2.0), so closing
+it brings the Wasm backend to parity with what source already runs. GAPs **D**
+(static fields) and **E** (inheritance/`super`) are now **DONE**.
 
 1. **GAP B** (remaining String methods) — by far the widest impact on real code
    (`.length`/`.isEmpty`/`.isNotEmpty` already done).
-2. **GAP D** (static fields) and **GAP C** (getters) — small, common,
-   independent; D is interpreter-supported.
-3. **GAP E** (inheritance/`super`) — one subsystem (field layout + method/vtable
-   resolution over the superclass chain); interpreter-supported.
-4. **GAP G** (nested collections / `m[0][1]`) — list/map literal codegen for a
+2. **GAP C** (getters) — small, common; lower a getter access to a zero-arg
+   method call on the receiver.
+3. **GAP G** (nested collections / `m[0][1]`) — list/map literal codegen for a
    nested element type; interpreter-supported.
-5. **GAP A** (generic field i64/boxing) and **GAP F** (aggregate returns) —
+4. **GAP A** (generic field i64/boxing) and **GAP F** (aggregate returns) —
    value-representation work; related boxing concerns.
 
 After each fix: `dart test -t wasm -x wasm-gc -x wasm-chrome` must stay green

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.3.0';
+  static final String VERSION = '2.4.0';
 
   static int _idCount = 0;
 

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -95,7 +95,11 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     var anonClosures = anon.closures;
 
     var functions = [...baseFunctions, ...anonClosures.map((c) => c.function)];
-    var module = WasmModuleContext(functions, classLayouts: classLayouts);
+    var module = WasmModuleContext(
+      functions,
+      classLayouts: classLayouts,
+      classDeclarations: {for (var c in root.classes) c.name: c},
+    );
 
     // Register a module global for each `static` field, up front (before any
     // enum-entry global) so global indices are stable. Only literal `int`/
@@ -186,12 +190,17 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
   /// Computes the heap layout of a class instance: instance fields in
   /// declaration order, each at a byte offset (int/double 8B, else 4B i32).
+  /// Inherited fields come first (superclass-first, see [_allInstanceFields]),
+  /// so an inherited field sits at the same offset on a subclass instance as on
+  /// the superclass — a superclass method compiled against the superclass layout
+  /// reads/writes the correct slot when invoked on a subclass instance.
   WasmClassLayout _buildClassLayout(ASTClassNormal clazz) {
     var offsets = <String, int>{};
     var types = <String, ASTType>{};
     var offset = 0;
-    for (var field in clazz.fields) {
-      if (field.modifiers.isStatic) continue; // statics aren't instance fields
+    for (var field in _allInstanceFields(clazz)) {
+      // On a name collision keep the first (inherited) declaration's offset.
+      if (offsets.containsKey(field.name)) continue;
       offsets[field.name] = offset;
       types[field.name] = field.type;
       offset += _elemSize(field.type);
@@ -223,6 +232,27 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     return WasmClassLayout(clazz.name, offsets, types, offset);
   }
 
+  /// All non-static instance fields visible on [clazz], **superclass-first**: a
+  /// field declared on the top of the `extends` chain appears before a subclass's
+  /// own fields. Duplicates (a subclass field named like an inherited one) keep
+  /// the superclass declaration's position; the caller de-dupes by name. Enums
+  /// have no superclass, so this returns their declared fields unchanged.
+  List<ASTClassField> _allInstanceFields(ASTClassNormal clazz) {
+    var chain = <ASTClassNormal>[];
+    for (ASTClass? c = clazz; c is ASTClassNormal; c = c.superClass) {
+      chain.add(c);
+    }
+    var result = <ASTClassField>[];
+    for (var k = chain.length - 1; k >= 0; k--) {
+      for (var field in chain[k].fields) {
+        // Statics aren't instance fields.
+        if (field.modifiers.isStatic) continue;
+        result.add(field);
+      }
+    }
+    return result;
+  }
+
   /// The seed value for a `static` field global: the field's literal `int` /
   /// `double` / `bool` initializer (bool as `0`/`1`), or `0` when there is no
   /// initializer or it is not a compile-time literal.
@@ -244,6 +274,8 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
 
   /// The `"Class.field"` key of a bare `static` field [name] of the current
   /// class (via `context.classLayout`), or `null` if it isn't a static field.
+  /// Static members are not inherited in Dart, so this does not walk the
+  /// `extends` chain (unlike instance-member resolution).
   String? _staticFieldKey(WasmContext context, String name) {
     var module = context.module;
     var className = context.classLayout?.className;
@@ -1697,6 +1729,29 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     context ??= WasmContext();
 
     var varName = expression.variable.name;
+
+    // `super.method(args)`: the receiver is the current instance (`this`), but
+    // method dispatch starts at the enclosing class's superclass (so an override
+    // in the current class is skipped — `super` reaches the inherited one).
+    if (varName == 'super') {
+      var thisVar = context.getLocalVariable('this');
+      var superName = context.module?.superClassNameOf(
+        context.classLayout?.className,
+      );
+      if (thisVar != null && superName != null) {
+        return _emitClassMethodCall(
+          recv: thisVar,
+          receiverDesc: 'super',
+          methodName: expression.name,
+          arguments: expression.arguments,
+          namedArguments: expression.namedArguments,
+          resolveClassName: superName,
+          out: out,
+          context: context,
+        );
+      }
+    }
+
     var localVar = _getLocalVariable(context, varName);
 
     // List.add(x)
@@ -1781,11 +1836,14 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     required String methodName,
     required List<ASTExpression> arguments,
     Map<String, ASTExpression>? namedArguments,
+    String? resolveClassName,
     required BytesOutput out,
     required WasmContext context,
   }) {
     var module = context.module!;
-    var className = recv.type.name;
+    // For `super.m()` the receiver stays the current instance but dispatch
+    // starts at the enclosing class's superclass ([resolveClassName]).
+    var className = resolveClassName ?? recv.type.name;
     // Supplied arity = positional + named. A call may omit trailing parameters
     // that have default values, so this can be less than the method's declared
     // arity; resolve at the declared arity (Wasm methods are fixed-arity).
@@ -5653,9 +5711,12 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         .toSet();
 
     // Field initializers (e.g. `int y = 5`) for fields not set by a `this.`
-    // parameter.
-    for (var field in clazz.fields) {
+    // parameter — including inherited fields (superclass-first, so a superclass
+    // initializer runs before the subclass's own; the seen-set keeps the first).
+    var initializedFields = <String>{};
+    for (var field in _allInstanceFields(clazz)) {
       if (field.modifiers.isStatic) continue;
+      if (!initializedFields.add(field.name)) continue;
       if (thisParamNames.contains(field.name)) continue;
       if (field is! ASTClassFieldWithInitialValue) continue;
 
@@ -10406,10 +10467,25 @@ class WasmModuleContext {
   /// Field memory layout for each class, keyed by class name.
   final Map<String, WasmClassLayout> classLayouts;
 
-  WasmModuleContext(this.functions, {this.classLayouts = const {}});
+  /// The class declarations, keyed by name — used to walk the `extends` chain
+  /// when resolving inherited members and `super` dispatch.
+  final Map<String, ASTClassNormal> classDeclarations;
+
+  WasmModuleContext(
+    this.functions, {
+    this.classLayouts = const {},
+    this.classDeclarations = const {},
+  });
 
   /// The field layout of the class whose instances have type [t], or `null`.
   WasmClassLayout? layoutForType(ASTType t) => classLayouts[t.name];
+
+  /// The name of the direct superclass of [className] (its `extends` target),
+  /// or `null` if the class is unknown or has no superclass.
+  String? superClassNameOf(String? className) {
+    if (className == null) return null;
+    return classDeclarations[className]?.superClass?.name;
+  }
 
   // --- Function table (for closures / function values via `call_indirect`) ---
 
@@ -10534,15 +10610,19 @@ class WasmModuleContext {
   }
 
   /// Resolves the Wasm function index of class [className]'s method
-  /// [methodName] taking [arity] declared arguments (excluding `this`).
+  /// [methodName] taking [arity] declared arguments (excluding `this`). Walks the
+  /// `extends` chain, so an inherited (non-overridden) method resolves to the
+  /// superclass function that defines it.
   int? methodIndex(String className, String methodName, int arity) {
-    for (var i = 0; i < functions.length; ++i) {
-      var f = functions[i];
-      if (f is _WasmMethodFunction &&
-          f.clazz.name == className &&
-          f.method.name == methodName &&
-          f.method.parameters.size == arity) {
-        return importCount + i;
+    for (String? cn = className; cn != null; cn = superClassNameOf(cn)) {
+      for (var i = 0; i < functions.length; ++i) {
+        var f = functions[i];
+        if (f is _WasmMethodFunction &&
+            f.clazz.name == cn &&
+            f.method.name == methodName &&
+            f.method.parameters.size == arity) {
+          return importCount + i;
+        }
       }
     }
     return null;
@@ -10558,23 +10638,28 @@ class WasmModuleContext {
     String methodName,
     int suppliedCount,
   ) {
-    int? bestIndex;
-    int? bestSize;
-    for (var i = 0; i < functions.length; ++i) {
-      var f = functions[i];
-      if (f is! _WasmMethodFunction ||
-          f.clazz.name != className ||
-          f.method.name != methodName) {
-        continue;
+    // Walk the `extends` chain: the most-derived class that declares the method
+    // wins (an override), falling back to an inherited superclass method.
+    for (String? cn = className; cn != null; cn = superClassNameOf(cn)) {
+      int? bestIndex;
+      int? bestSize;
+      for (var i = 0; i < functions.length; ++i) {
+        var f = functions[i];
+        if (f is! _WasmMethodFunction ||
+            f.clazz.name != cn ||
+            f.method.name != methodName) {
+          continue;
+        }
+        var size = f.method.parameters.size;
+        if (size < suppliedCount) continue;
+        if (bestSize == null || size < bestSize) {
+          bestSize = size;
+          bestIndex = importCount + i;
+        }
       }
-      var size = f.method.parameters.size;
-      if (size < suppliedCount) continue;
-      if (bestSize == null || size < bestSize) {
-        bestSize = size;
-        bestIndex = importCount + i;
-      }
+      if (bestIndex != null) return bestIndex;
     }
-    return bestIndex;
+    return null;
   }
 
   /// Like [methodIndexForCall] but for **static** methods (no receiver):

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.3.0
+version: 2.4.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/wasm/apollovm_wasm_inheritance_test.dart
+++ b/test/wasm/apollovm_wasm_inheritance_test.dart
@@ -1,0 +1,219 @@
+@TestOn('vm')
+@Tags(['wasm', 'dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+import 'wasm_runtime_setup.dart';
+
+/// Compiles [code] to Wasm and runs [functionName] (a `Class.method` static
+/// entry point) through both the AST interpreter and the compiled+executed
+/// module, asserting every entry in [executions].
+Future<void> _testWasm(
+  String code,
+  String functionName,
+  Map<List, Object?> executions,
+) async {
+  var vm = ApolloVM();
+  expect(
+    await vm.loadCodeUnit(SourceCodeUnit('dart', code, id: 'test')),
+    isTrue,
+    reason: "Can't load Dart source",
+  );
+
+  var dotAt = functionName.indexOf('.');
+  var className = dotAt < 0 ? null : functionName.substring(0, dotAt);
+  var methodName = dotAt < 0 ? functionName : functionName.substring(dotAt + 1);
+
+  var astRunner = vm.createRunner('dart')!;
+  for (var e in executions.entries) {
+    var r = className == null
+        ? await astRunner.executeFunction(
+            '',
+            methodName,
+            positionalParameters: e.key,
+          )
+        : await astRunner.executeClassMethod(
+            '',
+            className,
+            methodName,
+            positionalParameters: [e.key],
+            classInstanceFields: const {},
+          );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'AST $functionName(${e.key})',
+    );
+  }
+
+  var storage = vm.generateAllIn<BytesOutput>('wasm');
+  BytesOutput? compiled;
+  for (var ns in (await storage.allEntries()).values) {
+    for (var m in ns.values) {
+      compiled ??= m;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var vmWasm = ApolloVM();
+  expect(
+    await vmWasm.loadCodeUnit(
+      BinaryCodeUnit(
+        'wasm',
+        compiled!.output(),
+        id: 'test.wasm',
+        namespace: '',
+      ),
+    ),
+    isTrue,
+    reason: 'Compiled Wasm failed to load',
+  );
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  for (var e in executions.entries) {
+    var r = await wasmRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'WASM $functionName(${e.key})',
+    );
+  }
+}
+
+void main() {
+  setUpWasmRuntime();
+
+  // Inheritance in Wasm: a subclass instance carries its superclass's fields at
+  // the same offsets, so a superclass method compiled once works on a subclass
+  // instance; method dispatch walks the `extends` chain (override wins, else the
+  // inherited method), and `super.m()` starts dispatch at the superclass.
+  group('Wasm inheritance', () {
+    test('inherited method (implicit `this` call)', () async {
+      await _testWasm(
+        'class A { int base() { return 9; } }'
+            ' class B extends A { int run() { return base(); } }'
+            ' class M { static int go() { var b = B(); return b.run(); } }',
+        'M.go',
+        {[]: 9},
+      );
+    });
+
+    test('inherited method (via receiver)', () async {
+      await _testWasm(
+        'class A { int base() { return 7; } }'
+            ' class B extends A {}'
+            ' class M { static int go() { var b = B(); return b.base(); } }',
+        'M.go',
+        {[]: 7},
+      );
+    });
+
+    test('inherited method with arguments', () async {
+      await _testWasm(
+        'class A { int add(int a, int b) { return a + b; } }'
+            ' class B extends A { int run() { return add(3, 4); } }'
+            ' class M { static int go() { var b = B(); return b.run(); } }',
+        'M.go',
+        {[]: 7},
+      );
+    });
+
+    test('inherited field read', () async {
+      await _testWasm(
+        'class A { int x = 5; }'
+            ' class B extends A { int run() { return x; } }'
+            ' class M { static int go() { var b = B(); return b.run(); } }',
+        'M.go',
+        {[]: 5},
+      );
+    });
+
+    test('inherited field read via receiver', () async {
+      await _testWasm(
+        'class A { int x = 5; }'
+            ' class B extends A {}'
+            ' class M { static int go() { var b = B(); return b.x; } }',
+        'M.go',
+        {[]: 5},
+      );
+    });
+
+    test('inherited field write', () async {
+      await _testWasm(
+        'class A { int x = 5; }'
+            ' class B extends A { int run() { x = 20; return x; } }'
+            ' class M { static int go() { var b = B(); return b.run(); } }',
+        'M.go',
+        {[]: 20},
+      );
+    });
+
+    test('inherited `double` field', () async {
+      await _testWasm(
+        'class A { double x = 1.5; }'
+            ' class B extends A { double run() { return x + 1.0; } }'
+            ' class M { static double go() { var b = B(); return b.run(); } }',
+        'M.go',
+        {[]: 2.5},
+      );
+    });
+
+    test('own and inherited fields coexist (distinct offsets)', () async {
+      await _testWasm(
+        'class A { int a = 1; }'
+            ' class B extends A { int b = 2; int run() { return a + b; } }'
+            ' class M { static int go() { var v = B(); return v.run(); } }',
+        'M.go',
+        {[]: 3},
+      );
+    });
+
+    test('override on the subclass wins', () async {
+      await _testWasm(
+        'class A { int f() { return 1; } }'
+            ' class B extends A { int f() { return 2; } int run() { return f(); } }'
+            ' class M { static int go() { var b = B(); return b.run(); } }',
+        'M.go',
+        {[]: 2},
+      );
+    });
+
+    test('super.method()', () async {
+      await _testWasm(
+        'class A { int f() { return 10; } }'
+            ' class B extends A { int f() { return super.f() + 1; }'
+            ' int run() { return f(); } }'
+            ' class M { static int go() { var b = B(); return b.run(); } }',
+        'M.go',
+        {[]: 11},
+      );
+    });
+
+    test('super.method(args)', () async {
+      await _testWasm(
+        'class A { int g(int n) { return n * 2; } }'
+            ' class B extends A { int g(int n) { return super.g(n) + 1; }'
+            ' int run() { return g(5); } }'
+            ' class M { static int go() { var b = B(); return b.run(); } }',
+        'M.go',
+        {[]: 11},
+      );
+    });
+
+    test('two-level chain (C extends B extends A)', () async {
+      await _testWasm(
+        'class A { int f() { return 3; } }'
+            ' class B extends A {}'
+            ' class C extends B { int run() { return f(); } }'
+            ' class M { static int go() { var c = C(); return c.run(); } }',
+        'M.go',
+        {[]: 3},
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Wasm: class inheritance (`extends` / `super`) — GAP E

Closes **GAP E** in `WASM_BACKEND_PLAN.md`. The on-the-fly WebAssembly compiler now supports single inheritance, matching the AST interpreter.

### What changed
- **Field layout is superclass-first** (`_allInstanceFields`): a subclass instance carries its superclass's fields first, so an inherited field sits at the *same* offset on a subclass instance as on the superclass. A superclass method — compiled once against the superclass layout — reads/writes the correct slot when invoked on a subclass instance.
- **Method resolution walks the `extends` chain** (`methodIndex` / `methodIndexForCall`): the most-derived class that declares the method wins (an override), otherwise the inherited superclass method.
- **`super.method(args)`** keeps the current instance as the receiver but starts dispatch at the enclosing class's superclass (so an override in the current class is skipped).
- **Constructors run inherited field initializers** (superclass-first).

### Coverage (new `apollovm_wasm_inheritance_test.dart`, 12 cases)
Inherited method (bare + via receiver, with args), inherited field read/write (incl. `double`), own+inherited fields at distinct offsets, override-wins, `super.method()`/`super.method(args)`, two-level `extends` chain. Both the interpreter and the compiled+executed module are asserted for every case.

### Scope / follow-ups
- Dispatch is **static** (by the receiver's declared type); virtual dispatch through an upcast receiver (`A a = B();`) would need a vtable.
- `super.field` / `super.getter` and inherited user-getters are not wired (getters are GAP C generally).
- Static members are intentionally **not** inherited (matching Dart).
- The `: super(...)` constructor-initializer syntax is a separate parser gap.

Bumps to **2.4.0**. Full Wasm suite (445 tests) green; `dart analyze lib test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)