### PR TITLE
feat: String.compareTo — interpreter core + Wasm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.10.0
+
+### String `compareTo` (interpreter + Wasm)
+
+Adds `String.compareTo(other)` to the AST interpreter core (which was missing it)
+and to the on-the-fly WebAssembly compiler, so it now works on both backends with
+matching results. The Wasm implementation is a lexicographic byte comparison over
+the `[len][utf8]` layout, returning `-1` / `0` / `1` (a shorter string that is a
+prefix of the other sorts first).
+
+Still to come for String in Wasm: `split` (returns a `List`) and index `[]`.
+
 ## 2.9.0
 
 ### Wasm: String `replaceAll` / `replaceFirst`

--- a/WASM_BACKEND_PLAN.md
+++ b/WASM_BACKEND_PLAN.md
@@ -102,13 +102,13 @@ test('generic Box<int> field round-trips', () => _testWasm(
   passes (count matches to size the output buffer, then build it); handles
   grow/shrink/removal and matches at the ends; an empty `from` returns a copy —
   `apollovm_wasm_string_replace_test`.
-- **Still open**: `.split` (returns a `List`), index `[]`, and `.compareTo` (the
-  *interpreter* core lacks `String.compareTo` too — closing it means adding it to
-  `apollovm_core_base.dart` first, then the Wasm side; the Wasm codegen is a
-  straightforward lexicographic byte compare). Also: chaining a getter/method
-  onto a method *result* (`s.toUpperCase().length`, `s.substring(0,2) == 'x'`) —
-  the receiver must be a named local, and a bare `String == String` returning a
-  `bool` is a separate pre-existing limitation.
+- **Done (compareTo)**: `.compareTo(other)` — lexicographic byte compare
+  returning `-1`/`0`/`1`. Also added `String.compareTo` to the interpreter core
+  (`apollovm_core_base.dart`), which lacked it — `apollovm_wasm_string_compareto_test`.
+- **Still open**: `.split` (returns a `List`) and index `[]`. Also: chaining a
+  getter/method onto a method *result* (`s.toUpperCase().length`,
+  `s.substring(0,2) == 'x'`) — the receiver must be a named local, and a bare
+  `String == String` returning a `bool` is a separate pre-existing limitation.
 - **Fix direction**: same allocate-buffer + byte-loop pattern
   (`_generateStringCaseConvert`, `_emitBytesEqualNoBreak`). `.split`/`.replaceAll`
   build a fresh buffer/`List` from scan results. Stored length is UTF-8 bytes, so
@@ -254,8 +254,8 @@ GAPs **C** (getters), **D** (static fields), **E** (inheritance/`super`) and **G
 (nested collections / `m[0][1]`) are **DONE**; **GAP B** (String methods) is mostly
 done (slice/search/case complete). Remaining:
 
-1. **GAP B tail** — `.split`, index `[]`, and `.compareTo` (needs interpreter
-   core support first). (`.trim`/`.pad`/`.replaceAll`/`.replaceFirst` done.)
+1. **GAP B tail** — `.split` (returns a `List`) and index `[]`. (`.trim`/`.pad`/
+   `.replaceAll`/`.replaceFirst`/`.compareTo` done.)
 2. **GAP A** (generic field i64/boxing) and **GAP F** (aggregate returns) —
    value-representation work; related boxing concerns.
 

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.9.0';
+  static final String VERSION = '2.10.0';
 
   static int _idCount = 0;
 

--- a/lib/src/core/apollovm_core_base.dart
+++ b/lib/src/core/apollovm_core_base.dart
@@ -436,6 +436,8 @@ class CoreClassString extends CoreClassPrimitive<String> {
 
   late final ASTExternalClassFunction _functionCodeUnitAt;
 
+  late final ASTExternalClassFunction _functionCompareTo;
+
   late final ASTExternalFunction _functionValueOf;
 
   CoreClassString._() : super(ASTTypeString.instance, 'String') {
@@ -647,6 +649,18 @@ class CoreClassString extends CoreClassPrimitive<String> {
       (String o, int index) => o.codeUnitAt(index),
     );
 
+    _functionCompareTo = _externalClassFunctionArgs1(
+      'compareTo',
+      ASTTypeInt.instance,
+      ASTFunctionParameterDeclaration(
+        ASTTypeString.instance,
+        'other',
+        0,
+        false,
+      ),
+      (String o, String other) => o.compareTo(other),
+    );
+
     _functionValueOf = _externalStaticFunctionArgs1(
       'valueOf',
       ASTTypeString.instance,
@@ -747,6 +761,9 @@ class CoreClassString extends CoreClassPrimitive<String> {
 
       case 'codeUnitAt':
         return _functionCodeUnitAt;
+
+      case 'compareTo':
+        return _functionCompareTo;
 
       case 'valueOf':
         return _functionValueOf;

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -10438,7 +10438,142 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         context: context,
       );
     }
+    if (name == 'compareTo' && args.length == 1) {
+      return _generateStringCompareTo(
+        recv,
+        varName,
+        args[0],
+        out: out,
+        context: context,
+      );
+    }
     return null;
+  }
+
+  /// `s.compareTo(other)` -> `-1`/`0`/`1` (lexicographic byte comparison), as an
+  /// `int` (i64). Matches `String.compareTo`, which returns exactly `-1`/`0`/`1`.
+  BytesOutput _generateStringCompareTo(
+    ({ASTType type, int index}) recv,
+    String varName,
+    ASTExpression argExpr, {
+    required BytesOutput out,
+    required WasmContext context,
+  }) {
+    context.module!.requiresMemory = true;
+    final s0 = context.stackLength;
+
+    var src = context.scratchLocal(_astTypeString, 60);
+    var srcLen = context.scratchLocal(_astTypeString, 61);
+    var sub = context.scratchLocal(_astTypeString, 62);
+    var subLen = context.scratchLocal(_astTypeString, 63);
+    var minLen = context.scratchLocal(_astTypeString, 64);
+    var i = context.scratchLocal(_astTypeString, 65);
+    var ca = context.scratchLocal(_astTypeString, 66);
+    var cb = context.scratchLocal(_astTypeString, 67);
+    var result = context.scratchLocal(_astTypeString, 68);
+
+    generateASTExpression(argExpr, out: out, context: context);
+    context.stackDrop();
+    out.write(Wasm.localSet(sub));
+    _localVariableGet(out, context, recv.index, varName);
+    out.write(Wasm.localSet(src));
+    out.write(Wasm.localGet(src));
+    out.write(Wasm32.i32Load());
+    out.write(Wasm.localSet(srcLen));
+    out.write(Wasm.localGet(sub));
+    out.write(Wasm32.i32Load());
+    out.write(Wasm.localSet(subLen));
+
+    // minLen = (srcLen < subLen) ? srcLen : subLen
+    out.write(Wasm.localGet(srcLen));
+    out.write(Wasm.localGet(subLen));
+    out.write(Wasm.localGet(srcLen));
+    out.write(Wasm.localGet(subLen));
+    out.writeByte(Wasm32.i32LessThanUnsigned);
+    out.writeByte(Wasm.select);
+    out.write(Wasm.localSet(minLen));
+
+    // result = 0 ; i = 0
+    out.write(Wasm32.i32Const(0));
+    out.write(Wasm.localSet(result));
+    out.write(Wasm32.i32Const(0));
+    out.write(Wasm.localSet(i));
+
+    out.write(Wasm.block(WasmType.voidType));
+    context.controlDepth++;
+    final brk = context.controlDepth;
+    out.write(Wasm.loop(WasmType.voidType));
+    context.controlDepth++;
+    final rpt = context.controlDepth;
+    // if (i >= minLen) break
+    out.write(Wasm.localGet(i));
+    out.write(Wasm.localGet(minLen));
+    out.writeByte(Wasm32.i32GreaterThanOrEqualsUnsigned);
+    out.write(Wasm.brIf(context.controlDepth - brk));
+    // ca = src[i] ; cb = sub[i]
+    out.write(Wasm.localGet(src));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localGet(i));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm32.i32Load8U());
+    out.write(Wasm.localSet(ca));
+    out.write(Wasm.localGet(sub));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localGet(i));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm32.i32Load8U());
+    out.write(Wasm.localSet(cb));
+    // sign = (ca < cb) ? -1 : 1 ; result = (ca != cb) ? sign : result
+    out.write(Wasm32.i32Const(-1));
+    out.write(Wasm32.i32Const(1));
+    out.write(Wasm.localGet(ca));
+    out.write(Wasm.localGet(cb));
+    out.writeByte(Wasm32.i32LessThanUnsigned);
+    out.writeByte(Wasm.select);
+    out.write(Wasm.localGet(result));
+    out.write(Wasm.localGet(ca));
+    out.write(Wasm.localGet(cb));
+    out.writeByte(Wasm32.i32NotEquals);
+    out.writeByte(Wasm.select);
+    out.write(Wasm.localSet(result));
+    // break when ca != cb
+    out.write(Wasm.localGet(ca));
+    out.write(Wasm.localGet(cb));
+    out.writeByte(Wasm32.i32NotEquals);
+    out.write(Wasm.brIf(context.controlDepth - brk));
+    // i++
+    out.write(Wasm.localGet(i));
+    out.write(Wasm32.i32Const(1));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localSet(i));
+    out.write(Wasm.br(context.controlDepth - rpt));
+    out.writeByte(Wasm.end); // loop
+    context.controlDepth--;
+    out.writeByte(Wasm.end); // block
+    context.controlDepth--;
+
+    // Tie-break on length when the common prefix is equal (result still 0):
+    // result = (result == 0) ? ((srcLen>subLen) - (srcLen<subLen)) : result
+    out.write(Wasm.localGet(srcLen));
+    out.write(Wasm.localGet(subLen));
+    out.writeByte(Wasm32.i32GreaterThanUnsigned);
+    out.write(Wasm.localGet(srcLen));
+    out.write(Wasm.localGet(subLen));
+    out.writeByte(Wasm32.i32LessThanUnsigned);
+    out.writeByte(Wasm32.i32Subtract); // gt - lt in {-1, 0, 1}
+    out.write(Wasm.localGet(result));
+    out.write(Wasm.localGet(result));
+    out.writeByte(Wasm32.i32EqualsToZero);
+    out.writeByte(Wasm.select); // (result == 0) ? lengthCmp : result
+    out.write(Wasm.localSet(result));
+
+    out.write(Wasm.localGet(result));
+    out.writeByte(Wasm32.i32ExtendToI64Signed);
+    context.stackPush(_astTypeInt64, "$varName.compareTo");
+    context.assertStackLength(s0 + 1, "After String.compareTo");
+    return out;
   }
 
   /// `s.replaceAll(from, to)` / `s.replaceFirst(from, to)`: returns a fresh

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.9.0
+version: 2.10.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/wasm/apollovm_wasm_string_compareto_test.dart
+++ b/test/wasm/apollovm_wasm_string_compareto_test.dart
@@ -1,0 +1,140 @@
+@TestOn('vm')
+@Tags(['wasm', 'dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+import 'wasm_runtime_setup.dart';
+
+/// Compiles [code] to Wasm and runs [functionName] through both the AST
+/// interpreter and the compiled+executed module, asserting every entry in
+/// [executions].
+Future<void> _testWasm(
+  String code,
+  String functionName,
+  Map<List, Object?> executions,
+) async {
+  var vm = ApolloVM();
+  expect(
+    await vm.loadCodeUnit(SourceCodeUnit('dart', code, id: 'test')),
+    isTrue,
+    reason: "Can't load Dart source",
+  );
+
+  var astRunner = vm.createRunner('dart')!;
+  for (var e in executions.entries) {
+    var r = await astRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'AST $functionName(${e.key})',
+    );
+  }
+
+  var storage = vm.generateAllIn<BytesOutput>('wasm');
+  BytesOutput? compiled;
+  for (var ns in (await storage.allEntries()).values) {
+    for (var m in ns.values) {
+      compiled ??= m;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var vmWasm = ApolloVM();
+  expect(
+    await vmWasm.loadCodeUnit(
+      BinaryCodeUnit(
+        'wasm',
+        compiled!.output(),
+        id: 'test.wasm',
+        namespace: '',
+      ),
+    ),
+    isTrue,
+    reason: 'Compiled Wasm failed to load',
+  );
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  for (var e in executions.entries) {
+    var r = await wasmRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'WASM $functionName(${e.key})',
+    );
+  }
+}
+
+void main() {
+  setUpWasmRuntime();
+
+  // String.compareTo — lexicographic byte comparison returning -1/0/1, matching
+  // the interpreter (which gained `String.compareTo` in the same change).
+  group('Wasm String.compareTo', () {
+    test('less than', () async {
+      await _testWasm(
+        "int run() { var s = 'abc'; return s.compareTo('abd'); }",
+        'run',
+        {[]: -1},
+      );
+    });
+
+    test('equal', () async {
+      await _testWasm(
+        "int run() { var s = 'abc'; return s.compareTo('abc'); }",
+        'run',
+        {[]: 0},
+      );
+    });
+
+    test('greater than', () async {
+      await _testWasm(
+        "int run() { var s = 'abd'; return s.compareTo('abc'); }",
+        'run',
+        {[]: 1},
+      );
+    });
+
+    test('a prefix sorts before the longer string', () async {
+      await _testWasm(
+        "int run() { var s = 'ab'; return s.compareTo('abc'); }",
+        'run',
+        {[]: -1},
+      );
+      await _testWasm(
+        "int run() { var s = 'abc'; return s.compareTo('ab'); }",
+        'run',
+        {[]: 1},
+      );
+    });
+
+    test('empty string sorts first', () async {
+      await _testWasm(
+        "int run() { var s = ''; return s.compareTo('a'); }",
+        'run',
+        {[]: -1},
+      );
+      await _testWasm(
+        "int run() { var s = ''; return s.compareTo(''); }",
+        'run',
+        {[]: 0},
+      );
+    });
+
+    test('first differing byte decides', () async {
+      await _testWasm(
+        "int run() { var s = 'axz'; return s.compareTo('ayz'); }",
+        'run',
+        {[]: -1},
+      );
+    });
+  });
+}


### PR DESCRIPTION
## String.compareTo — interpreter core + Wasm

The AST interpreter core was **missing `String.compareTo`** (it threw "Can't find core function"), which is why the Wasm `compareTo` codegen was dropped from the 2.8.0 trim/pad PR — shipping only the Wasm side would have diverged from the interpreter. This PR adds `compareTo` to **both** backends so they agree.

### Interpreter core (`apollovm_core_base.dart`)
Registers `String.compareTo` via the existing `_externalClassFunctionArgs1` helper (returns `int`, one `String` param), delegating to Dart's `String.compareTo`.

### Wasm (`wasm_generator.dart`)
Re-adds `_generateStringCompareTo`: a lexicographic byte comparison over the `[len][utf8]` layout. Scans the common-length prefix; the first differing byte decides (`-1`/`1` via `select`), and on an equal prefix it tie-breaks on length (`(srcLen>subLen) - (srcLen<subLen)`). Returns `-1`/`0`/`1` — matching `String.compareTo`.

### Coverage (new `apollovm_wasm_string_compareto_test.dart`, 6 cases)
less/equal/greater, prefix ordering (shorter sorts first), empty strings, and first-differing-byte. Both the interpreter and the compiled module are asserted for every case, so the two backends are verified to agree.

Bumps to **2.10.0**. Full VM suite (2302 tests) green; `dart analyze lib test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)