### PR TITLE
fix(go,lua): Go `&^` semantics + Lua concat/indexing/interpolation (part of 2.15.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,26 @@
   responds to `OPTIONS` with `Access-Control-Allow-Origin/Methods/Headers`
   (`204`) instead of a `404`, unblocking cross-origin browser POSTs.
 
+### Go & Lua generator correctness fixes
+
+- **Go `&^` (AND NOT / bit clear) now computes `a & (~b)`.** It was mapped to a
+  plain bitwise-AND (`a & b`), silently producing wrong results and corrupting
+  Go→Go round-trips. It is now desugared at parse time to a bitwise-AND whose
+  right operand is the bitwise complement of the right-hand side, at the same
+  precedence as `&`.
+- **Lua string-variable concatenation emits `..`.** A `+` whose operands are
+  statically `String`-typed (e.g. `s1 + s2`, with no string *literal* to trip
+  the old heuristic) now generates Lua `..` instead of an invalid `+`.
+- **Lua list indexing is shifted to Lua's 1-based convention.** A list index
+  coming from a 0-based source language (`list[0]`) now generates `list[1]`
+  (`list[i]` → `list[(i) + 1]`). Map/table key access is left unchanged. The Lua
+  grammar does not parse index-access expressions, so no Lua→Lua round-trip is
+  double-shifted.
+- **Lua string-interpolation subexpressions are parenthesized.** An interpolated
+  expression that binds looser than `..` (e.g. `"${a < b}"`) is now wrapped in
+  parentheses (`"x" .. (a < b)`) so it no longer mis-associates under Lua's
+  concatenation precedence.
+
 ## 2.14.0
 
 ### Wasm: `String ==` / `String !=` content equality

--- a/lib/src/languages/go/go_grammar.dart
+++ b/lib/src/languages/go/go_grammar.dart
@@ -703,7 +703,9 @@ class GoGrammarDefinition extends GoGrammarLexer {
 
   Parser<ASTExpression> expressionOperationChain() =>
       (ref0(expressionNoOperation) &
-              (expressionOperator() & ref0(expressionNoOperation)).star())
+              (ref0(goAndNotOperand) |
+                      (expressionOperator() & ref0(expressionNoOperation)))
+                  .star())
           .map((v) {
             var exp1 = v[0];
             var rest = v[1] as List;
@@ -718,7 +720,6 @@ class GoGrammarDefinition extends GoGrammarLexer {
   Parser<ASTExpressionOperator> expressionOperator() =>
       (string('&&') |
               string('||') |
-              string('&^') |
               string('<<') |
               string('>>') |
               string('==') |
@@ -736,12 +737,23 @@ class GoGrammarDefinition extends GoGrammarLexer {
               char('<') |
               char('>'))
           .trimHidden()
-          .map((v) {
-            // `&^` (AND NOT) has no dedicated AST operator; approximate as
-            // bitwise-AND (rare; keeps parsing robust).
-            if (v == '&^') return ASTExpressionOperator.bitwiseAnd;
-            return getASTExpressionOperator(v as String);
-          });
+          .map((v) => getASTExpressionOperator(v as String));
+
+  /// Go `&^` (bit clear / AND NOT): `a &^ b` == `a & (^b)` == `a & (~b)`. There
+  /// is no dedicated binary AST operator, so desugar it to a bitwise-AND whose
+  /// right operand is the bitwise complement of `b`. Returned in the same
+  /// `[operator, operand]` shape as a normal operator/operand pair so the
+  /// operator-precedence reducer treats it exactly like `&`.
+  ///
+  /// This must be tried before [expressionOperator], whose `&` would otherwise
+  /// consume the `&` of `&^` and leave a dangling `^`.
+  Parser<List> goAndNotOperand() =>
+      (string('&^').trimHidden() & ref0(expressionNoOperation)).map(
+        (v) => <dynamic>[
+          ASTExpressionOperator.bitwiseAnd,
+          ASTExpressionBitwiseNot(v[1] as ASTExpression),
+        ],
+      );
 
   Parser<ASTExpression> expressionNoOperation() =>
       (expressionConditionalIIFE() |

--- a/lib/src/languages/lua/lua_generator.dart
+++ b/lib/src/languages/lua/lua_generator.dart
@@ -802,10 +802,86 @@ class ApolloCodeGeneratorLua extends ApolloCodeGenerator {
     if (expression.operator != ASTExpressionOperator.add) return false;
     var a = expression.expression1;
     var b = expression.expression2;
-    return a.isLiteralString ||
+    if (a.isLiteralString ||
         b.isLiteralString ||
         a.hasDescendantLiteralString ||
-        b.hasDescendantLiteralString;
+        b.hasDescendantLiteralString) {
+      return true;
+    }
+    // A `+` where either operand is statically String-typed (e.g. two `String`
+    // variables, `s1 + s2`) is also concatenation and must use `..` in Lua.
+    return _isStringTyped(a) || _isStringTyped(b);
+  }
+
+  /// Whether [e] resolves synchronously to a `String` type. Falls back to
+  /// `false` when the type is unknown or only resolvable asynchronously, so a
+  /// numeric `+` is never mistaken for concatenation.
+  bool _isStringTyped(ASTExpression e) {
+    var t = e.resolveType(null);
+    return t is ASTTypeString;
+  }
+
+  @override
+  StringBuffer generateASTExpressionVariableEntryAccess(
+    ASTExpressionVariableEntryAccess expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    generateASTVariable(
+      expression.variable,
+      out: out,
+      indent: indent,
+      headIndented: headIndented,
+    );
+
+    // Lua tables are 1-indexed for their array part, so a list index coming from
+    // a 0-based language (`list[0]`) must become `list[1]`. Map/table keys
+    // (strings or explicit keys) are left untouched. The Lua grammar does not
+    // parse index-access expressions, so every node reaching this generator
+    // originates from a 0-based source language — there is no Lua→Lua round-trip
+    // that would double-shift.
+    var t = expression.variable.resolveType(null);
+    ASTType? containerType = t is ASTType ? t : null;
+
+    for (var idx in [expression.expression, ...expression.extraIndices]) {
+      out.write('[');
+      if (containerType is ASTTypeArray) {
+        _writeLuaArrayIndex(idx, out, indent);
+      } else {
+        generateASTExpression(
+          idx,
+          out: out,
+          indent: indent,
+          headIndented: false,
+        );
+      }
+      out.write(']');
+      // Descend one container level for the next chained index (`m[0][1]`).
+      containerType = containerType is ASTTypeArray
+          ? containerType.elementType
+          : (containerType is ASTTypeMap ? containerType.valueType : null);
+    }
+    return out;
+  }
+
+  /// Writes a 0-based array index shifted to Lua's 1-based convention. An
+  /// integer literal is incremented in place (`list[0]` -> `list[1]`); any other
+  /// index expression gets `+ 1` appended (`list[i]` -> `list[(i) + 1]`).
+  void _writeLuaArrayIndex(ASTExpression idx, StringBuffer out, String indent) {
+    if (idx is ASTExpressionLiteral) {
+      var v = idx.value;
+      if (v is ASTValueInt) {
+        out.write(v.value + 1);
+        return;
+      }
+    }
+    out.write('(');
+    generateASTExpression(idx, out: out, indent: indent, headIndented: false);
+    out.write(') + 1');
   }
 
   @override
@@ -1037,7 +1113,12 @@ class ApolloCodeGeneratorLua extends ApolloCodeGenerator {
     } else if (value is ASTValueStringVariable) {
       return value.variable.name;
     } else if (value is ASTValueStringExpression) {
-      return generateASTExpression(value.expression).toString();
+      var inner = generateASTExpression(value.expression).toString();
+      // Lua's `..` binds tighter than comparison/logical operators, so an
+      // interpolated subexpression like `${a < b}` or `${a and b}` must be
+      // parenthesized or it would mis-associate with the surrounding
+      // concatenation (`"x" .. a < b` parses as `("x" .. a) < b`).
+      return value.expression.isComplex ? '($inner)' : inner;
     } else if (value is ASTValueStringConcatenation) {
       return value.values.map(_valuePart).join(' .. ');
     } else {

--- a/test/languages/apollovm_go_test.dart
+++ b/test/languages/apollovm_go_test.dart
@@ -298,6 +298,38 @@ func f(a int, b int) int {
       expect(ret.getValueNoContext(), equals(22));
     });
 
+    test('`&^` (AND NOT / bit clear) clears the masked bits', () async {
+      // `a &^ b` == `a & (~b)`: clear in `a` the bits set in `b`.
+      // 12 (1100) &^ 10 (1010) = 1100 & 0101 = 0100 = 4.
+      var ret = await _call(
+        'go',
+        r'''
+func f(a int, b int) int {
+  return a &^ b
+}
+''',
+        'f',
+        positionalParameters: [12, 10],
+      );
+      expect(ret.getValueNoContext(), equals(4));
+    });
+
+    test('`&^` round-trips through Go generation', () async {
+      // The desugaring must still execute correctly when combined with `&`.
+      var ret = await _call(
+        'go',
+        r'''
+func f(a int, b int, c int) int {
+  return (a &^ b) & c
+}
+''',
+        'f',
+        positionalParameters: [15, 10, 7],
+      );
+      // 15 &^ 10 = 1111 & 0101 = 0101 = 5; 5 & 7 = 0101 & 0111 = 0101 = 5.
+      expect(ret.getValueNoContext(), equals(5));
+    });
+
     test('switch (no fall-through)', () async {
       var ret = await _call(
         'go',

--- a/test/languages/apollovm_lua_test.dart
+++ b/test/languages/apollovm_lua_test.dart
@@ -376,6 +376,47 @@ end
     });
   });
 
+  // Dart -> Lua generator fidelity for constructs whose Lua form differs
+  // structurally from the source: `..` concatenation, 1-based array indexing,
+  // and parenthesized interpolation subexpressions.
+  group('Dart -> Lua generation fidelity', () {
+    Future<String> luaBody(String dart) async =>
+        _extractCodeUnit(await _translate('dart', dart, 'lua'));
+
+    test('String-variable concatenation uses `..`, not `+`', () async {
+      var lua = await luaBody('String f(String a, String b) { return a + b; }');
+      expect(lua, contains('return a .. b'));
+      expect(lua, isNot(contains('a + b')));
+    });
+
+    test('numeric `+` stays `+`', () async {
+      var lua = await luaBody('int f(int a, int b) { return a + b; }');
+      expect(lua, contains('return a + b'));
+    });
+
+    test('list index is shifted to Lua 1-based', () async {
+      var lua = await luaBody('int f(List<int> xs) { return xs[0]; }');
+      expect(lua, contains('xs[1]'));
+    });
+
+    test('map key access is left unchanged', () async {
+      var lua = await luaBody('int f(Map<String, int> m) { return m["k"]; }');
+      expect(lua, contains('m["k"]'));
+    });
+
+    test('non-literal list index gets `+ 1`', () async {
+      var lua = await luaBody('int f(List<int> xs, int i) { return xs[i]; }');
+      expect(lua, contains('xs[(i) + 1]'));
+    });
+
+    test('interpolated comparison is parenthesized under `..`', () async {
+      var lua = await luaBody(
+        'String f(int a, int b) { return "r=\${a < b}"; }',
+      );
+      expect(lua, contains('"r=" .. (a < b)'));
+    });
+  });
+
   // The table-based class convention is bidirectional: a class written in
   // another language translates to idiomatic Lua and re-executes identically.
   group('Lua cross-language classes', () {


### PR DESCRIPTION
Four verified generator/parser correctness fixes for Go and Lua, each covered by a regression test.

> **Stacked on #121** (`fix/lsp-mcp-batch`). These changes ship together as a single **2.15.0** release — this branch does **not** bump the version separately; its CHANGELOG notes are folded into the 2.15.0 section. Base is set to `fix/lsp-mcp-batch` so this diff shows only the Go/Lua changes; retarget to `master` once #121 merges.

## Fixes

| Item | Change |
|---|---|
| **GO-ANDNOT** | Go `&^` (AND NOT / bit clear) was mapped to a plain bitwise-AND, computing `a & b` instead of `a & (~b)` — wrong results and corrupted Go→Go round-trips. Now desugared at parse time to a bitwise-AND whose right operand is the bitwise complement, at the same precedence as `&`. No new AST operator (which would have cascaded non-exhaustive-switch changes across every generator). |
| **LUA-CONCAT** | A `+` whose operands are statically `String`-typed (`s1 + s2`, with no string *literal* to trip the old heuristic) now generates Lua `..` instead of an invalid `+`. |
| **LUA-INDEX** | A list index from a 0-based source language (`list[0]`) now generates Lua 1-based `list[1]` (`list[i]` → `list[(i) + 1]`). Map/table key access is unchanged. The Lua grammar does not parse index-access expressions, so every such node originates from a 0-based language — no Lua→Lua round-trip is double-shifted. |
| **LUA-INTERP** | An interpolated subexpression that binds looser than `..` (`"${a < b}"`) is now parenthesized (`"x" .. (a < b)`), fixing mis-association under Lua's concatenation precedence. |

## Tests

- Go: `&^` bit-clear + a combined `(a &^ b) & c` round-trip case.
- Lua: `Dart -> Lua generation fidelity` group — `..` concat, numeric `+` unchanged, list index shift, map key unchanged, non-literal index `+ 1`, parenthesized interpolation.
- Full VM suite (`dart test --platform vm --exclude-tags wasm-gc`) green (2359 tests); `dart analyze --fatal-infos --fatal-warnings lib test` clean; `dart format` clean.

Ships as part of **2.15.0** (no separate version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)