### PR TITLE
feat(dart): full null-safety semantics + null-aware operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,41 @@
-## 2.15.0
+## 2.16.0
+
+### Dart null-safety support
+
+- **Nullable type syntax (`T?`).** The Dart grammar now parses the `?` suffix on
+  simple, generic, collection and function types (`String?`, `List<String?>`,
+  `Map<String, User?>`, `Future<User?>`, `void Function()?`,
+  `String? Function(int)`). `ASTType` carries an `isNullable`/`nullable` flag
+  (via `asNullable()` / `withoutNullability()`), and the Dart/Kotlin generators
+  round-trip the `?` suffix (TypeScript renders nullable *types* without the
+  suffix — `T?` on a member isn't valid TS — and other targets drop it,
+  best-effort).
+- **Null-aware operators.** Added full parse + runtime + Dart round-trip support
+  for `??` (null-coalescing), `??=` (null-coalescing assignment), `?.`
+  (null-aware getter and method invocation), `?[` (null-aware indexing), postfix
+  `!` (null assertion — standalone `x!` and before access: `x!.f`, `x!.m()`,
+  `x![i]` — throwing `ApolloVMNullPointerException` on null), and cascades
+  `..` / `?..` (null-aware). `??` is wired into the operator-precedence
+  reducer as the loosest binary operator (relational/equality/logical tiers were
+  made explicit at the same time).
+- **Assignability is nullability-aware.** `ASTType.acceptsAssignment` (used by the
+  runtime declaration/instance-of checks) accepts `null` only for nullable slots
+  and lets a `T?` slot accept a `T` value.
+- **Static null-safety analysis pass.** A new pragmatic, flow-aware analyzer
+  (`NullSafetyAnalyzer`) reports assigning `null` to a non-nullable
+  declaration/parameter and unconditional member/method/index access on a
+  nullable local, with flow promotion for `if (x != null) { … }` /
+  `if (x == null) … else { … }` and suppression via `?.`/`!`. Its diagnostics are
+  surfaced through the LSP analyzer for Dart documents.
+- **Cross-language generation.** Kotlin emits the Elvis operator `?:` for `??`
+  and `!!` for `!`; TypeScript emits `??`, `?.`, `?.[` (element access) and `!`.
+  Java, JavaScript, C#, Go, Python and Lua are best-effort (C#/JS keep native
+  `??`; the rest render the closest form without failing).
+- **Wasm compilation.** The Wasm backend lowers null-safety syntax within its
+  non-null numeric domain: `x!` compiles to `x`, `a ?? b` to its left operand,
+  `?.`/`?[` to plain access, and a nullable `T?` to the underlying numeric type.
+  A `null` *literal* stays an explicit unsupported-construct error (Wasm has no
+  null value) rather than a silent miscompilation.
 
 ### LSP & MCP correctness fixes
 

--- a/lib/apollovm.dart
+++ b/lib/apollovm.dart
@@ -10,6 +10,7 @@ library;
 
 export 'package:async_extension/async_extension.dart';
 
+export 'src/analysis/null_safety_analyzer.dart';
 export 'src/apollovm_base.dart';
 export 'src/apollovm_generated_output.dart';
 export 'src/apollovm_generator.dart';

--- a/lib/src/analysis/null_safety_analyzer.dart
+++ b/lib/src/analysis/null_safety_analyzer.dart
@@ -1,0 +1,359 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import '../ast/apollovm_ast_expression.dart';
+import '../ast/apollovm_ast_statement.dart';
+import '../ast/apollovm_ast_toplevel.dart';
+import '../ast/apollovm_ast_type.dart';
+import '../ast/apollovm_ast_variable.dart';
+
+/// Severity of a [NullSafetyDiagnostic].
+enum NullSafetySeverity { error, warning, info }
+
+/// A single null-safety finding produced by [NullSafetyAnalyzer].
+///
+/// The AST does not carry source offsets, so [snippet] holds a representative
+/// slice of source text (e.g. `a.x` or `x = null`) that the LSP layer can
+/// locate to attach a range. It is best-effort (first match).
+class NullSafetyDiagnostic {
+  final String message;
+  final String code;
+  final NullSafetySeverity severity;
+  final String? snippet;
+
+  NullSafetyDiagnostic(
+    this.message, {
+    required this.code,
+    this.severity = NullSafetySeverity.error,
+    this.snippet,
+  });
+
+  @override
+  String toString() => '[$code/${severity.name}] $message';
+}
+
+/// A pragmatic, flow-aware Dart null-safety analyzer.
+///
+/// It is intentionally *not* a full soundness engine — it reasons only about
+/// local variables and parameters, and reports the clear, high-value cases:
+///
+/// - assigning a `null` literal to a non-nullable declaration/parameter;
+/// - unconditionally accessing a member/method/index on a nullable local
+///   variable without `?.`, `!` or a prior null check;
+/// - a `!` null-assertion applied to a `null` literal (always throws).
+///
+/// It performs flow promotion for the common guards `if (x != null) { … }` and
+/// `if (x == null) { … } else { … }`, narrowing a variable to non-nullable
+/// inside the guarded branch. Anything ambiguous (reassignment, closures,
+/// non-local receivers) conservatively bails to "not promoted".
+class NullSafetyAnalyzer {
+  final List<NullSafetyDiagnostic> _findings = [];
+
+  /// Analyzes [root] and returns the findings (deduplicated).
+  List<NullSafetyDiagnostic> analyze(ASTRoot root) {
+    _findings.clear();
+
+    // Function/method/getter bodies are themselves `ASTBlock`s; analyze each
+    // as an independent flow unit seeded with its parameters.
+    for (final node in root.descendantChildren) {
+      if (node is ASTInvocableDeclaration) {
+        _analyzeInvocable(node);
+      }
+    }
+
+    // Deduplicate (a nested body may be reached more than once).
+    final seen = <String>{};
+    final unique = <NullSafetyDiagnostic>[];
+    for (final f in _findings) {
+      final key = '${f.code}|${f.snippet}|${f.message}';
+      if (seen.add(key)) unique.add(f);
+    }
+    return unique;
+  }
+
+  void _analyzeInvocable(ASTInvocableDeclaration decl) {
+    final scope = _Scope();
+    // Seed parameter nullability.
+    for (final p in decl.parameters.allParameters) {
+      scope.declare(p.name, p.type.nullable);
+    }
+    _analyzeBlock(decl, scope);
+  }
+
+  void _analyzeBlock(ASTBlock block, _Scope parent) {
+    final scope = parent.child();
+    for (final stmt in block.statements) {
+      _analyzeStatement(stmt, scope);
+    }
+  }
+
+  void _analyzeStatement(ASTStatement stmt, _Scope scope) {
+    if (stmt is ASTStatementVariableDeclaration) {
+      final value = stmt.value;
+      if (value != null) {
+        _analyzeExpression(value, scope);
+        if (value is ASTExpressionNullValue && !_isNullableSlot(stmt.type)) {
+          _add(
+            "A value of type 'Null' can't be assigned to the non-nullable "
+            "variable '${stmt.name}' of type '${stmt.type.name}'.",
+            code: 'null-to-non-nullable',
+            snippet: '${stmt.name} = null',
+          );
+        }
+      }
+      scope.declare(stmt.name, stmt.type.nullable);
+      return;
+    }
+
+    if (stmt is ASTBranchIfBlock) {
+      _analyzeExpression(stmt.condition, scope);
+      final promo = _promotionsFrom(stmt.condition);
+      final thenScope = scope.child();
+      for (final n in promo.whenTrue) {
+        thenScope.promote(n);
+      }
+      _analyzeBlock(stmt.block, thenScope);
+      return;
+    }
+
+    if (stmt is ASTBranchIfElseBlock) {
+      _analyzeExpression(stmt.condition, scope);
+      final promo = _promotionsFrom(stmt.condition);
+      final thenScope = scope.child();
+      for (final n in promo.whenTrue) {
+        thenScope.promote(n);
+      }
+      _analyzeBlock(stmt.blockIf, thenScope);
+      final elseBlock = stmt.blockElse;
+      if (elseBlock != null) {
+        final elseScope = scope.child();
+        for (final n in promo.whenFalse) {
+          elseScope.promote(n);
+        }
+        _analyzeBlock(elseBlock, elseScope);
+      }
+      return;
+    }
+
+    if (stmt is ASTBranchIfElseIfsElseBlock) {
+      _analyzeExpression(stmt.condition, scope);
+      final promo = _promotionsFrom(stmt.condition);
+      final thenScope = scope.child();
+      for (final n in promo.whenTrue) {
+        thenScope.promote(n);
+      }
+      _analyzeBlock(stmt.blockIf, thenScope);
+      for (final elseIf in stmt.blocksElseIf) {
+        _analyzeExpression(elseIf.condition, scope);
+        _analyzeBlock(elseIf.block, scope.child());
+      }
+      final elseBlock = stmt.blockElse;
+      if (elseBlock != null) _analyzeBlock(elseBlock, scope.child());
+      return;
+    }
+
+    if (stmt is ASTStatementExpression) {
+      _analyzeExpression(stmt.expression, scope);
+      return;
+    }
+
+    if (stmt is ASTStatementReturnWithExpression) {
+      _analyzeExpression(stmt.expression, scope);
+      return;
+    }
+
+    if (stmt is ASTBlock) {
+      _analyzeBlock(stmt, scope);
+      return;
+    }
+
+    // Other statement kinds: descend into any nested blocks/expressions
+    // generically (no promotion tracking across them).
+    for (final child in stmt.children) {
+      if (child is ASTBlock) {
+        _analyzeBlock(child, scope);
+      } else if (child is ASTExpression) {
+        _analyzeExpression(child, scope);
+      } else if (child is ASTStatement) {
+        _analyzeStatement(child, scope);
+      }
+    }
+  }
+
+  void _analyzeExpression(ASTExpression expr, _Scope scope) {
+    // Null-aware access nodes are always safe — but still check their operands.
+    if (expr is ASTExpressionObjectGetterAccess) {
+      _checkNullableReceiver(
+        expr.variable,
+        expr.isNullAware || expr.assertReceiver,
+        member: expr.name,
+        scope: scope,
+      );
+    } else if (expr is ASTExpressionObjectFunctionInvocation) {
+      _checkNullableReceiver(
+        expr.variable,
+        expr.isNullAware || expr.assertReceiver,
+        member: '${expr.name}()',
+        scope: scope,
+      );
+    } else if (expr is ASTExpressionVariableEntryAccess) {
+      _checkNullableReceiver(
+        expr.variable,
+        expr.isNullAware || expr.assertReceiver,
+        member: '[]',
+        scope: scope,
+        isIndex: true,
+      );
+    } else if (expr is ASTExpressionNullAssertion) {
+      final inner = expr.expression;
+      if (inner is ASTExpressionNullValue) {
+        _add(
+          'The null-assertion operator (`!`) is applied to a `null` literal, '
+          'which always throws.',
+          code: 'null-assertion-on-null',
+          severity: NullSafetySeverity.warning,
+          snippet: 'null!',
+        );
+      }
+    } else if (expr is ASTExpressionVariableAssignment) {
+      // A reassignment invalidates promotion for that variable.
+      final v = expr.variable;
+      if (v is ASTScopeVariable) scope.demote(v.name);
+    }
+
+    for (final child in expr.children) {
+      if (child is ASTExpression) _analyzeExpression(child, scope);
+    }
+  }
+
+  void _checkNullableReceiver(
+    ASTVariable variable,
+    bool guarded, {
+    required String member,
+    required _Scope scope,
+    bool isIndex = false,
+  }) {
+    // `?.`/`?[` (null-aware) or `!` (null-assertion) make the access safe.
+    if (guarded) return;
+    if (variable is! ASTScopeVariable) return;
+
+    final name = variable.name;
+    final declaredNullable = scope.declaredNullable(name);
+    if (declaredNullable != true) return; // unknown or non-nullable: fine
+    if (scope.isPromoted(name)) return; // narrowed by a prior null check
+
+    final access = isIndex ? '$name[...]' : '$name.$member';
+    _add(
+      "The receiver '$name' can be 'null', so the ${isIndex ? 'index access' : "member '$member'"} "
+      "can't be accessed unconditionally. Use '?.'/'?[', '!' or a null check.",
+      code: 'unchecked-nullable-access',
+      snippet: access,
+    );
+  }
+
+  /// Whether a declared slot [type] accepts `null` without a diagnostic
+  /// (nullable, or an untyped/top slot where nullability is not enforced).
+  bool _isNullableSlot(ASTType type) {
+    if (type.nullable) return true;
+    if (type is ASTTypeDynamic) return true;
+    if (type is ASTTypeVar) return true;
+    if (type is ASTTypeObject) return true;
+    if (type is ASTTypeNull) return true;
+    return false;
+  }
+
+  /// Extracts the variable-name promotions implied by a boolean [condition]:
+  /// `x != null` promotes `x` when the condition is true; `x == null` promotes
+  /// `x` when the condition is false.
+  _Promotions _promotionsFrom(ASTExpression condition) {
+    final whenTrue = <String>{};
+    final whenFalse = <String>{};
+
+    void handle(ASTExpression e) {
+      if (e is ASTExpressionOperation) {
+        final op = e.operator;
+        if (op == ASTExpressionOperator.notEquals ||
+            op == ASTExpressionOperator.equals) {
+          final name = _nullComparisonVariable(e.expression1, e.expression2);
+          if (name != null) {
+            if (op == ASTExpressionOperator.notEquals) {
+              whenTrue.add(name);
+            } else {
+              whenFalse.add(name);
+            }
+          }
+        } else if (op == ASTExpressionOperator.and) {
+          // `x != null && …`: both sides promote when true.
+          handle(e.expression1);
+          handle(e.expression2);
+        }
+      }
+    }
+
+    handle(condition);
+    return _Promotions(whenTrue, whenFalse);
+  }
+
+  /// If [a]/[b] is a `variable <op> null` comparison, returns the variable name.
+  String? _nullComparisonVariable(ASTExpression a, ASTExpression b) {
+    String? nameOf(ASTExpression e) {
+      if (e is ASTExpressionVariableAccess) {
+        final v = e.variable;
+        if (v is ASTScopeVariable) return v.name;
+      }
+      return null;
+    }
+
+    if (b is ASTExpressionNullValue) return nameOf(a);
+    if (a is ASTExpressionNullValue) return nameOf(b);
+    return null;
+  }
+
+  void _add(
+    String message, {
+    required String code,
+    NullSafetySeverity severity = NullSafetySeverity.error,
+    String? snippet,
+  }) {
+    _findings.add(
+      NullSafetyDiagnostic(
+        message,
+        code: code,
+        severity: severity,
+        snippet: snippet,
+      ),
+    );
+  }
+}
+
+class _Promotions {
+  final Set<String> whenTrue;
+  final Set<String> whenFalse;
+  _Promotions(this.whenTrue, this.whenFalse);
+}
+
+class _Scope {
+  final _Scope? parent;
+  final Map<String, bool> _nullable = {};
+  final Set<String> _promoted = {};
+
+  _Scope([this.parent]);
+
+  _Scope child() => _Scope(this);
+
+  void declare(String name, bool nullable) {
+    _nullable[name] = nullable;
+    _promoted.remove(name);
+  }
+
+  bool? declaredNullable(String name) =>
+      _nullable[name] ?? parent?.declaredNullable(name);
+
+  bool isPromoted(String name) =>
+      _promoted.contains(name) || (parent?.isPromoted(name) ?? false);
+
+  void promote(String name) => _promoted.add(name);
+
+  void demote(String name) => _promoted.remove(name);
+}

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.15.0';
+  static final String VERSION = '2.16.0';
 
   static int _idCount = 0;
 

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -369,22 +369,42 @@ abstract class ApolloCodeGenerator
   }
 
   /// Emits a type, dispatching on its array rank.
+  /// Whether this target renders a nullable type with a trailing `?` suffix
+  /// (Dart, Kotlin, TypeScript). Targets without a nullable-type syntax
+  /// (Java, Go, …) leave this `false` and drop the suffix (best-effort).
+  bool get supportsNullableTypeSuffix => false;
+
+  /// Whether this target has native null-aware operators (`?.`, `?[`) that can
+  /// be emitted directly (Dart, Kotlin, TypeScript). Targets without them leave
+  /// this `false` and emit the plain `.`/`[` form (best-effort).
+  bool get supportsNullAwareOperators => false;
+
   StringBuffer generateASTType(
     ASTType type, {
     StringBuffer? out,
     String indent = '',
   }) {
+    out ??= newOutput();
+
     if (type is ASTTypeArray) {
-      return generateASTTypeArray(type, out: out, indent: indent);
+      generateASTTypeArray(type, out: out, indent: indent);
     } else if (type is ASTTypeArray2D) {
-      return generateASTTypeArray2D(type, out: out, indent: indent);
+      generateASTTypeArray2D(type, out: out, indent: indent);
     } else if (type is ASTTypeArray3D) {
-      return generateASTTypeArray3D(type, out: out, indent: indent);
+      generateASTTypeArray3D(type, out: out, indent: indent);
     } else if (type is ASTTypeFunction) {
-      return generateASTTypeFunction(type, out: out, indent: indent);
+      generateASTTypeFunction(type, out: out, indent: indent);
+    } else {
+      generateASTTypeDefault(type, out: out, indent: indent);
     }
 
-    return generateASTTypeDefault(type, out: out, indent: indent);
+    // Nullable `?` suffix (`String?`, `List<int>?`, `void Function()?`) for
+    // targets that support it.
+    if (type.nullable && supportsNullableTypeSuffix) {
+      out.write('?');
+    }
+
+    return out;
   }
 
   /// Renders a function type. The default drops the signature generics and
@@ -1448,6 +1468,20 @@ abstract class ApolloCodeGenerator
         indent: indent,
         headIndented: headIndented,
       );
+    } else if (expression is ASTExpressionNullAssertion) {
+      return generateASTExpressionNullAssertion(
+        expression,
+        out: out,
+        indent: indent,
+        headIndented: headIndented,
+      );
+    } else if (expression is ASTExpressionCascade) {
+      return generateASTExpressionCascade(
+        expression,
+        out: out,
+        indent: indent,
+        headIndented: headIndented,
+      );
     } else if (expression is ASTExpressionNegation) {
       return generateASTExpressionNegation(
         expression,
@@ -1817,6 +1851,83 @@ abstract class ApolloCodeGenerator
     return out;
   }
 
+  /// Renders a cascade (`receiver..sel..sel`, `receiver?..sel`). Each section
+  /// operates on the synthetic cascade target; rendering the section yields
+  /// `<target>.sel`, so the target prefix is stripped and the cascade operator
+  /// supplies the extra dot. Targets without cascades still emit valid (if less
+  /// idiomatic) output for the common single-section forms.
+  StringBuffer generateASTExpressionCascade(
+    ASTExpressionCascade expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    generateASTExpression(
+      expression.receiver,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+
+    final target = expression.targetVariableName;
+    final sections = expression.sections;
+
+    for (var i = 0; i < sections.length; i++) {
+      var s = generateASTExpression(
+        sections[i],
+        headIndented: false,
+      ).toString();
+      // Strip the synthetic target so `<target>.sel` becomes `.sel`.
+      if (s.startsWith(target)) {
+        s = s.substring(target.length);
+      }
+      var op = (i == 0 && expression.isNullAware && supportsNullAwareOperators)
+          ? '?.'
+          : '.';
+      out.write(op);
+      out.write(s);
+    }
+
+    return out;
+  }
+
+  /// The postfix null-assertion token for this target (`!` for Dart/TypeScript,
+  /// `!!` for Kotlin). Only emitted when [supportsNullAwareOperators] is true.
+  String get nullAssertionSuffix => '!';
+
+  /// The opening token for a null-aware index access (`?[` for Dart, `?.[` for
+  /// TypeScript). Only used when [supportsNullAwareOperators] is true.
+  String get nullAwareIndexOpen => '?[';
+
+  StringBuffer generateASTExpressionNullAssertion(
+    ASTExpressionNullAssertion expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    final inner = expression.expression;
+    final group = inner.isComplex;
+
+    if (group) out.write('(');
+    generateASTExpression(inner, out: out, indent: indent, headIndented: false);
+    if (group) out.write(')');
+
+    // Best-effort: targets without a null-assertion operator drop it.
+    if (supportsNullAwareOperators) {
+      out.write(nullAssertionSuffix);
+    }
+
+    return out;
+  }
+
   @override
   StringBuffer generateASTExpressionNegation(
     ASTExpressionNegation expression, {
@@ -1980,7 +2091,12 @@ abstract class ApolloCodeGenerator
       indent: indent,
       headIndented: false,
     );
-    out.write('.');
+    if (expression.assertReceiver && supportsNullAwareOperators) {
+      out.write(nullAssertionSuffix);
+    }
+    out.write(
+      expression.isNullAware && supportsNullAwareOperators ? '?.' : '.',
+    );
 
     final arguments = expression.arguments;
 
@@ -2159,7 +2275,12 @@ abstract class ApolloCodeGenerator
       indent: indent,
       headIndented: false,
     );
-    out.write('.');
+    if (expression.assertReceiver && supportsNullAwareOperators) {
+      out.write(nullAssertionSuffix);
+    }
+    out.write(
+      expression.isNullAware && supportsNullAwareOperators ? '?.' : '.',
+    );
 
     out.write(getterName);
 
@@ -2271,7 +2392,14 @@ abstract class ApolloCodeGenerator
       indent: indent,
       headIndented: headIndented,
     );
-    out.write('[');
+    if (expression.assertReceiver && supportsNullAwareOperators) {
+      out.write(nullAssertionSuffix);
+    }
+    out.write(
+      expression.isNullAware && supportsNullAwareOperators
+          ? nullAwareIndexOpen
+          : '[',
+    );
     generateASTExpression(
       expression.expression,
       out: out,

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -378,6 +378,93 @@ class ASTExpressionVariableAccess extends ASTExpression {
   }
 }
 
+/// [ASTExpression] for a Dart cascade (`receiver..a()..b = c`) and the
+/// null-aware cascade (`receiver?..a()`).
+///
+/// Each section is modeled as an operation on a synthetic
+/// [targetVariableName]; at runtime the receiver is evaluated once, bound to
+/// that name in a child scope, every section is executed against it, and the
+/// whole expression evaluates to the receiver. A null-aware cascade whose
+/// receiver is `null` short-circuits to `null`.
+class ASTExpressionCascade extends ASTExpression {
+  ASTExpression receiver;
+
+  /// The synthetic variable name the [sections] operate on.
+  final String targetVariableName;
+
+  final List<ASTExpression> sections;
+
+  bool isNullAware;
+
+  ASTExpressionCascade(
+    this.receiver,
+    this.targetVariableName,
+    this.sections, {
+    this.isNullAware = false,
+  });
+
+  @override
+  bool get isComplex => true;
+
+  @override
+  Iterable<ASTNode> get children => [receiver, ...sections];
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+    receiver.resolveNode(this);
+    for (var s in sections) {
+      s.resolveNode(this);
+    }
+  }
+
+  @override
+  FutureOr<ASTType> resolveType(VMContext? context) =>
+      receiver.resolveType(context);
+
+  @override
+  FutureOr<ASTValue> run(
+    VMContext parentContext,
+    ASTRunStatus runStatus,
+  ) async {
+    var recv = await receiver.run(parentContext, runStatus);
+
+    // Null-aware cascade (`obj?..`): short-circuit to `null`.
+    if (isNullAware && await _astValueIsNull(parentContext, recv)) {
+      return ASTValueNull.instance;
+    }
+
+    var cascadeContext = VMScopeContext(ASTBlock(null), parent: parentContext);
+    cascadeContext.declareVariableWithValue(
+      recv.type,
+      targetVariableName,
+      recv,
+    );
+
+    for (var section in sections) {
+      await section.run(cascadeContext, runStatus);
+    }
+
+    return recv;
+  }
+
+  @override
+  String toString({bool asGroup = false}) {
+    var b = StringBuffer('$receiver');
+    for (var i = 0; i < sections.length; i++) {
+      var s = sections[i].toString();
+      // Strip the synthetic target so `$target.sel` prints as `.sel`; the
+      // cascade operator then supplies the extra dot (`..sel`).
+      if (s.startsWith(targetVariableName)) {
+        s = s.substring(targetVariableName.length);
+      }
+      var op = (i == 0 && isNullAware) ? '?.' : '.';
+      b.write('$op$s');
+    }
+    return b.toString();
+  }
+}
+
 /// [ASTExpression] that declares a literal (number, boolean and String).
 class ASTExpressionLiteral extends ASTExpression {
   ASTValue value;
@@ -599,10 +686,20 @@ class ASTExpressionVariableEntryAccess extends ASTExpression {
   /// entry here is applied to the previous element in order.
   final List<ASTExpression> extraIndices;
 
+  /// Whether this is a null-aware index access (`list?[i]` / `map?[k]`): if the
+  /// receiver is `null`, the access short-circuits and evaluates to `null`.
+  bool isNullAware;
+
+  /// Whether the receiver carries a null-assertion (`list![i]`): if the
+  /// receiver is `null`, indexing it throws [ApolloVMNullPointerException].
+  bool assertReceiver;
+
   ASTExpressionVariableEntryAccess(
     this.variable,
     this.expression, [
     this.extraIndices = const [],
+    this.isNullAware = false,
+    this.assertReceiver = false,
   ]);
 
   /// All index expressions in order (the first plus any chained ones).
@@ -652,6 +749,18 @@ class ASTExpressionVariableEntryAccess extends ASTExpression {
     var context = defineRunContext(parentContext);
 
     var value = await variable.getValue(context);
+
+    // Null-assertion receiver (`list![i]`): throw on null.
+    if (assertReceiver && value is ASTValueNull) {
+      throw ApolloVMNullPointerException(
+        'Null check operator used on a null value',
+      );
+    }
+
+    // Null-aware index (`list?[i]`): short-circuit to `null`.
+    if (isNullAware && value is ASTValueNull) {
+      return ASTValueNull.instance;
+    }
 
     // Single index: keep the original statically-typed read path (precise
     // element type + null-pointer diagnostics).
@@ -824,6 +933,7 @@ enum ASTExpressionOperator {
   bitwiseXor,
   shiftLeft,
   shiftRight,
+  nullCoalesce,
 }
 
 ASTExpressionOperator getASTExpressionOperator(String op) {
@@ -867,6 +977,8 @@ ASTExpressionOperator getASTExpressionOperator(String op) {
       return ASTExpressionOperator.shiftLeft;
     case '>>':
       return ASTExpressionOperator.shiftRight;
+    case '??':
+      return ASTExpressionOperator.nullCoalesce;
     default:
       throw UnsupportedError(op);
   }
@@ -913,6 +1025,8 @@ String getASTExpressionOperatorText(ASTExpressionOperator op) {
       return '<<';
     case ASTExpressionOperator.shiftRight:
       return '>>';
+    case ASTExpressionOperator.nullCoalesce:
+      return '??';
   }
 }
 
@@ -967,6 +1081,53 @@ class ASTExpressionNegation extends ASTExpression {
   @override
   String toString({bool asGroup = false}) {
     var s = '!$expression';
+    return asGroup ? '($s)' : s;
+  }
+}
+
+/// [ASTExpression] for the Dart null-assertion postfix operator (`expr!`):
+/// evaluates [expression] and throws [ApolloVMNullPointerException] if the
+/// value is `null`, otherwise returns the (non-null) value.
+class ASTExpressionNullAssertion extends ASTExpression {
+  ASTExpression expression;
+
+  ASTExpressionNullAssertion(this.expression);
+
+  @override
+  bool get isComplex => false;
+
+  @override
+  Iterable<ASTNode> get children => [expression];
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+    expression.resolveNode(this);
+  }
+
+  @override
+  FutureOr<ASTType> resolveType(VMContext? context) => expression
+      .resolveType(context)
+      .resolveMapped((t) => t.withoutNullability());
+
+  @override
+  FutureOr<ASTValue> run(VMContext parentContext, ASTRunStatus runStatus) {
+    var context = defineRunContext(parentContext);
+    return expression.run(context, runStatus).resolveMapped((val) {
+      return _astValueIsNull(context, val).resolveMapped((isNull) {
+        if (isNull) {
+          throw ApolloVMNullPointerException(
+            'Null check operator used on a null value',
+          );
+        }
+        return val;
+      });
+    });
+  }
+
+  @override
+  String toString({bool asGroup = false}) {
+    var s = '$expression!';
     return asGroup ? '($s)' : s;
   }
 }
@@ -1234,6 +1395,13 @@ class ASTExpressionAwait extends ASTExpression {
 }
 
 /// [ASTExpression] for an operation between 2 expressions.
+/// Returns whether [val] represents `null` (a `null` literal/value, or a
+/// dynamic/boxed operand whose resolved value is `null`).
+FutureOr<bool> _astValueIsNull(VMContext context, ASTValue val) {
+  if (val is ASTValueNull) return true;
+  return val.getValue(context).resolveMapped((v) => v == null);
+}
+
 class ASTExpressionOperation extends ASTExpression {
   ASTExpression expression1;
   ASTExpressionOperator operator;
@@ -1290,6 +1458,15 @@ class ASTExpressionOperation extends ASTExpression {
       case ASTExpressionOperator.and:
       case ASTExpressionOperator.or:
         return ASTTypeBool.instance;
+      case ASTExpressionOperator.nullCoalesce:
+        {
+          var retT1 = expression1.resolveType(context);
+          var retT2 = expression2.resolveType(context);
+          return retT1.resolveBoth(retT2, (t1, t2) {
+            var nn = t1.withoutNullability();
+            return nn.commonType(t2) ?? t2;
+          });
+        }
     }
   }
 
@@ -1328,6 +1505,15 @@ class ASTExpressionOperation extends ASTExpression {
       case ASTExpressionOperator.and:
       case ASTExpressionOperator.or:
         return ASTTypeBool.instance;
+      case ASTExpressionOperator.nullCoalesce:
+        {
+          var retT1 = expression1.resolveRuntimeType(context, null);
+          var retT2 = expression2.resolveRuntimeType(context, null);
+          return retT1.resolveBoth(retT2, (t1, t2) {
+            var nn = t1.withoutNullability();
+            return nn.commonType(t2) ?? t2;
+          });
+        }
     }
   }
 
@@ -1412,6 +1598,18 @@ class ASTExpressionOperation extends ASTExpression {
 
     final operator = this.operator;
 
+    // Null-coalescing (`??`): evaluate the left operand; only evaluate the
+    // right operand when the left is `null`. Result is the left value when
+    // non-null, otherwise the right value.
+    if (operator == ASTExpressionOperator.nullCoalesce) {
+      return expression1.run(context, runStatus).resolveMapped((val1) {
+        return _astValueIsNull(context, val1).resolveMapped((isNull) {
+          if (!isNull) return val1;
+          return expression2.run(context, runStatus);
+        });
+      });
+    }
+
     // Short-circuit logical operators: only evaluate the right operand when the
     // left does not already determine the result. This matches Dart semantics
     // and keeps the interpreter consistent with the Wasm compiler.
@@ -1484,6 +1682,9 @@ class ASTExpressionOperation extends ASTExpression {
               return operatorShiftLeft(parentContext, c1, c2);
             case ASTExpressionOperator.shiftRight:
               return operatorShiftRight(parentContext, c1, c2);
+            case ASTExpressionOperator.nullCoalesce:
+              // Handled by the short-circuit branch above.
+              throw StateError('unreachable: nullCoalesce');
           }
         });
       });
@@ -1951,6 +2152,18 @@ class ASTExpressionVariableAssignment extends ASTExpression {
   ) async {
     var context = defineRunContext(parentContext);
 
+    // Null-coalescing assignment (`??=`): only evaluate the right-hand side and
+    // assign when the current value is `null`; otherwise leave it unchanged.
+    if (operator == ASTAssignmentOperator.nullCoalesce) {
+      var current = await variable.getValue(context);
+      if (!await _astValueIsNull(context, current)) {
+        return current;
+      }
+      var newValue = await expression.run(context, runStatus);
+      await variable.setValue(context, newValue);
+      return newValue;
+    }
+
     var value = await expression.run(context, runStatus);
     var variableValue = await variable.getValue(context);
 
@@ -1987,6 +2200,9 @@ class ASTExpressionVariableAssignment extends ASTExpression {
           result = variableValue * value;
           break;
         }
+      case ASTAssignmentOperator.nullCoalesce:
+        // Handled by the short-circuit branch above.
+        throw StateError('unreachable: nullCoalesce');
     }
 
     await variable.setValue(context, await result);
@@ -2020,6 +2236,10 @@ class ASTExpressionVariableAssignment extends ASTExpression {
       case ASTAssignmentOperator.divideAsInt:
         {
           return '$variable ~/= $expression';
+        }
+      case ASTAssignmentOperator.nullCoalesce:
+        {
+          return '$variable ??= $expression';
         }
     }
   }
@@ -2126,6 +2346,9 @@ class ASTExpressionVariableEntryAssignment extends ASTExpression {
         ASTAssignmentOperator.divideAsInt => current ~/ value,
         ASTAssignmentOperator.multiply => current * value,
         ASTAssignmentOperator.set => value,
+        // `m[k] ??= v`: keep the current value unless it is null.
+        ASTAssignmentOperator.nullCoalesce =>
+          (await _astValueIsNull(context, current)) ? value : current,
       };
     }
 
@@ -2151,6 +2374,7 @@ class ASTExpressionVariableEntryAssignment extends ASTExpression {
       ASTAssignmentOperator.multiply => '*=',
       ASTAssignmentOperator.divide => '/=',
       ASTAssignmentOperator.divideAsInt => '~/=',
+      ASTAssignmentOperator.nullCoalesce => '??=',
     };
     var keys = [keyExpression, ...extraKeys].map((k) => '[$k]').join();
     return '$variable$keys $op $expression';
@@ -2702,11 +2926,21 @@ class ASTExpressionObjectFunctionInvocation
     extends ASTExpressionFunctionInvocation {
   ASTVariable variable;
 
+  /// Whether this is a null-aware invocation (`obj?.method(...)`): if the
+  /// receiver is `null`, the call short-circuits and evaluates to `null`.
+  bool isNullAware;
+
+  /// Whether the receiver carries a null-assertion (`obj!.method(...)`): if the
+  /// receiver is `null`, the call throws [ApolloVMNullPointerException].
+  bool assertReceiver;
+
   ASTExpressionObjectFunctionInvocation(
     this.variable,
     String name,
     List<ASTExpression> arguments, [
     List<ASTExpressionChainFunctionInvocation>? chainFunctionInvocation,
+    this.isNullAware = false,
+    this.assertReceiver = false,
   ]) : super(name, arguments, chainFunctionInvocation);
 
   @override
@@ -2866,6 +3100,31 @@ class ASTExpressionObjectFunctionInvocation
       });
     }
 
+    // Null-assertion receiver (`obj!.method(...)`): throw on null.
+    if (assertReceiver) {
+      return _getVariableValue(parentContext).resolveMapped((obj) {
+        if (obj is ASTValueNull) {
+          throw ApolloVMNullPointerException(
+            'Null check operator used on a null value',
+          );
+        }
+        return _invoke(parentContext, runStatus);
+      });
+    }
+
+    // Null-aware invocation (`obj?.method(...)`): short-circuit to `null` when
+    // the receiver is `null`, without resolving/calling the method.
+    if (isNullAware) {
+      return _getVariableValue(parentContext).resolveMapped((obj) {
+        if (obj is ASTValueNull) return ASTValueNull.instance;
+        return _invoke(parentContext, runStatus);
+      });
+    }
+
+    return _invoke(parentContext, runStatus);
+  }
+
+  FutureOr<ASTValue> _invoke(VMContext parentContext, ASTRunStatus runStatus) {
     return _getFunction(parentContext).resolveMapped((f) {
       return _resolveArgumentsValues(
         parentContext,
@@ -3190,10 +3449,20 @@ class ASTExpressionObjectGetterAccess extends ASTExpressionGetterAccess
     with WithCallChainFunction {
   ASTVariable variable;
 
+  /// Whether this is a null-aware access (`obj?.field`): if the receiver is
+  /// `null`, the access short-circuits and evaluates to `null`.
+  bool isNullAware;
+
+  /// Whether the receiver carries a null-assertion (`obj!.field`): if the
+  /// receiver is `null`, accessing it throws [ApolloVMNullPointerException].
+  bool assertReceiver;
+
   ASTExpressionObjectGetterAccess(
     this.variable,
     String name, [
     List<ASTExpressionChainFunctionInvocation>? chainFunctionInvocation,
+    this.isNullAware = false,
+    this.assertReceiver = false,
   ]) : super(name) {
     _setChainFunctionInvocation(chainFunctionInvocation);
   }
@@ -3422,6 +3691,18 @@ class ASTExpressionObjectGetterAccess extends ASTExpressionGetterAccess
     }
 
     return _getVariableValue(parentContext).resolveMapped((obj) {
+      // Null-assertion receiver (`obj!.field`): throw on null.
+      if (assertReceiver && obj is ASTValueNull) {
+        throw ApolloVMNullPointerException(
+          'Null check operator used on a null value',
+        );
+      }
+
+      // Null-aware access (`obj?.field`): short-circuit to `null`.
+      if (isNullAware && obj is ASTValueNull) {
+        return ASTValueNull.instance;
+      }
+
       if (obj is ASTClassInstance) {
         var classContext = obj.createContext(parentContext);
         return obj.getField(classContext, name).resolveMapped((fieldValue) {
@@ -3503,7 +3784,11 @@ class ASTExpressionObjectSetterAssignment extends ASTExpression {
     return null;
   }
 
-  FutureOr<ASTValue> _applyOperator(ASTValue current, ASTValue value) {
+  FutureOr<ASTValue> _applyOperator(
+    VMContext context,
+    ASTValue current,
+    ASTValue value,
+  ) {
     switch (operator) {
       case ASTAssignmentOperator.set:
         return value;
@@ -3517,6 +3802,12 @@ class ASTExpressionObjectSetterAssignment extends ASTExpression {
         return current / value;
       case ASTAssignmentOperator.divideAsInt:
         return current ~/ value;
+      case ASTAssignmentOperator.nullCoalesce:
+        // `obj.field ??= v`: keep the current value unless it is null.
+        return _astValueIsNull(
+          context,
+          current,
+        ).resolveMapped((isNull) => isNull ? value : current);
     }
   }
 
@@ -3538,7 +3829,7 @@ class ASTExpressionObjectSetterAssignment extends ASTExpression {
         var current =
             await staticClass.getStaticFieldValue(context, name) ??
             ASTValueNull.instance;
-        resultValue = await _applyOperator(current, value);
+        resultValue = await _applyOperator(context, current, value);
       }
       await staticClass.setStaticFieldValue(context, name, resultValue);
       return resultValue;
@@ -3559,7 +3850,7 @@ class ASTExpressionObjectSetterAssignment extends ASTExpression {
     var value = await expression.run(context, runStatus);
 
     var current = await _currentField(classContext, obj);
-    var resultValue = await _applyOperator(current, value);
+    var resultValue = await _applyOperator(classContext, current, value);
     await obj.setField(classContext, name, resultValue);
     return resultValue;
   }

--- a/lib/src/ast/apollovm_ast_statement.dart
+++ b/lib/src/ast/apollovm_ast_statement.dart
@@ -606,7 +606,8 @@ enum ASTAssignmentOperator {
   divide('/'),
   divideAsInt('~/'),
   sum('+'),
-  subtract('-');
+  subtract('-'),
+  nullCoalesce('??');
 
   final String symbol;
 
@@ -624,6 +625,8 @@ enum ASTAssignmentOperator {
         return ASTExpressionOperator.divide;
       case divideAsInt:
         return ASTExpressionOperator.divideAsInt;
+      case nullCoalesce:
+        return ASTExpressionOperator.nullCoalesce;
       default:
         return null;
     }
@@ -646,6 +649,8 @@ ASTAssignmentOperator getASTAssignmentOperator(String op) {
       return ASTAssignmentOperator.sum;
     case '-=':
       return ASTAssignmentOperator.subtract;
+    case '??=':
+      return ASTAssignmentOperator.nullCoalesce;
     default:
       throw UnsupportedError(op);
   }
@@ -665,6 +670,8 @@ String getASTAssignmentOperatorText(ASTAssignmentOperator op) {
       return '+=';
     case ASTAssignmentOperator.subtract:
       return '-=';
+    case ASTAssignmentOperator.nullCoalesce:
+      return '??=';
   }
 }
 
@@ -1031,7 +1038,7 @@ class ASTStatementVariableDeclaration<V> extends ASTStatementTyped {
     ASTExpression value,
   ) async {
     if (valueResolvedType != ASTTypeDynamic.instance &&
-        !valueResolvedType.canCastToType(variableResolvedType)) {
+        !variableResolvedType.acceptsAssignment(valueResolvedType)) {
       throw ApolloVMRuntimeError(
         "Can't cast value type ($valueResolvedType) to variable type ($variableResolvedType).",
       );

--- a/lib/src/ast/apollovm_ast_type.dart
+++ b/lib/src/ast/apollovm_ast_type.dart
@@ -181,7 +181,48 @@ class ASTType<V> with ASTNode implements ASTTypedNode {
 
   final List<ASTAnnotation>? annotations;
 
-  ASTType(this.name, {this.generics, this.superType, this.annotations});
+  /// Whether this type is nullable (the Dart `?` suffix, e.g. `String?`).
+  ///
+  /// This is per-instance metadata. It must only ever be set on a fresh,
+  /// non-interned copy produced by [asNullable] — never mutated on a shared
+  /// singleton/interned instance.
+  bool nullable;
+
+  ASTType(
+    this.name, {
+    this.generics,
+    this.superType,
+    this.annotations,
+    this.nullable = false,
+  });
+
+  /// Whether this type is nullable (alias for [nullable]).
+  bool get isNullable => nullable;
+
+  /// Returns a fresh, non-interned copy of this concrete type (with
+  /// [nullable] reset to `false`). Subclasses override to preserve their
+  /// concrete class so that structural dispatch (`is ASTTypeArray`, etc.) and
+  /// typed value conversion keep working on nullable variants.
+  ASTType cloneType() => ASTType(
+    name,
+    generics: generics,
+    superType: superType,
+    annotations: annotations,
+  );
+
+  /// Returns a version of this type with the given [nullable] flag.
+  ///
+  /// Returns `this` unchanged when the flag already matches (so shared
+  /// singletons are never mutated); otherwise returns a fresh [cloneType].
+  ASTType<V> asNullable([bool nullable = true]) {
+    if (this.nullable == nullable) return this;
+    final copy = cloneType() as ASTType<V>;
+    copy.nullable = nullable;
+    return copy;
+  }
+
+  /// Returns the non-nullable form of this type.
+  ASTType<V> withoutNullability() => asNullable(false);
 
   @override
   Iterable<ASTNode> get children => [...?generics, ...?annotations, ?superType];
@@ -225,12 +266,25 @@ class ASTType<V> with ASTNode implements ASTTypedNode {
   /// Return true if [this] can be cast to [type];
   bool canCastToType(ASTType type) => type.acceptsType(this);
 
+  /// Whether a value of [type] can be assigned to a slot of [this] type,
+  /// accounting for nullability:
+  /// - `null`/`Null` is assignable only when [this] is [nullable];
+  /// - otherwise the underlying (non-nullable) types must be compatible, i.e.
+  ///   a `T?` slot accepts a `T` value.
+  bool acceptsAssignment(ASTType type) {
+    if (type is ASTTypeNull) return nullable || acceptsType(type);
+    return withoutNullability().acceptsType(type.withoutNullability());
+  }
+
   /// Will return true if [type] can be cast to [this] type.
   /// Note: This is similar to Java `isInstance` and `isAssignableFrom`.
   bool acceptsType(ASTType type) {
     if (type == this) return true;
 
     if (type == ASTTypeGenericWildcard.instance) return true;
+
+    // A nullable type accepts `Null`; a non-nullable type does not.
+    if (type is ASTTypeNull) return nullable;
 
     if (name != type.name) {
       var typeSuperType = type.superType;
@@ -308,6 +362,7 @@ class ASTType<V> with ASTNode implements ASTTypedNode {
       other is ASTType &&
           runtimeType == other.runtimeType &&
           name == other.name &&
+          nullable == other.nullable &&
           generics == other.generics &&
           superType == other.superType;
 
@@ -318,6 +373,7 @@ class ASTType<V> with ASTNode implements ASTTypedNode {
     final generics = this.generics;
 
     return name.hashCode ^
+        (nullable ? 0x40000000 : 0) ^
         (superType?.hashCode ?? 0) ^
         (generics != null ? _listEquality.hash(generics) : 0);
   }
@@ -340,7 +396,8 @@ class ASTType<V> with ASTNode implements ASTTypedNode {
 
   @override
   String toString() {
-    return generics == null ? name : '$name<${generics!.join(',')}>';
+    var s = generics == null ? name : '$name<${generics!.join(',')}>';
+    return nullable ? '$s?' : s;
   }
 }
 
@@ -373,6 +430,14 @@ class ASTTypeInterface<V> extends ASTType<V> {
   }) : super(superType: superInterface);
 
   @override
+  ASTType cloneType() => ASTTypeInterface<V>(
+    name,
+    generics: generics,
+    superInterface: superType,
+    annotations: annotations,
+  );
+
+  @override
   Iterable<ASTNode> get children => [];
 }
 
@@ -392,6 +457,9 @@ class ASTTypeBool extends ASTTypePrimitive<bool> {
   static final ASTTypeBool instance = ASTTypeBool();
 
   ASTTypeBool() : super('bool');
+
+  @override
+  ASTType cloneType() => ASTTypeBool();
 
   @override
   Iterable<ASTNode> get children => [];
@@ -469,6 +537,9 @@ class ASTTypeNum<T extends num> extends ASTTypeNumber<T> {
   ASTTypeNum() : this._('num');
 
   @override
+  ASTType cloneType() => ASTTypeNum<T>._(name, bits: bits);
+
+  @override
   Iterable<ASTNode> get children => [];
 
   @override
@@ -541,6 +612,9 @@ class ASTTypeInt extends ASTTypeNum<int> with StrictType {
   ASTTypeInt({super.bits}) : super._('int');
 
   @override
+  ASTType cloneType() => ASTTypeInt(bits: bits);
+
+  @override
   bool acceptsType(ASTType type) {
     if (type == this) return true;
     return false;
@@ -609,6 +683,9 @@ class ASTTypeDouble extends ASTTypeNum<double> with StrictType {
   static final ASTTypeDouble instance64 = ASTTypeDouble(bits: 64);
 
   ASTTypeDouble({super.bits}) : super._('double');
+
+  @override
+  ASTType cloneType() => ASTTypeDouble(bits: bits);
 
   @override
   bool acceptsType(ASTType type) {
@@ -703,6 +780,9 @@ class ASTTypeString extends ASTTypePrimitive<String> {
   ASTTypeString() : super('String');
 
   @override
+  ASTType cloneType() => ASTTypeString();
+
+  @override
   Iterable<ASTNode> get children => [];
 
   @override
@@ -760,6 +840,9 @@ class ASTTypeObject extends ASTType<Object> {
   static final ASTTypeObject instance = ASTTypeObject();
 
   ASTTypeObject() : super('Object');
+
+  @override
+  ASTType cloneType() => ASTTypeObject();
 
   @override
   Iterable<ASTNode> get children => [];
@@ -885,6 +968,9 @@ class ASTTypeVar extends ASTType<dynamic> {
 
   ASTTypeVar({this.unmodifiable = false})
     : super(unmodifiable ? 'final' : 'var');
+
+  @override
+  ASTType cloneType() => ASTTypeVar(unmodifiable: unmodifiable);
 
   @override
   Iterable<ASTNode> get children => [];
@@ -1154,6 +1240,9 @@ class ASTTypeArray<T extends ASTType<V>, V> extends ASTType<List<V>> {
 
   ASTTypeArray._(this.componentType) : super('List', generics: [componentType]);
 
+  @override
+  ASTType cloneType() => ASTTypeArray<T, V>._(componentType);
+
   factory ASTTypeArray(T type) {
     if (type is ASTTypeString) {
       return ASTTypeArray.instanceOfString as ASTTypeArray<T, V>;
@@ -1238,6 +1327,9 @@ class ASTTypeArray2D<T extends ASTType<V>, V>
     extends ASTTypeArray<ASTTypeArray<T, V>, List<V>> {
   ASTTypeArray2D(super.type) : super._();
 
+  @override
+  ASTType cloneType() => ASTTypeArray2D<T, V>(componentType);
+
   factory ASTTypeArray2D.fromElementType(ASTType<V> elementType) {
     var a1 = ASTTypeArray<T, V>._(elementType as T);
     return ASTTypeArray2D<T, V>(a1);
@@ -1283,6 +1375,10 @@ class ASTTypeArray2D<T extends ASTType<V>, V>
 class ASTTypeArray3D<T extends ASTType<V>, V>
     extends ASTTypeArray2D<ASTTypeArray<T, V>, List<V>> {
   ASTTypeArray3D(ASTTypeArray2D<T, V> super.type);
+
+  @override
+  ASTType cloneType() =>
+      ASTTypeArray3D<T, V>(componentType as ASTTypeArray2D<T, V>);
 
   factory ASTTypeArray3D.fromElementType(ASTType<V> elementType) {
     var a1 = ASTTypeArray<T, V>(elementType as T);
@@ -1357,6 +1453,9 @@ class ASTTypeMap<TK extends ASTType<K>, TV extends ASTType<V>, K, V>
 
   ASTTypeMap(this.keyType, this.valueType)
     : super('Map', generics: [keyType, valueType]);
+
+  @override
+  ASTType cloneType() => ASTTypeMap<TK, TV, K, V>(keyType, valueType);
 
   @override
   Iterable<ASTNode> get children => [keyType, valueType];
@@ -1437,6 +1536,9 @@ class ASTTypeMap<TK extends ASTType<K>, TV extends ASTType<V>, K, V>
 class ASTTypeFuture<T extends ASTType<V>, V> extends ASTType<Future<V>> {
   ASTTypeFuture(T type) : super('Future', generics: [type]);
 
+  @override
+  ASTType cloneType() => ASTTypeFuture<T, V>(futureValueType as T);
+
   /// The type of the value the [Future] resolves to (the `T` in `Future<T>`).
   ASTType get futureValueType {
     var generics = this.generics;
@@ -1471,6 +1573,14 @@ class ASTTypeFuture<T extends ASTType<V>, V> extends ASTType<Future<V>> {
 class ASTTypeFunction<F extends Function> extends ASTType<F> {
   ASTTypeFunction([ASTType? returnType, List<ASTType>? parameters])
     : super('Function', generics: [?returnType, ...?parameters]);
+
+  @override
+  ASTType cloneType() {
+    final g = generics ?? const <ASTType>[];
+    final returnType = g.isNotEmpty ? g.first : null;
+    final params = g.length > 1 ? g.sublist(1) : null;
+    return ASTTypeFunction<F>(returnType, params);
+  }
 
   /// Any function type is accepted as another function type. Function values
   /// carry their own declaration and are checked at call time, so signature

--- a/lib/src/ast/apollovm_ast_value.dart
+++ b/lib/src/ast/apollovm_ast_value.dart
@@ -89,18 +89,18 @@ abstract class ASTValue<T> with ASTNode implements ASTTypedNode {
 
     var valueType = resolveType(context);
     if (valueType is ASTType) {
-      return type.acceptsType(valueType);
+      return type.acceptsAssignment(valueType);
     } else {
       var value = context != null ? getValue(context) : getValueNoContext();
       var actualValueType = ASTType.from(value);
-      return type.acceptsType(actualValueType);
+      return type.acceptsAssignment(actualValueType);
     }
   }
 
   FutureOr<bool> isInstanceOfAsync(ASTType type) {
     var context = VMContext.getCurrent();
     return resolveType(context).resolveMapped((valueType) {
-      return type.acceptsType(valueType);
+      return type.acceptsAssignment(valueType);
     });
   }
 

--- a/lib/src/languages/dart/dart_generator.dart
+++ b/lib/src/languages/dart/dart_generator.dart
@@ -19,6 +19,12 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
     : super('dart', codeStorage);
 
   @override
+  bool get supportsNullableTypeSuffix => true;
+
+  @override
+  bool get supportsNullAwareOperators => true;
+
+  @override
   String normalizeTypeName(String typeName, [String? callingFunction]) {
     switch (typeName) {
       case 'Integer':

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -1162,9 +1162,19 @@ class DartGrammarDefinition extends DartGrammarLexer {
             );
           });
 
+  /// A primary expression optionally followed by the postfix null-assertion
+  /// operator (`expr!`). The `!` is only consumed when it is not the start of
+  /// `!=` (guarded by `char('=').not()`).
+  Parser<ASTExpression> expressionUnaryPostfix() =>
+      (ref0(expressionNoOperation) & (char('!') & char('=').not()).optional())
+          .map((v) {
+            var exp = v[0] as ASTExpression;
+            return v[1] != null ? ASTExpressionNullAssertion(exp) : exp;
+          });
+
   Parser<ASTExpression> expressionOperationChain() =>
-      (ref0(expressionNoOperation) &
-              (expressionOperator() & ref0(expressionNoOperation)).star())
+      (ref0(expressionUnaryPostfix) &
+              (expressionOperator() & ref0(expressionUnaryPostfix)).star())
           .map((v) {
             var exp1 = v[0];
 
@@ -1196,6 +1206,9 @@ class DartGrammarDefinition extends DartGrammarLexer {
               char('%') |
               string('&&') |
               string('||') |
+              // `??` must be matched before `?` disambiguation and before the
+              // single `&`/`|` operators; it is the null-coalescing operator.
+              string('??') |
               char('&') |
               char('|') |
               char('^'))
@@ -1212,8 +1225,88 @@ class DartGrammarDefinition extends DartGrammarLexer {
       (awaitToken() & (ref0(expressionNoOperation) | ref0(expressionGroup)))
           .map((v) => ASTExpressionAwait(v[1] as ASTExpression));
 
+  /// Synthetic variable name the cascade sections operate on. Stripped again
+  /// when the cascade is rendered back to source (see [ASTExpressionCascade]).
+  static const String cascadeTargetName = r'$cascadeTarget';
+
+  /// A cascade expression: `receiver..sel..sel` (and null-aware `receiver?..`).
+  /// Requires at least one `..`/`?..` section, so it never matches a plain
+  /// primary and can safely be tried first.
+  Parser<ASTExpression> expressionCascade() =>
+      ((expressionFunctionInvocation() |
+                      variable().map((v) => ASTExpressionVariableAccess(v)))
+                  .cast<ASTExpression>() &
+              cascadeSection().plus())
+          .map((v) {
+            var receiver = v[0] as ASTExpression;
+            var sectionsRaw = v[1] as List;
+            var isNullAware = false;
+            var sections = <ASTExpression>[];
+            for (var i = 0; i < sectionsRaw.length; i++) {
+              var rec =
+                  sectionsRaw[i]
+                      as ({bool isNullAware, ASTExpression selector});
+              if (i == 0) isNullAware = rec.isNullAware;
+              sections.add(rec.selector);
+            }
+            return ASTExpressionCascade(
+              receiver,
+              cascadeTargetName,
+              sections,
+              isNullAware: isNullAware,
+            );
+          });
+
+  Parser<({bool isNullAware, ASTExpression selector})> cascadeSection() =>
+      ((string('?..') | string('..')) & cascadeSelector()).map((v) {
+        return (isNullAware: v[0] == '?..', selector: v[1] as ASTExpression);
+      });
+
+  /// A single cascade selector applied to the implicit target: a method call
+  /// (`m(args)`), a setter (`f = v`, `f += v`), or a getter (`g`).
+  Parser<ASTExpression> cascadeSelector() =>
+      (identifier() &
+              ((char('(').trimHidden() &
+                          ref0(callArguments).optional() &
+                          char(')').trimHidden()) |
+                      (assigmentOperator() & ref0(expression)))
+                  .optional())
+          .map((v) {
+            var name = v[0] as String;
+            var rest = v[1];
+            var target = ASTScopeVariable(cascadeTargetName);
+
+            if (rest is List && rest.isNotEmpty && rest[0] == '(') {
+              var argsRec =
+                  rest[1]
+                      as ({
+                        List<ASTExpression> positional,
+                        Map<String, ASTExpression>? named,
+                      })?;
+              var args = argsRec?.positional ?? <ASTExpression>[];
+              var named = argsRec?.named;
+              return ASTExpressionObjectFunctionInvocation(
+                target,
+                name,
+                args,
+                const [],
+                false,
+              )..namedArguments = named;
+            } else if (rest is List && rest[0] is ASTAssignmentOperator) {
+              return ASTExpressionObjectSetterAssignment(
+                target,
+                name,
+                rest[0] as ASTAssignmentOperator,
+                rest[1] as ASTExpression,
+              );
+            } else {
+              return ASTExpressionObjectGetterAccess(target, name);
+            }
+          });
+
   Parser<ASTExpression> expressionNoOperation() =>
-      (expressionAwait() |
+      (expressionCascade() |
+              expressionAwait() |
               expressionAnonymousFunction() |
               expressionNegate() |
               expressionBitwiseNot() |
@@ -1303,7 +1396,8 @@ class DartGrammarDefinition extends DartGrammarLexer {
       // keyword is consumed and discarded — `new User()` and `User()` both
       // resolve to the class constructor via `ASTRoot.getFunction`.
       (newToken().optional() &
-              (identifier() & char('.')).optional() &
+              (identifier() & char('!').optional() & (string('?.') | char('.')))
+                  .optional() &
               identifier() &
               ref0(typeArguments).optional() &
               char('(').trimHidden() &
@@ -1313,6 +1407,8 @@ class DartGrammarDefinition extends DartGrammarLexer {
           .map((v) {
             var objOpt = v[1] as List?;
             var obj = objOpt != null ? objOpt[0] as String : null;
+            var assertReceiver = objOpt != null && objOpt[1] == '!';
+            var isNullAware = objOpt != null && objOpt[2] == '?.';
             var name = v[2] as String;
             // v[3]: optional generic type arguments (`<int>`), discarded — the
             // constructor/function resolves by name.
@@ -1335,6 +1431,8 @@ class DartGrammarDefinition extends DartGrammarLexer {
                 name,
                 args,
                 chainFunctions,
+                isNullAware,
+                assertReceiver,
               )..namedArguments = named;
             } else {
               return ASTExpressionLocalFunctionInvocation(
@@ -1346,13 +1444,15 @@ class DartGrammarDefinition extends DartGrammarLexer {
           });
 
   Parser<ASTExpressionGetterAccess> expressionGetterAccess() =>
-      ((identifier() & char('.')) &
+      ((identifier() & char('!').optional() & (string('?.') | char('.'))) &
               identifier().trimHidden() &
               expressionChainFunctionInvocation().star())
           .map((v) {
             var obj = v[0] as String?;
-            var name = v[2] as String;
-            var chainFunctions = (v[3] as List)
+            var assertReceiver = v[1] == '!';
+            var isNullAware = v[2] == '?.';
+            var name = v[3] as String;
+            var chainFunctions = (v[4] as List)
                 .whereType<ASTExpressionChainFunctionInvocation>()
                 .toList();
 
@@ -1365,6 +1465,8 @@ class DartGrammarDefinition extends DartGrammarLexer {
               variable,
               name,
               chainFunctions,
+              isNullAware,
+              assertReceiver,
             );
           });
 
@@ -1392,21 +1494,26 @@ class DartGrammarDefinition extends DartGrammarLexer {
 
   Parser<ASTExpressionVariableEntryAccess> expressionVariableEntryAccess() =>
       (variable() &
-              char('[') &
+              char('!').optional() &
+              (string('?[') | char('[')) &
               ref0(expression) &
               char(']') &
               (char('[').trimHidden() & ref0(expression) & char(']')).star())
           .map((v) {
             var variable = v[0];
-            var expression = v[2];
+            var assertReceiver = v[1] == '!';
+            var isNullAware = v[2] == '?[';
+            var expression = v[3];
             // Chained `[..]` accesses for nested indexing (`m[0][1]`).
-            var extra = (v[4] as List)
+            var extra = (v[5] as List)
                 .map((e) => (e as List)[1] as ASTExpression)
                 .toList();
             return ASTExpressionVariableEntryAccess(
               variable,
               expression,
               extra,
+              isNullAware,
+              assertReceiver,
             );
           });
 
@@ -1639,12 +1746,13 @@ class DartGrammarDefinition extends DartGrammarLexer {
           });
 
   Parser<ASTAssignmentOperator> assigmentOperator() =>
-      (char('=') |
+      (string('??=') |
               string('+=') |
               string('-=') |
               string('*=') |
               string('/=') |
-              string('~/='))
+              string('~/=') |
+              char('='))
           .trimHidden()
           .map((v) {
             return getASTAssignmentOperator(v);
@@ -1761,7 +1869,14 @@ class DartGrammarDefinition extends DartGrammarLexer {
           });
 
   Parser<ASTType> type() =>
-      (functionType() | typeNonFunction()).cast<ASTType>();
+      ((functionType() | typeNonFunction()).cast<ASTType>() &
+              char('?').trimHidden().optional())
+          .map((v) {
+            var t = v[0] as ASTType;
+            // A trailing `?` marks the whole type nullable (`String?`,
+            // `List<int>?`, `void Function()?`).
+            return v[1] != null ? t.asNullable() : t;
+          });
 
   /// Any type except a function type (used as the return type of a function
   /// type, and as the fallback when there is no trailing `Function(...)`).
@@ -1782,13 +1897,16 @@ class DartGrammarDefinition extends DartGrammarLexer {
 
   Parser<ASTType> functionTypeWithReturn() =>
       (ref0(typeNonFunction) &
+              char('?').trimHidden().optional() &
               string('Function').trim() &
               char('(').trimHidden() &
               functionTypeParameters().optional() &
               char(')').trimHidden())
           .map((v) {
             var returnType = v[0] as ASTType;
-            var parameters = v[3] as List<ASTType>?;
+            // A nullable return type (`String? Function(int)`).
+            if (v[1] != null) returnType = returnType.asNullable();
+            var parameters = v[4] as List<ASTType>?;
             return ASTTypeFunction(returnType, parameters);
           });
 

--- a/lib/src/languages/grammar.dart
+++ b/lib/src/languages/grammar.dart
@@ -195,6 +195,25 @@ abstract class BaseGrammarLexer extends GrammarDefinition {
     _reduceOps(block, {ASTExpressionOperator.bitwiseXor});
     _reduceOps(block, {ASTExpressionOperator.bitwiseOr});
 
+    // Relational, then equality (looser than the bitwise operators).
+    _reduceOps(block, {
+      ASTExpressionOperator.greater,
+      ASTExpressionOperator.greaterOrEq,
+      ASTExpressionOperator.lower,
+      ASTExpressionOperator.lowerOrEq,
+    });
+    _reduceOps(block, {
+      ASTExpressionOperator.equals,
+      ASTExpressionOperator.notEquals,
+    });
+
+    // Logical AND, then OR.
+    _reduceOps(block, {ASTExpressionOperator.and});
+    _reduceOps(block, {ASTExpressionOperator.or});
+
+    // Null-coalescing (`??`) is the loosest binary operator.
+    _reduceOps(block, {ASTExpressionOperator.nullCoalesce});
+
     // Final left-to-right fallback
     while (block.length >= 3) {
       var e1 = block.removeAt(0);

--- a/lib/src/languages/kotlin/kotlin_generator.dart
+++ b/lib/src/languages/kotlin/kotlin_generator.dart
@@ -86,6 +86,15 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
   }
 
   @override
+  bool get supportsNullableTypeSuffix => true;
+
+  @override
+  bool get supportsNullAwareOperators => true;
+
+  @override
+  String get nullAssertionSuffix => '!!';
+
+  @override
   String normalizeTypeName(String typeName, [String? callingFunction]) {
     switch (typeName) {
       case 'int':
@@ -781,6 +790,9 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
         return 'shl';
       case ASTExpressionOperator.shiftRight:
         return 'shr';
+      // Kotlin's null-coalescing is the Elvis operator `?:`, not `??`.
+      case ASTExpressionOperator.nullCoalesce:
+        return '?:';
       default:
         return getASTExpressionOperatorText(operator);
     }

--- a/lib/src/languages/typescript/ts/typescript_generator.dart
+++ b/lib/src/languages/typescript/ts/typescript_generator.dart
@@ -20,6 +20,16 @@ class ApolloCodeGeneratorTypeScript extends ApolloCodeGenerator {
   ApolloCodeGeneratorTypeScript(ApolloSourceCodeStorage codeStorage)
     : super('typescript', codeStorage);
 
+  // TypeScript has native `?.`, `!` and `??`, but a nullable *type* is written
+  // `T | null` (or an optional `?:` member), not a `T?` suffix — so the type
+  // suffix stays off (best-effort: nullability is dropped from type positions).
+  @override
+  bool get supportsNullAwareOperators => true;
+
+  // Null-aware element access in TS is `a?.[i]`, not `a?[i]`.
+  @override
+  String get nullAwareIndexOpen => '?.[';
+
   @override
   String normalizeTypeName(String typeName, [String? callingFunction]) {
     // Static-call targets (e.g. `Number.parseInt`) use the JS global object,

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -3711,6 +3711,12 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       );
     }
 
+    // Null-coalescing (`a ?? b`): Wasm values are never `null`, so the left
+    // operand always determines the result — compile it and drop the right.
+    if (expression.operator == ASTExpressionOperator.nullCoalesce) {
+      return generateASTExpression(expression1, out: out, context: context);
+    }
+
     final stackLng0 = context.stackLength;
 
     var exp1Out = generateASTExpression(expression1, context: context);
@@ -4961,6 +4967,10 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         return ASTExpressionOperator.divideAsInt;
       case ASTAssignmentOperator.set:
         throw ArgumentError("`set` is not a compound operator");
+      case ASTAssignmentOperator.nullCoalesce:
+        throw UnimplementedError(
+          "Wasm `??=` (null-coalescing assignment) is not supported yet.",
+        );
     }
   }
 
@@ -9369,6 +9379,14 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     } else if (expression is ASTExpressionLiteralFunction) {
       return generateASTExpressionLiteralFunction(
         expression,
+        out: out,
+        context: context,
+      );
+    } else if (expression is ASTExpressionNullAssertion) {
+      // Wasm's numeric domain has no `null`, so a null-assertion (`x!`) can
+      // never fail here — compile it as the inner expression.
+      return generateASTExpression(
+        expression.expression,
         out: out,
         context: context,
       );

--- a/lib/src/lsp/analysis/analyzer.dart
+++ b/lib/src/lsp/analysis/analyzer.dart
@@ -114,6 +114,9 @@ class Analyzer {
         ast = result.root;
         symbols = collectSymbols(ast!);
         diagnostics.addAll(_importDiagnostics(ast, text, lineIndex));
+        if (language == 'dart') {
+          diagnostics.addAll(_nullSafetyDiagnostics(ast, text, lineIndex));
+        }
       } else {
         diagnostics.add(
           _parseErrorDiagnostic(result, lineIndex, text, language),
@@ -188,6 +191,51 @@ class Analyzer {
       }
     }
     return out;
+  }
+
+  /// Runs the pragmatic null-safety analysis pass and maps its findings to LSP
+  /// diagnostics. Locations are best-effort: the finding's representative
+  /// snippet is located in the source (first match).
+  List<Diagnostic> _nullSafetyDiagnostics(
+    ASTRoot ast,
+    String text,
+    LineIndex lineIndex,
+  ) {
+    final out = <Diagnostic>[];
+    List<NullSafetyDiagnostic> findings;
+    try {
+      findings = NullSafetyAnalyzer().analyze(ast);
+    } catch (_) {
+      // The analysis pass is best-effort; never let it break diagnostics.
+      return out;
+    }
+
+    for (final f in findings) {
+      final snippet = f.snippet;
+      final range = (snippet != null && text.contains(snippet))
+          ? _locate(text, snippet, lineIndex)
+          : lineIndex.rangeAt(0, 1);
+      out.add(
+        Diagnostic(
+          range: range,
+          message: f.message,
+          severity: _severityOf(f.severity),
+          code: f.code,
+        ),
+      );
+    }
+    return out;
+  }
+
+  int _severityOf(NullSafetySeverity s) {
+    switch (s) {
+      case NullSafetySeverity.error:
+        return DiagnosticSeverity.error;
+      case NullSafetySeverity.warning:
+        return DiagnosticSeverity.warning;
+      case NullSafetySeverity.info:
+        return DiagnosticSeverity.information;
+    }
   }
 
   Range _locate(String text, String needle, LineIndex lineIndex) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.15.0
+version: 2.16.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/features/apollovm_null_safety_analyzer_test.dart
+++ b/test/features/apollovm_null_safety_analyzer_test.dart
@@ -1,0 +1,83 @@
+@TestOn('vm')
+@Tags(['dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+Future<List<NullSafetyDiagnostic>> _analyze(String source) async {
+  var parser = ApolloVM().getParser<String>('dart')!;
+  var result = await parser.parse(SourceCodeUnit('dart', source, id: 't'));
+  expect(result.isOK, isTrue, reason: 'cannot parse: $source');
+  return NullSafetyAnalyzer().analyze(result.root!);
+}
+
+Iterable<String> _codes(List<NullSafetyDiagnostic> f) => f.map((e) => e.code);
+
+void main() {
+  group('null-to-non-nullable', () {
+    test('flags null assigned to a non-nullable local', () async {
+      var f = await _analyze('void run() { int x = null; }');
+      expect(_codes(f), contains('null-to-non-nullable'));
+    });
+
+    test('allows null assigned to a nullable local', () async {
+      var f = await _analyze('void run() { int? x = null; }');
+      expect(_codes(f), isNot(contains('null-to-non-nullable')));
+    });
+
+    test('allows null assigned to var / dynamic / Object', () async {
+      expect(
+        _codes(await _analyze('void run() { var x = null; }')),
+        isNot(contains('null-to-non-nullable')),
+      );
+      expect(
+        _codes(await _analyze('void run() { dynamic x = null; }')),
+        isNot(contains('null-to-non-nullable')),
+      );
+    });
+  });
+
+  group('unchecked nullable access + flow promotion', () {
+    const cls = 'class A { int x = 1; int f() { return x; } } ';
+
+    test('flags unconditional member access on a nullable parameter', () async {
+      var f = await _analyze('${cls}void run(A? a) { a.x; }');
+      expect(_codes(f), contains('unchecked-nullable-access'));
+    });
+
+    test('flags unconditional method call on a nullable parameter', () async {
+      var f = await _analyze('${cls}void run(A? a) { a.f(); }');
+      expect(_codes(f), contains('unchecked-nullable-access'));
+    });
+
+    test('promotes inside if (x != null)', () async {
+      var f = await _analyze(
+        '${cls}void run(A? a) { if (a != null) { a.x; } }',
+      );
+      expect(_codes(f), isNot(contains('unchecked-nullable-access')));
+    });
+
+    test('promotes in else of if (x == null)', () async {
+      var f = await _analyze(
+        '${cls}void run(A? a) { if (a == null) { return; } else { a.x; } }',
+      );
+      expect(_codes(f), isNot(contains('unchecked-nullable-access')));
+    });
+
+    test('?. suppresses the diagnostic', () async {
+      var f = await _analyze('${cls}void run(A? a) { a?.x; }');
+      expect(_codes(f), isNot(contains('unchecked-nullable-access')));
+    });
+
+    test('! (assertion) suppresses the diagnostic', () async {
+      var f = await _analyze('${cls}void run(A? a) { a!.x; }');
+      expect(_codes(f), isNot(contains('unchecked-nullable-access')));
+    });
+
+    test('non-nullable parameter is never flagged', () async {
+      var f = await _analyze('${cls}void run(A a) { a.x; }');
+      expect(_codes(f), isNot(contains('unchecked-nullable-access')));
+    });
+  });
+}

--- a/test/features/apollovm_null_safety_test.dart
+++ b/test/features/apollovm_null_safety_test.dart
@@ -1,0 +1,267 @@
+@TestOn('vm')
+@Tags(['dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+Future<Object?> _run(
+  String source, {
+  String fn = 'run',
+  List args = const [],
+}) async {
+  var vm = ApolloVM();
+  expect(
+    await vm.loadCodeUnit(SourceCodeUnit('dart', source, id: 'test')),
+    isTrue,
+    reason: 'cannot parse: $source',
+  );
+  var r = await vm
+      .createRunner('dart')!
+      .executeFunction('', fn, positionalParameters: args);
+  return r.getValueNoContext();
+}
+
+Future<String> _regen(String source) async {
+  var vm = ApolloVM();
+  expect(
+    await vm.loadCodeUnit(SourceCodeUnit('dart', source, id: 'test')),
+    isTrue,
+    reason: 'cannot parse: $source',
+  );
+  var all = await vm.generateAllCodeIn('dart').writeAllSources();
+  return all.toString();
+}
+
+void main() {
+  group('null-coalescing (??)', () {
+    test('short-circuits on non-null / null', () async {
+      expect(await _run('int run() { int? a = null; return a ?? 42; }'), 42);
+      expect(await _run('int run() { int? a = 7; return a ?? 42; }'), 7);
+      expect(
+        await _run(
+          'int run() { int? a = null; int? b = null; return a ?? b ?? 9; }',
+        ),
+        9,
+      );
+    });
+
+    test('precedence: ?? binds looser than == (as ternary base)', () async {
+      // `(a ?? 1) == 1 ? 100 : 200`
+      expect(
+        await _run(
+          'int run() { int? a = null; return a ?? 1 == 1 ? 100 : 200; }',
+        ),
+        100,
+      );
+    });
+
+    test('Dart round-trip', () async {
+      expect(
+        await _regen('int run() { int? a = null; return a ?? 42; }'),
+        contains('a ?? 42'),
+      );
+    });
+  });
+
+  group('null-coalescing assignment (??=)', () {
+    test('assigns only when null', () async {
+      expect(await _run('int run() { int? a = null; a ??= 5; return a; }'), 5);
+      expect(await _run('int run() { int? a = 3; a ??= 5; return a; }'), 3);
+    });
+
+    test('Dart round-trip', () async {
+      expect(
+        await _regen('int run() { int? a = null; a ??= 5; return a; }'),
+        contains('a ??= 5'),
+      );
+    });
+  });
+
+  group('null-aware access (?.)', () {
+    test('getter short-circuits on null receiver', () async {
+      expect(
+        await _run(
+          'class A { int x = 5; } int? run() { A? a = null; return a?.x; }',
+        ),
+        isNull,
+      );
+      expect(
+        await _run(
+          'class A { int x = 5; } int? run() { A a = A(); return a?.x; }',
+        ),
+        5,
+      );
+    });
+
+    test('method invocation short-circuits on null receiver', () async {
+      expect(
+        await _run(
+          'class A { int f() { return 9; } } int? run() { A? a = null; return a?.f(); }',
+        ),
+        isNull,
+      );
+      expect(
+        await _run(
+          'class A { int f() { return 9; } } int? run() { A a = A(); return a?.f(); }',
+        ),
+        9,
+      );
+    });
+
+    test('Dart round-trip', () async {
+      expect(
+        await _regen(
+          'class A { int x = 5; } int? run() { A? a = null; return a?.x; }',
+        ),
+        contains('a?.x'),
+      );
+    });
+  });
+
+  group('null-aware index (?[ ])', () {
+    test('short-circuits on null receiver', () async {
+      expect(
+        await _run('int? run() { List<int>? xs = null; return xs?[0]; }'),
+        isNull,
+      );
+      expect(
+        await _run('int? run() { List<int> xs = [7, 8]; return xs?[1]; }'),
+        8,
+      );
+    });
+
+    test('Dart round-trip', () async {
+      expect(
+        await _regen('int? run() { List<int>? xs = null; return xs?[0]; }'),
+        contains('xs?[0]'),
+      );
+    });
+  });
+
+  group('null-assertion (!)', () {
+    test('returns the value when non-null', () async {
+      expect(await _run('int run() { int? a = 5; return a!; }'), 5);
+    });
+
+    test('throws on null', () async {
+      expect(
+        () async => await _run('int run() { int? a = null; return a!; }'),
+        throwsA(isA<ApolloVMNullPointerException>()),
+      );
+    });
+
+    test('Dart round-trip', () async {
+      expect(
+        await _regen('int run() { int? a = 5; return a!; }'),
+        contains('a!'),
+      );
+    });
+  });
+
+  group('assertion-then-access (! before . / [ )', () {
+    test('member access on asserted receiver', () async {
+      expect(
+        await _run(
+          'class A { int x = 5; } int run() { A? a = A(); return a!.x; }',
+        ),
+        5,
+      );
+      expect(
+        () async => await _run(
+          'class A { int x = 5; } int run() { A? a = null; return a!.x; }',
+        ),
+        throwsA(isA<ApolloVMNullPointerException>()),
+      );
+    });
+
+    test('method call on asserted receiver', () async {
+      expect(
+        await _run(
+          'class A { int f() { return 9; } } int run() { A? a = A(); return a!.f(); }',
+        ),
+        9,
+      );
+    });
+
+    test('index on asserted receiver', () async {
+      expect(
+        await _run('int run() { List<int>? xs = [7, 8]; return xs![1]; }'),
+        8,
+      );
+      expect(
+        () async =>
+            await _run('int run() { List<int>? xs = null; return xs![0]; }'),
+        throwsA(isA<ApolloVMNullPointerException>()),
+      );
+    });
+
+    test('Dart round-trip', () async {
+      expect(
+        await _regen(
+          'class A { int x = 5; } int run() { A? a = A(); return a!.x; }',
+        ),
+        contains('a!.x'),
+      );
+      expect(
+        await _regen('int run() { List<int>? xs = [7]; return xs![0]; }'),
+        contains('xs![0]'),
+      );
+    });
+  });
+
+  group('cascades (.. / ?..)', () {
+    const cls = 'class B { int n = 0; void add(int x) { n = n + x; } } ';
+
+    test('runs each section against the receiver, returns receiver', () async {
+      expect(
+        await _run(
+          '${cls}int run() { B b = B(); b..add(2)..add(3); return b.n; }',
+        ),
+        5,
+      );
+    });
+
+    test('null-aware cascade short-circuits on null receiver', () async {
+      expect(
+        await _run(
+          '${cls}int? run() { B? b = null; b?..add(2); return b?.n; }',
+        ),
+        isNull,
+      );
+    });
+
+    test('Dart round-trip', () async {
+      expect(
+        await _regen(
+          '${cls}int run() { B b = B(); b..add(2)..add(3); return b.n; }',
+        ),
+        contains('b..add(2)..add(3)'),
+      );
+      expect(
+        await _regen(
+          '${cls}int? run() { B? b = null; b?..add(2)..add(3); return b?.n; }',
+        ),
+        contains('b?..add(2)..add(3)'),
+      );
+    });
+  });
+
+  group('nullable types', () {
+    test(
+      'round-trip preserves ? on simple / collection / function types',
+      () async {
+        var out = await _regen(
+          'class C { List<String>? xs; void Function()? cb; String? Function(int) fmt; }',
+        );
+        expect(out, contains('List<String>?'));
+        expect(out, contains('void Function()?'));
+        expect(out, contains('String? Function(int)'));
+      },
+    );
+
+    test('nullable variable accepts null and its underlying type', () async {
+      expect(await _run('int run() { int? a = null; a = 5; return a; }'), 5);
+    });
+  });
+}

--- a/test/integration/apollovm_null_safety_generation_test.dart
+++ b/test/integration/apollovm_null_safety_generation_test.dart
@@ -1,0 +1,135 @@
+@TestOn('vm')
+@Tags(['dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Every source language ApolloVM can both parse and generate.
+const _languages = [
+  'dart',
+  'java11',
+  'javascript',
+  'typescript',
+  'kotlin',
+  'csharp',
+  'python',
+  'go',
+  'lua',
+];
+
+/// A Dart program exercising the full null-safety surface: nullable types,
+/// `??`, `??=`, `?.`, `?.method()`, `?[`, postfix `!` (standalone and before
+/// access) and cascades (`..` / `?..`).
+const _source = r'''
+class A {
+  int x = 1;
+  int add(int d) { x = x + d; return x; }
+
+  int coalesce(int? a, int b) { return a ?? b; }
+  int coalesceAssign(int? a, int b) { a ??= b; return a; }
+  int? field(A? a) { return a?.x; }
+  int? call(A? a) { return a?.add(1); }
+  int? index(List<int>? xs) { return xs?[0]; }
+  int assertField(A? a) { return a!.x; }
+  int assertIndex(List<int>? xs) { return xs![0]; }
+  int bang(int? a, int b) { int? v = a ?? b; return v!; }
+  A cascade(A a) { a..add(1)..add(2); return a; }
+
+  String? name;
+  List<String>? names;
+  void Function()? cb;
+}
+''';
+
+Future<ApolloVM> _load(String src) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', src, id: 'test'));
+  expect(ok, isTrue, reason: "can't load Dart source");
+  return vm;
+}
+
+Future<String> _generate(ApolloVM vm, String language) async {
+  var storage = vm.generateAllCodeIn(language);
+  await storage.writeAllSources();
+  var out = StringBuffer();
+  for (var ns in await storage.getNamespaces()) {
+    for (var id in await storage.getNamespaceCodeUnitsIDs(ns)) {
+      out.write((await storage.getNamespaceCodeUnit(ns, id))!);
+    }
+  }
+  return out.toString();
+}
+
+void main() {
+  group('null-safety generation', () {
+    test(
+      'every language generates without error and names the class',
+      () async {
+        var vm = await _load(_source);
+        for (var language in _languages) {
+          var code = await _generate(vm, language);
+          expect(code, isNotEmpty, reason: '$language generated nothing');
+          expect(
+            code,
+            contains('A'),
+            reason: '$language should name the generated class',
+          );
+        }
+      },
+    );
+
+    test('Dart round-trips every operator exactly', () async {
+      var vm = await _load(_source);
+      var dart = await _generate(vm, 'dart');
+
+      expect(dart, contains('int coalesce(int? a, int b)'));
+      expect(dart, contains('return a ?? b;'));
+      expect(dart, contains('a ??= b;'));
+      expect(dart, contains('return a?.x;'));
+      expect(dart, contains('return a?.add(1);'));
+      expect(dart, contains('return xs?[0];'));
+      expect(dart, contains('return a!.x;'));
+      expect(dart, contains('return xs![0];'));
+      expect(dart, contains('return v!;'));
+      expect(dart, contains('a..add(1)..add(2);'));
+      expect(dart, contains('String? name;'));
+      expect(dart, contains('List<String>? names;'));
+      expect(dart, contains('void Function()? cb;'));
+    });
+
+    test('Dart generated source parses back', () async {
+      var vm = await _load(_source);
+      var dart = await _generate(vm, 'dart');
+      var reloaded = ApolloVM();
+      var ok = await reloaded.loadCodeUnit(
+        SourceCodeUnit('dart', dart, id: 'test'),
+      );
+      expect(ok, isTrue, reason: 'Dart generated source it cannot parse');
+    });
+
+    test('Kotlin emits native null-aware forms (?:, ?., !!)', () async {
+      var vm = await _load(_source);
+      var kotlin = await _generate(vm, 'kotlin');
+      expect(kotlin, contains('a ?: b')); // Elvis, not `??`
+      expect(kotlin, contains('a?.x'));
+      expect(kotlin, contains('a!!.x'));
+      expect(kotlin, contains('Int?')); // nullable type suffix
+    });
+
+    test('TypeScript emits native null-aware forms (??, ?., ?.[, !)', () async {
+      var vm = await _load(_source);
+      var ts = await _generate(vm, 'typescript');
+      expect(ts, contains('a ?? b'));
+      expect(ts, contains('a?.x'));
+      expect(ts, contains('xs?.[0]')); // element access is `?.[`, not `?[`
+      expect(ts, contains('a!.x'));
+    });
+
+    test('C# emits `??` (native null-coalescing)', () async {
+      var vm = await _load(_source);
+      var csharp = await _generate(vm, 'csharp');
+      expect(csharp, contains('a ?? b'));
+    });
+  });
+}

--- a/test/tests_definitions/dart_null_aware.test.xml
+++ b/test/tests_definitions/dart_null_aware.test.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Null-safety: null-coalescing and null-aware index">
+    <source language="dart">
+        <![CDATA[
+class Calc {
+  int coalesce(int? a, int b) {
+    return a ?? b;
+  }
+  int? firstOr(List<int>? xs, int? d) {
+    return xs?[0] ?? d;
+  }
+}
+        ]]>
+    </source>
+    <call class="Calc" function="coalesce" return="5">
+        [null, 5]
+    </call>
+    <output>
+        []
+    </output>
+    <call class="Calc" function="coalesce" return="7">
+        [7, 5]
+    </call>
+    <output>
+        []
+    </output>
+    <call class="Calc" function="firstOr" return="9">
+        [null, 9]
+    </call>
+    <output>
+        []
+    </output>
+    <call class="Calc" function="firstOr" return="3">
+        [[3, 4], 9]
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Calc {
+
+  int coalesce(int? a, int b) {
+    return a ?? b;
+  }
+
+  int? firstOr(List<int>? xs, int? d) {
+    return xs?[0] ?? d;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/dart_null_aware_cascade.test.xml
+++ b/test/tests_definitions/dart_null_aware_cascade.test.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Null-safety: cascades, null-assertion access and ??=">
+    <source language="dart">
+        <![CDATA[
+class Box {
+  int n = 0;
+  void add(int x) { n = n + x; }
+  int cascadeSum(int a, int c) { Box bx = Box(); bx..add(a)..add(c); return bx.n; }
+  int forced(int a) { Box? bx = Box(); bx!.add(a); return bx.n; }
+  int orElse(int? a, int d) { int? v = a; v ??= d; return v; }
+}
+        ]]>
+    </source>
+    <call class="Box" function="cascadeSum" return="5">
+        [2, 3]
+    </call>
+    <output>
+        []
+    </output>
+    <call class="Box" function="forced" return="7">
+        [7]
+    </call>
+    <output>
+        []
+    </output>
+    <call class="Box" function="orElse" return="9">
+        [null, 9]
+    </call>
+    <output>
+        []
+    </output>
+    <call class="Box" function="orElse" return="4">
+        [4, 9]
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Box {
+
+  int n = 0;
+
+  void add(int x) {
+    n = n + x;
+  }
+
+  int cascadeSum(int a, int c) {
+    Box bx = Box();
+    bx..add(a)..add(c);
+    return bx.n;
+  }
+
+  int forced(int a) {
+    Box? bx = Box();
+    bx!.add(a);
+    return bx.n;
+  }
+
+  int orElse(int? a, int d) {
+    int? v = a;
+    v ??= d;
+    return v;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/unit/apollovm_ast_type_nullability_test.dart
+++ b/test/unit/apollovm_ast_type_nullability_test.dart
@@ -1,0 +1,70 @@
+@TestOn('vm')
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ASTType nullability', () {
+    test('asNullable returns a distinct, non-singleton nullable instance', () {
+      var base = ASTTypeInt.instance;
+      var nullable = base.asNullable();
+
+      expect(base.nullable, isFalse);
+      expect(nullable.nullable, isTrue);
+      expect(identical(base, nullable), isFalse);
+      // The shared singleton is never mutated.
+      expect(ASTTypeInt.instance.nullable, isFalse);
+    });
+
+    test('asNullable preserves the concrete type', () {
+      expect(ASTTypeString.instance.asNullable(), isA<ASTTypeString>());
+      expect(ASTTypeInt.instance.asNullable(), isA<ASTTypeInt>());
+      var arr = ASTTypeArray(ASTTypeString.instance).asNullable();
+      expect(arr, isA<ASTTypeArray>());
+      expect(arr.nullable, isTrue);
+    });
+
+    test('withoutNullability round-trips', () {
+      var n = ASTTypeString.instance.asNullable();
+      expect(n.nullable, isTrue);
+      expect(n.withoutNullability().nullable, isFalse);
+      // Non-nullable withoutNullability returns itself.
+      expect(
+        identical(
+          ASTTypeInt.instance.withoutNullability(),
+          ASTTypeInt.instance,
+        ),
+        isTrue,
+      );
+    });
+
+    test('equality distinguishes nullable from non-nullable', () {
+      expect(
+        ASTTypeString.instance.asNullable() == ASTTypeString.instance,
+        isFalse,
+      );
+      expect(
+        ASTTypeString.instance.asNullable() ==
+            ASTTypeString.instance.asNullable(),
+        isTrue,
+      );
+    });
+
+    group('acceptsAssignment', () {
+      test('T? accepts T, T? and Null', () {
+        var nullableInt = ASTTypeInt.instance.asNullable();
+        expect(nullableInt.acceptsAssignment(ASTTypeInt.instance), isTrue);
+        expect(nullableInt.acceptsAssignment(nullableInt), isTrue);
+        expect(nullableInt.acceptsAssignment(ASTTypeNull.instance), isTrue);
+      });
+
+      test('T (non-nullable) rejects Null', () {
+        expect(
+          ASTTypeInt.instance.acceptsAssignment(ASTTypeNull.instance),
+          isFalse,
+        );
+      });
+    });
+  });
+}

--- a/test/wasm/apollovm_wasm_null_safety_test.dart
+++ b/test/wasm/apollovm_wasm_null_safety_test.dart
@@ -1,0 +1,93 @@
+@TestOn('vm')
+@Tags(['wasm'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Compiles [src] (Dart) to a Wasm module and returns its bytes. Fails the test
+/// if the null-safety construct cannot be lowered to Wasm.
+Future<BytesOutput> _compile(String src) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', src, id: 't'));
+  expect(ok, isTrue, reason: 'cannot parse: $src');
+
+  var storage = vm.generateAllIn<BytesOutput>('wasm');
+  BytesOutput? compiled;
+  for (var ns in (await storage.allEntries()).values) {
+    for (var m in ns.values) {
+      compiled ??= m;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'no Wasm module generated for: $src');
+  return compiled!;
+}
+
+/// Compiles then, when a Wasm runtime is available on this platform (e.g. under
+/// the `wasm-chrome` tag), also executes [functionName] and returns its value.
+/// On platforms without a Wasm runtime the execution is skipped and `null` is
+/// returned — the compilation assertion above is the portable guarantee.
+Future<Object?> _compileAndMaybeRun(
+  String src,
+  String functionName,
+  List args,
+) async {
+  var compiled = await _compile(src);
+
+  var vmWasm = ApolloVM();
+  var loaded = await vmWasm.loadCodeUnit(
+    BinaryCodeUnit('wasm', compiled.output(), id: 't.wasm', namespace: ''),
+  );
+  expect(loaded, isTrue, reason: 'compiled Wasm failed to load');
+
+  try {
+    var r = await vmWasm
+        .createRunner('wasm')!
+        .executeFunction('', functionName, positionalParameters: args);
+    return r.getValueNoContext();
+  } on StateError catch (e) {
+    // No Wasm runtime on this platform — codegen already verified above.
+    if (e.message.contains('not supported on this platform')) return null;
+    rethrow;
+  }
+}
+
+void main() {
+  group('Wasm null-safety codegen (non-null numeric domain)', () {
+    test('null-assertion (x!) compiles and is a no-op', () async {
+      var r = await _compileAndMaybeRun(
+        'int f(int a) { int? x = a; return x!; }',
+        'f',
+        [7],
+      );
+      if (r != null) expect(r, 7);
+    });
+
+    test('null-coalescing (a ?? b) compiles to its left operand', () async {
+      var r = await _compileAndMaybeRun(
+        'int f(int a, int b) { int? x = a; return x ?? b; }',
+        'f',
+        [3, 9],
+      );
+      if (r != null) expect(r, 3);
+    });
+
+    test('nullable-typed parameters/locals compile', () async {
+      // Exercises `int?` in parameter, local and return positions.
+      await _compile('int f(int? a, int b) { int? x = a ?? b; return x!; }');
+    });
+
+    test('null-aware field access (a?.x) compiles', () async {
+      await _compile('class A { int x = 5; } int f(A a) { return a?.x; }');
+    });
+
+    test('the null literal remains an unsupported Wasm construct', () async {
+      // Wasm has no `null` value; assigning a null literal is a clean error,
+      // not a silent miscompilation.
+      await expectLater(
+        _compile('int f(int b) { int? x = null; return x ?? b; }'),
+        throwsA(anyOf(isA<UnimplementedError>(), isA<UnsupportedError>())),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds Dart-compatible null-safety across the whole pipeline — parse, type-check, runtime, and transpilation — plus a static null-safety analysis pass and Wasm lowering. Ships as version `2.16.0`.

### Nullable types
- Parses `T?` on simple, generic, collection and function types (`String?`, `List<String?>`, `Map<String, User?>`, `Future<User?>`, `void Function()?`, `String? Function(int)`).
- `ASTType` carries a `nullable` flag via `asNullable()` / `withoutNullability()`; interned singletons are never mutated (`cloneType()` preserves the concrete subclass).
- Nullability-aware `ASTType.acceptsAssignment` gates the runtime declaration/instance-of checks: a `T?` slot accepts `T` and `Null`; `T` rejects `Null`.

### Null-aware operators
`??`, `??=`, `?.` (getter + method), `?[`, postfix `!` (standalone **and** before access — `x!.f`, `x!.m()`, `x![i]`), and `..`/`?..` cascades. All parse, evaluate with correct short-circuit semantics (`?.`/`?[`/`?..` → `null`; `!` throws `ApolloVMNullPointerException`; `??`/`??=` coalesce; cascade returns the receiver), and round-trip through the Dart generator. `??` is wired into the precedence reducer as the loosest binary operator (relational/equality/logical tiers were made explicit at the same time).

### Static analysis (new)
`NullSafetyAnalyzer` — pragmatic, flow-aware. Reports assigning `null` to a non-nullable declaration/parameter and unconditional member/method/index access on a nullable local, with flow promotion for `if (x != null) { … }` / `if (x == null) … else { … }` and suppression via `?.`/`!`. Surfaced through the LSP analyzer for Dart documents.

### Cross-language generation
- **Dart**: exact round-trip (guaranteed).
- **Kotlin**: `?:` (Elvis), `!!`, `?.`, nullable `T?`.
- **TypeScript**: `??`, `?.`, `?.[` (element access), `!`.
- **C# / JavaScript**: native `??`.
- Java / Go / Python / Lua: best-effort (closest form, no failure).

### Wasm
The Wasm backend lowers null-safety within its non-null numeric domain: `x!`→`x`, `a ?? b`→left operand, `?.`/`?[`→plain access, `T?`→underlying numeric type. A `null` **literal** stays an explicit unsupported-construct error (Wasm has no null value) rather than a silent miscompile.

## Tests
- `test/features/apollovm_null_safety_test.dart` — runtime + Dart round-trip for every operator.
- `test/features/apollovm_null_safety_analyzer_test.dart` — analyzer detection, flow promotion, suppression.
- `test/unit/apollovm_ast_type_nullability_test.dart` — `ASTType` nullability.
- `test/integration/apollovm_null_safety_generation_test.dart` — cross-language generation.
- `test/wasm/apollovm_wasm_null_safety_test.dart` — Wasm codegen.
- `test/tests_definitions/dart_null_aware*.test.xml` (×2) — declarative parse → run → exact transpile → reload → re-run.

Full suite: **2410 passing**, `dart analyze` clean, `dart format` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)