### PR TITLE
feat(wasm): nested collections & chained indexing (m[0][1]) — GAP G

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 2.6.0
+
+### Wasm: nested collections & chained indexing (`m[0][1]`)
+
+The on-the-fly WebAssembly compiler now supports collections nested inside
+collections and chained subscript access. A nested collection is stored as a
+pointer to the inner header, so a `List`/`Map` literal can hold `List`/`Map`
+elements (`[[1, 2], [3, 4]]`, `{'a': {'b': 5}}`), and chained subscripts read and
+write through every level (`m[0][1]`, `m['a']['b']`, `m[0]['x']`, `m['k'][1]`),
+including compound assignment (`m[0][1] += 5`) and multi-level nesting. Nested
+literals use depth-offset scratch locals so an inner literal never clobbers the
+enclosing one's buffers; single-level collections stay byte-identical.
+
+Writing into an *innermost* `Map` (`list[0]['k'] = v`) — reads of that shape
+already work — and a subscript/method on a non-variable receiver (`getList()[0]`,
+`m[1].length`) remain follow-ups.
+
 ## 2.5.0
 
 ### Wasm: custom instance getters

--- a/WASM_BACKEND_PLAN.md
+++ b/WASM_BACKEND_PLAN.md
@@ -192,16 +192,28 @@ test('inherited superclass method', () => _testWasm(
 
 ---
 
-## GAP G — nested lists & nested indexing (`m[0][1]`) (INTERPRETER-SUPPORTED since 2.2.0)
+## GAP G — nested lists & nested indexing (`m[0][1]`) — DONE
 
-- **Error** (compile): `UnimplementedError: Wasm list literal of element type
-  List<int> is not supported yet.` — the blocker is the **2D list literal**
-  (`[[1, 2], [3, 4]]`), not the index chain itself.
-- **Trigger**: a list whose element type is a `List`/`Map` (a nested collection),
-  and, once buildable, chained access/assignment `m[0][1]` / `m['a']['b'] = v`.
-- **Fix direction**: support a nested-collection element type in list/map literal
-  codegen (element is a pointer to another list/map header), then confirm the
-  chained index/key read+write path compiles.
+A nested collection is stored as an i32 pointer to the inner header, so a
+`List`/`Map` literal can now hold `List`/`Map` elements (`_isSupportedElemType`
+accepts `ASTTypeArray`/`ASTTypeMap`; `_emitElemStore`/`_emitElemLoad` already
+handled the i32-pointer slot). Nested literals use **depth-offset scratch locals**
+(`collectionLiteralDepth` on the context, distinct slot bands per level) so an
+inner literal never aliases the enclosing literal's header/buffer locals — depth 0
+keeps the original slots, so single-level collections stay byte-identical.
+
+Chained subscripts read and write through every level: `_emitApplyIndexOnStack`
+applies one index to a container pointer already on the stack (list or map),
+looping over `expression.expression + extraIndices` for reads and navigating
+all-but-last for `m[0][1] = v` writes (`_generateChainedEntryAssignment`,
+including the `+=` compound form). Covers 2D/3D lists, nested maps, list-of-map,
+map-of-list, mixed navigation, and writes (incl. through a map into a nested
+list). See `apollovm_wasm_nested_collection_test.dart`.
+
+**Remaining (follow-up):** writing into an *innermost `Map`* (`list[0]['k'] = v`)
+— reads of that shape work, but the write path only stores into an innermost
+`List`. Also `getList()[0]` / `m[1].length` (a subscript/method on a non-variable
+receiver) is a separate parser/receiver gap.
 
 ```dart
 test('nested list read', () => _testWasm(
@@ -229,15 +241,12 @@ test('return a List', () => _testWasm(
 
 ## Suggested order
 
-GAP G below is **already implemented in the AST interpreter** (2.2.0), so closing
-it brings the Wasm backend to parity with what source already runs. GAPs **C**
-(getters), **D** (static fields) and **E** (inheritance/`super`) are now **DONE**.
+GAPs **C** (getters), **D** (static fields), **E** (inheritance/`super`) and **G**
+(nested collections / `m[0][1]`) are now **DONE**. Remaining:
 
 1. **GAP B** (remaining String methods) — by far the widest impact on real code
    (`.length`/`.isEmpty`/`.isNotEmpty` already done).
-2. **GAP G** (nested collections / `m[0][1]`) — list/map literal codegen for a
-   nested element type; interpreter-supported.
-3. **GAP A** (generic field i64/boxing) and **GAP F** (aggregate returns) —
+2. **GAP A** (generic field i64/boxing) and **GAP F** (aggregate returns) —
    value-representation work; related boxing concerns.
 
 After each fix: `dart test -t wasm -x wasm-gc -x wasm-chrome` must stay green

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.5.0';
+  static final String VERSION = '2.6.0';
 
   static int _idCount = 0;
 

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -2125,6 +2125,17 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   int _elemSize(ASTType elemType) =>
       (elemType is ASTTypeInt || elemType is ASTTypeDouble) ? 8 : 4;
 
+  // Scratch-local slot numbers for a collection literal's header/buffer locals,
+  // parameterized by nesting [depth]. Depth 0 keeps the original slots (6/9 for
+  // a list; 15/16/17 for a map) so single-level literals stay byte-identical;
+  // deeper levels use a disjoint high range (lists and maps in separate bands)
+  // so a nested literal never aliases the enclosing one's locals.
+  int _listHdrSlot(int depth) => depth == 0 ? 6 : 200 + depth * 2;
+  int _listDataSlot(int depth) => depth == 0 ? 9 : 201 + depth * 2;
+  int _mapHdrSlot(int depth) => depth == 0 ? 15 : 400 + depth * 3;
+  int _mapKeysSlot(int depth) => depth == 0 ? 16 : 401 + depth * 3;
+  int _mapValsSlot(int depth) => depth == 0 ? 17 : 402 + depth * 3;
+
   /// A class-instance reference: an i32 pointer to a heap struct.
   bool _isWasmObjectRef(ASTType t) => t is ASTType<VMObject>;
 
@@ -2189,13 +2200,17 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     return elemType;
   }
 
-  /// Element types that compile to Wasm list storage: `int`/`double` (8B) and
-  /// `String`/`bool` (4B i32). Other element types are unsupported.
+  /// Element types that compile to Wasm list storage: `int`/`double` (8B),
+  /// `String`/`bool` (4B i32), and a **nested collection** (`List`/`Map`, stored
+  /// as a 4B i32 pointer to the inner header). Other element types are
+  /// unsupported.
   bool _isSupportedElemType(ASTType t) =>
       t is ASTTypeInt ||
       t is ASTTypeDouble ||
       t is ASTTypeString ||
-      t is ASTTypeBool;
+      t is ASTTypeBool ||
+      t is ASTTypeArray ||
+      t is ASTTypeMap;
 
   @override
   BytesOutput generateASTExpressionListLiteral(
@@ -2243,8 +2258,12 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     var n = values.length;
     // Indirect layout: header [length@0][capacity@4][dataPtr@8]; elements live
     // in a separate buffer so `.add` can realloc without moving the handle.
-    var hdrLocal = context.scratchLocal(_astTypeString, 6);
-    var dataLocal = context.scratchLocal(_astTypeString, 9);
+    // Depth-offset the scratch slots so a nested list literal (an element that is
+    // itself a `List`/`Map`) doesn't alias this literal's header/data locals.
+    var depth = context.collectionLiteralDepth;
+    var hdrLocal = context.scratchLocal(_astTypeString, _listHdrSlot(depth));
+    var dataLocal = context.scratchLocal(_astTypeString, _listDataSlot(depth));
+    context.collectionLiteralDepth = depth + 1;
 
     final s0 = context.stackLength;
 
@@ -2282,6 +2301,8 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       context.stackDrop(); // value consumed by the store
       _emitElemStore(out, elemType, i * size);
     }
+
+    context.collectionLiteralDepth = depth;
 
     // list handle (the header pointer)
     out.write(Wasm.localGet(hdrLocal));
@@ -3043,9 +3064,13 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     var keySize = _mapKeySize(keyType);
     var valSize = _elemSize(valueType);
 
-    var hdrLocal = context.scratchLocal(_astTypeString, 15);
-    var keysLocal = context.scratchLocal(_astTypeString, 16);
-    var valsLocal = context.scratchLocal(_astTypeString, 17);
+    // Depth-offset the scratch slots so a nested collection value (a `Map`/`List`
+    // value) doesn't alias this literal's header/keys/values locals.
+    var depth = context.collectionLiteralDepth;
+    var hdrLocal = context.scratchLocal(_astTypeString, _mapHdrSlot(depth));
+    var keysLocal = context.scratchLocal(_astTypeString, _mapKeysSlot(depth));
+    var valsLocal = context.scratchLocal(_astTypeString, _mapValsSlot(depth));
+    context.collectionLiteralDepth = depth + 1;
 
     final s0 = context.stackLength;
 
@@ -3089,6 +3114,8 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       context.stackDrop();
       _emitElemStore(out, valueType, i * valSize);
     }
+
+    context.collectionLiteralDepth = depth;
 
     out.write(Wasm.localGet(hdrLocal));
     context.stackPush(mapType, "map literal");
@@ -4580,6 +4607,24 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     var localVar = _getLocalVariable(context, name);
     var containerType = localVar.type;
 
+    // Nested/chained access (`m[0][1]` / `m['a']['b']`): push the base container,
+    // then apply each index to the value produced by the previous level (an inner
+    // `List`/`Map` pointer). Each intermediate value stays on the stack.
+    if (expression.extraIndices.isNotEmpty) {
+      final s0 = context.stackLength;
+      _localVariableGet(out, context, localVar.index, name);
+      context.stackPush(containerType, "chain base `$name`");
+      var curType = containerType;
+      for (var indexExpr in [
+        expression.expression,
+        ...expression.extraIndices,
+      ]) {
+        curType = _emitApplyIndexOnStack(out, context, curType, indexExpr);
+      }
+      context.assertStackLength(s0 + 1, "After chained index `$name`");
+      return out;
+    }
+
     if (containerType is ASTTypeMap) {
       return _generateMapGet(expression, localVar, out: out, context: context);
     }
@@ -4612,6 +4657,88 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     context.stackPush(_elemStackType(elemType), "list[index]");
     context.assertStackLength(s0 + 1, "After list index");
     return out;
+  }
+
+  /// Applies one subscript to the container whose header pointer is on top of the
+  /// (real and virtual) Wasm stack, typed [containerType]. Reads the element at
+  /// [indexExpr], replacing the container on the stack with the element value.
+  /// Returns the element/value type (used to drive the next chained level).
+  ASTType _emitApplyIndexOnStack(
+    BytesOutput out,
+    WasmContext context,
+    ASTType containerType,
+    ASTExpression indexExpr,
+  ) {
+    if (containerType is ASTTypeArray) {
+      var elemType = containerType.componentType;
+      var size = _elemSize(elemType);
+      // stack: [header] -> [dataPtr]
+      out.write(Wasm32.i32Load(2, 8)); // dataPtr = load(header, 8)
+      generateASTExpression(
+        indexExpr,
+        out: out,
+        context: context,
+      ); // index (i64)
+      out.writeByte(Wasm64.i64WrapToi32);
+      out.write(Wasm32.i32Const(size));
+      out.writeByte(Wasm32.i32Multiply);
+      out.writeByte(Wasm32.i32Add); // dataPtr + index*size
+      _emitElemLoad(out, elemType, 0);
+      context.stackDrop(); // the index
+      context.stackDrop(); // the container
+      context.stackPush(_elemStackType(elemType), "list[index] (chain)");
+      return elemType;
+    }
+
+    if (containerType is ASTTypeMap) {
+      var mapType = _requireMapType(containerType, 'chain', 'm[k]');
+      var keyType = mapType.keyType;
+      var valueType = mapType.valueType;
+      var valSize = _elemSize(valueType);
+
+      var hdr = context.scratchLocal(_astTypeString, 15);
+      var keys = context.scratchLocal(_astTypeString, 16);
+      var iLoc = context.scratchLocal(_astTypeString, 18);
+      var keyLoc = context.scratchLocal(keyType, 19);
+      var result = context.scratchLocal(valueType, 25);
+
+      // header is on the stack: pop it into a local for the scan.
+      out.write(Wasm.localSet(hdr));
+      context.stackDrop(); // the container
+      generateASTExpression(indexExpr, out: out, context: context); // key
+      context.stackDrop();
+      out.write(Wasm.localSet(keyLoc));
+      _emitZeroDefault(out, valueType);
+      out.write(Wasm.localSet(result));
+
+      _emitMapScan(
+        out,
+        context,
+        keyType: keyType,
+        hdrScratch: hdr,
+        keysScratch: keys,
+        iScratch: iLoc,
+        keyScratch: keyLoc,
+        onMatch: () {
+          out.write(Wasm.localGet(hdr));
+          out.write(Wasm32.i32Load(2, 12)); // valuesPtr
+          out.write(Wasm.localGet(iLoc));
+          out.write(Wasm32.i32Const(valSize));
+          out.writeByte(Wasm32.i32Multiply);
+          out.writeByte(Wasm32.i32Add);
+          _emitElemLoad(out, valueType, 0);
+          out.write(Wasm.localSet(result));
+        },
+      );
+
+      out.write(Wasm.localGet(result));
+      context.stackPush(_elemStackType(valueType), "map[key] (chain)");
+      return valueType;
+    }
+
+    throw UnimplementedError(
+      "Wasm chained index access on $containerType is not supported yet.",
+    );
   }
 
   /// `m[k]` map lookup: linear scan by key; pushes the matching value, or a
@@ -4699,12 +4826,14 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     out ??= newOutput();
     context ??= WasmContext();
 
-    // Desugar a compound assignment `c[k] OP= v` into `c[k] = (c[k] OP v)`.
+    // Desugar a compound assignment `c[k] OP= v` into `c[k] = (c[k] OP v)`
+    // (carrying any chained indices so `m[0][1] += v` desugars correctly).
     if (expression.operator != ASTAssignmentOperator.set) {
       var binOp = _compoundToOperator(expression.operator);
       var access = ASTExpressionVariableEntryAccess(
         expression.variable,
         expression.keyExpression,
+        expression.extraKeys,
       );
       var operation = ASTExpressionOperation(
         access,
@@ -4716,6 +4845,7 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         expression.keyExpression,
         ASTAssignmentOperator.set,
         operation,
+        expression.extraKeys,
       );
       desugared.resolveNode(expression.parentNode);
       return _generateWasmEntryAssignment(
@@ -4728,6 +4858,17 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     var name = expression.variable.name;
     var localVar = _getLocalVariable(context, name);
     var containerType = localVar.type;
+
+    // Chained write (`m[0][1] = v`): navigate through all but the last index to
+    // the innermost container, then store at the last index.
+    if (expression.extraKeys.isNotEmpty) {
+      return _generateChainedEntryAssignment(
+        expression,
+        localVar,
+        out: out,
+        context: context,
+      );
+    }
 
     if (containerType is ASTTypeMap) {
       return _generateMapSet(expression, localVar, out: out, context: context);
@@ -4794,6 +4935,60 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     _emitElemStore(out, elemType, 0);
 
     context.assertStackLength(s0, "After list[i] = v");
+    return out;
+  }
+
+  /// Chained subscript assignment `m[0][1] = v`: navigate through all but the
+  /// last index (reading each level's inner `List`/`Map` pointer onto the stack)
+  /// then store `v` at the last index of the innermost container. The innermost
+  /// container must be a `List`; navigation levels may be `List` or `Map`.
+  BytesOutput _generateChainedEntryAssignment(
+    ASTExpressionVariableEntryAssignment expression,
+    ({ASTType type, int index}) localVar, {
+    required BytesOutput out,
+    required WasmContext context,
+  }) {
+    var name = expression.variable.name;
+    final s0 = context.stackLength;
+
+    // Push the base container, then navigate all-but-last index.
+    _localVariableGet(out, context, localVar.index, name);
+    context.stackPush(localVar.type, "chain base `$name`");
+    var curType = localVar.type;
+    var indices = [expression.keyExpression, ...expression.extraKeys];
+    for (var i = 0; i < indices.length - 1; ++i) {
+      curType = _emitApplyIndexOnStack(out, context, curType, indices[i]);
+    }
+
+    if (curType is! ASTTypeArray) {
+      // Writing into an innermost `Map` (`list[0]['k'] = v`) needs the full
+      // scan/append path against a stack container — left as a follow-up.
+      throw UnimplementedError(
+        "Wasm chained assignment into $curType is not supported yet.",
+      );
+    }
+
+    var elemType = curType.componentType;
+    var size = _elemSize(elemType);
+
+    // Innermost list header is on the stack: addr = dataPtr + lastIndex*size.
+    out.write(Wasm32.i32Load(2, 8)); // dataPtr
+    generateASTExpression(
+      indices.last,
+      out: out,
+      context: context,
+    ); // index i64
+    out.writeByte(Wasm64.i64WrapToi32);
+    out.write(Wasm32.i32Const(size));
+    out.writeByte(Wasm32.i32Multiply);
+    out.writeByte(Wasm32.i32Add); // addr
+    generateASTExpression(expression.expression, out: out, context: context);
+    _emitElemStore(out, elemType, 0);
+
+    context.stackDrop(); // RHS value
+    context.stackDrop(); // last index
+    context.stackDrop(); // innermost container
+    context.assertStackLength(s0, "After chained assignment `$name`");
     return out;
   }
 
@@ -11214,6 +11409,14 @@ class WasmContext {
   /// set, integer division emits a non-trapping guard that raises a catchable
   /// exception on a zero/overflowing divisor instead of trapping the module.
   bool exceptionMode = false;
+
+  /// Nesting depth of the collection literal (`List`/`Map`) currently being
+  /// generated: 0 for a top-level literal, +1 for each literal nested as an
+  /// element/value. Used to offset the header/buffer scratch-local slots so a
+  /// nested literal never aliases the enclosing literal's locals (which the
+  /// global scratch cache would otherwise share). Depth 0 keeps the original
+  /// slot numbers, so single-level collections stay byte-identical.
+  int collectionLiteralDepth = 0;
 
   /// Number of currently-open structured control instructions (`block`/`loop`/
   /// `if`). A Wasm `br L` targets the structure `L` levels up from the innermost,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.5.0
+version: 2.6.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/wasm/apollovm_wasm_nested_collection_test.dart
+++ b/test/wasm/apollovm_wasm_nested_collection_test.dart
@@ -1,0 +1,180 @@
+@TestOn('vm')
+@Tags(['wasm', 'dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+import 'wasm_runtime_setup.dart';
+
+/// Compiles [code] to Wasm and runs [functionName] through both the AST
+/// interpreter and the compiled+executed module, asserting every entry in
+/// [executions].
+Future<void> _testWasm(
+  String code,
+  String functionName,
+  Map<List, Object?> executions,
+) async {
+  var vm = ApolloVM();
+  expect(
+    await vm.loadCodeUnit(SourceCodeUnit('dart', code, id: 'test')),
+    isTrue,
+    reason: "Can't load Dart source",
+  );
+
+  var astRunner = vm.createRunner('dart')!;
+  for (var e in executions.entries) {
+    var r = await astRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'AST $functionName(${e.key})',
+    );
+  }
+
+  var storage = vm.generateAllIn<BytesOutput>('wasm');
+  BytesOutput? compiled;
+  for (var ns in (await storage.allEntries()).values) {
+    for (var m in ns.values) {
+      compiled ??= m;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var vmWasm = ApolloVM();
+  expect(
+    await vmWasm.loadCodeUnit(
+      BinaryCodeUnit(
+        'wasm',
+        compiled!.output(),
+        id: 'test.wasm',
+        namespace: '',
+      ),
+    ),
+    isTrue,
+    reason: 'Compiled Wasm failed to load',
+  );
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  for (var e in executions.entries) {
+    var r = await wasmRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'WASM $functionName(${e.key})',
+    );
+  }
+}
+
+void main() {
+  setUpWasmRuntime();
+
+  // A nested collection is stored as an i32 pointer to the inner header, so a
+  // `List`/`Map` literal can hold `List`/`Map` elements and chained subscripts
+  // (`m[0][1]`) read/write through each level. Nested literals use depth-offset
+  // scratch locals so an inner literal doesn't clobber the outer's buffers.
+  group('Wasm nested collections', () {
+    test('2D list literal + chained read', () async {
+      await _testWasm(
+        'int run() { var m = [[1, 2], [3, 4]]; return m[0][1]; }',
+        'run',
+        {[]: 2},
+      );
+    });
+
+    test('2D list chained read (other cell)', () async {
+      await _testWasm(
+        'int run() { var m = [[1, 2], [3, 4]]; return m[1][0]; }',
+        'run',
+        {[]: 3},
+      );
+    });
+
+    test('nested `double` list', () async {
+      await _testWasm(
+        'double run() { var m = [[1.5, 2.5]]; return m[0][1]; }',
+        'run',
+        {[]: 2.5},
+      );
+    });
+
+    test('3D list chained read', () async {
+      await _testWasm(
+        'int run() { var m = [[[1, 2], [3, 4]]]; return m[0][1][0]; }',
+        'run',
+        {[]: 3},
+      );
+    });
+
+    test('nested map (`m[\'a\'][\'b\']`)', () async {
+      await _testWasm(
+        "int run() { var m = {'a': {'b': 5}}; return m['a']['b']; }",
+        'run',
+        {[]: 5},
+      );
+    });
+
+    test('list of maps', () async {
+      await _testWasm(
+        "int run() { var m = [{'x': 9}]; return m[0]['x']; }",
+        'run',
+        {[]: 9},
+      );
+    });
+
+    test('map of lists', () async {
+      await _testWasm(
+        "int run() { var m = {'k': [7, 8]}; return m['k'][1]; }",
+        'run',
+        {[]: 8},
+      );
+    });
+
+    test('2D list chained write', () async {
+      await _testWasm(
+        'int run() { var m = [[1, 2], [3, 4]]; m[0][1] = 9; return m[0][1]; }',
+        'run',
+        {[]: 9},
+      );
+    });
+
+    test('chained write does not corrupt a sibling', () async {
+      await _testWasm(
+        'int run() { var m = [[1, 2], [3, 4]]; m[0][1] = 9; return m[1][0]; }',
+        'run',
+        {[]: 3},
+      );
+    });
+
+    test('chained compound assignment (`m[0][1] += 5`)', () async {
+      await _testWasm(
+        'int run() { var m = [[1, 2], [3, 4]]; m[0][1] += 5; return m[0][1]; }',
+        'run',
+        {[]: 7},
+      );
+    });
+
+    test('3D list chained write', () async {
+      await _testWasm(
+        'int run() { var m = [[[1, 2]]]; m[0][0][1] = 20; return m[0][0][1]; }',
+        'run',
+        {[]: 20},
+      );
+    });
+
+    test('write through a map into a nested list', () async {
+      await _testWasm(
+        "int run() { var m = {'k': [7, 8]}; m['k'][1] = 88; return m['k'][1]; }",
+        'run',
+        {[]: 88},
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Wasm: nested collections & chained indexing (`m[0][1]`) — GAP G

Closes **GAP G** in `WASM_BACKEND_PLAN.md`. The on-the-fly WebAssembly compiler now supports collections nested inside collections and chained subscript access, matching the AST interpreter.

### What changed
- **Nested-collection storage**: `_isSupportedElemType` now accepts `List`/`Map` element/value types (stored as an i32 pointer to the inner header; `_emitElemStore`/`_emitElemLoad` already handled that slot). So `[[1,2],[3,4]]` and `{'a': {'b': 5}}` build.
- **Depth-offset scratch locals**: a `collectionLiteralDepth` counter on the context offsets the header/buffer scratch-local slots per nesting level, so an inner literal never aliases the enclosing literal's locals (the global scratch cache would otherwise share them). **Depth 0 keeps the original slots, so single-level collections stay byte-identical** — no byte-exact test churn.
- **Chained read**: `_emitApplyIndexOnStack` applies one subscript to a container pointer already on the stack (list or map), looping over `expression + extraIndices`.
- **Chained write**: `_generateChainedEntryAssignment` navigates all-but-last index, then stores at the innermost list; the compound desugar (`m[0][1] += v`) now carries `extraKeys`.

### Coverage (new `apollovm_wasm_nested_collection_test.dart`, 12 cases)
2D/3D lists, nested `double` list, nested maps, list-of-map, map-of-list, chained writes (incl. `+=`, 3D, write-through-a-map-into-a-list, and a no-sibling-corruption check). Both the interpreter and the compiled+executed module are asserted for every case.

### Scope / follow-ups
- Writing into an **innermost `Map`** (`list[0]['k'] = v`) — reads of that shape work; the write path only stores into an innermost `List`.
- A subscript/method on a **non-variable receiver** (`getList()[0]`, `m[1].length`) is a separate parser/receiver gap.

Bumps to **2.6.0**. Full Wasm suite (466 tests) green; `dart analyze lib test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)