### PR TITLE
feat(wasm): compile custom instance getters — GAP C

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 2.5.0
+
+### Wasm: custom instance getters
+
+The on-the-fly WebAssembly compiler now supports user-declared instance getters
+(`int get x { ... }`). A getter is synthesized as a zero-argument instance method,
+so an access via a receiver (`c.x`) lowers to a 0-arg method call — reusing the
+whole instance-method path (argument marshalling, return conversion) and the
+superclass-chain resolution, so inherited and overridden getters resolve just like
+methods. Covers `int`/`double`/`bool`/`String` getters, a computed-expression
+getter body, and a getter used inside an expression (read once or twice), plus
+inherited and overridden getters.
+
+Bare getter access inside a method body (`x` resolving to `this.x`, no receiver)
+and setters remain follow-ups (bare access is not resolved by the interpreter yet
+either).
+
 ## 2.4.0
 
 ### Wasm: class inheritance (`extends` / `super`)

--- a/WASM_BACKEND_PLAN.md
+++ b/WASM_BACKEND_PLAN.md
@@ -114,20 +114,29 @@ test('String.substring', () => _testWasm(
 
 ---
 
-## GAP C — custom instance getters
+## GAP C — custom instance getters — DONE
 
-- **Error** (compile): `UnimplementedError: Wasm getter .x on C is not
-  supported yet.`
-- **Trigger**: a user-declared getter, `int get x { return _x; }`, read as
-  `c.x`. (External/plain field reads already work; this is the *getter method*
-  form.)
-- **Fix direction**: lower a getter access to a zero-argument method call on the
-  receiver, reusing the instance-method-call path.
+A user-declared getter (`int get x { ... }`) is synthesized as a zero-argument
+instance method (see `_buildClassFunctions`), so a getter access via a receiver
+(`c.x`) lowers to a 0-arg method call on the receiver — reusing the whole
+instance-method path (argument marshalling, return conversion) and the
+superclass-chain resolution, so **inherited getters** and **overrides** resolve
+just like methods. `hasGetter` distinguishes a getter from a same-named 0-arg
+method (both compile to the same shape). Covers `int`/`double`/`bool`/`String`
+getters, a computed-expression getter body, a getter used inside an expression
+(read once or twice), inherited, and overridden getters. See
+`apollovm_wasm_getter_test.dart`.
+
+**Remaining (follow-up):** **bare** getter access inside a method body (`x`
+resolving to `this.x`, no receiver) is not wired — the AST interpreter does not
+resolve it yet either, so closing it means fixing both together, and it is left
+as a shared follow-up. Setters (`set x(v)`) are likewise unimplemented.
 
 ```dart
 test('instance getter', () => _testWasm(
   'class C { int _x = 5; int get x { return _x; } }'
-  ' int run() { var c = C(); return c.x; }', 'run', {[]: 5}));
+  ' class M { static int go() { var c = C(); return c.x; } }',
+  'M.go', {[]: 5}));
 ```
 
 ---
@@ -221,16 +230,14 @@ test('return a List', () => _testWasm(
 ## Suggested order
 
 GAP G below is **already implemented in the AST interpreter** (2.2.0), so closing
-it brings the Wasm backend to parity with what source already runs. GAPs **D**
-(static fields) and **E** (inheritance/`super`) are now **DONE**.
+it brings the Wasm backend to parity with what source already runs. GAPs **C**
+(getters), **D** (static fields) and **E** (inheritance/`super`) are now **DONE**.
 
 1. **GAP B** (remaining String methods) — by far the widest impact on real code
    (`.length`/`.isEmpty`/`.isNotEmpty` already done).
-2. **GAP C** (getters) — small, common; lower a getter access to a zero-arg
-   method call on the receiver.
-3. **GAP G** (nested collections / `m[0][1]`) — list/map literal codegen for a
+2. **GAP G** (nested collections / `m[0][1]`) — list/map literal codegen for a
    nested element type; interpreter-supported.
-4. **GAP A** (generic field i64/boxing) and **GAP F** (aggregate returns) —
+3. **GAP A** (generic field i64/boxing) and **GAP F** (aggregate returns) —
    value-representation work; related boxing concerns.
 
 After each fix: `dart test -t wasm -x wasm-gc -x wasm-chrome` must stay green

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.4.0';
+  static final String VERSION = '2.5.0';
 
   static int _idCount = 0;
 

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -379,6 +379,37 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       }
     }
 
+    // User-declared getters (`int get x { ... }`) compile to a zero-argument
+    // instance method (`this` is param 0). A getter access then lowers to a
+    // 0-arg method call, and an inherited getter resolves through the same
+    // superclass-chain method lookup as an inherited method.
+    for (var getter in clazz.getter) {
+      if (getter is! ASTClassGetterDeclaration) continue;
+      if (getter.modifiers.isStatic) continue;
+      // A fabricated 0-arg method carrying the getter's name/return type: used
+      // only for resolution (`.method.name` / `.parameters.size`); the body is
+      // the getter block passed as `block:` below.
+      var method = ASTClassFunctionDeclaration(
+        clazz,
+        getter.name,
+        ASTFunctionParametersDeclaration(const []),
+        getter.returnType,
+      );
+      method.clazz = clazz;
+      result.add(
+        _WasmMethodFunction(
+          clazz,
+          method,
+          '${clazz.name}.${getter.name}',
+          ASTFunctionParametersDeclaration([
+            ASTFunctionParameterDeclaration(clazz.type, 'this', 0, false),
+          ]),
+          getter.returnType,
+          block: getter,
+        ),
+      );
+    }
+
     return result;
   }
 
@@ -5058,6 +5089,22 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       context.stackPush(_elemStackType(fieldType), "$varName.$name");
       context.assertStackLength(s0 + 1, "After getter $varName.$name");
       return out;
+    }
+
+    // `obj.x` where `x` is a user-declared getter: it compiled to a zero-arg
+    // method (see `_buildClassFunctions`), so lower the access to a method call.
+    // `hasGetter`/`methodIndex` walk the `extends` chain, so an inherited getter
+    // resolves too.
+    if (classLayout != null &&
+        (context.module?.hasGetter(listType.name, name) ?? false)) {
+      return _emitClassMethodCall(
+        recv: localVar,
+        receiverDesc: varName,
+        methodName: name,
+        arguments: const [],
+        out: out,
+        context: context,
+      );
     }
 
     // `.length`/`.isEmpty`/`.isNotEmpty` read header[0] (length), which is the
@@ -10485,6 +10532,17 @@ class WasmModuleContext {
   String? superClassNameOf(String? className) {
     if (className == null) return null;
     return classDeclarations[className]?.superClass?.name;
+  }
+
+  /// Whether [className] (or a superclass) declares a user getter named [name].
+  /// Distinguishes a getter access from a same-named 0-arg method (a getter is
+  /// compiled as a zero-arg method, so `methodIndex` alone can't tell them
+  /// apart).
+  bool hasGetter(String? className, String name) {
+    for (var cn = className; cn != null; cn = superClassNameOf(cn)) {
+      if (classDeclarations[cn]?.getGetterWithName(name) != null) return true;
+    }
+    return false;
   }
 
   // --- Function table (for closures / function values via `call_indirect`) ---

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.4.0
+version: 2.5.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/wasm/apollovm_wasm_getter_test.dart
+++ b/test/wasm/apollovm_wasm_getter_test.dart
@@ -1,0 +1,181 @@
+@TestOn('vm')
+@Tags(['wasm', 'dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+import 'wasm_runtime_setup.dart';
+
+/// Compiles [code] to Wasm and runs [functionName] (a `Class.method` static
+/// entry point) through both the AST interpreter and the compiled+executed
+/// module, asserting every entry in [executions].
+Future<void> _testWasm(
+  String code,
+  String functionName,
+  Map<List, Object?> executions,
+) async {
+  var vm = ApolloVM();
+  expect(
+    await vm.loadCodeUnit(SourceCodeUnit('dart', code, id: 'test')),
+    isTrue,
+    reason: "Can't load Dart source",
+  );
+
+  var dotAt = functionName.indexOf('.');
+  var className = dotAt < 0 ? null : functionName.substring(0, dotAt);
+  var methodName = dotAt < 0 ? functionName : functionName.substring(dotAt + 1);
+
+  var astRunner = vm.createRunner('dart')!;
+  for (var e in executions.entries) {
+    var r = className == null
+        ? await astRunner.executeFunction(
+            '',
+            methodName,
+            positionalParameters: e.key,
+          )
+        : await astRunner.executeClassMethod(
+            '',
+            className,
+            methodName,
+            positionalParameters: [e.key],
+            classInstanceFields: const {},
+          );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'AST $functionName(${e.key})',
+    );
+  }
+
+  var storage = vm.generateAllIn<BytesOutput>('wasm');
+  BytesOutput? compiled;
+  for (var ns in (await storage.allEntries()).values) {
+    for (var m in ns.values) {
+      compiled ??= m;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var vmWasm = ApolloVM();
+  expect(
+    await vmWasm.loadCodeUnit(
+      BinaryCodeUnit(
+        'wasm',
+        compiled!.output(),
+        id: 'test.wasm',
+        namespace: '',
+      ),
+    ),
+    isTrue,
+    reason: 'Compiled Wasm failed to load',
+  );
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  for (var e in executions.entries) {
+    var r = await wasmRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'WASM $functionName(${e.key})',
+    );
+  }
+}
+
+void main() {
+  setUpWasmRuntime();
+
+  // A user-declared getter (`int get x { ... }`) compiles to a zero-argument
+  // instance method; a getter access via a receiver (`c.x`) lowers to a call of
+  // it. Inherited getters and overrides resolve through the same superclass-chain
+  // method lookup as methods. (Bare getter access inside a method body — `x`
+  // resolving to `this.x` — is a separate follow-up: the AST interpreter does
+  // not resolve it yet either, so it is out of scope here.)
+  group('Wasm getters', () {
+    test('getter via receiver', () async {
+      await _testWasm(
+        'class C { int _x = 5; int get x { return _x; } }'
+            ' class M { static int go() { var c = C(); return c.x; } }',
+        'M.go',
+        {[]: 5},
+      );
+    });
+
+    test('getter with a computed expression', () async {
+      await _testWasm(
+        'class C { int _x = 5; int get doubled { return _x * 2; } }'
+            ' class M { static int go() { var c = C(); return c.doubled; } }',
+        'M.go',
+        {[]: 10},
+      );
+    });
+
+    test('getter used within an expression', () async {
+      await _testWasm(
+        'class C { int _x = 5; int get x { return _x; } }'
+            ' class M { static int go() { var c = C(); return c.x + 3; } }',
+        'M.go',
+        {[]: 8},
+      );
+    });
+
+    test('getter read twice in one expression', () async {
+      await _testWasm(
+        'class C { int get x { return 10; } }'
+            ' class M { static int go() { var c = C(); return c.x + c.x; } }',
+        'M.go',
+        {[]: 20},
+      );
+    });
+
+    test('`double` getter', () async {
+      await _testWasm(
+        'class C { double get pi { return 3.14; } }'
+            ' class M { static double go() { var c = C(); return c.pi; } }',
+        'M.go',
+        {[]: 3.14},
+      );
+    });
+
+    test('`bool` getter', () async {
+      await _testWasm(
+        'class C { int _n = 0; bool get isZero { return _n == 0; } }'
+            ' class M { static bool go() { var c = C(); return c.isZero; } }',
+        'M.go',
+        {[]: true},
+      );
+    });
+
+    test('`String` getter', () async {
+      await _testWasm(
+        'class C { String get greeting { return "hi"; } }'
+            ' class M { static String go() { var c = C(); return c.greeting; } }',
+        'M.go',
+        {[]: 'hi'},
+      );
+    });
+
+    test('inherited getter', () async {
+      await _testWasm(
+        'class A { int _x = 7; int get x { return _x; } }'
+            ' class B extends A {}'
+            ' class M { static int go() { var b = B(); return b.x; } }',
+        'M.go',
+        {[]: 7},
+      );
+    });
+
+    test('overridden getter (subclass wins)', () async {
+      await _testWasm(
+        'class A { int get x { return 1; } }'
+            ' class B extends A { int get x { return 2; } }'
+            ' class M { static int go() { var b = B(); return b.x; } }',
+        'M.go',
+        {[]: 2},
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Wasm: custom instance getters — GAP C

Closes **GAP C** in `WASM_BACKEND_PLAN.md`. The on-the-fly WebAssembly compiler now supports user-declared instance getters (`int get x { ... }`).

### What changed
- **Getters are synthesized as zero-argument instance methods** (`_buildClassFunctions`): a getter becomes a `this`-taking 0-arg method under the `Class.getter` name.
- **A getter access via a receiver (`c.x`) lowers to a 0-arg method call** (`_generateWasmGetterAccess`), reusing the whole instance-method path — argument marshalling, return-type conversion — and the `extends`-chain method resolution, so **inherited** and **overridden** getters resolve exactly like methods.
- **`hasGetter`** (chain-walking) distinguishes a getter from a same-named 0-arg method, since both compile to the same shape.

### Coverage (new `apollovm_wasm_getter_test.dart`, 9 cases)
`int`/`double`/`bool`/`String` getters, a computed-expression getter body, a getter used inside an expression (read once or twice), inherited and overridden getters. Both the interpreter and the compiled+executed module are asserted for every case.

### Scope / follow-ups
- **Bare** getter access inside a method body (`x` resolving to `this.x`, no receiver) is not wired — the AST interpreter doesn't resolve it yet either, so closing it means fixing both together (left as a shared follow-up).
- Setters (`set x(v)`) remain unimplemented.

Bumps to **2.5.0**. Full Wasm suite (454 tests) green; `dart analyze lib test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)