### PR TITLE
fix(lsp,mcp): includeDeclaration, full field range, safe arg coercion, CORS preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+## 2.15.0
+
+### LSP & MCP correctness fixes
+
+- **LSP `textDocument/references` now honors `context.includeDeclaration`.** The
+  flag was plumbed through every layer but discarded, so the declaration
+  occurrence was always returned. When `includeDeclaration` is `false`, the
+  occurrence that coincides with the symbol's declaration is now excluded.
+- **LSP field/variable `documentSymbol` range covers the whole declaration.** A
+  field/variable range previously stopped at the name; it now extends to the
+  terminating `;` (skipping over any `(`/`[`/`{ }` in an initializer), matching
+  how methods and enum members already cover their full entry.
+- **MCP tools coerce client arguments instead of hard-casting them.** Decoded
+  JSON numbers may arrive as `double` (e.g. `1000.0`) or as strings, so
+  `timeoutMs`/`maxDepth`/`args`/`className` were coerced via new
+  `mcpCoerceInt`/`_strOrNull`/`_listOrEmpty` helpers rather than an unsafe
+  `as int?`/`as List?` that threw a raw `TypeError` and crashed the tool. Applies
+  to `apollovm.execute`/`apollovm.ast` and both isolate executors.
+- **MCP HTTP/SSE transport answers CORS preflight.** `HttpSseTransport` now
+  responds to `OPTIONS` with `Access-Control-Allow-Origin/Methods/Headers`
+  (`204`) instead of a `404`, unblocking cross-origin browser POSTs.
+
 ## 2.14.0
 
 ### Wasm: `String ==` / `String !=` content equality

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.14.0';
+  static final String VERSION = '2.15.0';
 
   static int _idCount = 0;
 

--- a/lib/src/lsp/analysis/token_index.dart
+++ b/lib/src/lsp/analysis/token_index.dart
@@ -711,6 +711,25 @@ class TokenIndex {
               tokens[start].isIdent &&
               _modifierKeywords.contains(tokens[start].value));
       if (!hasType) return 0;
+      // Extend the range to the terminating `;` so the whole declaration —
+      // type, name, and any `= initializer` — is selectable, matching how
+      // methods and enum members cover their full entry rather than stopping at
+      // the name. Scan from the terminator to the first `;` at bracket depth 0
+      // (an initializer's own `(`/`[`/`{ }` and their contents are skipped).
+      var fullEnd = nameTok.end;
+      var depth = 0;
+      for (var k = j; k < tokens.length; k++) {
+        final tk = tokens[k];
+        if (tk.sym('(') || tk.sym('[') || tk.sym('{')) {
+          depth++;
+        } else if (tk.sym(')') || tk.sym(']') || tk.sym('}')) {
+          if (depth == 0) break;
+          depth--;
+        } else if (depth == 0 && tk.sym(';')) {
+          fullEnd = tk.end;
+          break;
+        }
+      }
       onDecl(
         DeclSite(
           name: nameTok.value,
@@ -718,7 +737,7 @@ class TokenIndex {
           nameStart: nameTok.start,
           nameEnd: nameTok.end,
           fullStart: idents.first.start,
-          fullEnd: nameTok.end,
+          fullEnd: fullEnd,
           container: container,
         ),
       );

--- a/lib/src/lsp/server/server.dart
+++ b/lib/src/lsp/server/server.dart
@@ -532,9 +532,23 @@ class LspServer {
     final ident = cur?.ident;
     if (ident == null) return const [];
 
+    // `context.includeDeclaration` (defaults to `true` per LSP) controls whether
+    // the declaration occurrence itself is part of the result. When `false`, drop
+    // any occurrence that coincides with a declaration of the same name.
+    final context = p['context'];
+    final includeDeclaration = context is Map
+        ? context['includeDeclaration'] != false
+        : true;
+    final declStarts = includeDeclaration
+        ? const <int>{}
+        : <int>{
+            for (final d in unit.tokenIndex.declarations)
+              if (d.name == ident.name) d.nameStart,
+          };
+
     return [
       for (final t in unit.tokenIndex.identifiers)
-        if (t.name == ident.name)
+        if (t.name == ident.name && !declStarts.contains(t.start))
           Location(uri, unit.lineIndex.rangeAt(t.start, t.end)).toJson(),
     ];
   }

--- a/lib/src/mcp/apollo_mcp_server.dart
+++ b/lib/src/mcp/apollo_mcp_server.dart
@@ -82,7 +82,7 @@ final class ApolloMcpServer extends MCPServer with ToolsSupport {
 
     final Map<String, Object?> result;
     if (limits.runsInIsolate(name)) {
-      final timeoutMs = (args['timeoutMs'] as int?) ?? limits.timeoutMs;
+      final timeoutMs = mcpCoerceInt(args['timeoutMs']) ?? limits.timeoutMs;
       result = await runToolInIsolate(
         name,
         args,

--- a/lib/src/mcp/runtime/isolate_executor_generic.dart
+++ b/lib/src/mcp/runtime/isolate_executor_generic.dart
@@ -17,7 +17,7 @@ Future<Map<String, Object?>> computeToolIsolated(
   Map<String, Object?> args,
   McpLimits limits,
 ) {
-  final timeoutMs = (args['timeoutMs'] as int?) ?? limits.timeoutMs;
+  final timeoutMs = mcpCoerceInt(args['timeoutMs']) ?? limits.timeoutMs;
   return runToolInIsolate(
     toolName,
     args,

--- a/lib/src/mcp/runtime/isolate_executor_io.dart
+++ b/lib/src/mcp/runtime/isolate_executor_io.dart
@@ -30,7 +30,7 @@ Future<Map<String, Object?>> computeToolIsolated(
   Map<String, Object?> args,
   McpLimits limits,
 ) {
-  final timeoutMs = (args['timeoutMs'] as int?) ?? limits.timeoutMs;
+  final timeoutMs = mcpCoerceInt(args['timeoutMs']) ?? limits.timeoutMs;
   return runToolInIsolate(
     toolName,
     args,

--- a/lib/src/mcp/tools/apollo_tools.dart
+++ b/lib/src/mcp/tools/apollo_tools.dart
@@ -159,8 +159,42 @@ List<Tool> buildTools() => [
   ...buildLspTools(),
 ];
 
-String _str(Map<String, Object?> args, String key, [String fallback = '']) =>
-    (args[key] as String?) ?? fallback;
+// Client arguments arrive as decoded JSON, so their runtime types are whatever
+// the client sent. These coercions never throw a raw `TypeError`: a wrong or
+// missing value degrades to the fallback/`null` instead of crashing the tool.
+
+String _str(Map<String, Object?> args, String key, [String fallback = '']) {
+  final v = args[key];
+  return v is String ? v : fallback;
+}
+
+/// Nullable string; a non-string (or missing) value is treated as absent.
+String? _strOrNull(Map<String, Object?> args, String key) {
+  final v = args[key];
+  return v is String ? v : null;
+}
+
+/// Nullable int. JSON numbers may decode to `double` (e.g. `1000.0`) and some
+/// clients send numbers as strings, so accept `num` and numeric `String`.
+int? _intOrNull(Map<String, Object?> args, String key) =>
+    mcpCoerceInt(args[key]);
+
+/// Coerces an arbitrary decoded-JSON [value] to `int?` without throwing a
+/// `TypeError`. JSON numbers may decode to `double` (e.g. `1000.0`) and some
+/// clients send numbers as strings, so `num` and numeric `String` are accepted;
+/// anything else (or `null`) yields `null`.
+int? mcpCoerceInt(Object? value) {
+  if (value is int) return value;
+  if (value is num) return value.toInt();
+  if (value is String) return int.tryParse(value.trim());
+  return null;
+}
+
+/// A list of arbitrary elements; a non-list (or missing) value yields `const []`.
+List<Object?> _listOrEmpty(Map<String, Object?> args, String key) {
+  final v = args[key];
+  return v is List ? v.cast<Object?>() : const [];
+}
 
 /// Runs the tool named [name] with [args] and returns its JSON result map.
 ///
@@ -198,7 +232,7 @@ Future<Map<String, Object?>> computeTool(
       if (o.root == null) {
         return <String, Object?>{'diagnostics': o.diagnostics, 'isError': true};
       }
-      final requested = (args['maxDepth'] as int?) ?? limits.maxAstDepth;
+      final requested = _intOrNull(args, 'maxDepth') ?? limits.maxAstDepth;
       final depth = math.min(requested, limits.maxAstDepth);
       return <String, Object?>{
         'ast': astNodeToJson(o.root!, maxDepth: depth),
@@ -223,14 +257,14 @@ Future<Map<String, Object?>> computeTool(
       return <String, Object?>{...typesToJson(o.root!), 'isError': false};
 
     case executeToolName:
-      final rawArgs = (args['args'] as List?)?.cast<Object?>() ?? const [];
+      final rawArgs = _listOrEmpty(args, 'args');
       final o = await rt.execute(
         _str(args, 'language'),
         _str(args, 'source'),
         function: _str(args, 'function', 'main'),
-        className: args['className'] as String?,
+        className: _strOrNull(args, 'className'),
         args: rawArgs,
-        timeoutMs: args['timeoutMs'] as int?,
+        timeoutMs: _intOrNull(args, 'timeoutMs'),
       );
       return <String, Object?>{
         'result': o.result,

--- a/lib/src/mcp/transport/http_sse_transport.dart
+++ b/lib/src/mcp/transport/http_sse_transport.dart
@@ -85,7 +85,12 @@ class HttpSseTransport {
 
   Future<void> _handleRequest(HttpRequest request) async {
     final path = request.uri.path;
-    if (request.method == 'GET' && (path == '/sse' || path == '/')) {
+    if (request.method == 'OPTIONS') {
+      // CORS preflight: browsers send this before a cross-origin POST. Answer it
+      // with the allowed methods/headers instead of a 404, which would block the
+      // subsequent request.
+      await _handlePreflight(request);
+    } else if (request.method == 'GET' && (path == '/sse' || path == '/')) {
       _openSseSession(request);
     } else if (request.method == 'POST' &&
         (path == '/message' || path == '/sse' || path == '/')) {
@@ -94,6 +99,17 @@ class HttpSseTransport {
       request.response.statusCode = HttpStatus.notFound;
       await request.response.close();
     }
+  }
+
+  Future<void> _handlePreflight(HttpRequest request) async {
+    final response = request.response;
+    response.statusCode = HttpStatus.noContent;
+    response.headers
+      ..set('Access-Control-Allow-Origin', '*')
+      ..set('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
+      ..set('Access-Control-Allow-Headers', 'Content-Type')
+      ..set('Access-Control-Max-Age', '86400');
+    await response.close();
   }
 
   void _openSseSession(HttpRequest request) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.14.0
+version: 2.15.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/lsp/server_features_test.dart
+++ b/test/lsp/server_features_test.dart
@@ -136,6 +136,31 @@ void main() {
     expect(locs.every((l) => l['uri'] == _uri), isTrue);
   });
 
+  test('references honors context.includeDeclaration', () async {
+    const uri = 'file:///ws/refs.dart';
+    const content = '''
+int total = 0;
+int run() {
+  return total + total;
+}
+''';
+    Future<int> countRefs(bool includeDeclaration) async {
+      final c = _Client();
+      await c.open(uri, content);
+      final resp = await c.request('textDocument/references', {
+        'textDocument': _td(uri),
+        'position': c.pos(0, 5), // the `total` declaration
+        'context': {'includeDeclaration': includeDeclaration},
+      });
+      return (resp['result'] as List).length;
+    }
+
+    // `total`: 1 declaration + 2 uses.
+    expect(await countRefs(true), 3);
+    // With the declaration excluded, only the 2 uses remain.
+    expect(await countRefs(false), 2);
+  });
+
   test('rename edits every same-name occurrence', () async {
     final c = _Client();
     await c.open(_uri, _content);

--- a/test/lsp/token_index_test.dart
+++ b/test/lsp/token_index_test.dart
@@ -206,6 +206,45 @@ class Config {
     expect(kinds['Config'], DeclKind.classDecl);
   });
 
+  group('field / variable ranges cover the whole declaration', () {
+    String fieldRangeOf(String src, String name) {
+      final d = TokenIndex.scan(src).declarations.firstWhere(
+        (d) =>
+            (d.kind == DeclKind.field || d.kind == DeclKind.variable) &&
+            d.name == name,
+      );
+      return src.substring(d.fullStart, d.fullEnd);
+    }
+
+    test('a field without an initializer covers up to `;`', () {
+      const src = 'class Box {\n  int width;\n}\n';
+      expect(fieldRangeOf(src, 'width'), 'int width;');
+    });
+
+    test('a field with an initializer covers the initializer', () {
+      const src = 'class Box {\n  int count = 5;\n}\n';
+      expect(fieldRangeOf(src, 'count'), 'int count = 5;');
+    });
+
+    test('a top-level variable covers its full initializer', () {
+      const src = 'var total = 1 + 2;\n';
+      expect(fieldRangeOf(src, 'total'), 'var total = 1 + 2;');
+    });
+
+    test('an initializer with brackets/commas is not cut short', () {
+      const src = 'final xs = [1, 2, 3];\n';
+      expect(fieldRangeOf(src, 'xs'), 'final xs = [1, 2, 3];');
+    });
+
+    test('the name span still covers only the name', () {
+      const src = 'class Box {\n  int width;\n}\n';
+      final d = TokenIndex.scan(
+        src,
+      ).declarations.firstWhere((d) => d.name == 'width');
+      expect(src.substring(d.nameStart, d.nameEnd), 'width');
+    });
+  });
+
   test('handles generic return types and a constructor', () {
     final idx = TokenIndex.scan('''
 class Box {

--- a/test/mcp/http_sse_transport_test.dart
+++ b/test/mcp/http_sse_transport_test.dart
@@ -111,4 +111,21 @@ void main() {
     expect(resp.statusCode, HttpStatus.notFound);
     await resp.drain<void>();
   });
+
+  test('CORS preflight (OPTIONS) is answered, not 404', () async {
+    final port = transport.port!;
+    final req = await http.openUrl(
+      'OPTIONS',
+      Uri.parse('http://127.0.0.1:$port/message'),
+    );
+    final resp = await req.close();
+    expect(resp.statusCode, HttpStatus.noContent);
+    expect(resp.headers.value('access-control-allow-origin'), '*');
+    expect(
+      resp.headers.value('access-control-allow-methods'),
+      contains('POST'),
+    );
+    expect(resp.headers.value('access-control-allow-headers'), isNotNull);
+    await resp.drain<void>();
+  });
 }

--- a/test/mcp/mcp_server_test.dart
+++ b/test/mcp/mcp_server_test.dart
@@ -264,4 +264,51 @@ func main() {
       expect(result['isError'], isTrue);
     });
   });
+
+  // Client arguments arrive as decoded JSON: a whole number sent as `1000.0`
+  // decodes to `double`, a wrong-typed value is whatever the client sent. These
+  // must be coerced, never cast with a raw `as int?`/`as List?` that throws a
+  // `TypeError` and crashes the tool.
+  group('client-arg coercion (no raw TypeError)', () {
+    const limits = McpLimits(timeoutMs: 2000);
+
+    test('execute tolerates a JSON-double timeoutMs', () async {
+      final r = await computeTool('apollovm.execute', {
+        'language': 'dart',
+        'source': dartSource,
+        'timeoutMs': 1000.0, // JSON number → double
+      }, limits);
+      expect(r['isError'], isFalse);
+      expect(r['result'], 42);
+    });
+
+    test('execute tolerates a non-list `args`', () async {
+      final r = await computeTool('apollovm.execute', {
+        'language': 'dart',
+        'source': dartSource,
+        'args': 'not-a-list',
+      }, limits);
+      expect(r['isError'], isFalse);
+      expect(r['result'], 42);
+    });
+
+    test('execute tolerates a numeric className (treated as absent)', () async {
+      final r = await computeTool('apollovm.execute', {
+        'language': 'dart',
+        'source': dartSource,
+        'className': 123,
+      }, limits);
+      expect(r['isError'], isFalse);
+    });
+
+    test('ast tolerates a JSON-double maxDepth', () async {
+      final r = await computeTool('apollovm.ast', {
+        'language': 'dart',
+        'source': dartSource,
+        'maxDepth': 2.0,
+      }, limits);
+      expect(r['isError'], isFalse);
+      expect(r['ast'], isNotNull);
+    });
+  });
 }


### PR DESCRIPTION
Four verified correctness fixes across the LSP and MCP subsystems, each surfaced by a source-level audit and covered by a regression test.

## Fixes

| Item | Change |
|---|---|
| **LSP-INCLUDEDECL** | `textDocument/references` now honors `context.includeDeclaration`. The flag was plumbed through every layer but discarded, so the declaration occurrence was always returned; when `false`, the occurrence coinciding with the symbol's declaration is now excluded. |
| **LSP-FIELD-RANGE** | A field/variable `documentSymbol` range previously stopped at the name; it now extends to the terminating `;` (skipping `(`/`[`/`{ }` in an initializer), matching how methods and enum members already cover their full entry. |
| **MCP-CASTS** | MCP tools coerce client args instead of hard-casting. Decoded JSON numbers may arrive as `double` (`1000.0`) or as strings, so `timeoutMs`/`maxDepth`/`args`/`className` go through new `mcpCoerceInt`/`_strOrNull`/`_listOrEmpty` helpers rather than an unsafe `as int?`/`as List?` that threw a raw `TypeError` and crashed the tool. Applies to `apollovm.execute`/`apollovm.ast`, `apollo_mcp_server`, and both isolate executors. |
| **MCP-CORS** | `HttpSseTransport` now answers `OPTIONS` preflight with `Access-Control-Allow-Origin/Methods/Headers` (`204`) instead of `404`, unblocking cross-origin browser POSTs. |

## Tests

- LSP: `references honors context.includeDeclaration` (3 → 2); 5 cases in `field / variable ranges cover the whole declaration`.
- MCP: 4 cases in `client-arg coercion (no raw TypeError)`; `CORS preflight (OPTIONS) is answered, not 404`.
- Full LSP + MCP suites (281 tests) green; `dart analyze --fatal-infos --fatal-warnings lib test` clean; `dart format` clean.

Bumps version to **2.15.0** and updates CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)