### PR TITLE
feat(wasm): String slice & search methods — GAP B (partial)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+## 2.7.0
+
+### Wasm: String slice & search methods
+
+The on-the-fly WebAssembly compiler now supports the common String slice/search
+methods over its `[len][utf8]` layout: `substring(start, [end])` (a fresh-buffer
+`memory.copy` slice), `codeUnitAt(i)`, `startsWith` / `endsWith`, `indexOf`, and
+`contains` (byte scans, guarded against out-of-bounds reads). These join the
+already-supported `length` / `isEmpty` / `isNotEmpty` getters and
+`toUpperCase` / `toLowerCase`. Methods are byte-indexed, so results are exact for
+ASCII text.
+
+Still to come: `trim`, `split`, `replaceAll` / `replaceFirst`, `padLeft` /
+`padRight`, `compareTo`, and index `[]`; chaining a method onto a method result
+(the receiver must be a named local).
+
 ## 2.6.0
 
 ### Wasm: nested collections & chained indexing (`m[0][1]`)

--- a/WASM_BACKEND_PLAN.md
+++ b/WASM_BACKEND_PLAN.md
@@ -85,26 +85,26 @@ test('generic Box<int> field round-trips', () => _testWasm(
 
 ---
 
-## GAP B — String methods & getters (HIGHEST IMPACT, partially done)
+## GAP B — String methods & getters (HIGHEST IMPACT, mostly done)
 
-- **Done**: `.length`, `.isEmpty`, `.isNotEmpty` (read the `[len:i32][utf8]`
-  header) — see `apollovm_wasm_string_length_test.dart`; `.toUpperCase`,
-  `.toLowerCase` (ASCII, fresh buffer + case-bit shift) — see
+- **Done (getters)**: `.length`, `.isEmpty`, `.isNotEmpty` (read the
+  `[len:i32][utf8]` header) — `apollovm_wasm_string_length_test.dart`.
+- **Done (transforms)**: `.toUpperCase`, `.toLowerCase` (ASCII case-bit shift) —
   `apollovm_wasm_string_case_test.dart`.
-- **Still open** (compile error `UnimplementedError: Wasm getter/method .X on
-  String is not supported yet.`): `.substring`, `.contains`, `.indexOf`,
-  `.trim`, `.split`, `.replaceAll` (and siblings). Also: chaining a getter/method
-  onto a method *result* (`s.toUpperCase().length`) — the receiver must be a
-  named local today.
-- **Trigger**: any String manipulation beyond concatenation/interpolation and
-  the length/emptiness getters above. Still the broadest gap.
-- **Fix direction**: implement runtime helpers over the String memory layout the
-  backend already uses for `__streq`/concatenation (see `_emitStringConcat2` and
-  `_generateStringCaseConvert` for the allocate-buffer + byte-loop pattern).
-  `.substring` (copy a slice), `.indexOf`/`.contains` (byte scan), `.split`,
-  `.replaceAll` build on the same buffer ops. Note the stored length is UTF-8
-  bytes, so any method whose Dart semantics are in UTF-16 code units is only
-  correct for ASCII until the layout carries a code-unit count.
+- **Done (slice/search)**: `.substring(start,[end])` (fresh-buffer `memory.copy`
+  slice), `.codeUnitAt(i)`, `.startsWith`/`.endsWith`, `.indexOf`, `.contains`
+  (byte scans over the layout, OOB-guarded) — `apollovm_wasm_string_methods_test`
+  and `_tryGenerateStringMethod`.
+- **Still open**: `.trim`, `.split` (returns a `List`), `.replaceAll` /
+  `.replaceFirst`, `.padLeft`/`.padRight`, `.compareTo`, index `[]`. Also:
+  chaining a getter/method onto a method *result* (`s.toUpperCase().length`,
+  `s.substring(0,2) == 'x'`) — the receiver must be a named local, and a bare
+  `String == String` returning a `bool` is a separate pre-existing limitation.
+- **Fix direction**: same allocate-buffer + byte-loop pattern
+  (`_generateStringCaseConvert`, `_emitBytesEqualNoBreak`). `.split`/`.replaceAll`
+  build a fresh buffer/`List` from scan results. Stored length is UTF-8 bytes, so
+  byte-indexed methods are exact for ASCII; UTF-16-code-unit semantics need the
+  layout to carry a code-unit count.
 
 ```dart
 test('String.substring', () => _testWasm(
@@ -242,10 +242,11 @@ test('return a List', () => _testWasm(
 ## Suggested order
 
 GAPs **C** (getters), **D** (static fields), **E** (inheritance/`super`) and **G**
-(nested collections / `m[0][1]`) are now **DONE**. Remaining:
+(nested collections / `m[0][1]`) are **DONE**; **GAP B** (String methods) is mostly
+done (slice/search/case complete). Remaining:
 
-1. **GAP B** (remaining String methods) — by far the widest impact on real code
-   (`.length`/`.isEmpty`/`.isNotEmpty` already done).
+1. **GAP B tail** — `.trim`, `.split`, `.replaceAll`/`.replaceFirst`,
+   `.padLeft`/`.padRight`, `.compareTo`, index `[]`.
 2. **GAP A** (generic field i64/boxing) and **GAP F** (aggregate returns) —
    value-representation work; related boxing concerns.
 

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.6.0';
+  static final String VERSION = '2.7.0';
 
   static int _idCount = 0;
 

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -1823,6 +1823,19 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       );
     }
 
+    // Other String methods (ASCII/UTF-8 byte ops over the `[len][utf8]` layout):
+    // substring, codeUnitAt, startsWith, endsWith, indexOf, contains.
+    if (localVar.type is ASTTypeString) {
+      var handled = _tryGenerateStringMethod(
+        expression,
+        localVar,
+        varName,
+        out: out,
+        context: context,
+      );
+      if (handled != null) return handled;
+    }
+
     // Instance method call on a class: `recv.method(args)`.
     if (context.module?.layoutForType(localVar.type) != null) {
       return _generateMethodInvocation(
@@ -10322,6 +10335,435 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   /// each byte shifting ASCII letters by `0x20` (case bit). Non-letter bytes and
   /// non-ASCII bytes are copied unchanged, so this matches Dart semantics for
   /// ASCII input (the same restriction as the byte-length `.length`).
+  /// Dispatches a supported String method (over the `[len:i32][utf8]` layout) to
+  /// its byte-level codegen, or returns `null` if [expression.name] isn't one of
+  /// them (the caller then errors). Byte-indexed, so exact for ASCII text (a
+  /// multi-byte UTF-8 code point counts as its byte length).
+  BytesOutput? _tryGenerateStringMethod(
+    ASTExpressionObjectFunctionInvocation expression,
+    ({ASTType type, int index}) recv,
+    String varName, {
+    required BytesOutput out,
+    required WasmContext context,
+  }) {
+    var name = expression.name;
+    var args = expression.arguments;
+    if (name == 'codeUnitAt' && args.length == 1) {
+      return _generateStringCodeUnitAt(
+        recv,
+        varName,
+        args[0],
+        out: out,
+        context: context,
+      );
+    }
+    if (name == 'substring' && (args.length == 1 || args.length == 2)) {
+      return _generateStringSubstring(
+        recv,
+        varName,
+        args,
+        out: out,
+        context: context,
+      );
+    }
+    if (name == 'startsWith' && args.length == 1) {
+      return _generateStringStartsEndsWith(
+        recv,
+        varName,
+        args[0],
+        ends: false,
+        out: out,
+        context: context,
+      );
+    }
+    if (name == 'endsWith' && args.length == 1) {
+      return _generateStringStartsEndsWith(
+        recv,
+        varName,
+        args[0],
+        ends: true,
+        out: out,
+        context: context,
+      );
+    }
+    if (name == 'indexOf' && args.length == 1) {
+      return _generateStringIndexOf(
+        recv,
+        varName,
+        args[0],
+        asContains: false,
+        out: out,
+        context: context,
+      );
+    }
+    if (name == 'contains' && args.length == 1) {
+      return _generateStringIndexOf(
+        recv,
+        varName,
+        args[0],
+        asContains: true,
+        out: out,
+        context: context,
+      );
+    }
+    return null;
+  }
+
+  /// `s.codeUnitAt(i)` -> the (unsigned) byte at `s + 4 + i` as an `int` (i64).
+  BytesOutput _generateStringCodeUnitAt(
+    ({ASTType type, int index}) recv,
+    String varName,
+    ASTExpression indexExpr, {
+    required BytesOutput out,
+    required WasmContext context,
+  }) {
+    context.module!.requiresMemory = true;
+    final s0 = context.stackLength;
+    _localVariableGet(out, context, recv.index, varName); // src ptr
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    generateASTExpression(indexExpr, out: out, context: context); // index (i64)
+    context.stackDrop();
+    out.writeByte(Wasm64.i64WrapToi32);
+    out.writeByte(Wasm32.i32Add); // src + 4 + index
+    out.write(Wasm32.i32Load8U());
+    out.writeByte(Wasm32.i32ExtendToI64Unsigned);
+    context.stackPush(_astTypeInt64, "$varName.codeUnitAt");
+    context.assertStackLength(s0 + 1, "After String.codeUnitAt");
+    return out;
+  }
+
+  /// `s.substring(start, [end])` -> a fresh String holding the byte slice
+  /// `[start, end)` (end defaults to the length).
+  BytesOutput _generateStringSubstring(
+    ({ASTType type, int index}) recv,
+    String varName,
+    List<ASTExpression> args, {
+    required BytesOutput out,
+    required WasmContext context,
+  }) {
+    var module = context.module!;
+    module.requiresMemory = true;
+    module.requiresHeapGlobal = true;
+    final s0 = context.stackLength;
+
+    var src = context.scratchLocal(_astTypeString, 30);
+    var srcLen = context.scratchLocal(_astTypeString, 31);
+    var startL = context.scratchLocal(_astTypeString, 32);
+    var endL = context.scratchLocal(_astTypeString, 33);
+    var dest = context.scratchLocal(_astTypeString, 34);
+    var newLen = context.scratchLocal(_astTypeString, 35);
+
+    // src = recv ; srcLen = load(src, 0)
+    _localVariableGet(out, context, recv.index, varName);
+    out.write(Wasm.localSet(src));
+    out.write(Wasm.localGet(src));
+    out.write(Wasm32.i32Load());
+    out.write(Wasm.localSet(srcLen));
+
+    // start = arg0 (i64 -> i32)
+    generateASTExpression(args[0], out: out, context: context);
+    context.stackDrop();
+    out.writeByte(Wasm64.i64WrapToi32);
+    out.write(Wasm.localSet(startL));
+
+    // end = arg1 if present, else srcLen
+    if (args.length >= 2) {
+      generateASTExpression(args[1], out: out, context: context);
+      context.stackDrop();
+      out.writeByte(Wasm64.i64WrapToi32);
+      out.write(Wasm.localSet(endL));
+    } else {
+      out.write(Wasm.localGet(srcLen));
+      out.write(Wasm.localSet(endL));
+    }
+
+    // newLen = end - start
+    out.write(Wasm.localGet(endL));
+    out.write(Wasm.localGet(startL));
+    out.writeByte(Wasm32.i32Subtract);
+    out.write(Wasm.localSet(newLen));
+
+    // dest = alloc(newLen + 4) ; store newLen at dest[0]
+    out.write(Wasm.localGet(newLen));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    _emitInlineAlloc(out, context);
+    out.write(Wasm.localSet(dest));
+    out.write(Wasm.localGet(dest));
+    out.write(Wasm.localGet(newLen));
+    out.write(Wasm32.i32Store());
+
+    // memory.copy(dest + 4, src + 4 + start, newLen)
+    out.write(Wasm.localGet(dest));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localGet(src));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localGet(startL));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localGet(newLen));
+    out.write(Wasm.memoryCopy);
+
+    out.write(Wasm.localGet(dest));
+    context.stackPush(_astTypeString, "$varName.substring");
+    context.assertStackLength(s0 + 1, "After String.substring");
+    return out;
+  }
+
+  /// `s.startsWith(p)` / `s.endsWith(p)` -> a `bool` (i32): whether the pattern's
+  /// bytes match at the start (or end) of the receiver.
+  BytesOutput _generateStringStartsEndsWith(
+    ({ASTType type, int index}) recv,
+    String varName,
+    ASTExpression argExpr, {
+    required bool ends,
+    required BytesOutput out,
+    required WasmContext context,
+  }) {
+    context.module!.requiresMemory = true;
+    final s0 = context.stackLength;
+
+    var src = context.scratchLocal(_astTypeString, 36);
+    var srcLen = context.scratchLocal(_astTypeString, 37);
+    var sub = context.scratchLocal(_astTypeString, 38);
+    var subLen = context.scratchLocal(_astTypeString, 39);
+    var aAddr = context.scratchLocal(_astTypeString, 40);
+    var bAddr = context.scratchLocal(_astTypeString, 41);
+    var res = context.scratchLocal(_astTypeString, 42);
+    var j = context.scratchLocal(_astTypeString, 43);
+
+    // sub = eval(arg) ; src = recv
+    generateASTExpression(argExpr, out: out, context: context);
+    context.stackDrop();
+    out.write(Wasm.localSet(sub));
+    _localVariableGet(out, context, recv.index, varName);
+    out.write(Wasm.localSet(src));
+    out.write(Wasm.localGet(src));
+    out.write(Wasm32.i32Load());
+    out.write(Wasm.localSet(srcLen));
+    out.write(Wasm.localGet(sub));
+    out.write(Wasm32.i32Load());
+    out.write(Wasm.localSet(subLen));
+
+    // bAddr = sub + 4
+    out.write(Wasm.localGet(sub));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localSet(bAddr));
+    // aAddr = src + 4 (+ srcLen - subLen for endsWith)
+    out.write(Wasm.localGet(src));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    if (ends) {
+      out.write(Wasm.localGet(srcLen));
+      out.write(Wasm.localGet(subLen));
+      out.writeByte(Wasm32.i32Subtract);
+      out.writeByte(Wasm32.i32Add);
+    }
+    out.write(Wasm.localSet(aAddr));
+
+    // res = 0 ; only compare when the pattern fits (guards an OOB read).
+    out.write(Wasm32.i32Const(0));
+    out.write(Wasm.localSet(res));
+    out.write(Wasm.localGet(subLen));
+    out.write(Wasm.localGet(srcLen));
+    out.writeByte(Wasm32.i32LessThanOrEqualsUnsigned);
+    out.write(Wasm.ifInstruction(WasmType.voidType));
+    _emitBytesEqualNoBreak(
+      out,
+      context,
+      aLoc: aAddr,
+      bLoc: bAddr,
+      lenLoc: subLen,
+      jLoc: j,
+      outLoc: res,
+    );
+    out.writeByte(Wasm.end); // if
+
+    out.write(Wasm.localGet(res));
+    context.stackPush(
+      _astTypeInt32,
+      "$varName.${ends ? 'endsWith' : 'startsWith'}",
+    );
+    context.assertStackLength(s0 + 1, "After String.startsWith/endsWith");
+    return out;
+  }
+
+  /// `s.indexOf(p)` -> the first byte offset where `p` occurs (or `-1`), as an
+  /// `int` (i64); or, when [asContains], `s.contains(p)` as a `bool` (i32).
+  BytesOutput _generateStringIndexOf(
+    ({ASTType type, int index}) recv,
+    String varName,
+    ASTExpression argExpr, {
+    required bool asContains,
+    required BytesOutput out,
+    required WasmContext context,
+  }) {
+    context.module!.requiresMemory = true;
+    final s0 = context.stackLength;
+
+    var src = context.scratchLocal(_astTypeString, 44);
+    var srcLen = context.scratchLocal(_astTypeString, 45);
+    var sub = context.scratchLocal(_astTypeString, 46);
+    var subLen = context.scratchLocal(_astTypeString, 47);
+    var iL = context.scratchLocal(_astTypeString, 48);
+    var match = context.scratchLocal(_astTypeString, 49);
+    var j = context.scratchLocal(_astTypeString, 50);
+    var result = context.scratchLocal(_astTypeString, 51);
+    var aAddr = context.scratchLocal(_astTypeString, 52);
+    var bAddr = context.scratchLocal(_astTypeString, 53);
+
+    // sub = eval(arg) ; src = recv
+    generateASTExpression(argExpr, out: out, context: context);
+    context.stackDrop();
+    out.write(Wasm.localSet(sub));
+    _localVariableGet(out, context, recv.index, varName);
+    out.write(Wasm.localSet(src));
+    out.write(Wasm.localGet(src));
+    out.write(Wasm32.i32Load());
+    out.write(Wasm.localSet(srcLen));
+    out.write(Wasm.localGet(sub));
+    out.write(Wasm32.i32Load());
+    out.write(Wasm.localSet(subLen));
+
+    // bAddr = sub + 4 ; result = -1 ; i = 0
+    out.write(Wasm.localGet(sub));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localSet(bAddr));
+    out.write(Wasm32.i32Const(-1));
+    out.write(Wasm.localSet(result));
+    out.write(Wasm32.i32Const(0));
+    out.write(Wasm.localSet(iL));
+
+    // block { loop { ... } } scanning positions i = 0..srcLen-subLen.
+    out.write(Wasm.block(WasmType.voidType));
+    context.controlDepth++;
+    final breakLevel = context.controlDepth;
+    out.write(Wasm.loop(WasmType.voidType));
+    context.controlDepth++;
+    final repeatLevel = context.controlDepth;
+
+    // if (i + subLen > srcLen) break — no room for a match.
+    out.write(Wasm.localGet(iL));
+    out.write(Wasm.localGet(subLen));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localGet(srcLen));
+    out.writeByte(Wasm32.i32GreaterThanUnsigned);
+    out.write(Wasm.brIf(context.controlDepth - breakLevel));
+
+    // aAddr = src + 4 + i ; match = (subLen bytes at aAddr == bAddr)
+    out.write(Wasm.localGet(src));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localGet(iL));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localSet(aAddr));
+    _emitBytesEqualNoBreak(
+      out,
+      context,
+      aLoc: aAddr,
+      bLoc: bAddr,
+      lenLoc: subLen,
+      jLoc: j,
+      outLoc: match,
+    );
+
+    // result = match ? i : result ; break when matched.
+    out.write(Wasm.localGet(iL));
+    out.write(Wasm.localGet(result));
+    out.write(Wasm.localGet(match));
+    out.writeByte(Wasm.select);
+    out.write(Wasm.localSet(result));
+    out.write(Wasm.localGet(match));
+    out.write(Wasm.brIf(context.controlDepth - breakLevel));
+
+    // i++ ; repeat
+    out.write(Wasm.localGet(iL));
+    out.write(Wasm32.i32Const(1));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localSet(iL));
+    out.write(Wasm.br(context.controlDepth - repeatLevel));
+
+    out.writeByte(Wasm.end); // loop
+    context.controlDepth--;
+    out.writeByte(Wasm.end); // block
+    context.controlDepth--;
+
+    if (asContains) {
+      out.write(Wasm.localGet(result));
+      out.write(Wasm32.i32Const(-1));
+      out.writeByte(Wasm32.i32NotEquals);
+      context.stackPush(_astTypeInt32, "$varName.contains");
+    } else {
+      out.write(Wasm.localGet(result));
+      out.writeByte(Wasm32.i32ExtendToI64Signed); // -1 stays -1
+      context.stackPush(_astTypeInt64, "$varName.indexOf");
+    }
+    context.assertStackLength(s0 + 1, "After String.indexOf/contains");
+    return out;
+  }
+
+  /// Emits a byte-compare loop: sets [outLoc] to 1 if the [lenLoc] bytes at
+  /// address [aLoc] equal those at [bLoc], else 0 (AND-accumulated, no early
+  /// exit, so it never branches out of an enclosing `if`). [jLoc] is a scratch
+  /// counter. The caller must guarantee both ranges are in-bounds.
+  void _emitBytesEqualNoBreak(
+    BytesOutput out,
+    WasmContext context, {
+    required int aLoc,
+    required int bLoc,
+    required int lenLoc,
+    required int jLoc,
+    required int outLoc,
+  }) {
+    out.write(Wasm32.i32Const(1));
+    out.write(Wasm.localSet(outLoc));
+    out.write(Wasm32.i32Const(0));
+    out.write(Wasm.localSet(jLoc));
+
+    out.write(Wasm.block(WasmType.voidType));
+    context.controlDepth++;
+    final breakLevel = context.controlDepth;
+    out.write(Wasm.loop(WasmType.voidType));
+    context.controlDepth++;
+    final repeatLevel = context.controlDepth;
+
+    // if (j >= len) break
+    out.write(Wasm.localGet(jLoc));
+    out.write(Wasm.localGet(lenLoc));
+    out.writeByte(Wasm32.i32GreaterThanOrEqualsUnsigned);
+    out.write(Wasm.brIf(context.controlDepth - breakLevel));
+
+    // out = out & (load8(a + j) == load8(b + j))
+    out.write(Wasm.localGet(outLoc));
+    out.write(Wasm.localGet(aLoc));
+    out.write(Wasm.localGet(jLoc));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm32.i32Load8U());
+    out.write(Wasm.localGet(bLoc));
+    out.write(Wasm.localGet(jLoc));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm32.i32Load8U());
+    out.writeByte(Wasm32.i32Equals);
+    out.writeByte(Wasm32.i32BitwiseAnd);
+    out.write(Wasm.localSet(outLoc));
+
+    // j++ ; repeat
+    out.write(Wasm.localGet(jLoc));
+    out.write(Wasm32.i32Const(1));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localSet(jLoc));
+    out.write(Wasm.br(context.controlDepth - repeatLevel));
+
+    out.writeByte(Wasm.end); // loop
+    context.controlDepth--;
+    out.writeByte(Wasm.end); // block
+    context.controlDepth--;
+  }
+
   BytesOutput _generateStringCaseConvert(
     ({ASTType type, int index}) localVar,
     String varName, {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.6.0
+version: 2.7.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/wasm/apollovm_wasm_string_methods_test.dart
+++ b/test/wasm/apollovm_wasm_string_methods_test.dart
@@ -1,0 +1,224 @@
+@TestOn('vm')
+@Tags(['wasm', 'dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+import 'wasm_runtime_setup.dart';
+
+/// Compiles [code] to Wasm and runs [functionName] through both the AST
+/// interpreter and the compiled+executed module, asserting every entry in
+/// [executions].
+Future<void> _testWasm(
+  String code,
+  String functionName,
+  Map<List, Object?> executions,
+) async {
+  var vm = ApolloVM();
+  expect(
+    await vm.loadCodeUnit(SourceCodeUnit('dart', code, id: 'test')),
+    isTrue,
+    reason: "Can't load Dart source",
+  );
+
+  var astRunner = vm.createRunner('dart')!;
+  for (var e in executions.entries) {
+    var r = await astRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'AST $functionName(${e.key})',
+    );
+  }
+
+  var storage = vm.generateAllIn<BytesOutput>('wasm');
+  BytesOutput? compiled;
+  for (var ns in (await storage.allEntries()).values) {
+    for (var m in ns.values) {
+      compiled ??= m;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var vmWasm = ApolloVM();
+  expect(
+    await vmWasm.loadCodeUnit(
+      BinaryCodeUnit(
+        'wasm',
+        compiled!.output(),
+        id: 'test.wasm',
+        namespace: '',
+      ),
+    ),
+    isTrue,
+    reason: 'Compiled Wasm failed to load',
+  );
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  for (var e in executions.entries) {
+    var r = await wasmRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'WASM $functionName(${e.key})',
+    );
+  }
+}
+
+void main() {
+  setUpWasmRuntime();
+
+  // String methods over the `[len:i32][utf8]` layout — byte-indexed, so exact for
+  // ASCII text. The receiver must be a named local (chaining onto a method result
+  // is a separate limitation).
+  group('Wasm String methods', () {
+    test('substring(start, end)', () async {
+      await _testWasm(
+        "String run() { var s = 'hello'; return s.substring(1, 3); }",
+        'run',
+        {[]: 'el'},
+      );
+    });
+
+    test('substring(start) to end', () async {
+      await _testWasm(
+        "String run() { var s = 'hello'; return s.substring(2); }",
+        'run',
+        {[]: 'llo'},
+      );
+    });
+
+    test('substring full and empty slices', () async {
+      await _testWasm(
+        "String run() { var s = 'hello'; return s.substring(0, 5); }",
+        'run',
+        {[]: 'hello'},
+      );
+      await _testWasm(
+        "String run() { var s = 'hello'; return s.substring(2, 2); }",
+        'run',
+        {[]: ''},
+      );
+    });
+
+    test('substring result length', () async {
+      await _testWasm(
+        "int run() { var s = 'hello'; var t = s.substring(1, 4);"
+            " return t.length; }",
+        'run',
+        {[]: 3},
+      );
+    });
+
+    test('codeUnitAt', () async {
+      await _testWasm(
+        "int run() { var s = 'ABC'; return s.codeUnitAt(0); }",
+        'run',
+        {[]: 65},
+      );
+      await _testWasm(
+        "int run() { var s = 'ABC'; return s.codeUnitAt(2); }",
+        'run',
+        {[]: 67},
+      );
+    });
+
+    test('contains', () async {
+      await _testWasm(
+        "bool run() { var s = 'hello'; return s.contains('ell'); }",
+        'run',
+        {[]: true},
+      );
+    });
+
+    test('contains — absent / pattern longer than string', () async {
+      await _testWasm(
+        "bool run() { var s = 'hello'; return s.contains('xyz'); }",
+        'run',
+        {[]: false},
+      );
+      await _testWasm(
+        "bool run() { var s = 'hi'; return s.contains('hello'); }",
+        'run',
+        {[]: false},
+      );
+    });
+
+    test('contains used in a condition', () async {
+      await _testWasm(
+        "int run() { var s = 'hello';"
+            " if (s.contains('ell')) { return 1; } return 0; }",
+        'run',
+        {[]: 1},
+      );
+    });
+
+    test('indexOf — found', () async {
+      await _testWasm(
+        "int run() { var s = 'hello'; return s.indexOf('l'); }",
+        'run',
+        {[]: 2},
+      );
+      await _testWasm(
+        "int run() { var s = 'hello'; return s.indexOf('lo'); }",
+        'run',
+        {[]: 3},
+      );
+      await _testWasm(
+        "int run() { var s = 'hello'; return s.indexOf('h'); }",
+        'run',
+        {[]: 0},
+      );
+    });
+
+    test('indexOf — not found returns -1', () async {
+      await _testWasm(
+        "int run() { var s = 'hello'; return s.indexOf('z'); }",
+        'run',
+        {[]: -1},
+      );
+    });
+
+    test('startsWith', () async {
+      await _testWasm(
+        "bool run() { var s = 'hello'; return s.startsWith('he'); }",
+        'run',
+        {[]: true},
+      );
+      await _testWasm(
+        "bool run() { var s = 'hello'; return s.startsWith('lo'); }",
+        'run',
+        {[]: false},
+      );
+    });
+
+    test('startsWith — pattern longer than string', () async {
+      await _testWasm(
+        "bool run() { var s = 'hi'; return s.startsWith('hello'); }",
+        'run',
+        {[]: false},
+      );
+    });
+
+    test('endsWith', () async {
+      await _testWasm(
+        "bool run() { var s = 'hello'; return s.endsWith('lo'); }",
+        'run',
+        {[]: true},
+      );
+      await _testWasm(
+        "bool run() { var s = 'hello'; return s.endsWith('he'); }",
+        'run',
+        {[]: false},
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Wasm: String slice & search methods — GAP B (partial)

Extends **GAP B** in `WASM_BACKEND_PLAN.md`. The on-the-fly WebAssembly compiler now supports the common String slice/search methods over its `[len:i32][utf8]` layout.

### New methods
- **`substring(start, [end])`** — allocates a fresh `[len][utf8]` buffer and `memory.copy`s the byte slice (`end` defaults to the length).
- **`codeUnitAt(i)`** — unsigned byte load at `s + 4 + i`.
- **`startsWith(p)` / `endsWith(p)`** — byte compare at the start/end, guarded so a pattern longer than the string returns `false` without an out-of-bounds read.
- **`indexOf(p)`** — position scan (returns `-1` when absent).
- **`contains(p)`** — `indexOf(p) != -1`.

These join the already-supported `length`/`isEmpty`/`isNotEmpty` and `toUpperCase`/`toLowerCase`. A shared `_emitBytesEqualNoBreak` helper does the byte compare by AND-accumulating (no early break, so it never branches out of an enclosing `if` — keeps the structured-control label math simple). Methods are byte-indexed, so exact for ASCII text.

### Coverage (new `apollovm_wasm_string_methods_test.dart`, 13 cases)
substring (2-arg/1-arg/full/empty/result-length), codeUnitAt, contains (present/absent/pattern-longer/in-condition), indexOf (found/multi-char/at-0/not-found), startsWith & endsWith (true/false/pattern-longer). Both the interpreter and the compiled+executed module are asserted for every case.

### Scope / follow-ups
- Remaining String methods: `trim`, `split` (returns a `List`), `replaceAll`/`replaceFirst`, `padLeft`/`padRight`, `compareTo`, index `[]`.
- Chaining a method onto a method *result* (`s.substring(0,2) == 'x'`) requires a named-local receiver; a bare `String == String` returning a `bool` is a separate pre-existing limitation.

Bumps to **2.7.0**. Full Wasm suite (479 tests) green; `dart analyze lib test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)