### PR TITLE
feat(wasm): String replaceAll / replaceFirst — GAP B (tail)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 2.9.0
+
+### Wasm: String `replaceAll` / `replaceFirst`
+
+The on-the-fly WebAssembly compiler now supports `replaceAll(from, to)` and
+`replaceFirst(from, to)` over its `[len][utf8]` layout. Each is compiled as two
+passes — the first counts non-overlapping matches to size the output buffer, the
+second builds it (copying `to` for a match, else one byte). Handles a replacement
+that grows, shrinks, or removes the match, and matches at either end; an empty
+`from` returns a copy (avoiding a non-terminating scan).
+
+Still to come for String: `split` (returns a `List`), index `[]`, and `compareTo`
+(which also needs `String.compareTo` in the interpreter core first).
+
 ## 2.8.0
 
 ### Wasm: String trim & pad methods

--- a/WASM_BACKEND_PLAN.md
+++ b/WASM_BACKEND_PLAN.md
@@ -98,13 +98,17 @@ test('generic Box<int> field round-trips', () => _testWasm(
 - **Done (trim/pad)**: `.trim`/`.trimLeft`/`.trimRight` (ASCII-whitespace strip)
   and `.padLeft`/`.padRight(width,[pad])` (single-byte pad) —
   `apollovm_wasm_string_methods2_test`.
-- **Still open**: `.split` (returns a `List`), `.replaceAll` / `.replaceFirst`,
-  index `[]`, and `.compareTo` (the *interpreter* core lacks `String.compareTo`
-  too — closing it means adding it to `apollovm_core_base.dart` first, then the
-  Wasm side; the Wasm codegen is straightforward, a lexicographic byte compare).
-  Also: chaining a getter/method onto a method *result* (`s.toUpperCase().length`,
-  `s.substring(0,2) == 'x'`) — the receiver must be a named local, and a bare
-  `String == String` returning a `bool` is a separate pre-existing limitation.
+- **Done (replace)**: `.replaceAll(from,to)` / `.replaceFirst(from,to)` — two
+  passes (count matches to size the output buffer, then build it); handles
+  grow/shrink/removal and matches at the ends; an empty `from` returns a copy —
+  `apollovm_wasm_string_replace_test`.
+- **Still open**: `.split` (returns a `List`), index `[]`, and `.compareTo` (the
+  *interpreter* core lacks `String.compareTo` too — closing it means adding it to
+  `apollovm_core_base.dart` first, then the Wasm side; the Wasm codegen is a
+  straightforward lexicographic byte compare). Also: chaining a getter/method
+  onto a method *result* (`s.toUpperCase().length`, `s.substring(0,2) == 'x'`) —
+  the receiver must be a named local, and a bare `String == String` returning a
+  `bool` is a separate pre-existing limitation.
 - **Fix direction**: same allocate-buffer + byte-loop pattern
   (`_generateStringCaseConvert`, `_emitBytesEqualNoBreak`). `.split`/`.replaceAll`
   build a fresh buffer/`List` from scan results. Stored length is UTF-8 bytes, so
@@ -250,8 +254,8 @@ GAPs **C** (getters), **D** (static fields), **E** (inheritance/`super`) and **G
 (nested collections / `m[0][1]`) are **DONE**; **GAP B** (String methods) is mostly
 done (slice/search/case complete). Remaining:
 
-1. **GAP B tail** — `.split`, `.replaceAll`/`.replaceFirst`, index `[]`, and
-   `.compareTo` (needs interpreter core support first). (`.trim`/`.pad` done.)
+1. **GAP B tail** — `.split`, index `[]`, and `.compareTo` (needs interpreter
+   core support first). (`.trim`/`.pad`/`.replaceAll`/`.replaceFirst` done.)
 2. **GAP A** (generic field i64/boxing) and **GAP F** (aggregate returns) —
    value-representation work; related boxing concerns.
 

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.8.0';
+  static final String VERSION = '2.9.0';
 
   static int _idCount = 0;
 

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -10428,7 +10428,295 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         context: context,
       );
     }
+    if ((name == 'replaceAll' || name == 'replaceFirst') && args.length == 2) {
+      return _generateStringReplace(
+        recv,
+        varName,
+        args,
+        all: name == 'replaceAll',
+        out: out,
+        context: context,
+      );
+    }
     return null;
+  }
+
+  /// `s.replaceAll(from, to)` / `s.replaceFirst(from, to)`: returns a fresh
+  /// String with (all / the first) non-overlapping occurrence(s) of `from`
+  /// replaced by `to`. Two passes over the byte layout — pass 1 counts matches
+  /// to size the output buffer, pass 2 builds it. An empty `from` is treated as
+  /// no match (returns a copy) to avoid a non-terminating scan.
+  BytesOutput _generateStringReplace(
+    ({ASTType type, int index}) recv,
+    String varName,
+    List<ASTExpression> args, {
+    required bool all,
+    required BytesOutput out,
+    required WasmContext context,
+  }) {
+    var module = context.module!;
+    module.requiresMemory = true;
+    module.requiresHeapGlobal = true;
+    final s0 = context.stackLength;
+
+    var src = context.scratchLocal(_astTypeString, 60);
+    var srcLen = context.scratchLocal(_astTypeString, 61);
+    var from = context.scratchLocal(_astTypeString, 62);
+    var fromLen = context.scratchLocal(_astTypeString, 63);
+    var to = context.scratchLocal(_astTypeString, 64);
+    var toLen = context.scratchLocal(_astTypeString, 65);
+    var count = context.scratchLocal(_astTypeString, 66);
+    var i = context.scratchLocal(_astTypeString, 67);
+    var dest = context.scratchLocal(_astTypeString, 68);
+    var outLen = context.scratchLocal(_astTypeString, 69);
+    var w = context.scratchLocal(_astTypeString, 70);
+    var match = context.scratchLocal(_astTypeString, 71);
+    var j = context.scratchLocal(_astTypeString, 72);
+    var aAddr = context.scratchLocal(_astTypeString, 73);
+    var fromData = context.scratchLocal(_astTypeString, 74);
+
+    // from = arg0 ; to = arg1 ; src = recv
+    generateASTExpression(args[0], out: out, context: context);
+    context.stackDrop();
+    out.write(Wasm.localSet(from));
+    generateASTExpression(args[1], out: out, context: context);
+    context.stackDrop();
+    out.write(Wasm.localSet(to));
+    _localVariableGet(out, context, recv.index, varName);
+    out.write(Wasm.localSet(src));
+    out.write(Wasm.localGet(src));
+    out.write(Wasm32.i32Load());
+    out.write(Wasm.localSet(srcLen));
+    out.write(Wasm.localGet(from));
+    out.write(Wasm32.i32Load());
+    out.write(Wasm.localSet(fromLen));
+    out.write(Wasm.localGet(to));
+    out.write(Wasm32.i32Load());
+    out.write(Wasm.localSet(toLen));
+    // fromData = from + 4 (the pattern's byte start, reused by both passes)
+    out.write(Wasm.localGet(from));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localSet(fromData));
+
+    // Pass 1: count non-overlapping matches into `count`.
+    _emitReplaceScan(
+      out,
+      context,
+      src: src,
+      srcLen: srcLen,
+      fromData: fromData,
+      fromLen: fromLen,
+      iLoc: i,
+      matchLoc: match,
+      jLoc: j,
+      aAddr: aAddr,
+      counterLoc: count,
+      all: all,
+      dest: null,
+      w: w,
+      to: to,
+      toLen: toLen,
+    );
+
+    // outLen = srcLen + count * (toLen - fromLen)
+    out.write(Wasm.localGet(srcLen));
+    out.write(Wasm.localGet(count));
+    out.write(Wasm.localGet(toLen));
+    out.write(Wasm.localGet(fromLen));
+    out.writeByte(Wasm32.i32Subtract);
+    out.writeByte(Wasm32.i32Multiply);
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localSet(outLen));
+
+    // dest = alloc(outLen + 4) ; store outLen
+    out.write(Wasm.localGet(outLen));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    _emitInlineAlloc(out, context);
+    out.write(Wasm.localSet(dest));
+    out.write(Wasm.localGet(dest));
+    out.write(Wasm.localGet(outLen));
+    out.write(Wasm32.i32Store());
+
+    // Pass 2: build the output at `dest`.
+    _emitReplaceScan(
+      out,
+      context,
+      src: src,
+      srcLen: srcLen,
+      fromData: fromData,
+      fromLen: fromLen,
+      iLoc: i,
+      matchLoc: match,
+      jLoc: j,
+      aAddr: aAddr,
+      counterLoc: count,
+      all: all,
+      dest: dest,
+      w: w,
+      to: to,
+      toLen: toLen,
+    );
+
+    out.write(Wasm.localGet(dest));
+    context.stackPush(_astTypeString, "$varName.replace");
+    context.assertStackLength(s0 + 1, "After String.replace");
+    return out;
+  }
+
+  /// One scan pass for [_generateStringReplace]. With [dest] null it counts
+  /// matches into [counterLoc]; otherwise it builds the output at [dest] (copying
+  /// `to` for a match, else one byte), reusing [counterLoc] to gate replaceFirst.
+  void _emitReplaceScan(
+    BytesOutput out,
+    WasmContext context, {
+    required int src,
+    required int srcLen,
+    required int fromData,
+    required int fromLen,
+    required int iLoc,
+    required int matchLoc,
+    required int jLoc,
+    required int aAddr,
+    required int counterLoc,
+    required bool all,
+    required int? dest,
+    required int w,
+    required int to,
+    required int toLen,
+  }) {
+    final building = dest != null;
+    out.write(Wasm32.i32Const(0));
+    out.write(Wasm.localSet(counterLoc));
+    out.write(Wasm32.i32Const(0));
+    out.write(Wasm.localSet(iLoc));
+    if (building) {
+      out.write(Wasm32.i32Const(0));
+      out.write(Wasm.localSet(w));
+    }
+
+    out.write(Wasm.block(WasmType.voidType));
+    context.controlDepth++;
+    final brk = context.controlDepth;
+    out.write(Wasm.loop(WasmType.voidType));
+    context.controlDepth++;
+    final rpt = context.controlDepth;
+
+    // if (i >= srcLen) break
+    out.write(Wasm.localGet(iLoc));
+    out.write(Wasm.localGet(srcLen));
+    out.writeByte(Wasm32.i32GreaterThanOrEqualsUnsigned);
+    out.write(Wasm.brIf(context.controlDepth - brk));
+
+    // aAddr = src + 4 + i ; match = (fromLen bytes at aAddr == from)
+    out.write(Wasm.localGet(src));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localGet(iLoc));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localSet(aAddr));
+    _emitBytesEqualNoBreak(
+      out,
+      context,
+      aLoc: aAddr,
+      bLoc: fromData,
+      lenLoc: fromLen,
+      jLoc: jLoc,
+      outLoc: matchLoc,
+    );
+    // match &= (fromLen != 0) & (i + fromLen <= srcLen)
+    out.write(Wasm.localGet(matchLoc));
+    out.write(Wasm.localGet(fromLen));
+    out.write(Wasm32.i32Const(0));
+    out.writeByte(Wasm32.i32NotEquals);
+    out.writeByte(Wasm32.i32BitwiseAnd);
+    out.write(Wasm.localGet(iLoc));
+    out.write(Wasm.localGet(fromLen));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localGet(srcLen));
+    out.writeByte(Wasm32.i32LessThanOrEqualsUnsigned);
+    out.writeByte(Wasm32.i32BitwiseAnd);
+    out.write(Wasm.localSet(matchLoc));
+    // replaceFirst: only the first match counts (gate on counter == 0)
+    if (!all) {
+      out.write(Wasm.localGet(matchLoc));
+      out.write(Wasm.localGet(counterLoc));
+      out.writeByte(Wasm32.i32EqualsToZero);
+      out.writeByte(Wasm32.i32BitwiseAnd);
+      out.write(Wasm.localSet(matchLoc));
+    }
+
+    if (!building) {
+      // count += match ; i += match ? fromLen : 1
+      out.write(Wasm.localGet(counterLoc));
+      out.write(Wasm.localGet(matchLoc));
+      out.writeByte(Wasm32.i32Add);
+      out.write(Wasm.localSet(counterLoc));
+      out.write(Wasm.localGet(iLoc));
+      out.write(Wasm.localGet(fromLen));
+      out.write(Wasm32.i32Const(1));
+      out.write(Wasm.localGet(matchLoc));
+      out.writeByte(Wasm.select);
+      out.writeByte(Wasm32.i32Add);
+      out.write(Wasm.localSet(iLoc));
+    } else {
+      out.write(Wasm.localGet(matchLoc));
+      out.write(Wasm.ifInstruction(WasmType.voidType));
+      // match: memory.copy(dest + 4 + w, to + 4, toLen)
+      out.write(Wasm.localGet(dest));
+      out.write(Wasm32.i32Const(4));
+      out.writeByte(Wasm32.i32Add);
+      out.write(Wasm.localGet(w));
+      out.writeByte(Wasm32.i32Add);
+      out.write(Wasm.localGet(to));
+      out.write(Wasm32.i32Const(4));
+      out.writeByte(Wasm32.i32Add);
+      out.write(Wasm.localGet(toLen));
+      out.write(Wasm.memoryCopy);
+      // w += toLen ; i += fromLen ; count++
+      out.write(Wasm.localGet(w));
+      out.write(Wasm.localGet(toLen));
+      out.writeByte(Wasm32.i32Add);
+      out.write(Wasm.localSet(w));
+      out.write(Wasm.localGet(iLoc));
+      out.write(Wasm.localGet(fromLen));
+      out.writeByte(Wasm32.i32Add);
+      out.write(Wasm.localSet(iLoc));
+      out.write(Wasm.localGet(counterLoc));
+      out.write(Wasm32.i32Const(1));
+      out.writeByte(Wasm32.i32Add);
+      out.write(Wasm.localSet(counterLoc));
+      out.writeByte(Wasm.elseInstruction);
+      // no match: dest[4 + w] = src[4 + i] ; w++ ; i++
+      out.write(Wasm.localGet(dest));
+      out.write(Wasm32.i32Const(4));
+      out.writeByte(Wasm32.i32Add);
+      out.write(Wasm.localGet(w));
+      out.writeByte(Wasm32.i32Add);
+      out.write(Wasm.localGet(src));
+      out.write(Wasm32.i32Const(4));
+      out.writeByte(Wasm32.i32Add);
+      out.write(Wasm.localGet(iLoc));
+      out.writeByte(Wasm32.i32Add);
+      out.write(Wasm32.i32Load8U());
+      out.write(Wasm32.i32Store8());
+      out.write(Wasm.localGet(w));
+      out.write(Wasm32.i32Const(1));
+      out.writeByte(Wasm32.i32Add);
+      out.write(Wasm.localSet(w));
+      out.write(Wasm.localGet(iLoc));
+      out.write(Wasm32.i32Const(1));
+      out.writeByte(Wasm32.i32Add);
+      out.write(Wasm.localSet(iLoc));
+      out.writeByte(Wasm.end); // if
+    }
+
+    out.write(Wasm.br(context.controlDepth - rpt));
+    out.writeByte(Wasm.end); // loop
+    context.controlDepth--;
+    out.writeByte(Wasm.end); // block
+    context.controlDepth--;
   }
 
   /// Pushes `1` if the char in [chLoc] is ASCII whitespace (space, or `\t`..`\r`,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.8.0
+version: 2.9.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/wasm/apollovm_wasm_string_replace_test.dart
+++ b/test/wasm/apollovm_wasm_string_replace_test.dart
@@ -1,0 +1,163 @@
+@TestOn('vm')
+@Tags(['wasm', 'dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+import 'wasm_runtime_setup.dart';
+
+/// Compiles [code] to Wasm and runs [functionName] through both the AST
+/// interpreter and the compiled+executed module, asserting every entry in
+/// [executions].
+Future<void> _testWasm(
+  String code,
+  String functionName,
+  Map<List, Object?> executions,
+) async {
+  var vm = ApolloVM();
+  expect(
+    await vm.loadCodeUnit(SourceCodeUnit('dart', code, id: 'test')),
+    isTrue,
+    reason: "Can't load Dart source",
+  );
+
+  var astRunner = vm.createRunner('dart')!;
+  for (var e in executions.entries) {
+    var r = await astRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'AST $functionName(${e.key})',
+    );
+  }
+
+  var storage = vm.generateAllIn<BytesOutput>('wasm');
+  BytesOutput? compiled;
+  for (var ns in (await storage.allEntries()).values) {
+    for (var m in ns.values) {
+      compiled ??= m;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var vmWasm = ApolloVM();
+  expect(
+    await vmWasm.loadCodeUnit(
+      BinaryCodeUnit(
+        'wasm',
+        compiled!.output(),
+        id: 'test.wasm',
+        namespace: '',
+      ),
+    ),
+    isTrue,
+    reason: 'Compiled Wasm failed to load',
+  );
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  for (var e in executions.entries) {
+    var r = await wasmRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'WASM $functionName(${e.key})',
+    );
+  }
+}
+
+void main() {
+  setUpWasmRuntime();
+
+  // replaceAll / replaceFirst — two passes over `[len][utf8]`: count matches to
+  // size the output, then build it (copy `to` for a match, else one byte).
+  group('Wasm String replace', () {
+    test('replaceAll — single-char pattern', () async {
+      await _testWasm(
+        "String run() { var s = 'a-b-c'; return s.replaceAll('-', '+'); }",
+        'run',
+        {[]: 'a+b+c'},
+      );
+    });
+
+    test('replaceAll — multi-char pattern', () async {
+      await _testWasm(
+        "String run() { var s = 'axxbxxc'; return s.replaceAll('xx', '-'); }",
+        'run',
+        {[]: 'a-b-c'},
+      );
+    });
+
+    test('replaceAll — replacement longer than pattern (grows)', () async {
+      await _testWasm(
+        "String run() { var s = 'a.b'; return s.replaceAll('.', '__'); }",
+        'run',
+        {[]: 'a__b'},
+      );
+    });
+
+    test('replaceAll — replacement shorter than pattern (shrinks)', () async {
+      await _testWasm(
+        "String run() { var s = 'aXXb'; return s.replaceAll('XX', 'Y'); }",
+        'run',
+        {[]: 'aYb'},
+      );
+    });
+
+    test('replaceAll — empty replacement removes matches', () async {
+      await _testWasm(
+        "String run() { var s = 'a-b-c'; return s.replaceAll('-', ''); }",
+        'run',
+        {[]: 'abc'},
+      );
+    });
+
+    test('replaceAll — no match is unchanged', () async {
+      await _testWasm(
+        "String run() { var s = 'abc'; return s.replaceAll('z', '+'); }",
+        'run',
+        {[]: 'abc'},
+      );
+    });
+
+    test('replaceAll — matches at both ends', () async {
+      await _testWasm(
+        "String run() { var s = '-a-'; return s.replaceAll('-', '+'); }",
+        'run',
+        {[]: '+a+'},
+      );
+    });
+
+    test('replaceAll — output length after growth', () async {
+      await _testWasm(
+        "int run() { var s = 'a-b-c'; var t = s.replaceAll('-', '++');"
+            " return t.length; }",
+        'run',
+        {[]: 7},
+      );
+    });
+
+    test('replaceFirst — only the first occurrence', () async {
+      await _testWasm(
+        "String run() { var s = 'a-b-c'; return s.replaceFirst('-', '+'); }",
+        'run',
+        {[]: 'a+b-c'},
+      );
+    });
+
+    test('replaceFirst — no match is unchanged', () async {
+      await _testWasm(
+        "String run() { var s = 'abc'; return s.replaceFirst('z', '+'); }",
+        'run',
+        {[]: 'abc'},
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Wasm: String `replaceAll` / `replaceFirst` — GAP B (tail)

Continues **GAP B** in `WASM_BACKEND_PLAN.md`. The on-the-fly WebAssembly compiler now supports `replaceAll(from, to)` and `replaceFirst(from, to)` over its `[len:i32][utf8]` layout.

### Approach — two passes
- **Pass 1** scans left-to-right, counting non-overlapping matches (via the shared `_emitBytesEqualNoBreak` helper), to compute `outLen = srcLen + count*(toLen - fromLen)` and allocate the output buffer.
- **Pass 2** rebuilds into the buffer with an `if`/`else` per position: on a match, `memory.copy` the replacement and advance by `fromLen`; otherwise copy one byte.

`replaceFirst` gates matching on a "replaced" counter (`match &= counter == 0`) so only the first occurrence is affected — applied identically in both passes so the size and the build agree. An empty `from` is treated as no match (returns a copy) to avoid a non-terminating scan.

### Coverage (new `apollovm_wasm_string_replace_test.dart`, 10 cases)
Single-char and multi-char patterns; replacement that grows / shrinks / removes (empty `to`); no-match; matches at both ends; output length after growth; replaceFirst (first-only and no-match). Both the interpreter and the compiled+executed module are asserted for every case.

### Scope / follow-ups
- Remaining String methods: `split` (returns a `List`), index `[]`, and `compareTo` (needs `String.compareTo` in the interpreter core first).

Bumps to **2.9.0**. Full Wasm suite (490 tests) green; `dart analyze lib test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)