### PR TITLE
feat: String index s[i] — interpreter core + Wasm (restores 2.11.0 removal)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.12.0
+
+### String index `s[i]` (interpreter + Wasm)
+
+Adds `String[i]` — Dart's index operator, which returns the character at `i` as a
+length-1 String — to the AST interpreter core (which was missing it, throwing a
+null-pointer error) and to the on-the-fly WebAssembly compiler. Both backends now
+agree. This restores functionality briefly dropped in 2.11.0, where `s[i]` had
+been mistaken for invalid Dart; it is valid, so it is now supported end to end.
+
 ## 2.11.0
 
 ### Wasm: String `split`

--- a/WASM_BACKEND_PLAN.md
+++ b/WASM_BACKEND_PLAN.md
@@ -110,11 +110,13 @@ test('generic Box<int> field round-trips', () => _testWasm(
   handles multi-char separators and leading/trailing empty pieces. An empty `sep`
   yields a single whole-string piece (Dart's char-split for `''` is a follow-up)
   — `apollovm_wasm_string_split_test`.
+- **Done (index)**: `s[i]` -> a length-1 String (the byte at `s + 4 + i`). Also
+  added `String[]` (`readIndex`) to the interpreter, which lacked it —
+  `apollovm_wasm_string_index_test`.
 - **Still open**: chaining a getter/method onto a method/index *result*
   (`s.toUpperCase().length`, `s.split(',')[0].length`, `s.substring(0,2) == 'x'`)
   — the receiver must be a named local; a bare `String == String` returning a
-  `bool` is a separate pre-existing limitation. (Note: Dart `String` has no
-  `operator []`, so `s[i]` is not a real gap.)
+  `bool` is a separate pre-existing limitation.
 - **Fix direction**: same allocate-buffer + byte-loop pattern
   (`_generateStringCaseConvert`, `_emitBytesEqualNoBreak`). `.split`/`.replaceAll`
   build a fresh buffer/`List` from scan results. Stored length is UTF-8 bytes, so

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.11.0';
+  static final String VERSION = '2.12.0';
 
   static int _idCount = 0;
 

--- a/lib/src/ast/apollovm_ast_value.dart
+++ b/lib/src/ast/apollovm_ast_value.dart
@@ -333,6 +333,9 @@ class ASTValueStatic<T> extends ASTValue<T> {
 
     if (value is List) {
       return value[index] as V;
+    } else if (value is String) {
+      // Dart `String[index]` returns the character at [index] as a String.
+      return value[index] as V;
     } else if (value is Iterable) {
       return value.elementAt(index);
     } else if (value is Map) {

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -4642,6 +4642,18 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       return _generateMapGet(expression, localVar, out: out, context: context);
     }
 
+    // `s[i]` on a String: a fresh length-1 String holding the byte at `s + 4 + i`
+    // (Dart's `String[]` returns a length-1 String).
+    if (containerType is ASTTypeString) {
+      return _generateStringIndexAccess(
+        localVar,
+        name,
+        expression.expression,
+        out: out,
+        context: context,
+      );
+    }
+
     if (containerType is! ASTTypeArray) {
       throw UnimplementedError(
         "Wasm index access on `$name` ($containerType) is not supported yet.",
@@ -11126,6 +11138,55 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     context.controlDepth--;
     out.writeByte(Wasm.end); // block
     context.controlDepth--;
+  }
+
+  /// `s[i]` -> a fresh length-1 String holding the byte at `s + 4 + i`.
+  BytesOutput _generateStringIndexAccess(
+    ({ASTType type, int index}) recv,
+    String varName,
+    ASTExpression indexExpr, {
+    required BytesOutput out,
+    required WasmContext context,
+  }) {
+    var module = context.module!;
+    module.requiresMemory = true;
+    module.requiresHeapGlobal = true;
+    final s0 = context.stackLength;
+
+    var src = context.scratchLocal(_astTypeString, 60);
+    var dest = context.scratchLocal(_astTypeString, 61);
+    var ch = context.scratchLocal(_astTypeString, 62);
+
+    // ch = load8(src + 4 + i)
+    _localVariableGet(out, context, recv.index, varName);
+    out.write(Wasm.localSet(src));
+    out.write(Wasm.localGet(src));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    generateASTExpression(indexExpr, out: out, context: context); // index (i64)
+    context.stackDrop();
+    out.writeByte(Wasm64.i64WrapToi32);
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm32.i32Load8U());
+    out.write(Wasm.localSet(ch));
+
+    // dest = alloc(1 + 4) ; store len=1 ; store8(dest + 4, ch)
+    out.write(Wasm32.i32Const(5));
+    _emitInlineAlloc(out, context);
+    out.write(Wasm.localSet(dest));
+    out.write(Wasm.localGet(dest));
+    out.write(Wasm32.i32Const(1));
+    out.write(Wasm32.i32Store());
+    out.write(Wasm.localGet(dest));
+    out.write(Wasm32.i32Const(4));
+    out.writeByte(Wasm32.i32Add);
+    out.write(Wasm.localGet(ch));
+    out.write(Wasm32.i32Store8());
+
+    out.write(Wasm.localGet(dest));
+    context.stackPush(_astTypeString, "$varName[index]");
+    context.assertStackLength(s0 + 1, "After String index");
+    return out;
   }
 
   /// Pushes `1` if the char in [chLoc] is ASCII whitespace (space, or `\t`..`\r`,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.11.0
+version: 2.12.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/wasm/apollovm_wasm_string_index_test.dart
+++ b/test/wasm/apollovm_wasm_string_index_test.dart
@@ -1,0 +1,113 @@
+@TestOn('vm')
+@Tags(['wasm', 'dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+import 'wasm_runtime_setup.dart';
+
+/// Compiles [code] to Wasm and runs [functionName] through both the AST
+/// interpreter and the compiled+executed module, asserting every entry in
+/// [executions].
+Future<void> _testWasm(
+  String code,
+  String functionName,
+  Map<List, Object?> executions,
+) async {
+  var vm = ApolloVM();
+  expect(
+    await vm.loadCodeUnit(SourceCodeUnit('dart', code, id: 'test')),
+    isTrue,
+    reason: "Can't load Dart source",
+  );
+
+  var astRunner = vm.createRunner('dart')!;
+  for (var e in executions.entries) {
+    var r = await astRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'AST $functionName(${e.key})',
+    );
+  }
+
+  var storage = vm.generateAllIn<BytesOutput>('wasm');
+  BytesOutput? compiled;
+  for (var ns in (await storage.allEntries()).values) {
+    for (var m in ns.values) {
+      compiled ??= m;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'No compiled Wasm module');
+
+  var vmWasm = ApolloVM();
+  expect(
+    await vmWasm.loadCodeUnit(
+      BinaryCodeUnit(
+        'wasm',
+        compiled!.output(),
+        id: 'test.wasm',
+        namespace: '',
+      ),
+    ),
+    isTrue,
+    reason: 'Compiled Wasm failed to load',
+  );
+  var wasmRunner = vmWasm.createRunner('wasm')!;
+  for (var e in executions.entries) {
+    var r = await wasmRunner.executeFunction(
+      '',
+      functionName,
+      positionalParameters: e.key,
+    );
+    expect(
+      r.getValueNoContext(),
+      e.value,
+      reason: 'WASM $functionName(${e.key})',
+    );
+  }
+}
+
+void main() {
+  setUpWasmRuntime();
+
+  // Dart's `String[i]` returns the character at [i] as a length-1 String. Added
+  // to the interpreter core (which lacked it) and the Wasm backend so both agree.
+  group('Wasm String index (s[i])', () {
+    test('first character', () async {
+      await _testWasm("String run() { var s = 'abc'; return s[0]; }", 'run', {
+        []: 'a',
+      });
+    });
+
+    test('middle and last characters', () async {
+      await _testWasm("String run() { var s = 'hello'; return s[1]; }", 'run', {
+        []: 'e',
+      });
+      await _testWasm("String run() { var s = 'hello'; return s[4]; }", 'run', {
+        []: 'o',
+      });
+    });
+
+    test('index from a variable', () async {
+      await _testWasm(
+        "String run() { var s = 'hello'; var i = 2; return s[i]; }",
+        'run',
+        {[]: 'l'},
+      );
+    });
+
+    test('index from an expression', () async {
+      await _testWasm(
+        "String run() { var s = 'hello'; return s[1 + 1]; }",
+        'run',
+        {[]: 'l'},
+      );
+    });
+  });
+}


### PR DESCRIPTION
## String index `s[i]` — interpreter core + Wasm

Dart's `String[i]` returns the character at `i` as a **length-1 String** — it is valid Dart (`"abc"[0] == "a"`). In 2.11.0 I mistakenly removed the Wasm `s[i]` codegen, wrongly believing String had no index operator; the dual-harness test had actually failed because the **interpreter** lacked `String[]`, not because it was invalid. This PR fixes both so they agree.

### Interpreter core (`apollovm_ast_value.dart`)
`ASTValueStatic.readIndex` now handles a `String` receiver, returning `value[index]` (a length-1 String). Previously it fell through to a null-pointer error.

### Wasm (`wasm_generator.dart`)
Re-adds the `s[i]` codegen: allocate a fresh `[len=1][byte]` String from the byte at `s + 4 + i`.

### Coverage (new `apollovm_wasm_string_index_test.dart`, 4 cases)
first character, middle/last, index from a variable, index from an expression. Both the interpreter and the compiled module are asserted, verifying the two backends agree.

Thanks to @gracilianomp for catching the mistaken removal.

Bumps to **2.12.0**. Full VM suite (2314 tests) green; `dart analyze lib test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)