### PR TITLE
v2.17.0 - null-safety fixes: nullable params, null-aware typing, access chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,65 @@
+## 2.17.0
+
+### Null-safety fixes: nullable parameters, null-aware typing, access chains
+
+Four gaps found by exercising the 2.16.0 null-safety surface end-to-end.
+
+- **A `T?` parameter now accepts a `T` argument.** Calling a method with a
+  `String?` parameter and a non-null `String` failed with `parameters signature
+  not compatible`, though passing `null` worked. Argument passing is an
+  assignment, so `ASTFunctionParameters.parameterAcceptsType` now uses
+  `ASTType.acceptsAssignment` instead of `acceptsType`. (`int?`/`double?` only
+  appeared to work because `StrictType` ignores `nullable` in `==`, while
+  `ASTTypeString` compares it — so `String?` and `String` were unequal and
+  `ASTTypeString.acceptsType` rejected the argument.) A non-nullable parameter
+  still rejects `null`.
+- **A null-aware access now reports a nullable static type.** Storing a
+  short-circuited result in a local failed: `var v = s?.length` on a `null`
+  receiver threw ``Class not set for type: Null``, and `var v = xs?[0]` threw
+  ``Can't cast initial (null) value to type: int``. `?.` (getter and method) and
+  `?[` now resolve to `T?`, and resolving the type of an access whose receiver
+  is `null` reports `Null` instead of trying to find a class for it. Using the
+  result in a `return`, inline with `??`, or in a string interpolation already
+  worked and is unchanged.
+- **Member-access chains parse.** `a.b.c`, `a.b?.c`, `a.b!.c`, `a.b.m()`,
+  `a.b?.m(x)` and chained writes (`a.b.c = v`) previously failed — the grammar
+  accepted only a *single* identifier receiver, so `a.next?.value` reported
+  ``SyntaxError: digit expected`` (the `?` was read as the start of a number)
+  and even plain `a.next.value` reported ``"(" expected``. A new chain rule
+  folds each segment onto the previous one, wrapping it in the new
+  `ASTExpressionVariable` (an `ASTVariable` backed by an expression) so the
+  existing object-access nodes supply the runtime, null-aware and
+  code-generation behaviour. Chains of any depth work, in any mix of `.`, `?.`
+  and `!`. Single-segment access keeps its own rules — the chain rule requires
+  two or more segments — so enum entries, static fields and import prefixes
+  resolve exactly as before. A field read off a parenthesized receiver
+  (`(a).v`, `(a)?.v`) also parses now; only `(expr).m().field` remains
+  unsupported.
+- **`??` and `??=` no longer leak into targets that cannot compile them.**
+  Java, Lua, Python and Go emitted `a ?? b` verbatim, and `??=` leaked into
+  *every* target — including Kotlin, which had a correct `?:` for `??` but no
+  hook for the assignment form. `??` now goes through an overridable
+  `renderNullCoalesce`, and `??=` is lowered to `t = t ?? v` wherever
+  `supportsNullCoalesceAssignment` is false, so each target defines only one
+  desugaring:
+  - Java: `(a != null ? a : b)`
+  - Python: `(a if a is not None else b)` — an `is not None` test, so `0`/`''`/
+    `False` are preserved
+  - Lua: an immediately-invoked function with an explicit `nil` test, because
+    both `a or b` and the `a ~= nil and a or b` idiom return `b` for a non-nil
+    `false`; it also binds `a` to a local, so it is evaluated once
+  - Kotlin: `?:` for `??`, and `t = t ?: v` for `??=`
+  - Dart, C#, JavaScript, TypeScript: unchanged, they have both operators
+  - Go: reports an `UnsupportedSyntaxError`. Go has neither a null-coalescing
+    operator nor a conditional *expression*, and this generator maps a nullable
+    `T?` onto a plain Go `T`, which for a value type cannot be compared to
+    `nil` — any rendering would be code that does not compile. Representing
+    `T?` as `*T` throughout the Go generator is separate work.
+
+Also adds an overridable `resolveASTAssignmentOperatorText`, which lets the
+Python generator drop its whole `generateASTExpressionVariableAssignment`
+override (it existed only to spell integer division `//=`).
+
 ## 2.16.0
 
 ### Dart null-safety support

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.16.0';
+  static final String VERSION = '2.17.0';
 
   static int _idCount = 0;
 

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -1194,25 +1194,57 @@ abstract class ApolloCodeGenerator
 
     if (headIndented) out.write(indent);
 
-    generateASTVariable(
+    // The assignment target, captured so `??=` can repeat it when the target
+    // language has no such operator (`t ??= v` -> `t = t ?? v`).
+    var target = generateASTVariable(
       expression.variable,
-      out: out,
       indent: indent,
-      headIndented: headIndented,
-    );
+      headIndented: false,
+    ).toString();
 
-    var op = getASTAssignmentOperatorText(expression.operator);
-    out.write(' ');
-    out.write(op);
-    out.write(' ');
-    generateASTExpression(
+    out.write(target);
+
+    var value = generateASTExpression(
       expression.expression,
-      out: out,
       indent: '$indent  ',
       headIndented: false,
-    );
+    ).toString();
+
+    _writeAssignment(out, expression.operator, target, value);
 
     return out;
+  }
+
+  /// Resolves the assignment operator text for the target language.
+  ///
+  /// Defaults to the shared spelling; a target overrides this where its own
+  /// differs (e.g. Python writes integer division as `//=`, not `~/=`).
+  String resolveASTAssignmentOperatorText(ASTAssignmentOperator operator) =>
+      getASTAssignmentOperatorText(operator);
+
+  /// Writes the operator and right-hand side of an assignment whose left-hand
+  /// side [target] has already been written to [out].
+  ///
+  /// A `??=` against a target without that operator is lowered to
+  /// `= target ?? value`, so only [renderNullCoalesce] has to be defined per
+  /// language.
+  void _writeAssignment(
+    StringBuffer out,
+    ASTAssignmentOperator operator,
+    String target,
+    String value,
+  ) {
+    if (operator == ASTAssignmentOperator.nullCoalesce &&
+        !supportsNullCoalesceAssignment) {
+      out.write(' = ');
+      out.write(renderNullCoalesce(target, value));
+      return;
+    }
+
+    out.write(' ');
+    out.write(resolveASTAssignmentOperatorText(operator));
+    out.write(' ');
+    out.write(value);
   }
 
   @override
@@ -1226,43 +1258,43 @@ abstract class ApolloCodeGenerator
 
     if (headIndented) out.write(indent);
 
-    generateASTVariable(
+    // The indexed write target, captured so `??=` can repeat it.
+    var target = generateASTVariable(
       expression.variable,
-      out: out,
       indent: indent,
-      headIndented: headIndented,
+      headIndented: false,
     );
 
-    out.write('[');
+    target.write('[');
     generateASTExpression(
       expression.keyExpression,
-      out: out,
+      out: target,
       indent: '$indent  ',
       headIndented: false,
     );
-    out.write(']');
+    target.write(']');
     // Chained keys for a nested write target (`m[0][1] = v`).
     for (var extra in expression.extraKeys) {
-      out.write('[');
+      target.write('[');
       generateASTExpression(
         extra,
-        out: out,
+        out: target,
         indent: '$indent  ',
         headIndented: false,
       );
-      out.write(']');
+      target.write(']');
     }
 
-    var op = getASTAssignmentOperatorText(expression.operator);
-    out.write(' ');
-    out.write(op);
-    out.write(' ');
-    generateASTExpression(
+    var targetStr = target.toString();
+    out.write(targetStr);
+
+    var value = generateASTExpression(
       expression.expression,
-      out: out,
       indent: '$indent  ',
       headIndented: false,
-    );
+    ).toString();
+
+    _writeAssignment(out, expression.operator, targetStr, value);
 
     return out;
   }
@@ -1600,6 +1632,17 @@ abstract class ApolloCodeGenerator
     final expression2 = expression.expression2;
     final operator = expression.operator;
 
+    // `a ?? b` has no operator form in several targets, so it goes through a
+    // dedicated hook that can desugar it into a conditional expression.
+    if (operator == ASTExpressionOperator.nullCoalesce) {
+      return generateASTExpressionNullCoalesce(
+        expression1,
+        expression2,
+        out: out,
+        indent: indent,
+      );
+    }
+
     var groupComplexExpressions = true;
 
     if (operator == ASTExpressionOperator.add) {
@@ -1649,6 +1692,61 @@ abstract class ApolloCodeGenerator
     if (group2) out.write('(');
     out.write(exp2);
     if (group2) out.write(')');
+
+    return out;
+  }
+
+  /// Renders the null-coalescing expression `a ?? b` from already-generated
+  /// operand texts.
+  ///
+  /// The default emits the operator form, resolved through
+  /// [resolveASTExpressionOperatorText] so a target with its own spelling (e.g.
+  /// Kotlin's Elvis `?:`) is honoured. Targets with no null-coalescing operator
+  /// (Java, Lua, Python) override this to desugar into a conditional; a target
+  /// that cannot express it at all (Go) throws an [UnsupportedSyntaxError].
+  ///
+  /// A desugaring override repeats [a] in its output, so it is only safe for
+  /// operands that can be evaluated twice — which is what `??` / `??=` targets
+  /// are in practice (variables, fields and index reads).
+  String renderNullCoalesce(String a, String b) {
+    var op = resolveASTExpressionOperatorText(
+      ASTExpressionOperator.nullCoalesce,
+      ASTNumType.nan,
+      ASTNumType.nan,
+    );
+    return '$a $op $b';
+  }
+
+  /// Whether the target language has a null-coalescing *assignment* operator
+  /// (`??=`). When false, `t ??= v` is generated as `t = t ?? v`, routing the
+  /// `??` through [renderNullCoalesce] so each target needs only one desugar.
+  ///
+  /// Dart, C#, JavaScript and TypeScript have `??=`; Kotlin, Java, Lua, Python
+  /// and Go do not.
+  bool get supportsNullCoalesceAssignment => true;
+
+  /// Generates the null-coalescing expression `a ?? b`.
+  StringBuffer generateASTExpressionNullCoalesce(
+    ASTExpression expression1,
+    ASTExpression expression2, {
+    StringBuffer? out,
+    String indent = '',
+  }) {
+    out ??= newOutput();
+
+    var a = generateASTExpression(
+      expression1,
+      indent: '$indent  ',
+      headIndented: false,
+    ).toString();
+
+    var b = generateASTExpression(
+      expression2,
+      indent: '$indent  ',
+      headIndented: false,
+    ).toString();
+
+    out.write(renderNullCoalesce(a, b));
 
     return out;
   }
@@ -2299,25 +2397,25 @@ abstract class ApolloCodeGenerator
 
     if (headIndented) out.write(indent);
 
-    generateASTVariable(
+    // The `obj.field` write target, captured so `??=` can repeat it.
+    var target = generateASTVariable(
       expression.variable,
-      out: out,
       indent: indent,
       headIndented: false,
     );
-    out.write('.');
-    out.write(normalizeIdentifier(expression.name));
+    target.write('.');
+    target.write(normalizeIdentifier(expression.name));
 
-    var op = getASTAssignmentOperatorText(expression.operator);
-    out.write(' ');
-    out.write(op);
-    out.write(' ');
-    generateASTExpression(
+    var targetStr = target.toString();
+    out.write(targetStr);
+
+    var value = generateASTExpression(
       expression.expression,
-      out: out,
       indent: '$indent  ',
       headIndented: false,
-    );
+    ).toString();
+
+    _writeAssignment(out, expression.operator, targetStr, value);
 
     return out;
   }
@@ -2429,7 +2527,18 @@ abstract class ApolloCodeGenerator
     String indent = '',
     bool headIndented = true,
   }) {
-    if (variable is ASTScopeVariable) {
+    if (variable is ASTExpressionVariable) {
+      // A member-access chain wraps each preceding segment as a receiver
+      // "variable"; generating it means generating that expression, not a name.
+      out ??= newOutput();
+      if (headIndented) out.write(indent);
+      return generateASTExpression(
+        variable.expression,
+        out: out,
+        indent: indent,
+        headIndented: false,
+      );
+    } else if (variable is ASTScopeVariable) {
       return generateASTScopeVariable(
         variable,
         callingFunction: callingFunction,

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -724,7 +724,11 @@ class ASTExpressionVariableEntryAccess extends ASTExpression {
             cur = ASTTypeDynamic.instance;
           }
         }
-        return cur;
+        // A null-aware index (`list?[i]`) short-circuits to `null`, so its
+        // static type is the *nullable* element type. Without this a
+        // `var v = xs?[0]` on a `List<int>` would infer plain `int` and reject
+        // the short-circuited `null` at declaration time.
+        return isNullAware ? cur.asNullable() : cur;
       });
 
   @override
@@ -3019,6 +3023,22 @@ class ASTExpressionObjectFunctionInvocation
     return _functionClass!;
   }
 
+  @override
+  FutureOr<ASTType> resolveType(VMContext? context) {
+    if (context == null || !isNullAware) return super.resolveType(context);
+
+    // A null-aware invocation (`obj?.m()`) short-circuits to `null` on a null
+    // receiver, which has no class to resolve the method against. Otherwise the
+    // call can still short-circuit at another site, so its static type is the
+    // nullable form of the method's return type.
+    return _getVariableValue(context).resolveMapped((obj) {
+      if (obj is ASTValueNull) return ASTTypeNull.instance;
+      return super
+          .resolveType(context)
+          .resolveMapped((type) => type.asNullable());
+    });
+  }
+
   /// If [variable] names a whole-module import prefix (`import 'x' as p; ...
   /// p.member(...)`), resolves `member` (a top-level function or a class
   /// constructor) in the imported module. Returns `null` when the receiver is
@@ -3624,19 +3644,31 @@ class ASTExpressionObjectGetterAccess extends ASTExpressionGetterAccess
     }
 
     return _getVariableValue(context).resolveMapped((obj) {
+      // Null-aware access (`obj?.field`) on a `null` receiver evaluates to
+      // `null`, and a `null` receiver has no class to resolve the getter
+      // against — mirror `run` and report `Null` instead of trying (and
+      // throwing `Class not set for type: Null`).
+      if (isNullAware && obj is ASTValueNull) {
+        return ASTTypeNull.instance;
+      }
+
       if (obj is ASTClassInstance) {
         var classContext = obj.createContext(context);
         return obj.getField(classContext, name).resolveMapped((fieldValue) {
           if (fieldValue != null) {
-            return fieldValue.type;
+            return _nullableIf(fieldValue.type);
           }
-          return super.resolveType(context);
+          return super.resolveType(context).resolveMapped(_nullableIf);
         });
       }
 
-      return super.resolveType(context);
+      return super.resolveType(context).resolveMapped(_nullableIf);
     });
   }
+
+  /// A null-aware access can always evaluate to `null`, so its static type is
+  /// the nullable form of the accessed member's type.
+  ASTType _nullableIf(ASTType type) => isNullAware ? type.asNullable() : type;
 
   @override
   FutureOr<ASTType<dynamic>> resolveRuntimeType(
@@ -3653,17 +3685,25 @@ class ASTExpressionObjectGetterAccess extends ASTExpressionGetterAccess
     if (staticFieldType != null) return staticFieldType;
 
     return _getVariableValue(context).resolveMapped((obj) {
+      // See `resolveType`: a short-circuited null-aware access has no receiver
+      // class to resolve against.
+      if (isNullAware && obj is ASTValueNull) {
+        return ASTTypeNull.instance;
+      }
+
       if (obj is ASTClassInstance) {
         var classContext = obj.createContext(context);
         return obj.getField(classContext, name).resolveMapped((fieldValue) {
           if (fieldValue != null) {
-            return fieldValue.type;
+            return _nullableIf(fieldValue.type);
           }
-          return super.resolveRuntimeType(context, node);
+          return super
+              .resolveRuntimeType(context, node)
+              .resolveMapped(_nullableIf);
         });
       }
 
-      return super.resolveRuntimeType(context, node);
+      return super.resolveRuntimeType(context, node).resolveMapped(_nullableIf);
     });
   }
 

--- a/lib/src/ast/apollovm_ast_toplevel.dart
+++ b/lib/src/ast/apollovm_ast_toplevel.dart
@@ -2441,6 +2441,13 @@ abstract class ASTParametersDeclaration<P extends ASTParameterDeclaration> {
   /// Returns true if [param] accepts [type].
   ///
   /// - [exactType]: if true the [param] should be exact to [type].
+  ///
+  /// Passing an argument to a parameter is an *assignment*, so the non-exact
+  /// path uses [ASTType.acceptsAssignment]: a `T?` parameter accepts a `T`
+  /// argument (and `null`), while a `T` parameter still rejects `null`.
+  /// [ASTType.acceptsType] alone would reject `String` for a `String?` slot,
+  /// because [ASTTypeString] compares `nullable` in its `==` (the numeric types
+  /// only appeared to work because [StrictType] ignores it).
   static bool parameterAcceptsType(
     ASTParameterDeclaration? param,
     ASTType? type,
@@ -2452,7 +2459,7 @@ abstract class ASTParametersDeclaration<P extends ASTParameterDeclaration> {
 
     if (exactType) {
       if (param.type != type) return false;
-    } else if (type is! ASTTypeDynamic && !param.type.acceptsType(type)) {
+    } else if (type is! ASTTypeDynamic && !param.type.acceptsAssignment(type)) {
       return false;
     }
 

--- a/lib/src/ast/apollovm_ast_variable.dart
+++ b/lib/src/ast/apollovm_ast_variable.dart
@@ -5,6 +5,7 @@
 import 'package:async_extension/async_extension.dart';
 
 import '../apollovm_base.dart';
+import '../apollovm_parser.dart';
 import 'apollovm_ast_base.dart';
 import 'apollovm_ast_expression.dart';
 import 'apollovm_ast_statement.dart';
@@ -433,4 +434,53 @@ class ASTStaticFieldVariable<T> extends ASTVariable {
   @override
   FutureOr<void> setValue(VMContext context, ASTValue value) =>
       clazz.setStaticFieldValue(context, name, value).resolveMapped((_) {});
+}
+
+/// An [ASTVariable] whose value is produced by evaluating an [ASTExpression].
+///
+/// The object-access nodes ([ASTExpressionObjectGetterAccess],
+/// [ASTExpressionObjectFunctionInvocation], [ASTExpressionVariableEntryAccess])
+/// all take an [ASTVariable] receiver, which restricted a member access to a
+/// *single* identifier: `a.b` parsed, but `a.b.c` and `a.b?.c` did not.
+///
+/// Wrapping the preceding segment of a chain in this variable lets those same
+/// nodes compose, so an access chain of any depth — and any mix of `.`, `?.`
+/// and `!` — reuses the existing runtime, null-aware and code-generation paths
+/// instead of needing a parallel set of expression-receiver nodes.
+class ASTExpressionVariable extends ASTVariable {
+  final ASTExpression expression;
+
+  ASTExpressionVariable(this.expression) : super('<expression>');
+
+  @override
+  Iterable<ASTNode> get children => [expression];
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+    expression.resolveNode(parentNode);
+  }
+
+  @override
+  ASTVariable resolveVariable(VMContext context) => this;
+
+  /// Evaluates the wrapped expression. A receiver expression cannot carry
+  /// control flow (`return`/`break`), so a fresh [ASTRunStatus] is enough.
+  @override
+  FutureOr<ASTValue> getValue(VMContext context) =>
+      expression.run(context, ASTRunStatus());
+
+  @override
+  FutureOr<void> setValue(VMContext context, ASTValue value) {
+    throw UnsupportedSyntaxError(
+      "Can't assign to the result of an expression: $expression",
+    );
+  }
+
+  @override
+  FutureOr<ASTType> resolveType(VMContext? context) =>
+      expression.resolveType(context);
+
+  @override
+  String toString() => '$expression';
 }

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -1312,6 +1312,16 @@ class DartGrammarDefinition extends DartGrammarLexer {
               expressionBitwiseNot() |
               expressionLiteral() |
               expressionGroupFunctionInvocation() |
+              // `(expr).field`, `(expr)?.field`, `(expr).a.b` — a member chain
+              // on a parenthesized receiver.
+              //
+              // Deliberately *after* the group-invocation rule: putting it
+              // first lets it win on parenthesized arithmetic and changes how
+              // the operation chain groups, which breaks round-trip generation.
+              // The cost is that a call followed by a field — `(e).m().field` —
+              // still does not parse, since the invocation rule consumes
+              // `(e).m()` and only chains further calls.
+              expressionGroupMemberChain() |
               expressionGroup() |
               expressionListEmptyLiteral() |
               expressionListLiteral() |
@@ -1319,8 +1329,14 @@ class DartGrammarDefinition extends DartGrammarLexer {
               expressionMapLiteral() |
               expressionVariableDirectOperation() |
               expressionVariableEntryAssignment() |
+              expressionObjectFieldChainAssignment() |
               expressionObjectFieldAssignment() |
               expressionVariableAssigment() |
+              // Multi-segment member access (`a.b.c`, `a.b?.c`, `a.b.m()`).
+              // Placed after the assignment rules so a chained *write* still
+              // reaches them first, and before the single-segment access rules
+              // (it requires two or more segments, so it can't shadow them).
+              expressionMemberChain() |
               expressionFunctionInvocation() |
               expressionObjectEntryFunctionInvocation() |
               expressionVariableEntryAccess() |
@@ -1554,6 +1570,156 @@ class DartGrammarDefinition extends DartGrammarLexer {
             )..namedArguments = named;
           });
 
+  /// One segment of a member-access chain: an optional `!` asserting the
+  /// *preceding* value, the `.` or `?.` accessor, the member name, and — when
+  /// it is a method call — its argument list.
+  Parser<
+    ({
+      bool assertReceiver,
+      bool isNullAware,
+      String name,
+      ({List<ASTExpression> positional, Map<String, ASTExpression>? named})?
+      args,
+    })
+  >
+  memberChainSegment() =>
+      (char('!').optional() &
+              (string('?.') | char('.')) &
+              identifier() &
+              (char('(').trimHidden() &
+                      ref0(callArguments).optional() &
+                      char(')').trimHidden())
+                  .optional())
+          .map((v) {
+            var call = v[3] as List?;
+            return (
+              assertReceiver: v[0] == '!',
+              isNullAware: v[1] == '?.',
+              name: v[2] as String,
+              args: call == null
+                  ? null
+                  : (call[1]
+                            as ({
+                              List<ASTExpression> positional,
+                              Map<String, ASTExpression>? named,
+                            })?) ??
+                        (positional: <ASTExpression>[], named: null),
+            );
+          });
+
+  /// A member-access chain on a parenthesized receiver: `(a).v`, `(a)?.v`,
+  /// `(a.next)?.v`, `(a).b.c`.
+  ///
+  /// The grammar previously accepted only `(expr).method()` (via
+  /// [expressionGroupFunctionInvocation]), so a *field* read off a group — and
+  /// any `?.` after one — failed to parse. Segments fold exactly as in
+  /// [expressionMemberChain].
+  Parser<ASTExpression> expressionGroupMemberChain() =>
+      (ref0(expressionGroup) & ref0(memberChainSegment).plus()).map((v) {
+        var current = v[0] as ASTExpression;
+        var segments = (v[1] as List)
+            .cast<
+              ({
+                bool assertReceiver,
+                bool isNullAware,
+                String name,
+                ({
+                  List<ASTExpression> positional,
+                  Map<String, ASTExpression>? named,
+                })?
+                args,
+              })
+            >();
+
+        for (var seg in segments) {
+          var variable = ASTExpressionVariable(current);
+          var args = seg.args;
+          if (args != null) {
+            current = ASTExpressionObjectFunctionInvocation(
+              variable,
+              seg.name,
+              args.positional,
+              null,
+              seg.isNullAware,
+              seg.assertReceiver,
+            )..namedArguments = args.named;
+          } else {
+            current = ASTExpressionObjectGetterAccess(
+              variable,
+              seg.name,
+              null,
+              seg.isNullAware,
+              seg.assertReceiver,
+            );
+          }
+        }
+
+        return current;
+      });
+
+  /// A member-access chain of **two or more** segments: `a.b.c`, `a.b?.c`,
+  /// `a.b!.c`, `a.b.m()`, `a.b?.m(x)` and any mix of them.
+  ///
+  /// Single-segment accesses keep their own dedicated rules (which also resolve
+  /// enum entries, static fields and import prefixes), so this only takes over
+  /// where nothing matched before — every chain here previously failed to parse.
+  ///
+  /// Each segment is folded onto the previous one, with the accumulated
+  /// expression wrapped as an [ASTExpressionVariable] receiver, so the existing
+  /// object-access nodes provide the runtime, null-aware and code-generation
+  /// behaviour.
+  Parser<ASTExpression> expressionMemberChain() =>
+      (variable() & ref0(memberChainSegment) & ref0(memberChainSegment).plus())
+          .map((v) {
+            var receiver = v[0] as ASTVariable;
+            var segments = [
+              v[1]
+                  as ({
+                    bool assertReceiver,
+                    bool isNullAware,
+                    String name,
+                    ({
+                      List<ASTExpression> positional,
+                      Map<String, ASTExpression>? named,
+                    })?
+                    args,
+                  }),
+              ...(v[2] as List).cast(),
+            ];
+
+            ASTExpression? current;
+
+            for (var seg in segments) {
+              // The head keeps the parsed receiver variable; later segments
+              // wrap the expression built so far.
+              var variable = current == null
+                  ? receiver
+                  : ASTExpressionVariable(current);
+
+              var args = seg.args;
+              if (args != null) {
+                current = ASTExpressionObjectFunctionInvocation(
+                  variable,
+                  seg.name,
+                  args.positional,
+                  null,
+                  seg.isNullAware,
+                  seg.assertReceiver,
+                )..namedArguments = args.named;
+              } else {
+                current = ASTExpressionObjectGetterAccess(
+                  variable,
+                  seg.name,
+                  null,
+                  seg.isNullAware,
+                  seg.assertReceiver,
+                );
+              }
+            }
+
+            return current!;
+          });
+
   Parser<ASTExpressionChainFunctionInvocation>
   expressionChainFunctionInvocation() =>
       (char('.').trimHidden() &
@@ -1720,6 +1886,83 @@ class DartGrammarDefinition extends DartGrammarLexer {
               extra,
             );
           });
+
+  /// `a.b.field = value` — a field write whose receiver is itself a member
+  /// chain (`a.b`, `a.b.c`, `a.b!.c`, …), including `+=`, `??=` etc.
+  ///
+  /// Requires **two or more** segments so the single-segment
+  /// [expressionObjectFieldAssignment] keeps handling `obj.field = value`. The
+  /// leading segments are folded into the receiver exactly as in
+  /// [expressionMemberChain]; the final segment names the field being written,
+  /// so it must be a plain `.name` (not `?.` and not a call).
+  Parser<ASTExpressionObjectSetterAssignment>
+  expressionObjectFieldChainAssignment() =>
+      (variable() &
+              ref0(memberChainSegment) &
+              ref0(memberChainSegment).plus() &
+              assigmentOperator() &
+              ref0(expression))
+          .map((v) {
+            var receiverVar = v[0] as ASTVariable;
+            var segments = [v[1], ...(v[2] as List)]
+                .cast<
+                  ({
+                    bool assertReceiver,
+                    bool isNullAware,
+                    String name,
+                    ({
+                      List<ASTExpression> positional,
+                      Map<String, ASTExpression>? named,
+                    })?
+                    args,
+                  })
+                >();
+
+            var op = v[3] as ASTAssignmentOperator;
+            var valueExpr = v[4] as ASTExpression;
+
+            var last = segments.last;
+            // The write target must be a plain field access.
+            if (last.isNullAware || last.args != null) {
+              return null;
+            }
+
+            ASTExpression? current;
+            for (var seg in segments.take(segments.length - 1)) {
+              var variable = current == null
+                  ? receiverVar
+                  : ASTExpressionVariable(current);
+
+              var args = seg.args;
+              if (args != null) {
+                current = ASTExpressionObjectFunctionInvocation(
+                  variable,
+                  seg.name,
+                  args.positional,
+                  null,
+                  seg.isNullAware,
+                  seg.assertReceiver,
+                )..namedArguments = args.named;
+              } else {
+                current = ASTExpressionObjectGetterAccess(
+                  variable,
+                  seg.name,
+                  null,
+                  seg.isNullAware,
+                  seg.assertReceiver,
+                );
+              }
+            }
+
+            return ASTExpressionObjectSetterAssignment(
+              ASTExpressionVariable(current!),
+              last.name,
+              op,
+              valueExpr,
+            );
+          })
+          .where((v) => v != null)
+          .cast<ASTExpressionObjectSetterAssignment>();
 
   /// `obj.field = value` (and `this.field = value`), including `+=` etc.
   Parser<ASTExpressionObjectSetterAssignment>

--- a/lib/src/languages/go/go_generator.dart
+++ b/lib/src/languages/go/go_generator.dart
@@ -4,6 +4,7 @@
 
 import '../../apollovm_code_generator.dart';
 import '../../apollovm_code_storage.dart';
+import '../../apollovm_parser.dart';
 import '../../ast/apollovm_ast_base.dart';
 import '../../ast/apollovm_ast_expression.dart';
 import '../../ast/apollovm_ast_statement.dart';
@@ -1238,6 +1239,29 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     }
     return getASTExpressionOperatorText(operator);
   }
+
+  /// Go has neither a null-coalescing operator nor a conditional *expression*,
+  /// and this generator maps a nullable `T?` onto a plain Go `T` — which for a
+  /// value type (`int`, `string`, …) cannot be compared to `nil` at all. Any
+  /// rendering would therefore be code that does not compile, so `??` is
+  /// reported as unsupported instead of emitted.
+  ///
+  /// Supporting it properly means representing `T?` as `*T` throughout the Go
+  /// generator (declarations, assignments and dereferences), which is a
+  /// separate piece of work.
+  @override
+  String renderNullCoalesce(String a, String b) {
+    throw UnsupportedSyntaxError(
+      'Go has no null-coalescing operator (`??`) and no conditional '
+      'expression, and a nullable `T?` is generated as a non-nullable Go `T`, '
+      'which cannot be tested against `nil`.',
+    );
+  }
+
+  /// Go has no `??=`; the lowering to `t = t ?? v` still goes through
+  /// [renderNullCoalesce], which reports it as unsupported.
+  @override
+  bool get supportsNullCoalesceAssignment => false;
 
   /// Go writes bitwise NOT as a prefix `^`.
   @override

--- a/lib/src/languages/java/java11/java11_generator.dart
+++ b/lib/src/languages/java/java11/java11_generator.dart
@@ -401,6 +401,16 @@ class ApolloCodeGeneratorJava11 extends ApolloCodeGenerator {
     return getASTExpressionOperatorText(operator);
   }
 
+  /// Java has no null-coalescing operator, so `a ?? b` becomes the equivalent
+  /// ternary. `a` is repeated, which is safe for the variable/field/index reads
+  /// that `??` and `??=` target.
+  @override
+  String renderNullCoalesce(String a, String b) => '($a != null ? $a : $b)';
+
+  /// Java has no `??=`; a null-coalescing assignment becomes `t = (t != null ? t : v)`.
+  @override
+  bool get supportsNullCoalesceAssignment => false;
+
   @override
   StringBuffer generateASTExpressionListLiteral(
     ASTExpressionListLiteral expression, {

--- a/lib/src/languages/kotlin/kotlin_generator.dart
+++ b/lib/src/languages/kotlin/kotlin_generator.dart
@@ -798,6 +798,11 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
     }
   }
 
+  /// Kotlin has the Elvis operator `?:` but no `??=`, so a null-coalescing
+  /// assignment is generated as `t = t ?: v`.
+  @override
+  bool get supportsNullCoalesceAssignment => false;
+
   /// Kotlin writes bitwise-not as `x.inv()` (a method call), not `~x`.
   @override
   StringBuffer generateASTExpressionBitwiseNot(

--- a/lib/src/languages/lua/lua_generator.dart
+++ b/lib/src/languages/lua/lua_generator.dart
@@ -701,6 +701,22 @@ class ApolloCodeGeneratorLua extends ApolloCodeGenerator {
     }
   }
 
+  /// Lua has no null-coalescing operator, and neither `a or b` nor the
+  /// `a ~= nil and a or b` idiom is correct: Lua treats `false` as falsy, so a
+  /// non-nil `false` on the left would wrongly fall through to `b`.
+  ///
+  /// An immediately-invoked function gives the exact semantics — only `nil`
+  /// falls through — and as a bonus binds `a` to a local, so it is evaluated
+  /// once rather than twice like the ternary-based targets.
+  @override
+  String renderNullCoalesce(String a, String b) =>
+      '(function() local __nc = $a if __nc ~= nil then return __nc end '
+      'return $b end)()';
+
+  /// Lua has no `??=`; it becomes `t = (t ~= nil and t or v)`.
+  @override
+  bool get supportsNullCoalesceAssignment => false;
+
   @override
   StringBuffer generateASTExpressionLiteralFunction(
     ASTExpressionLiteralFunction expression, {

--- a/lib/src/languages/python/python_generator.dart
+++ b/lib/src/languages/python/python_generator.dart
@@ -1015,6 +1015,17 @@ class ApolloCodeGeneratorPython extends ApolloCodeGenerator {
     }
   }
 
+  /// Python has no null-coalescing operator, so `a ?? b` becomes a conditional
+  /// expression. It tests `is not None` rather than truthiness, so `0` / `''` /
+  /// `False` are preserved (unlike an `a or b` shortcut).
+  @override
+  String renderNullCoalesce(String a, String b) =>
+      '($a if $a is not None else $b)';
+
+  /// Python has no `??=`; it becomes `t = (t if t is not None else v)`.
+  @override
+  bool get supportsNullCoalesceAssignment => false;
+
   @override
   StringBuffer generateASTExpressionLiteralFunction(
     ASTExpressionLiteralFunction expression, {
@@ -1098,27 +1109,9 @@ class ApolloCodeGeneratorPython extends ApolloCodeGenerator {
     return out;
   }
 
+  /// Python spells integer division `//`, so its assignment form is `//=`.
   @override
-  StringBuffer generateASTExpressionVariableAssignment(
-    ASTExpressionVariableAssignment expression, {
-    StringBuffer? out,
-    String indent = '',
-    bool headIndented = true,
-  }) {
-    out ??= newOutput();
-    if (headIndented) out.write(indent);
-
-    generateASTVariable(expression.variable, out: out, headIndented: false);
-
-    out.write(' ');
-    out.write(_assignmentOperatorText(expression.operator));
-    out.write(' ');
-    generateASTExpression(expression.expression, out: out, headIndented: false);
-
-    return out;
-  }
-
-  String _assignmentOperatorText(ASTAssignmentOperator operator) {
+  String resolveASTAssignmentOperatorText(ASTAssignmentOperator operator) {
     var text = getASTAssignmentOperatorText(operator);
     return text == '~/=' ? '//=' : text;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.16.0
+version: 2.17.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/features/apollovm_null_safety_test.dart
+++ b/test/features/apollovm_null_safety_test.dart
@@ -264,4 +264,244 @@ void main() {
       expect(await _run('int run() { int? a = null; a = 5; return a; }'), 5);
     });
   });
+
+  group('nullable parameters accept a non-null argument', () {
+    // Argument passing is an assignment, so a `T?` parameter must accept a `T`.
+    // `String?` used to be rejected ("parameters signature not compatible")
+    // because `ASTTypeString` compares `nullable` in `==`, while the numeric
+    // types only appeared to work because `StrictType` ignores it.
+    test('String? accepts a String', () async {
+      expect(
+        await _run("String run(String? s) { return s ?? 'x'; }", args: ['hi']),
+        'hi',
+      );
+    });
+
+    test('String? still accepts null', () async {
+      expect(
+        await _run("String run(String? s) { return s ?? 'x'; }", args: [null]),
+        'x',
+      );
+    });
+
+    test('int? / double? / List<int>? accept non-null arguments', () async {
+      expect(await _run('int run(int? a) { return a ?? 1; }', args: [7]), 7);
+      expect(
+        await _run('double run(double? d) { return d ?? 1.5; }', args: [2.5]),
+        2.5,
+      );
+      expect(
+        await _run(
+          'int run(List<int>? xs) { return xs?[0] ?? -1; }',
+          args: [
+            [3, 4],
+          ],
+        ),
+        3,
+      );
+    });
+
+    test('multiple nullable parameters, all non-null', () async {
+      expect(
+        await _run(
+          "String run(String? s, int? p) { return '\$s/\$p'; }",
+          args: ['hi', 9],
+        ),
+        'hi/9',
+      );
+    });
+  });
+
+  group('null-aware access stored in a local', () {
+    // A short-circuited `?.` / `?[` evaluates to null, so the expression's
+    // static type must be nullable — otherwise a `var` / `int?` declaration
+    // rejects that null at declaration time.
+    test('?. getter into `var` and into `int?`', () async {
+      expect(
+        await _run(
+          'int run() { String? s = null; var v = s?.length; return v ?? -1; }',
+        ),
+        -1,
+      );
+      expect(
+        await _run(
+          'int run() { String? s = null; int? v = s?.length; return v ?? -1; }',
+        ),
+        -1,
+      );
+      expect(
+        await _run(
+          "int run() { String? s = 'abcd'; var v = s?.length; return v ?? -1; }",
+        ),
+        4,
+      );
+    });
+
+    test('?. on a user class into a local', () async {
+      expect(
+        await _run(
+          'class A { int x = 5; } '
+          'int run() { A? a = null; var v = a?.x; return v ?? -1; }',
+        ),
+        -1,
+      );
+      expect(
+        await _run(
+          'class A { int x = 5; } '
+          'int run() { A a = A(); var v = a?.x; return v ?? -1; }',
+        ),
+        5,
+      );
+    });
+
+    test('?. method invocation into a local', () async {
+      expect(
+        await _run(
+          "int run() { String? s = null; String? v = s?.toUpperCase(); "
+          'return v == null ? -1 : 0; }',
+        ),
+        -1,
+      );
+    });
+
+    test('?[ index into `var`', () async {
+      expect(
+        await _run(
+          'int run() { List<int>? xs = null; var v = xs?[0]; return v ?? -1; }',
+        ),
+        -1,
+      );
+      expect(
+        await _run(
+          'int run() { List<int>? xs = [7, 8]; var v = xs?[1]; return v ?? -1; }',
+        ),
+        8,
+      );
+    });
+  });
+
+  group('member-access chains', () {
+    const cls =
+        'class C { int v = 3; C? next; void link(C n) { next = n; } '
+        'C mk() { var n = C(); n.v = 9; return n; } } ';
+
+    test('plain chain reads at depth 2 and 3', () async {
+      expect(
+        await _run(
+          '${cls}int run() { var a = C(); var b = C(); b.v = 7; a.link(b); '
+          'return a.next.v; }',
+        ),
+        7,
+      );
+      expect(
+        await _run(
+          '${cls}int run() { var a = C(); var b = C(); var d = C(); d.v = 7; '
+          'b.link(d); a.link(b); return a.next.next.v; }',
+        ),
+        7,
+      );
+    });
+
+    test('null-aware chain short-circuits at the first null link', () async {
+      expect(
+        await _run(
+          '${cls}int run() { var a = C(); return a.next?.next?.v ?? -1; }',
+        ),
+        -1,
+      );
+    });
+
+    test('`this.field.member` chain', () async {
+      expect(
+        await _run(
+          '${cls}class K { C c = C(); int read() { return this.c.v; } } '
+          'int run() { return K().read(); }',
+        ),
+        3,
+      );
+    });
+
+    test('method call inside a chain', () async {
+      expect(
+        await _run('${cls}int run() { var a = C(); return a.mk().v; }'),
+        9,
+      );
+      expect(
+        await _run(
+          '${cls}int run() { var a = C(); var b = C(); a.link(b); '
+          'return a.next.mk().v; }',
+        ),
+        9,
+      );
+    });
+
+    test('`!` inside a chain asserts the preceding link', () async {
+      expect(
+        await _run(
+          '${cls}int run() { var a = C(); var b = C(); a.link(b); '
+          'return a.next!.v; }',
+        ),
+        3,
+      );
+    });
+
+    test('chained field write', () async {
+      expect(
+        await _run(
+          '${cls}int run() { var a = C(); var b = C(); a.link(b); '
+          'a.next.v = 42; return a.next.v; }',
+        ),
+        42,
+      );
+    });
+
+    test('chain in an argument and in arithmetic', () async {
+      expect(
+        await _run(
+          '${cls}int add(int x) { return x + 1; } '
+          'int run() { var a = C(); var b = C(); a.link(b); '
+          'return add(a.next.v) + a.next.v * 2; }',
+        ),
+        10,
+      );
+    });
+
+    test('Dart round-trip keeps the chain', () async {
+      var out = await _regen(
+        '${cls}int run() { var a = C(); return a.next?.v ?? -1; }',
+      );
+      expect(out, contains('a.next?.v'));
+    });
+
+    test('single-segment access is unchanged', () async {
+      expect(await _run('${cls}int run() { var a = C(); return a.v; }'), 3);
+      expect(
+        await _run('${cls}int run() { var a = C(); a.v = 8; return a.v; }'),
+        8,
+      );
+    });
+
+    test('parenthesized receiver: (a).v, (a)?.v, (a.next)?.v', () async {
+      // Only `(expr).method()` used to parse; a *field* read off a group, and
+      // any `?.` after one, did not.
+      expect(await _run('${cls}int run() { var a = C(); return (a).v; }'), 3);
+      expect(
+        await _run('${cls}int run() { var a = C(); return (a)?.v ?? -1; }'),
+        3,
+      );
+      expect(
+        await _run(
+          '${cls}int run() { var a = C(); return (a.next)?.v ?? -1; }',
+        ),
+        -1,
+      );
+      // The existing group-invocation path still works.
+      expect(
+        await _run(
+          '${cls}int run() { var a = C(); var m = (a).mk(); return m.v; }',
+        ),
+        9,
+      );
+    });
+  });
 }

--- a/test/integration/apollovm_null_safety_generation_test.dart
+++ b/test/integration/apollovm_null_safety_generation_test.dart
@@ -18,6 +18,13 @@ const _languages = [
   'lua',
 ];
 
+/// Languages that can express `??` — every target except Go, which has neither
+/// a null-coalescing operator nor a conditional expression, and which maps a
+/// nullable `T?` onto a non-nullable Go `T` that cannot be compared to `nil`.
+/// Go reports `??` as an [UnsupportedSyntaxError] rather than emitting Go that
+/// does not compile.
+final _languagesWithNullCoalesce = _languages.where((l) => l != 'go').toList();
+
 /// A Dart program exercising the full null-safety surface: nullable types,
 /// `??`, `??=`, `?.`, `?.method()`, `?[`, postfix `!` (standalone and before
 /// access) and cascades (`..` / `?..`).
@@ -67,7 +74,7 @@ void main() {
       'every language generates without error and names the class',
       () async {
         var vm = await _load(_source);
-        for (var language in _languages) {
+        for (var language in _languagesWithNullCoalesce) {
           var code = await _generate(vm, language);
           expect(code, isNotEmpty, reason: '$language generated nothing');
           expect(
@@ -78,6 +85,29 @@ void main() {
         }
       },
     );
+
+    test(
+      'Go reports `??` as unsupported instead of emitting broken Go',
+      () async {
+        var vm = await _load(_source);
+        expect(
+          () => _generate(vm, 'go'),
+          throwsA(isA<UnsupportedSyntaxError>()),
+          reason:
+              'Go cannot express `??`, so it must fail loudly rather than emit '
+              'source that does not compile',
+        );
+      },
+    );
+
+    test('Go still generates a program with no null-coalescing', () async {
+      var vm = await _load(
+        'class B { int add(int a, int b) { return a + b; } }',
+      );
+      var go = await _generate(vm, 'go');
+      expect(go, contains('func'));
+      expect(go, isNot(contains('??')));
+    });
 
     test('Dart round-trips every operator exactly', () async {
       var vm = await _load(_source);
@@ -130,6 +160,56 @@ void main() {
       var vm = await _load(_source);
       var csharp = await _generate(vm, 'csharp');
       expect(csharp, contains('a ?? b'));
+    });
+
+    test('no target leaks a literal `??` or `??=` it cannot compile', () async {
+      var vm = await _load(_source);
+      // Targets that genuinely have the operators keep them.
+      const native = {'dart', 'javascript', 'typescript', 'csharp'};
+
+      for (var language in _languagesWithNullCoalesce) {
+        var code = await _generate(vm, language);
+        if (native.contains(language)) continue;
+
+        expect(
+          code,
+          isNot(contains('??')),
+          reason: '$language has no `??`/`??=` and must desugar them',
+        );
+      }
+    });
+
+    test('Java desugars `??` and `??=` into ternaries', () async {
+      var vm = await _load(_source);
+      var java = await _generate(vm, 'java11');
+      expect(java, contains('(a != null ? a : b)'));
+      // `a ??= b` becomes `a = (a != null ? a : b)`.
+      expect(java, contains('a = (a != null ? a : b)'));
+    });
+
+    test(
+      'Python desugars `??` and `??=` into conditional expressions',
+      () async {
+        var vm = await _load(_source);
+        var python = await _generate(vm, 'python');
+        expect(python, contains('(a if a is not None else b)'));
+        expect(python, contains('a = (a if a is not None else b)'));
+      },
+    );
+
+    test('Lua desugars `??` with an explicit nil test (not `or`)', () async {
+      var vm = await _load(_source);
+      var lua = await _generate(vm, 'lua');
+      // `a or b` would be wrong: Lua treats `false` as falsy, so a non-nil
+      // `false` must NOT fall through to `b`.
+      expect(lua, contains('~= nil'));
+      expect(lua, isNot(contains('a or b')));
+    });
+
+    test('Kotlin lowers `??=` to `t = t ?: v` (it has no `??=`)', () async {
+      var vm = await _load(_source);
+      var kotlin = await _generate(vm, 'kotlin');
+      expect(kotlin, contains('a = a ?: b'));
     });
   });
 }


### PR DESCRIPTION
Four gaps found by exercising the 2.16.0 null-safety surface end-to-end, plus one pre-existing parser limitation found alongside them.

## Fixes

**A `T?` parameter now accepts a `T` argument.** Calling a method with a `String?` parameter and a non-null `String` failed with `parameters signature not compatible`, though passing `null` worked. Passing an argument is an assignment, so `ASTFunctionParameters.parameterAcceptsType` now uses `ASTType.acceptsAssignment` instead of `acceptsType`.

Root cause: `ASTTypeString` compares `nullable` in its `==`, so `String?` != `String` and `ASTTypeString.acceptsType` rejected the argument. `int?`/`double?` only *appeared* to work because `StrictType` ignores `nullable`. A non-nullable parameter still rejects `null`.

**A null-aware access now reports a nullable static type.** Storing a short-circuited result in a local failed — `var v = s?.length` on a null receiver threw ``Class not set for type: Null``, and `var v = xs?[0]` threw ``Can't cast initial (null) value to type: int``. `?.` (getter and method) and `?[` now resolve to `T?`, and resolving the type of an access whose receiver is null reports `Null` instead of looking for a class. Using the result in a `return`, inline with `??`, or in a string interpolation already worked and is unchanged.

**Member-access chains parse.** `a.b.c`, `a.b?.c`, `a.b!.c`, `a.b.m()`, `a.b?.m(x)` and chained writes (`a.b.c = v`) previously failed: the grammar accepted only a *single* identifier receiver, so `a.next?.value` reported ``SyntaxError: digit expected`` (the `?` read as the start of a number) and even plain `a.next.value` reported ``"(" expected``.

A new chain rule folds each segment onto the previous one, wrapping it in the new `ASTExpressionVariable` (an `ASTVariable` backed by an expression) so the existing object-access nodes supply the runtime, null-aware and code-generation behaviour — rather than a parallel set of expression-receiver nodes needing per-language generators.

The chain rule requires **two or more** segments, so single-segment access keeps its own rules and enum entries, static fields and import prefixes resolve exactly as before.

**`??` and `??=` no longer leak into targets that cannot compile them.** Java, Lua, Python and Go emitted `a ?? b` verbatim, and `??=` leaked into *every* target — including Kotlin, which had a correct `?:` for `??` but no hook for the assignment form.

`??` now goes through an overridable `renderNullCoalesce`, and `??=` is lowered to `t = t ?? v` wherever `supportsNullCoalesceAssignment` is false, so each target defines only one desugaring:

| Target | `a ?? b` |
|---|---|
| Java | `(a != null ? a : b)` |
| Python | `(a if a is not None else b)` — `is not None`, so `0`/`''`/`False` survive |
| Lua | IIFE with an explicit `nil` test |
| Kotlin | `?:` (and `t = t ?: v` for `??=`) |
| Dart, C#, JS, TS | unchanged — both operators are native |
| Go | `UnsupportedSyntaxError` |

Lua needs the IIFE because both `a or b` and the `a ~= nil and a or b` idiom return `b` for a non-nil `false`. It also binds `a` to a local, so it is evaluated once rather than twice like the ternary targets.

Go is deliberately unsupported: it has neither a null-coalescing operator nor a conditional *expression*, and this generator maps a nullable `T?` onto a plain Go `T`, which for a value type cannot be compared to `nil` — any rendering would be code that does not compile. (Related and pre-existing: Go already emits `var s string = nil` for a nullable local.) Representing `T?` as `*T` throughout the Go generator is separate work.

**Also:** a field read off a parenthesized receiver (`(a).v`, `(a)?.v`) now parses — previously only `(expr).method()` did. Pre-existing, unrelated to null-safety, cheap once the chain machinery existed. `(expr).m().field` remains unsupported: ordering the group-chain rule first makes it win on parenthesized arithmetic and changes how the operation chain groups, which breaks round-trip generation, so the ordering stays conservative (documented in the grammar).

Adds an overridable `resolveASTAssignmentOperatorText`, which lets the Python generator drop its whole `generateASTExpressionVariableAssignment` override (it existed only to spell integer division `//=`).

## Tests

`test/features/apollovm_null_safety_test.dart` previously exercised `?.` only in *return* position on *user classes* — precisely the shape that already worked, which is why these slipped through. New coverage targets the failing shapes directly: nullable parameters with non-null arguments, null-aware results in locals, and member-access chains (depth, mixed operators, chained writes, round-trip, parenthesized receivers).

`test/integration/apollovm_null_safety_generation_test.dart` gains per-target desugaring assertions and a guard that no target leaks a literal `??`/`??=` it cannot compile. Its "every language generates without error" case now excludes Go, which is asserted to throw `UnsupportedSyntaxError` instead — the old contract said "never fail", the new one says "never emit code that does not compile".

**2435 VM tests pass** (up from 2410), plus WasmGC and wasm-chrome in Chrome. `dart analyze` clean, `dart format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)