### PR TITLE
v2.18.0 - Wasm `null` in the boxed-Object domain + two analyzer gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,56 @@
+## 2.18.0
+
+### Wasm: `null` in the boxed-`Object` domain
+
+Compiling a `null` literal to Wasm threw a bare
+`UnimplementedError: generateASTExpressionNullValue` — a leftover `TODO` — so an
+ordinary Dart idiom such as `var a = args.length > 0 ? args[0] : null;` could
+not be compiled at all.
+
+`null` is now a real value in the backend's *boxed* domain: **the boxed-`Object`
+pointer 0**. The heap never allocates at address 0, so it needs no cell, costs no
+allocation, and is distinguishable from every real box.
+
+- **Ternary arms unify.** Both arms of a conditional are now coerced to the
+  block's result type, and an arm that is `null` forces that type to a boxed
+  `Object` — otherwise `c ? 1 : null` mixed an i64 with an i32 and produced a
+  module that failed to validate.
+- **`??` tests a boxed operand.** It previously always yielded its left operand
+  ("a Wasm value is never null"), which remains correct in the *numeric* domain.
+  A boxed operand is now compared against the null box, so `a ?? 99` falls back
+  when `a` is null.
+- **String interpolation prints `null`.** The box-to-string helper checks the
+  null box before dereferencing a tag.
+- **`__alloc` look-ahead.** Boxing allocates, but the alloc export is decided
+  *before* the Code section while the boxing is only discovered while writing
+  it — so `[1, null, 3]` and `a ?? 99` aborted at run time with
+  `No exported Wasm function __alloc`. The generator now scans function bodies
+  for a `null` literal up front.
+- **An `Object?` return decodes to `null`** instead of the raw pointer `0`. Two
+  causes: the return path had no `Object` case, and `_typeTag`'s fallback gave
+  tag `5` to *both* `Object` and a class instance, so the runner could not tell
+  a box from a bare instance pointer. A class instance now carries tag `8`,
+  leaving `5` unambiguously "boxed value".
+
+Where `null` genuinely has no representation — a slot whose Wasm type is
+concrete, such as `int` (i64) or `String` (a string pointer) — the compiler now
+reports an `UnsupportedSyntaxError` naming the type and suggesting `var` /
+`Object?` / `dynamic`, rather than emitting a module that fails to validate.
+
+### Null-safety analyzer: operands and nullable-to-non-nullable assignment
+
+The analyzer checked unconditional *member/method/index* access on a nullable,
+and the `null` *literal* assigned to a non-nullable slot. Two adjacent mistakes
+went unreported:
+
+- **A nullable operand in an operation** (`x + (y ?? 0)` where `x` is `int?`)
+  now reports `unchecked-nullable-operand`. `??`, `==` and `!=` are exempt — a
+  nullable operand is exactly what they exist to handle — and `!` or a preceding
+  null check still suppress it.
+- **A nullable *value* assigned to a non-nullable slot** (`int x = a;` where `a`
+  is `int?`) now reports `nullable-to-non-nullable`. Previously only a literal
+  `null` was caught, so the same error one step removed passed silently.
+
 ## 2.17.0
 
 ### Null-safety fixes: nullable parameters, null-aware typing, access chains

--- a/lib/src/analysis/null_safety_analyzer.dart
+++ b/lib/src/analysis/null_safety_analyzer.dart
@@ -93,13 +93,29 @@ class NullSafetyAnalyzer {
       final value = stmt.value;
       if (value != null) {
         _analyzeExpression(value, scope);
-        if (value is ASTExpressionNullValue && !_isNullableSlot(stmt.type)) {
-          _add(
-            "A value of type 'Null' can't be assigned to the non-nullable "
-            "variable '${stmt.name}' of type '${stmt.type.name}'.",
-            code: 'null-to-non-nullable',
-            snippet: '${stmt.name} = null',
-          );
+        if (!_isNullableSlot(stmt.type)) {
+          if (value is ASTExpressionNullValue) {
+            _add(
+              "A value of type 'Null' can't be assigned to the non-nullable "
+              "variable '${stmt.name}' of type '${stmt.type.name}'.",
+              code: 'null-to-non-nullable',
+              snippet: '${stmt.name} = null',
+            );
+          } else {
+            // A nullable *variable* flowing into a non-nullable slot
+            // (`int x = a;` where `a` is `int?`) is the same error one step
+            // removed, and is only safe behind `!`, `??` or a null check.
+            final name = _nullableVariableRead(value, scope);
+            if (name != null) {
+              _add(
+                "A nullable value ('$name') can't be assigned to the "
+                "non-nullable variable '${stmt.name}' of type "
+                "'${stmt.type.name}'. Use '??', '!' or a null check.",
+                code: 'nullable-to-non-nullable',
+                snippet: '${stmt.name} = $name',
+              );
+            }
+          }
         }
       }
       scope.declare(stmt.name, stmt.type.nullable);
@@ -216,6 +232,8 @@ class NullSafetyAnalyzer {
           snippet: 'null!',
         );
       }
+    } else if (expr is ASTExpressionOperation) {
+      _checkOperationOperands(expr, scope);
     } else if (expr is ASTExpressionVariableAssignment) {
       // A reassignment invalidates promotion for that variable.
       final v = expr.variable;
@@ -250,6 +268,63 @@ class NullSafetyAnalyzer {
       code: 'unchecked-nullable-access',
       snippet: access,
     );
+  }
+
+  /// The name of the variable [expr] reads, when that variable is declared
+  /// nullable and has not been promoted by a preceding null check — i.e. the
+  /// expression can be `null` here. Otherwise `null`.
+  ///
+  /// Only a bare variable read qualifies: `x!` is an [ASTExpressionNullAssertion]
+  /// and `x ?? 0` an [ASTExpressionOperation], so both correctly fall through.
+  String? _nullableVariableRead(ASTExpression expr, _Scope scope) {
+    if (expr is! ASTExpressionVariableAccess) return null;
+
+    final v = expr.variable;
+    if (v is! ASTScopeVariable) return null;
+
+    final name = v.name;
+    if (scope.declaredNullable(name) != true) return null;
+    if (scope.isPromoted(name)) return null;
+
+    return name;
+  }
+
+  /// Reports a nullable operand used in an operation that would dereference it.
+  ///
+  /// `??`, `==` and `!=` are exempt: a nullable operand is exactly what they
+  /// exist to handle.
+  void _checkOperationOperands(ASTExpressionOperation expr, _Scope scope) {
+    final op = expr.operator;
+    if (op == ASTExpressionOperator.nullCoalesce ||
+        op == ASTExpressionOperator.equals ||
+        op == ASTExpressionOperator.notEquals) {
+      return;
+    }
+
+    // The diagnostic range is located by searching the source for the snippet,
+    // so pair the operand with the operator: a bare name like `x` would match
+    // its own declaration line instead of the operation.
+    final opText = getASTExpressionOperatorText(op);
+
+    final left = _nullableVariableRead(expr.expression1, scope);
+    if (left != null) {
+      _add(
+        "The operand '$left' can be 'null', so it can't be used in an "
+        "operation unconditionally. Use '??', '!' or a null check.",
+        code: 'unchecked-nullable-operand',
+        snippet: '$left $opText',
+      );
+    }
+
+    final right = _nullableVariableRead(expr.expression2, scope);
+    if (right != null) {
+      _add(
+        "The operand '$right' can be 'null', so it can't be used in an "
+        "operation unconditionally. Use '??', '!' or a null check.",
+        code: 'unchecked-nullable-operand',
+        snippet: '$opText $right',
+      );
+    }
   }
 
   /// Whether a declared slot [type] accepts `null` without a diagnostic

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.17.0';
+  static final String VERSION = '2.18.0';
 
   static int _idCount = 0;
 

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -127,6 +127,15 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       module.ensureAllocFunction();
     }
 
+    // A `null` literal is a boxed-`Object` pointer, so unifying it with a
+    // concrete value (`c ? 1 : null`, `[1, null, 3]`, `a ?? 99`) boxes that
+    // value — which allocates. `__alloc` has to exist before the Code section
+    // is written, and the boxing is only discovered while writing it, so look
+    // ahead for a `null` in any function body.
+    if (_hasNullLiteral(module)) {
+      module.ensureAllocFunction();
+    }
+
     // Body-first: generate the Code section first so that body codegen can
     // register host imports and string literals on [module]; the Type/Import/
     // Memory/Data sections below then reflect what was discovered.
@@ -426,8 +435,16 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     // A plain `num` (TS/JS `number`) is represented as i64 (int), so tag it as
     // int — NOT as `Object` (5), so the host passes a raw i64, not a box.
     if (t is ASTTypeNum) return 1;
-    return 5;
+    // `Object`/`dynamic` (5) is a *boxed* value the runner must decode. Anything
+    // else reaching here is a class instance, whose value is a bare pointer —
+    // tagged separately (8) so the runner doesn't try to read it as a box.
+    if (_isObjectTypeStatic(t) || t is ASTTypeNull) return 5;
+    return 8;
   }
+
+  /// Static form of `_isObjectType`, for use from [_typeTag].
+  static bool _isObjectTypeStatic(ASTType t) =>
+      t is ASTTypeObject || t is ASTTypeDynamic;
 
   /// Encodes a type as a descriptor for the `apollovm_sig` section. Scalars are
   /// a single tag byte; a list is `[6, <element tag>]` and a map is
@@ -464,6 +481,23 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         // knows to pass a host-allocated box (not a raw scalar).
         if (needs(p.type)) return true;
       }
+    }
+    return false;
+  }
+
+  /// Whether any function body contains a `null` literal.
+  bool _hasNullLiteral(WasmModuleContext module) {
+    bool scan(ASTNode node, int depth) {
+      if (node is ASTExpressionNullValue) return true;
+      if (depth > 64) return false; // depth guard against a cyclic AST
+      for (final child in node.children) {
+        if (scan(child, depth + 1)) return true;
+      }
+      return false;
+    }
+
+    for (var f in module.functions) {
+      if (scan(f, 0)) return true;
     }
     return false;
   }
@@ -2158,12 +2192,24 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   /// [_boxTagInstance]). A concrete class type stays a bare instance pointer.
   bool _isObjectType(ASTType t) => t is ASTTypeObject || t is ASTTypeDynamic;
 
+  /// Whether a slot of type [t] can hold the Wasm `null` (the boxed-`Object`
+  /// pointer 0). `var` counts: its type is inferred from the initializer, which
+  /// for a `null`-bearing expression resolves to a boxed `Object`.
+  bool _acceptsWasmNull(ASTType t) => _isObjectType(t) || t is ASTTypeVar;
+
   // Boxed-`Object` tags (must match `wasm_runner.dart`'s `_boxTag*`).
   static const int _boxTagInt = 1;
   static const int _boxTagDouble = 2;
   static const int _boxTagBool = 3;
   static const int _boxTagString = 4;
   static const int _boxTagInstance = 5;
+
+  /// The boxed-`Object` pointer representing `null`.
+  ///
+  /// The heap never allocates at address 0, so 0 is a free sentinel: `null`
+  /// needs no cell, and any real box compares unequal to it. Must match
+  /// `wasm_runner.dart`'s `_boxPtrNull`.
+  static const int _boxPtrNull = 0;
 
   // Boxed-`Object` cell layout (16 bytes).
   static const int _boxSize = 16;
@@ -3574,22 +3620,44 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       );
     }
 
+    // A `null` arm is the boxed-Object pointer 0, so the whole conditional has
+    // to yield a boxed `Object` — otherwise the other arm's concrete value
+    // (an i64 `int`, say) would disagree with the block's result type and
+    // produce a module that fails to validate.
+    if (expression.valueIfTrue is ASTExpressionNullValue ||
+        expression.valueIfFalse is ASTExpressionNullValue) {
+      resultType = ASTTypeObject.instance;
+    }
+
     out.write(
       Wasm.ifInstruction(resultType.wasmType),
       description: "[OP] conditional (ternary): $expression",
     );
     context.stackDrop(_astTypeInt32);
 
-    // `then` branch value.
+    // `then` branch value, coerced to the block's result type (the two arms can
+    // differ — e.g. `c ? 1 : null` mixes an `int` with a boxed `null`).
     generateASTExpression(expression.valueIfTrue, out: out, context: context);
+    _autoConvertStackTypes(
+      context.stackGet(0)!.type,
+      resultType,
+      out: out,
+      context: context,
+    );
     // The two branches are mutually exclusive: drop the `then` result from the
     // virtual stack before generating the `else` branch.
     context.stackDrop();
 
     out.writeByte(Wasm.elseInstruction, description: "[OP] conditional else");
 
-    // `else` branch value.
+    // `else` branch value, coerced the same way.
     generateASTExpression(expression.valueIfFalse, out: out, context: context);
+    _autoConvertStackTypes(
+      context.stackGet(0)!.type,
+      resultType,
+      out: out,
+      context: context,
+    );
 
     out.writeByte(Wasm.end, description: "[OP] conditional end");
 
@@ -3711,10 +3779,48 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       );
     }
 
-    // Null-coalescing (`a ?? b`): Wasm values are never `null`, so the left
-    // operand always determines the result — compile it and drop the right.
+    // Null-coalescing (`a ?? b`).
     if (expression.operator == ASTExpressionOperator.nullCoalesce) {
-      return generateASTExpression(expression1, out: out, context: context);
+      generateASTExpression(expression1, out: out, context: context);
+      var leftType = context.stackGet(0)!.type;
+
+      // In the numeric domain a value can never be null, so the left operand
+      // always determines the result and the right one is dropped.
+      if (!_isObjectType(leftType)) return out;
+
+      // A boxed value *can* be the null pointer, so test it and fall back to
+      // the right operand. The result is boxed either way.
+      var leftTmp = context.scratchLocal(_astTypeString, 78); // i32 box ptr
+      out.write(
+        Wasm.localSet(leftTmp),
+        description: "[OP] `??`: stash left operand",
+      );
+      context.stackDrop();
+
+      out.write(Wasm.localGet(leftTmp));
+      out.write(Wasm32.i32Const(_boxPtrNull));
+      out.writeByte(Wasm32.i32Equals, description: "[OP] `??`: left is null?");
+      out.write(Wasm.ifInstruction(WasmType.i32Type));
+
+      // then: the left operand is null — evaluate the right one, boxed.
+      generateASTExpression(expression2, out: out, context: context);
+      _autoConvertStackTypes(
+        context.stackGet(0)!.type,
+        ASTTypeObject.instance,
+        out: out,
+        context: context,
+      );
+      context.stackDrop();
+
+      out.writeByte(Wasm.elseInstruction);
+      out.write(
+        Wasm.localGet(leftTmp),
+        description: "[OP] `??`: left operand (non-null)",
+      );
+      out.writeByte(Wasm.end);
+
+      context.stackPush(ASTTypeObject.instance, "`??` result");
+      return out;
     }
 
     final stackLng0 = context.stackLength;
@@ -4242,8 +4348,24 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     BytesOutput? out,
     WasmContext? context,
   }) {
-    // TODO: implement generateASTExpressionNullValue
-    throw UnimplementedError("generateASTExpressionNullValue");
+    out ??= newOutput();
+    context ??= WasmContext();
+
+    // `null` is the boxed-`Object` pointer 0 (see [_boxPtrNull]): the heap never
+    // hands out address 0, so it is distinguishable from every real box, and it
+    // needs no allocation. It types as `Object`, so it unifies with any other
+    // boxed value — e.g. the two arms of `c ? args[0] : null`.
+    //
+    // Wasm has no null in its *numeric* domain, so this only works where the
+    // value stays boxed; a `null` flowing into an `int`/`double` slot still
+    // fails, at the point of that conversion.
+    out.write(
+      Wasm32.i32Const(_boxPtrNull),
+      description: "[OP] null (boxed Object pointer 0)",
+    );
+    context.stackPush(ASTTypeObject.instance, "null");
+
+    return out;
   }
 
   @override
@@ -9146,6 +9268,20 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       return out;
     }
 
+    // `null` exists only in the boxed-`Object` domain (see
+    // [generateASTExpressionNullValue]). A slot with a concrete Wasm
+    // representation — `int` as i64, `double` as f64, `String` as a string
+    // pointer — has no encoding for it, so refuse the declaration explicitly
+    // rather than emit a module that fails to validate.
+    if (value is ASTExpressionNullValue && !_acceptsWasmNull(statement.type)) {
+      throw UnsupportedSyntaxError(
+        "Wasm has no null value for `${statement.type}`: can't compile "
+        "`${statement.type} ${statement.name} = null`. Wasm represents `null` "
+        "only in the boxed-`Object` domain, so declare the variable as `var` / "
+        "`Object?` / `dynamic`, or give it a non-null initial value.",
+      );
+    }
+
     var name = statement.name;
 
     // A capture-free closure assigned to a call-only `var` carries no function
@@ -10148,6 +10284,19 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     );
     var truePtr = module.internStringLiteral('true');
     var falsePtr = module.internStringLiteral('false');
+    var nullPtr = module.internStringLiteral('null');
+
+    // if (box == null) -> "null". Checked first: a null box has no cell, so its
+    // tag must not be dereferenced.
+    out.write(Wasm.localGet(boxLocal));
+    out.write(Wasm32.i32Const(_boxPtrNull));
+    out.writeByte(Wasm32.i32Equals);
+    out.write(Wasm.ifInstruction(WasmType.i32Type));
+    out.write(
+      Wasm32.i32Const(nullPtr),
+      description: "[OP] box null -> \"null\"",
+    );
+    out.writeByte(Wasm.elseInstruction);
 
     // if (tag == int)
     out.write(Wasm.localGet(tagLocal));
@@ -10218,6 +10367,7 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     out.writeByte(Wasm.end); // bool
     out.writeByte(Wasm.end); // double
     out.writeByte(Wasm.end); // int
+    out.writeByte(Wasm.end); // null
 
     context.stackDrop(); // box ptr consumed
     context.stackPush(_astTypeString, "Object box to string");

--- a/lib/src/languages/wasm/wasm_runner.dart
+++ b/lib/src/languages/wasm/wasm_runner.dart
@@ -495,6 +495,18 @@ class ApolloRunnerWasm extends ApolloRunner {
         mapReturn = (keyTag: sigReturn.elemTag, valTag: sigReturn.valTag);
       }
 
+      // `Object`/`dynamic` return: an i32 boxed-`Object` pointer, where 0 is
+      // `null` (see `_readBox`). Without this the caller would see the raw
+      // pointer — notably `0` instead of `null`.
+      // For a module loaded from raw bytes the reconstructed AST return type is
+      // the *Wasm* type (i32), so the signature tag is the only source of truth.
+      // Tag 5 is strictly `Object`/`dynamic`; a class instance carries tag 8.
+      var objectReturn = astFunction?.returnType;
+      var returnsObject =
+          objectReturn is ASTTypeObject ||
+          objectReturn is ASTTypeDynamic ||
+          sigReturn?.tag == _tagObject;
+
       if (returnsString) {
         res = decodeString(res as int);
       } else if (returnsBool && res is! bool) {
@@ -503,6 +515,18 @@ class ApolloRunnerWasm extends ApolloRunner {
         res = decodeList(res as int, listReturn);
       } else if (mapReturn != null) {
         res = decodeMap(res as int, mapReturn.keyTag, mapReturn.valTag);
+      } else if (returnsObject) {
+        var boxPtr = res as int;
+        if (boxPtr == _boxPtrNull) {
+          // The null box needs no cell — and a module that only ever returns
+          // `null` may not even declare a memory.
+          res = null;
+        } else {
+          var mem = loadedModule.readMemory();
+          res = mem == null
+              ? boxPtr
+              : _readBox(ByteData.sublistView(mem), boxPtr, decodeString);
+        }
       }
     }
 
@@ -672,6 +696,10 @@ class ApolloRunnerWasm extends ApolloRunner {
     int boxPtr,
     String Function(int) decodeString,
   ) {
+    // `null` is the box pointer 0 — it has no cell, so return before reading a
+    // tag from address 0.
+    if (boxPtr == _boxPtrNull) return null;
+
     var tag = bd.getInt32(boxPtr + 0, Endian.little);
     switch (tag) {
       case _boxTagInt:
@@ -717,6 +745,10 @@ class ApolloRunnerWasm extends ApolloRunner {
   static const int _boxTagString = 4;
   static const int _boxTagInstance = 5;
   static const int _boxSize = 16;
+
+  /// The boxed-`Object` pointer representing `null`. The heap never allocates
+  /// at address 0. Must match `wasm_generator.dart`'s `_boxPtrNull`.
+  static const int _boxPtrNull = 0;
 
   /// Per-module signature cache, keyed by the wasm binary's identity.
   final Map<Uint8List, ({Map<String, _WasmSig> sigs, Set<String> asyncFns})>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.17.0
+version: 2.18.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/features/apollovm_null_safety_analyzer_test.dart
+++ b/test/features/apollovm_null_safety_analyzer_test.dart
@@ -80,4 +80,102 @@ void main() {
       expect(_codes(f), isNot(contains('unchecked-nullable-access')));
     });
   });
+
+  group('nullable-to-non-nullable', () {
+    test(
+      'flags a nullable variable assigned to a non-nullable local',
+      () async {
+        // The `null` *literal* was already caught; a nullable-typed *value* is
+        // the same error one step removed.
+        var f = await _analyze('void run(int? a) { int x = a; }');
+        expect(_codes(f), contains('nullable-to-non-nullable'));
+      },
+    );
+
+    test('allows it into a nullable / var slot', () async {
+      expect(
+        _codes(await _analyze('void run(int? a) { int? x = a; }')),
+        isNot(contains('nullable-to-non-nullable')),
+      );
+      expect(
+        _codes(await _analyze('void run(int? a) { var x = a; }')),
+        isNot(contains('nullable-to-non-nullable')),
+      );
+    });
+
+    test('a non-nullable source is never flagged', () async {
+      var f = await _analyze('void run(int a) { int x = a; }');
+      expect(_codes(f), isNot(contains('nullable-to-non-nullable')));
+    });
+
+    test('`!` / `??` / a null check suppress it', () async {
+      expect(
+        _codes(await _analyze('void run(int? a) { int x = a!; }')),
+        isNot(contains('nullable-to-non-nullable')),
+      );
+      expect(
+        _codes(await _analyze('void run(int? a) { int x = a ?? 0; }')),
+        isNot(contains('nullable-to-non-nullable')),
+      );
+      expect(
+        _codes(
+          await _analyze('void run(int? a) { if (a != null) { int x = a; } }'),
+        ),
+        isNot(contains('nullable-to-non-nullable')),
+      );
+    });
+  });
+
+  group('unchecked-nullable-operand', () {
+    test('flags a nullable operand in arithmetic', () async {
+      var f = await _analyze(
+        'void run(int? a, int b) { int? x = a; int? y = b; '
+        'var base = x + (y ?? 0); print(base); }',
+      );
+      expect(_codes(f), contains('unchecked-nullable-operand'));
+    });
+
+    test('flags a nullable operand on either side', () async {
+      expect(
+        _codes(await _analyze('void run(int? a) { var v = 1 + a; }')),
+        contains('unchecked-nullable-operand'),
+      );
+    });
+
+    test('`!` suppresses it', () async {
+      var f = await _analyze(
+        'void run(int? a, int b) { int? x = a; int? y = b; '
+        'var base = x! + (y ?? 0); print(base); }',
+      );
+      expect(_codes(f), isNot(contains('unchecked-nullable-operand')));
+    });
+
+    test('`??`, `==` and `!=` accept a nullable operand', () async {
+      // These operators exist precisely to handle a nullable value.
+      expect(
+        _codes(await _analyze('void run(int? a) { var v = a ?? 0; }')),
+        isNot(contains('unchecked-nullable-operand')),
+      );
+      expect(
+        _codes(await _analyze('void run(int? a) { var v = a == null; }')),
+        isNot(contains('unchecked-nullable-operand')),
+      );
+      expect(
+        _codes(await _analyze('void run(int? a) { var v = a != null; }')),
+        isNot(contains('unchecked-nullable-operand')),
+      );
+    });
+
+    test('a null check promotes the variable', () async {
+      var f = await _analyze(
+        'void run(int? a) { if (a != null) { var v = a + 1; } }',
+      );
+      expect(_codes(f), isNot(contains('unchecked-nullable-operand')));
+    });
+
+    test('a non-nullable operand is never flagged', () async {
+      var f = await _analyze('void run(int a, int b) { var v = a + b; }');
+      expect(_codes(f), isNot(contains('unchecked-nullable-operand')));
+    });
+  });
 }

--- a/test/wasm/apollovm_wasm_null_safety_test.dart
+++ b/test/wasm/apollovm_wasm_null_safety_test.dart
@@ -81,13 +81,73 @@ void main() {
       await _compile('class A { int x = 5; } int f(A a) { return a?.x; }');
     });
 
-    test('the null literal remains an unsupported Wasm construct', () async {
-      // Wasm has no `null` value; assigning a null literal is a clean error,
-      // not a silent miscompilation.
+    test('a null literal in a concrete numeric slot is a clean error', () async {
+      // `int` is i64 in Wasm and has no encoding for `null`, so this is an
+      // explicit unsupported-construct error — not a silent miscompilation, and
+      // not a module that fails to validate.
       await expectLater(
         _compile('int f(int b) { int? x = null; return x ?? b; }'),
-        throwsA(anyOf(isA<UnimplementedError>(), isA<UnsupportedError>())),
+        throwsA(isA<UnsupportedSyntaxError>()),
       );
+    });
+
+    test('a null literal in a String slot is a clean error', () async {
+      await expectLater(
+        _compile('int f() { String? s = null; return 0; }'),
+        throwsA(isA<UnsupportedSyntaxError>()),
+      );
+    });
+  });
+
+  // `null` *is* representable in the boxed-`Object` domain: it is the box
+  // pointer 0 (it needs no cell, and the heap never allocates at address 0).
+  group('Wasm null in the boxed-Object domain', () {
+    test('a null literal compiles in a `var` / `Object?` slot', () async {
+      await _compile('int f(int n) { var a = n > 0 ? 1 : null; return 0; }');
+      await _compile('Object? f() { return null; }');
+    });
+
+    test('a `null` arm in a ternary boxes the other arm', () async {
+      // Both arms must agree on the block's result type, so the `int` arm is
+      // boxed rather than left as an i64 (which would not validate).
+      var whenNull = await _compileAndMaybeRun(
+        'Object? f(int n) { return n > 0 ? 1 : null; }',
+        'f',
+        [0],
+      );
+      expect(whenNull, isNull);
+
+      var whenValue = await _compileAndMaybeRun(
+        'Object? f(int n) { return n > 0 ? 1 : null; }',
+        'f',
+        [5],
+      );
+      if (whenValue != null) expect(whenValue, 1);
+    });
+
+    test('`== null` distinguishes the null box from a value', () async {
+      const src =
+          'int f(int n) { Object? a = n > 0 ? 1 : null; '
+          'if (a == null) { return -1; } return 1; }';
+
+      var isNullCase = await _compileAndMaybeRun(src, 'f', [0]);
+      if (isNullCase != null) expect(isNullCase, -1);
+
+      var notNullCase = await _compileAndMaybeRun(src, 'f', [5]);
+      if (notNullCase != null) expect(notNullCase, 1);
+    });
+
+    test('`??` falls back when the boxed left operand is null', () async {
+      // In the *numeric* domain `a ?? b` still yields `a` (a number is never
+      // null); a boxed operand is tested against the null box.
+      const src =
+          'Object? f(int n) { Object? a = n > 0 ? 1 : null; return a ?? 99; }';
+
+      var fellBack = await _compileAndMaybeRun(src, 'f', [0]);
+      if (fellBack != null) expect(fellBack, 99);
+
+      var kept = await _compileAndMaybeRun(src, 'f', [5]);
+      if (kept != null) expect(kept, 1);
     });
   });
 }


### PR DESCRIPTION
Reported: compiling this to Wasm threw `UnimplementedError: generateASTExpressionNullValue`.

```dart
class Foo {
  static void main(List<Object> args) {
    print("ARGS: $args");
    var a = args.length > 0 ? args[0] : null ;
    print("a: $a");
  }
}
```

It was a leftover `// TODO: implement` throwing a bare `UnimplementedError`, so an ordinary Dart idiom could not be compiled at all.

## `null` as a boxed value

Rather than improve the message, `null` is now a real value in the backend's *boxed* domain: **the boxed-`Object` pointer 0**. The heap never allocates at address 0, so it needs no cell, costs no allocation, and is distinguishable from every real box.

Both backends now agree on the reported snippet:

```
[INTERP] args=[x, y] -> ARGS: [x, y] | a: x
[WASM  ] args=[x, y] -> ARGS: [x, y] | a: x
[INTERP] args=[]     -> ARGS: [] | a: null
[WASM  ] args=[]     -> ARGS: [] | a: null
```

Four follow-on pieces were needed:

- **Ternary arms unify.** The reported case only worked because both arms were already boxed. `c ? 1 : null` mixed an i64 with an i32 and produced a module that failed to validate. Both arms are now coerced to the block's result type, and a `null` arm forces that type to a boxed `Object`.
- **`??` tests a boxed operand.** It previously always yielded its left operand ("a Wasm value is never null") — still correct in the *numeric* domain, but wrong once a box can be null. A boxed operand is now compared against the null box, so `a ?? 99` falls back.
- **String interpolation prints `null`**, checking the null box before dereferencing a tag.
- **`__alloc` look-ahead.** Boxing allocates, but the alloc export is decided *before* the Code section while the boxing is only discovered while writing it — so `[1, null, 3]` and `a ?? 99` aborted at run time with `No exported Wasm function __alloc`. The generator now scans function bodies for a `null` literal up front.

Separately, an `Object?` return decoded to `0` instead of `null`. Two causes: the return path had no `Object` case, and `_typeTag`'s fallback gave tag `5` to *both* `Object` and a class instance, so the runner could not tell a box from a bare instance pointer. A class instance now carries tag `8`, leaving `5` unambiguously "boxed value".

### Where `null` still has no representation

A slot whose Wasm type is concrete — `int` (i64), `String` (a string pointer) — cannot hold it. That is now an explicit error instead of an invalid module:

```
[Unsupported Syntax] Wasm has no null value for `int`: can't compile `int x = null`.
Wasm represents `null` only in the boxed-`Object` domain, so declare the variable
as `var` / `Object?` / `dynamic`, or give it a non-null initial value.
```

## Analyzer: two adjacent gaps

Both reported against real snippets. The analyzer checked unconditional *member/method/index* access on a nullable, and the `null` *literal* assigned to a non-nullable slot — but not these:

```dart
void run(int? a, int b) {
  int? x = a;
  int? y = b;
  var base = x + (y ?? 0);   // <- x can be null; was not reported
}

void run(int? a) {
  int x = a;                 // <- int? into int; was not reported
}
```

- `unchecked-nullable-operand` — a nullable operand in an operation. `??`, `==` and `!=` are exempt (a nullable operand is exactly what they handle), and `!` or a preceding null check still suppress it. The diagnostic snippet pairs the operand with its operator so the range lands on the operation, not the declaration.
- `nullable-to-non-nullable` — a nullable *value* assigned to a non-nullable slot, i.e. the existing literal-`null` error one step removed.

## Tests

**+15 tests, 2450 passing** (from 2435), plus Chrome `wasm-gc` and `wasm-chrome`.

- Wasm: `null` in a `var`/`Object?` slot, ternary arm boxing, `Object?` return decoding, `== null`, `??` fallback, and both clean-error cases.
- Analyzer: two new groups covering the reported snippets plus suppression via `!` / `??` / null check, and non-nullable negatives.

The old test named *"the null literal remains an unsupported Wasm construct"* was rewritten — that contract has changed, and it now asserts the narrower "concrete slot is a clean error".

Verified against the downstream playground: 100/100 examples still run on both backends, and all 100 stay clean under the analyzer (no false positives from the new rules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)