### PR TITLE
v2.19.0 - `x == null` no longer throws; Wasm null equality; group chains; Go nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,67 @@
+## 2.19.0
+
+### `x == null` no longer throws
+
+`x == null` — the most common null check in Dart — threw for **any** typed left
+operand:
+
+```dart
+int? a = 1;  if (a == null) { … }
+// _TypeError: type 'Null' is not a subtype of type 'FutureOr<int>' in type cast
+```
+
+No ternary, nullable slot or `?.` was needed; `String s = 'x'; s == null` failed
+the same way. Only the reversed `null == x` worked, because `ASTValueNull.equals`
+type-tests instead of casting.
+
+`ASTValue.equals` read the other operand through `_getValue`, which casts it to
+*this* value's `T`. That is right for arithmetic — a mismatched operand there is
+a real error — but wrong for equality, where a different type must compare
+`false`. Equality now reads both operands uncast, so `x == null` is `false`,
+`x == 'other type'` is `false`, and neither throws. The three `equals` overrides
+(`ASTValueStatic`, `ASTValuePrimitive`, `ASTValueNum`) had the same cast and were
+fixed with it.
+
+This predates the null-safety work — it is in the base `ASTValue` — but 2.16.0
+made `x == null` the idiom people reach for, so it went from obscure to
+prominent.
+
+### Wasm: `== null` / `!= null` against the null box
+
+With `null` representable since 2.18.0, the equality paths had to learn about it.
+A comparison against a `null` literal is now recognised **before** the String and
+numeric paths:
+
+- a **boxed** operand compares its pointer against the null box, so
+  `a[0] == null` on a `List<Object>` answers correctly (it previously took the
+  `__streq` route and compared *contents* against address 0, reporting a non-null
+  String as null);
+- a **concrete** operand (`int`, `double`, `String`, an instance) can never be
+  the null box, so the result is a constant — and, importantly, a *valid* module.
+  `String s; s == null` previously pushed two i32 handles into an `i64.eq` and
+  produced a module that failed to validate.
+
+### Grammar: `(expr).m().field`
+
+A group *invocation* followed by member access did not parse — the
+group-invocation rule chains only further invocations, so a trailing `.field` had
+nothing to match it. A new rule reuses that rule for the head and folds the
+trailing segments. It requires at least one trailing segment, so `(expr).m()`
+keeps its own rule and parenthesized arithmetic is untouched (reordering the
+rules instead changes how the operation chain groups and breaks round-trip
+generation).
+
+### Go: no more `var s string = nil`
+
+The Go generator emitted `var s string = nil` for a nullable local — source that
+does not compile. It now reports an `UnsupportedSyntaxError` naming the type,
+consistent with how `??` is already handled. A `List`/`Map` still accepts `nil`,
+since those become a Go slice/map, which are nilable.
+
+Go's nullable representation remains the open item: supporting `T?` properly
+means generating `*T` throughout — declarations, zero values, every dereference,
+and parameter/return types.
+
 ## 2.18.0
 
 ### Wasm: `null` in the boxed-`Object` domain

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -60,7 +60,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.18.0';
+  static final String VERSION = '2.19.0';
 
   static int _idCount = 0;
 

--- a/lib/src/ast/apollovm_ast_value.dart
+++ b/lib/src/ast/apollovm_ast_value.dart
@@ -179,6 +179,16 @@ abstract class ASTValue<T> with ASTNode implements ASTTypedNode {
       ? v.getValue(context) as FutureOr<T>
       : v.getValueNoContext() as FutureOr<T>;
 
+  /// Reads [v]'s value *without* forcing it into this value's type [T].
+  ///
+  /// [_getValue] casts to `FutureOr<T>`, which is right for arithmetic — where
+  /// a mismatched operand is a real error — but wrong for equality: comparing
+  /// against a different type must be `false`, not a throw. In particular
+  /// `x == null` would evaluate `null as FutureOr<int>` and fail with
+  /// ``type 'Null' is not a subtype of type 'FutureOr<int>'``.
+  FutureOr<Object?> _getValueUncast(VMContext? context, ASTValue v) =>
+      context != null ? v.getValue(context) : v.getValueNoContext();
+
   T? _getValueSafe(VMContext? context, ASTValue v) {
     try {
       var val = _getValue(context, v);
@@ -217,8 +227,8 @@ abstract class ASTValue<T> with ASTNode implements ASTTypedNode {
 
     if (other is ASTValue) {
       var context = VMContext.getCurrent();
-      var v1 = await _getValue(context, this);
-      var v2 = await _getValue(context, other);
+      var v1 = await _getValueUncast(context, this);
+      var v2 = await _getValueUncast(context, other);
       return v1 == v2;
     }
     return false;
@@ -435,7 +445,7 @@ class ASTValueStatic<T> extends ASTValue<T> {
       return value == other.value;
     } else if (other is ASTValue) {
       var context = VMContext.getCurrent();
-      var otherValue = await _getValue(context, other);
+      var otherValue = await _getValueUncast(context, other);
       return value == otherValue;
     }
 
@@ -486,7 +496,7 @@ abstract class ASTValuePrimitive<T> extends ASTValueStatic<T> {
       return value == other.value;
     } else if (other is ASTValue) {
       var context = VMContext.getCurrent();
-      var v2 = await _getValue(context, other);
+      var v2 = await _getValueUncast(context, other);
       return value == v2;
     }
 
@@ -620,7 +630,7 @@ abstract class ASTValueNum<T extends num> extends ASTValuePrimitive<T> {
       return value == other.value;
     } else if (other is ASTValue) {
       var context = VMContext.getCurrent();
-      var v2 = await _getValue(context, other);
+      var v2 = await _getValueUncast(context, other);
       return value == v2;
     }
     return false;

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -1311,6 +1311,9 @@ class DartGrammarDefinition extends DartGrammarLexer {
               expressionNegate() |
               expressionBitwiseNot() |
               expressionLiteral() |
+              // `(expr).m().field` — needs at least one trailing segment, so it
+              // cannot shadow the plain group-invocation rule below.
+              expressionGroupInvocationChain() |
               expressionGroupFunctionInvocation() |
               // `(expr).field`, `(expr)?.field`, `(expr).a.b` — a member chain
               // on a parenthesized receiver.
@@ -1405,6 +1408,59 @@ class DartGrammarDefinition extends DartGrammarLexer {
               args,
               chainFunctions,
             )..namedArguments = named;
+          });
+
+  /// `(expr).m().field` — a group *invocation* followed by further member
+  /// access, which [expressionGroupFunctionInvocation] cannot express (it
+  /// chains only further invocations).
+  ///
+  /// Reuses that rule for the head and folds the trailing segments the same way
+  /// as [expressionMemberChain]. It requires **at least one** trailing segment,
+  /// so `(expr).m()` keeps its own rule and parenthesized arithmetic is
+  /// untouched — the reason this is a separate rule rather than a reordering.
+  Parser<ASTExpression> expressionGroupInvocationChain() =>
+      (ref0(expressionGroupFunctionInvocation) &
+              ref0(memberChainSegment).plus())
+          .map((v) {
+            var current = v[0] as ASTExpression;
+            var segments = (v[1] as List)
+                .cast<
+                  ({
+                    bool assertReceiver,
+                    bool isNullAware,
+                    String name,
+                    ({
+                      List<ASTExpression> positional,
+                      Map<String, ASTExpression>? named,
+                    })?
+                    args,
+                  })
+                >();
+
+            for (var seg in segments) {
+              var variable = ASTExpressionVariable(current);
+              var args = seg.args;
+              if (args != null) {
+                current = ASTExpressionObjectFunctionInvocation(
+                  variable,
+                  seg.name,
+                  args.positional,
+                  null,
+                  seg.isNullAware,
+                  seg.assertReceiver,
+                )..namedArguments = args.named;
+              } else {
+                current = ASTExpressionObjectGetterAccess(
+                  variable,
+                  seg.name,
+                  null,
+                  seg.isNullAware,
+                  seg.assertReceiver,
+                );
+              }
+            }
+
+            return current;
           });
 
   Parser<ASTExpressionFunctionInvocation> expressionFunctionInvocation() =>

--- a/lib/src/languages/go/go_generator.dart
+++ b/lib/src/languages/go/go_generator.dart
@@ -512,6 +512,22 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     final type = statement.type;
     final value = statement.value;
 
+    // This generator maps a nullable `T?` onto a plain Go `T`, and a Go value
+    // type (`int`, `string`, a struct) cannot hold `nil` — `var s string = nil`
+    // does not compile. Report it rather than emit source that does not build.
+    //
+    // Supporting it means representing `T?` as `*T` throughout: declarations,
+    // zero values, every dereference, and parameter/return types. That is
+    // separate work; until then this is an explicit gap, like `??` (see
+    // `renderNullCoalesce`).
+    if (value is ASTExpressionNullValue && !_goAcceptsNil(type)) {
+      throw UnsupportedSyntaxError(
+        "Go can't assign `nil` to `${_goTypeName(type)}`: this generator maps a "
+        "nullable `$type` onto a non-pointer Go type, which has no `nil`. "
+        "Representing `T?` as `*T` is not implemented yet.",
+      );
+    }
+
     if (value != null && type is ASTTypeVar) {
       // Inferred + value: `x := expr`.
       out.write(_goIdent(statement.name));
@@ -1239,6 +1255,22 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     }
     return getASTExpressionOperatorText(operator);
   }
+
+  /// Whether a Go slot of type [t] can hold `nil`.
+  ///
+  /// `var` is inferred (`x := nil` is still refused separately by the compiler,
+  /// but the declaration itself is not the problem), and a List/Map become a Go
+  /// slice/map, which are nilable. Value types — `int`, `string`, `bool`, a
+  /// struct — are not.
+  bool _goAcceptsNil(ASTType t) =>
+      t is ASTTypeVar ||
+      t is ASTTypeDynamic ||
+      t is ASTTypeObject ||
+      t is ASTTypeArray ||
+      t is ASTTypeMap;
+
+  /// A short, readable name for [t] in a diagnostic.
+  String _goTypeName(ASTType t) => t.name;
 
   /// Go has neither a null-coalescing operator nor a conditional *expression*,
   /// and this generator maps a nullable `T?` onto a plain Go `T` — which for a

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -3873,6 +3873,52 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       return out;
     }
 
+    // `x == null` / `x != null`. Checked before the String and numeric paths:
+    // `null` is the boxed-`Object` pointer 0, so neither of those is right —
+    // `__streq` would compare *contents* against address 0, and the numeric
+    // path would push two i32 handles into an `i64.eq` (an invalid module).
+    var isNull1 = expression1 is ASTExpressionNullValue;
+    var isNull2 = expression2 is ASTExpressionNullValue;
+    if ((expression.operator == ASTExpressionOperator.equals ||
+            expression.operator == ASTExpressionOperator.notEquals) &&
+        (isNull1 || isNull2)) {
+      var wantEquals = expression.operator == ASTExpressionOperator.equals;
+      var otherOut = isNull1 ? exp2Out : exp1Out;
+      var otherType = isNull1 ? stackType2 : stackType1;
+
+      context.stackDrop(); // operand 2
+      context.stackDrop(); // operand 1
+
+      if (_isObjectType(otherType)) {
+        // A boxed value: compare the pointer against the null box.
+        out.writeBytes(otherOut);
+        out.write(Wasm32.i32Const(_boxPtrNull));
+        out.writeByte(
+          wantEquals ? Wasm32.i32Equals : Wasm32.i32NotEquals,
+          description: "[OP] boxed `${wantEquals ? '==' : '!='} null`",
+        );
+      } else {
+        // A concrete slot (`int`, `double`, `String`, an instance) has no null
+        // representation in Wasm, so the answer is constant. The operand is
+        // still emitted and dropped, to keep its side effects.
+        out.writeBytes(otherOut);
+        out.writeByte(
+          Wasm.drop,
+          description: "[OP] drop non-null operand of `== null`",
+        );
+        out.write(
+          Wasm32.i32Const(wantEquals ? 0 : 1),
+          description:
+              "[OP] `${wantEquals ? '==' : '!='} null` on a non-nullable "
+              "$otherType is constant",
+        );
+      }
+
+      context.stackPush(_astTypeInt32, "`== null` result");
+      context.assertStackLength(stackLng0 + 1, "After `== null`");
+      return out;
+    }
+
     // String `==` / `!=` -> content equality via the `__streq` helper. Both
     // operands are String handles (i32 pointers); a numeric comparison would
     // test pointer identity (and emit invalid Wasm when the pointers reach an

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.18.0
+version: 2.19.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/features/apollovm_null_safety_test.dart
+++ b/test/features/apollovm_null_safety_test.dart
@@ -495,12 +495,84 @@ void main() {
         ),
         -1,
       );
+      // A call followed by a field access — the group-invocation rule chains
+      // only further calls, so this needs its own rule.
+      expect(
+        await _run('${cls}int run() { var a = C(); return (a).mk().v; }'),
+        9,
+      );
       // The existing group-invocation path still works.
       expect(
         await _run(
           '${cls}int run() { var a = C(); var m = (a).mk(); return m.v; }',
         ),
         9,
+      );
+    });
+  });
+
+  group('`== null` / `!= null` against a typed operand', () {
+    // `ASTValue.equals` used to read the other operand through `_getValue`,
+    // which casts it to *this* value's `T` — so `x == null` evaluated
+    // `null as FutureOr<int>` and threw instead of returning false. Only the
+    // reversed `null == x` worked, because `ASTValueNull.equals` type-tests.
+    test('a non-null typed local compares false against null', () async {
+      expect(
+        await _run(
+          'int run() { int? a = 1; if (a == null) { return -1; } return 1; }',
+        ),
+        1,
+      );
+      expect(
+        await _run(
+          'int run() { Object? a = 1; if (a == null) { return -1; } return 1; }',
+        ),
+        1,
+      );
+      expect(
+        await _run(
+          "int run() { String s = 'x'; if (s == null) { return -1; } return 1; }",
+        ),
+        1,
+      );
+    });
+
+    test('a null local compares true against null', () async {
+      expect(
+        await _run(
+          'int run() { Object? a = null; if (a == null) { return -1; } return 1; }',
+        ),
+        -1,
+      );
+    });
+
+    test('a nullable parameter compares both ways', () async {
+      const src = 'int run(int? a) { if (a == null) { return -1; } return 1; }';
+      expect(await _run(src, args: [1]), 1);
+      expect(await _run(src, args: [null]), -1);
+    });
+
+    test('`!=` mirrors `==`', () async {
+      const src = 'int run(int? a) { if (a != null) { return 1; } return -1; }';
+      expect(await _run(src, args: [1]), 1);
+      expect(await _run(src, args: [null]), -1);
+    });
+
+    test('the reversed form still works', () async {
+      expect(
+        await _run(
+          'int run() { int? a = 1; if (null == a) { return -1; } return 1; }',
+        ),
+        1,
+      );
+    });
+
+    test('comparing different types is false, not an error', () async {
+      expect(
+        await _run(
+          "int run() { int a = 1; if (a == 'x') { return -1; } return 1; }",
+        ),
+        1,
       );
     });
   });

--- a/test/integration/apollovm_null_safety_generation_test.dart
+++ b/test/integration/apollovm_null_safety_generation_test.dart
@@ -179,6 +179,24 @@ void main() {
       }
     });
 
+    test('Go refuses `nil` into a non-pointer slot', () async {
+      // This generator maps `T?` onto a plain Go `T`, which for a value type
+      // cannot hold `nil` — `var s string = nil` does not compile. Reported
+      // rather than emitted, like `??`.
+      var vm = await _load(
+        'class K { int f() { String? s = null; return 0; } }',
+      );
+      expect(() => _generate(vm, 'go'), throwsA(isA<UnsupportedSyntaxError>()));
+    });
+
+    test('Go still allows `nil` into a slice/map (they are nilable)', () async {
+      var vm = await _load(
+        'class K { int f() { List<int>? xs = null; return 0; } }',
+      );
+      var go = await _generate(vm, 'go');
+      expect(go, contains('nil'));
+    });
+
     test('Java desugars `??` and `??=` into ternaries', () async {
       var vm = await _load(_source);
       var java = await _generate(vm, 'java11');

--- a/test/wasm/apollovm_wasm_null_safety_test.dart
+++ b/test/wasm/apollovm_wasm_null_safety_test.dart
@@ -137,6 +137,30 @@ void main() {
       if (notNullCase != null) expect(notNullCase, 1);
     });
 
+    test('`== null` on a boxed String is not a content comparison', () async {
+      // The `__streq` path requires *both* operands to be String; `null` types
+      // as `Object`, so a String-vs-null comparison used to fall through to the
+      // numeric path — comparing contents against address 0, or pushing two i32
+      // handles into an `i64.eq` (an invalid module).
+      const src =
+          'int f(List<Object> a) { var s = a[0]; if (s == null) { return -1; } return 1; }';
+      var r = await _compileAndMaybeRun(src, 'f', [
+        ['x'],
+      ]);
+      if (r != null) expect(r, 1);
+    });
+
+    test('`== null` on a non-nullable String compiles and is false', () async {
+      // A Wasm String handle is never the null box, so the answer is constant —
+      // but it must still be a *valid* module.
+      var r = await _compileAndMaybeRun(
+        'int f(String s) { if (s == null) { return -1; } return 1; }',
+        'f',
+        ['x'],
+      );
+      if (r != null) expect(r, 1);
+    });
+
     test('`??` falls back when the boxed left operand is null', () async {
       // In the *numeric* domain `a ?? b` still yields `a` (a number is never
       // null); a boxed operand is tested against the null box.


### PR DESCRIPTION
Four gaps, explained and fixed. The first is the serious one.

## 1. `x == null` threw for any typed left operand

```dart
int? a = 1;      if (a == null) { … }   // _TypeError: 'Null' is not a subtype of 'FutureOr<int>'
Object? a = 1;   if (a == null) { … }   // same
String s = 'x';  if (s == null) { … }   // 'Null' is not a subtype of 'FutureOr<String>'
```

No ternary, nullable slot or `?.` needed — the most common null check in Dart threw on the interpreter. Only the reversed `null == x` worked.

**Root cause** — `apollovm_ast_value.dart`:

```dart
FutureOr<T> _getValue(VMContext? context, ASTValue v) => context != null
    ? v.getValue(context) as FutureOr<T>      // casts the OTHER operand to *this* value's T
    : v.getValueNoContext() as FutureOr<T>;
```

`ASTValue.equals(other)` called it on `other`, so `ASTValueInt` (`T = int`) evaluated `null as FutureOr<int>`. That predicts the asymmetry exactly: `ASTValueNull.equals` type-tests rather than casting, which is why the reversed form worked.

Equality now reads both operands **uncast**. Comparing different types is `false`, not a throw — so `x == null` and `1 == 'x'` both behave. The three `equals` overrides (`ASTValueStatic`, `ASTValuePrimitive`, `ASTValueNum`) carried the same cast and were fixed with it. Arithmetic still uses the casting read, where a mismatched operand *is* a real error.

This predates the null-safety work — it is in the base `ASTValue` — but 2.16.0 made `x == null` the idiom people reach for. It survived because the tests *compiled* `== null` in flow-promotion cases but never **ran** one against a typed operand.

## 2. Wasm: `== null` against the null box

With `null` representable since 2.18.0, the equality paths had to learn about it. A comparison against a `null` literal is now recognised **before** the String and numeric paths:

- a **boxed** operand compares its pointer against the null box. Previously `a[0] == null` on a `List<Object>` took the `__streq` route and compared *contents* against address 0, reporting a non-null String as null.
- a **concrete** operand (`int`, `double`, `String`, an instance) can never be the null box, so the answer is constant — and, importantly, a *valid* module. `String s; s == null` previously pushed two i32 handles into an `i64.eq`, producing a module that failed to validate.

## 3. Grammar: `(expr).m().field`

A group *invocation* followed by member access did not parse — `expressionGroupFunctionInvocation` chains only further invocations, so a trailing `.field` had nothing to match it.

A new rule reuses that rule for the head and folds the trailing segments. It requires **at least one** trailing segment, so `(expr).m()` keeps its own rule and parenthesized arithmetic is untouched — reordering the rules instead (tried first) changes how the operation chain groups and breaks four round-trip generation tests.

## 4. Go: no more `var s string = nil`

The Go generator emitted `var s string = nil` for a nullable local — source that does not compile, independent of `??`. It now reports an `UnsupportedSyntaxError` naming the type, consistent with how `??` is already handled. A `List`/`Map` still accepts `nil`, since those become a Go slice/map, which are nilable.

**Still open:** Go's nullable *representation*. Supporting `T?` properly means generating `*T` throughout — declarations, zero values, every dereference, and parameter/return types. That is a separate project, and half-doing it (valid declarations, wrong uses) would be worse than the current explicit gap.

## Tests

**+10 tests, 2460 passing** (from 2450), plus Chrome `wasm-gc` and `wasm-chrome`.

- Equality: typed local / `Object?` / `String` / nullable parameter compared both ways, `!=` mirroring `==`, the reversed form, and cross-type comparison being `false` rather than an error.
- Wasm: `== null` on a boxed String, and on a non-nullable String (compiles and is constant).
- Grammar: `(a).mk().v`, alongside the existing group and chain cases.
- Go: refuses `nil` into a value type, still allows it into a slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)