### PR TITLE
feat(wasm): String trim & pad methods — GAP B (tail)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## 2.8.0
+
+### Wasm: String trim & pad methods
+
+The on-the-fly WebAssembly compiler now supports the String trim and pad methods
+over its `[len][utf8]` layout: `trim()` / `trimLeft()` / `trimRight()` (ASCII
+whitespace stripping) and `padLeft(width, [pad])` / `padRight(width, [pad])`
+(single-byte pad, default space). These join the slice/search methods added in
+2.7.0. Byte-indexed, so exact for ASCII text.
+
+Still to come: `split`, `replaceAll` / `replaceFirst`, index `[]`, and
+`compareTo` (which also needs `String.compareTo` in the interpreter core first).
+
 ## 2.7.0
 
 ### Wasm: String slice & search methods

--- a/WASM_BACKEND_PLAN.md
+++ b/WASM_BACKEND_PLAN.md
@@ -95,9 +95,14 @@ test('generic Box<int> field round-trips', () => _testWasm(
   slice), `.codeUnitAt(i)`, `.startsWith`/`.endsWith`, `.indexOf`, `.contains`
   (byte scans over the layout, OOB-guarded) — `apollovm_wasm_string_methods_test`
   and `_tryGenerateStringMethod`.
-- **Still open**: `.trim`, `.split` (returns a `List`), `.replaceAll` /
-  `.replaceFirst`, `.padLeft`/`.padRight`, `.compareTo`, index `[]`. Also:
-  chaining a getter/method onto a method *result* (`s.toUpperCase().length`,
+- **Done (trim/pad)**: `.trim`/`.trimLeft`/`.trimRight` (ASCII-whitespace strip)
+  and `.padLeft`/`.padRight(width,[pad])` (single-byte pad) —
+  `apollovm_wasm_string_methods2_test`.
+- **Still open**: `.split` (returns a `List`), `.replaceAll` / `.replaceFirst`,
+  index `[]`, and `.compareTo` (the *interpreter* core lacks `String.compareTo`
+  too — closing it means adding it to `apollovm_core_base.dart` first, then the
+  Wasm side; the Wasm codegen is straightforward, a lexicographic byte compare).
+  Also: chaining a getter/method onto a method *result* (`s.toUpperCase().length`,
   `s.substring(0,2) == 'x'`) — the receiver must be a named local, and a bare
   `String == String` returning a `bool` is a separate pre-existing limitation.
 - **Fix direction**: same allocate-buffer + byte-loop pattern
@@ -245,8 +250,8 @@ GAPs **C** (getters), **D** (static fields), **E** (inheritance/`super`) and **G
 (nested collections / `m[0][1]`) are **DONE**; **GAP B** (String methods) is mostly
 done (slice/search/case complete). Remaining:
 
-1. **GAP B tail** — `.trim`, `.split`, `.replaceAll`/`.replaceFirst`,
-   `.padLeft`/`.padRight`, `.compareTo`, index `[]`.
+1. **GAP B tail** — `.split`, `.replaceAll`/`.replaceFirst`, index `[]`, and
+   `.compareTo` (needs interpreter core support first). (`.trim`/`.pad` done.)
 2. **GAP A** (generic field i64/boxing) and **GAP F** (aggregate returns) —
    value-representation work; related boxing concerns.
 

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.7.0';
+  static final String VERSION = '2.8.0';
 
   static int _idCount = 0;
 

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -10406,7 +10406,314 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         context: context,
       );
     }
+    if ((name == 'trim' || name == 'trimLeft' || name == 'trimRight') &&
+        args.isEmpty) {
+      return _generateStringTrim(
+        recv,
+        varName,
+        left: name != 'trimRight',
+        right: name != 'trimLeft',
+        out: out,
+        context: context,
+      );
+    }
+    if ((name == 'padLeft' || name == 'padRight') &&
+        (args.length == 1 || args.length == 2)) {
+      return _generateStringPad(
+        recv,
+        varName,
+        args,
+        left: name == 'padLeft',
+        out: out,
+        context: context,
+      );
+    }
     return null;
+  }
+
+  /// Pushes `1` if the char in [chLoc] is ASCII whitespace (space, or `\t`..`\r`,
+  /// i.e. `0x09..0x0D`), else `0`.
+  void _emitCharIsWhitespace(BytesOutput out, int chLoc) {
+    out.write(Wasm.localGet(chLoc));
+    out.write(Wasm32.i32Const(0x20));
+    out.writeByte(Wasm32.i32Equals); // ch == ' '
+    out.write(Wasm.localGet(chLoc));
+    out.write(Wasm32.i32Const(0x09));
+    out.writeByte(Wasm32.i32GreaterThanOrEqualsUnsigned);
+    out.write(Wasm.localGet(chLoc));
+    out.write(Wasm32.i32Const(0x0D));
+    out.writeByte(Wasm32.i32LessThanOrEqualsUnsigned);
+    out.writeByte(Wasm32.i32BitwiseAnd); // 0x09 <= ch <= 0x0D
+    out.writeByte(Wasm32.i32BitwiseOr);
+  }
+
+  /// `s.trim()` / `s.trimLeft()` / `s.trimRight()`: returns a fresh String with
+  /// ASCII whitespace stripped from the requested side(s).
+  BytesOutput _generateStringTrim(
+    ({ASTType type, int index}) recv,
+    String varName, {
+    required bool left,
+    required bool right,
+    required BytesOutput out,
+    required WasmContext context,
+  }) {
+    var module = context.module!;
+    module.requiresMemory = true;
+    module.requiresHeapGlobal = true;
+    final s0 = context.stackLength;
+
+    var src = context.scratchLocal(_astTypeString, 60);
+    var srcLen = context.scratchLocal(_astTypeString, 61);
+    var a = context.scratchLocal(_astTypeString, 62);
+    var b = context.scratchLocal(_astTypeString, 63);
+    var ch = context.scratchLocal(_astTypeString, 64);
+    var dest = context.scratchLocal(_astTypeString, 65);
+    var newLen = context.scratchLocal(_astTypeString, 66);
+
+    _localVariableGet(out, context, recv.index, varName);
+    out.write(Wasm.localSet(src));
+    out.write(Wasm.localGet(src));
+    out.write(Wasm32.i32Load());
+    out.write(Wasm.localSet(srcLen));
+
+    // a = 0 ; b = srcLen
+    out.write(Wasm32.i32Const(0));
+    out.write(Wasm.localSet(a));
+    out.write(Wasm.localGet(srcLen));
+    out.write(Wasm.localSet(b));
+
+    if (left) {
+      // while (a < b && isWs(src[a])) a++
+      out.write(Wasm.block(WasmType.voidType));
+      context.controlDepth++;
+      final brk = context.controlDepth;
+      out.write(Wasm.loop(WasmType.voidType));
+      context.controlDepth++;
+      final rpt = context.controlDepth;
+      // if (a >= b) break
+      out.write(Wasm.localGet(a));
+      out.write(Wasm.localGet(b));
+      out.writeByte(Wasm32.i32GreaterThanOrEqualsUnsigned);
+      out.write(Wasm.brIf(context.controlDepth - brk));
+      // ch = src[a] ; if (!isWs(ch)) break
+      out.write(Wasm.localGet(src));
+      out.write(Wasm32.i32Const(4));
+      out.writeByte(Wasm32.i32Add);
+      out.write(Wasm.localGet(a));
+      out.writeByte(Wasm32.i32Add);
+      out.write(Wasm32.i32Load8U());
+      out.write(Wasm.localSet(ch));
+      _emitCharIsWhitespace(out, ch);
+      out.writeByte(Wasm32.i32EqualsToZero); // !isWs
+      out.write(Wasm.brIf(context.controlDepth - brk));
+      // a++
+      out.write(Wasm.localGet(a));
+      out.write(Wasm32.i32Const(1));
+      out.writeByte(Wasm32.i32Add);
+      out.write(Wasm.localSet(a));
+      out.write(Wasm.br(context.controlDepth - rpt));
+      out.writeByte(Wasm.end);
+      context.controlDepth--;
+      out.writeByte(Wasm.end);
+      context.controlDepth--;
+    }
+
+    if (right) {
+      // while (b > a && isWs(src[b-1])) b--
+      out.write(Wasm.block(WasmType.voidType));
+      context.controlDepth++;
+      final brk = context.controlDepth;
+      out.write(Wasm.loop(WasmType.voidType));
+      context.controlDepth++;
+      final rpt = context.controlDepth;
+      // if (b <= a) break
+      out.write(Wasm.localGet(b));
+      out.write(Wasm.localGet(a));
+      out.writeByte(Wasm32.i32LessThanOrEqualsUnsigned);
+      out.write(Wasm.brIf(context.controlDepth - brk));
+      // ch = src[b-1] ; if (!isWs(ch)) break
+      out.write(Wasm.localGet(src));
+      out.write(Wasm32.i32Const(4));
+      out.writeByte(Wasm32.i32Add);
+      out.write(Wasm.localGet(b));
+      out.write(Wasm32.i32Const(1));
+      out.writeByte(Wasm32.i32Subtract);
+      out.writeByte(Wasm32.i32Add);
+      out.write(Wasm32.i32Load8U());
+      out.write(Wasm.localSet(ch));
+      _emitCharIsWhitespace(out, ch);
+      out.writeByte(Wasm32.i32EqualsToZero);
+      out.write(Wasm.brIf(context.controlDepth - brk));
+      // b--
+      out.write(Wasm.localGet(b));
+      out.write(Wasm32.i32Const(1));
+      out.writeByte(Wasm32.i32Subtract);
+      out.write(Wasm.localSet(b));
+      out.write(Wasm.br(context.controlDepth - rpt));
+      out.writeByte(Wasm.end);
+      context.controlDepth--;
+      out.writeByte(Wasm.end);
+      context.controlDepth--;
+    }
+
+    // newLen = b - a ; dest = alloc(newLen+4) ; copy [a, b)
+    out.write(Wasm.localGet(b));
+    out.write(Wasm.localGet(a));
+    out.writeByte(Wasm32.i32Subtract);
+    out.write(Wasm.localSet(newLen));
+    out.write(Wasm.localGet(newLen));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    _emitInlineAlloc(out, context);
+    out.write(Wasm.localSet(dest));
+    out.write(Wasm.localGet(dest));
+    out.write(Wasm.localGet(newLen));
+    out.write(Wasm32.i32Store());
+    // memory.copy(dest+4, src+4+a, newLen)
+    out.write(Wasm.localGet(dest));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localGet(src));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localGet(a));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localGet(newLen));
+    out.write(Wasm.memoryCopy);
+
+    out.write(Wasm.localGet(dest));
+    context.stackPush(_astTypeString, "$varName.trim");
+    context.assertStackLength(s0 + 1, "After String.trim");
+    return out;
+  }
+
+  /// `s.padLeft(width, [pad])` / `s.padRight(width, [pad])`: returns a fresh
+  /// String padded to at least [width] bytes with the first byte of `pad`
+  /// (default space). A single-byte pad is assumed (the common case).
+  BytesOutput _generateStringPad(
+    ({ASTType type, int index}) recv,
+    String varName,
+    List<ASTExpression> args, {
+    required bool left,
+    required BytesOutput out,
+    required WasmContext context,
+  }) {
+    var module = context.module!;
+    module.requiresMemory = true;
+    module.requiresHeapGlobal = true;
+    final s0 = context.stackLength;
+
+    var src = context.scratchLocal(_astTypeString, 60);
+    var srcLen = context.scratchLocal(_astTypeString, 61);
+    var width = context.scratchLocal(_astTypeString, 62);
+    var padCh = context.scratchLocal(_astTypeString, 63);
+    var padCount = context.scratchLocal(_astTypeString, 64);
+    var dest = context.scratchLocal(_astTypeString, 65);
+    var newLen = context.scratchLocal(_astTypeString, 66);
+    var k = context.scratchLocal(_astTypeString, 67);
+
+    // width = arg0 ; padCh = arg1[0] or ' '
+    generateASTExpression(args[0], out: out, context: context);
+    context.stackDrop();
+    out.writeByte(Wasm64.i64WrapToi32);
+    out.write(Wasm.localSet(width));
+    if (args.length >= 2) {
+      generateASTExpression(args[1], out: out, context: context);
+      context.stackDrop();
+      out.write(Wasm32.i32Const(4));
+      out.writeByte(Wasm32.i32Add);
+      out.write(Wasm32.i32Load8U()); // pad[0]
+      out.write(Wasm.localSet(padCh));
+    } else {
+      out.write(Wasm32.i32Const(0x20));
+      out.write(Wasm.localSet(padCh));
+    }
+
+    _localVariableGet(out, context, recv.index, varName);
+    out.write(Wasm.localSet(src));
+    out.write(Wasm.localGet(src));
+    out.write(Wasm32.i32Load());
+    out.write(Wasm.localSet(srcLen));
+
+    // padCount = (width > srcLen) ? width - srcLen : 0
+    out.write(Wasm.localGet(width));
+    out.write(Wasm.localGet(srcLen));
+    out.writeByte(Wasm32.i32Subtract);
+    out.write(Wasm32.i32Const(0));
+    out.write(Wasm.localGet(width));
+    out.write(Wasm.localGet(srcLen));
+    out.writeByte(Wasm32.i32GreaterThanUnsigned);
+    out.writeByte(Wasm.select); // (width>srcLen) ? (width-srcLen) : 0
+    out.write(Wasm.localSet(padCount));
+
+    // newLen = srcLen + padCount ; dest = alloc(newLen+4)
+    out.write(Wasm.localGet(srcLen));
+    out.write(Wasm.localGet(padCount));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localSet(newLen));
+    out.write(Wasm.localGet(newLen));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    _emitInlineAlloc(out, context);
+    out.write(Wasm.localSet(dest));
+    out.write(Wasm.localGet(dest));
+    out.write(Wasm.localGet(newLen));
+    out.write(Wasm32.i32Store());
+
+    // Copy the source bytes to their position (offset padCount for padLeft).
+    out.write(Wasm.localGet(dest));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    if (left) {
+      out.write(Wasm.localGet(padCount));
+      out.writeByte(Wasm32.i32Add);
+    }
+    out.write(Wasm.localGet(src));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localGet(srcLen));
+    out.write(Wasm.memoryCopy);
+
+    // Fill the pad bytes: k = 0 ; while (k < padCount) dest[base+k] = padCh.
+    // base = padLeft ? dest+4 : dest+4+srcLen.
+    out.write(Wasm32.i32Const(0));
+    out.write(Wasm.localSet(k));
+    out.write(Wasm.block(WasmType.voidType));
+    context.controlDepth++;
+    final brk = context.controlDepth;
+    out.write(Wasm.loop(WasmType.voidType));
+    context.controlDepth++;
+    final rpt = context.controlDepth;
+    out.write(Wasm.localGet(k));
+    out.write(Wasm.localGet(padCount));
+    out.writeByte(Wasm32.i32GreaterThanOrEqualsUnsigned);
+    out.write(Wasm.brIf(context.controlDepth - brk));
+    // addr = dest + 4 + (left ? 0 : srcLen) + k
+    out.write(Wasm.localGet(dest));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    if (!left) {
+      out.write(Wasm.localGet(srcLen));
+      out.writeByte(Wasm32.i32Add);
+    }
+    out.write(Wasm.localGet(k));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localGet(padCh));
+    out.write(Wasm32.i32Store8());
+    out.write(Wasm.localGet(k));
+    out.write(Wasm32.i32Const(1));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localSet(k));
+    out.write(Wasm.br(context.controlDepth - rpt));
+    out.writeByte(Wasm.end);
+    context.controlDepth--;
+    out.writeByte(Wasm.end);
+    context.controlDepth--;
+
+    out.write(Wasm.localGet(dest));
+    context.stackPush(_astTypeString, "$varName.pad");
+    context.assertStackLength(s0 + 1, "After String.pad");
+    return out;
   }
 
   /// `s.codeUnitAt(i)` -> the (unsigned) byte at `s + 4 + i` as an `int` (i64).

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.7.0
+version: 2.8.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/wasm/apollovm_wasm_string_methods2_test.dart
+++ b/test/wasm/apollovm_wasm_string_methods2_test.dart
@@ -1,0 +1,170 @@
+@TestOn('vm')
+@Tags(['wasm', 'dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+import 'wasm_runtime_setup.dart';
+
+/// Compiles [code] to Wasm and runs [functionName] through both the AST
+/// interpreter and the compiled+executed module, asserting every entry in
+/// [executions].
+Future<void> _testWasm(
+  String code,
+  String functionName,
+  Map<List, Object?> executions,
+) async {
+  var vm = ApolloVM();
+  expect(
+    await vm.loadCodeUnit(SourceCodeUnit('dart', code, id: 'test')),
+    isTrue,
+    reason: "Can't load Dart source",
+  );
+
+  var astRunner = vm.createRunner('dart')!;
+  for (var e in executions.entries) {
+    var r = await astRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'AST $functionName(${e.key})',
+    );
+  }
+
+  var storage = vm.generateAllIn<BytesOutput>('wasm');
+  BytesOutput? compiled;
+  for (var ns in (await storage.allEntries()).values) {
+    for (var m in ns.values) {
+      compiled ??= m;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var vmWasm = ApolloVM();
+  expect(
+    await vmWasm.loadCodeUnit(
+      BinaryCodeUnit(
+        'wasm',
+        compiled!.output(),
+        id: 'test.wasm',
+        namespace: '',
+      ),
+    ),
+    isTrue,
+    reason: 'Compiled Wasm failed to load',
+  );
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  for (var e in executions.entries) {
+    var r = await wasmRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'WASM $functionName(${e.key})',
+    );
+  }
+}
+
+void main() {
+  setUpWasmRuntime();
+
+  // More String methods (byte ops over `[len][utf8]`, ASCII-exact): trim family,
+  // padLeft/padRight.
+  group('Wasm String methods (trim/pad)', () {
+    test('trim', () async {
+      await _testWasm(
+        "String run() { var s = '  hi  '; return s.trim(); }",
+        'run',
+        {[]: 'hi'},
+      );
+    });
+
+    test('trim — no whitespace is a no-op', () async {
+      await _testWasm(
+        "String run() { var s = 'hi'; return s.trim(); }",
+        'run',
+        {[]: 'hi'},
+      );
+    });
+
+    test('trim — all whitespace yields empty', () async {
+      await _testWasm(
+        "int run() { var s = '   '; var t = s.trim(); return t.length; }",
+        'run',
+        {[]: 0},
+      );
+    });
+
+    test('trim — tabs and newlines', () async {
+      await _testWasm(
+        "String run() { var s = '\\n\\thi\\n'; return s.trim(); }",
+        'run',
+        {[]: 'hi'},
+      );
+    });
+
+    test('trimLeft', () async {
+      await _testWasm(
+        "String run() { var s = '  hi  '; return s.trimLeft(); }",
+        'run',
+        {[]: 'hi  '},
+      );
+    });
+
+    test('trimRight', () async {
+      await _testWasm(
+        "String run() { var s = '  hi  '; return s.trimRight(); }",
+        'run',
+        {[]: '  hi'},
+      );
+    });
+
+    test('padLeft with a fill char', () async {
+      await _testWasm(
+        "String run() { var s = '42'; return s.padLeft(5, '0'); }",
+        'run',
+        {[]: '00042'},
+      );
+    });
+
+    test('padLeft default (space)', () async {
+      await _testWasm(
+        "String run() { var s = 'x'; return s.padLeft(4); }",
+        'run',
+        {[]: '   x'},
+      );
+    });
+
+    test('padRight with a fill char', () async {
+      await _testWasm(
+        "String run() { var s = '42'; return s.padRight(5, '.'); }",
+        'run',
+        {[]: '42...'},
+      );
+    });
+
+    test('padRight default (space)', () async {
+      await _testWasm(
+        "String run() { var s = 'x'; return s.padRight(3); }",
+        'run',
+        {[]: 'x  '},
+      );
+    });
+
+    test('pad — width not greater than length is a copy', () async {
+      await _testWasm(
+        "String run() { var s = 'hello'; return s.padLeft(3); }",
+        'run',
+        {[]: 'hello'},
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Wasm: String trim & pad methods — GAP B (tail)

Continues **GAP B** in `WASM_BACKEND_PLAN.md`. The on-the-fly WebAssembly compiler now supports the String trim/pad methods over its `[len:i32][utf8]` layout.

### New methods
- **`trim()` / `trimLeft()` / `trimRight()`** — strip ASCII whitespace (space, `\t`..`\r`): two scan loops find the trimmed `[a, b)` range, then a fresh-buffer `memory.copy` of the slice.
- **`padLeft(width, [pad])` / `padRight(width, [pad])`** — pad to at least `width` bytes with the first byte of `pad` (default space); a width not exceeding the length is a plain copy. Single-byte pad assumed (the common case).

A shared `_emitCharIsWhitespace` helper classifies a byte. Byte-indexed, so exact for ASCII text. These join the slice/search methods from 2.7.0.

### Coverage (new `apollovm_wasm_string_methods2_test.dart`, 11 cases)
trim (basic / no-op / all-whitespace / tabs+newlines), trimLeft, trimRight, padLeft & padRight (with fill char and default space), and pad-width-not-greater-is-a-copy. Both the interpreter and the compiled+executed module are asserted for every case.

### Note on `compareTo`
I implemented `compareTo` (a lexicographic byte compare) but **dropped it from this PR**: the AST interpreter core doesn't implement `String.compareTo`, so shipping only the Wasm side would make the backend diverge from the interpreter for the same source. Left as a follow-up — add `String.compareTo` to `apollovm_core_base.dart` first, then re-add the (straightforward) Wasm codegen.

### Scope / follow-ups
- Remaining String methods: `split` (returns a `List`), `replaceAll`/`replaceFirst`, index `[]`, `compareTo` (see above).

Bumps to **2.8.0**. Full Wasm suite (490 tests) green; `dart analyze lib test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)