### PR TITLE
v2.23.0 - Expose `nullSafetyChecks` through the CLI and MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,58 @@
+## 2.23.0
+
+### `nullSafetyChecks` is reachable from the CLI and MCP
+
+2.22.0 added `ApolloVM(nullSafetyChecks: true)`, but the only way to turn it on
+was to construct the VM in Dart. It is now exposed at every entry point that
+actually loads code.
+
+**CLI** — `--null-safety` on `run`, `translate` and `compile` (added once on the
+shared `CommandSourceFileBase`, like `--pub`):
+
+```shell
+$ apollovm run --null-safety foo.dart
+** NULL SAFETY: Can't load `foo.dart` (dart): 1 null-safety error(s).
+   - The operand 'b' can be 'null', so it can't be used in an operation
+     unconditionally. Use '??', '!' or a null check.
+$ echo $?
+1
+```
+
+The rejection is printed as a report rather than escaping as an unhandled error
+with a stack trace, and it is not restated as a parse failure. `main` now maps a
+command result of `false` to exit status 1, so a check can gate a build; no
+existing command path returns `false`.
+
+**MCP** — every source tool takes an optional `nullSafety` argument, and
+`--null-safety` on both `apollovm mcp serve` and `apollovm mcp call` sets the
+default (a per-call value always wins). The two tool kinds behave differently,
+by design:
+
+- the tools that **load** — `apollovm.execute`, `apollovm.translate`,
+  `apollovm.wasm` — reject the source, returning the findings as diagnostics
+  rather than throwing;
+- the **parse-based** tools — `apollovm.parse`, `apollovm.ast`,
+  `apollovm.symbols`, `apollovm.types` — never load anything, so a "fail the
+  load" flag would be meaningless. They add the findings to `diagnostics` and
+  still succeed, which is the useful form for inspection.
+
+The server default is merged into the tool arguments at the single dispatch
+point shared by the in-process and isolate paths. That matters: `_IsolateJob`
+carries only the arguments and limits, so a field on the server object would
+never reach a spawned isolate — and `apollovm.execute` runs in one by default.
+It is deliberately *not* stored in `McpLimits`, which is documented as resource
+and security limits.
+
+Adds `mcpCoerceBool` beside `mcpCoerceInt`, so a client sending `"true"` or `1`
+is handled rather than crashing the tool on a hard cast — the same class of bug
+2.16.0 fixed for the integer arguments.
+
+### Not changed
+
+The LSP was checked and deliberately left alone: its `Analyzer` uses its VM only
+for `getParser` and never loads a code unit, and it already reports null-safety
+findings as diagnostics. An editor must report, not refuse to open a file.
+
 ## 2.22.0
 
 ### The null-safety analyzer had never seen a class method

--- a/README.md
+++ b/README.md
@@ -214,6 +214,22 @@ Off by default, so loading is unchanged unless you opt in. Only `error`-severity
 findings block; warnings and info stay diagnostic-only. The thrown error carries
 the offending `findings`.
 
+The same check is reachable without writing Dart:
+
+```shell
+# CLI — `run`, `translate` and `compile`; exits non-zero on a finding.
+apollovm run --null-safety script.dart
+
+# MCP — per call, or as the server default via `apollovm mcp --null-safety`.
+{"name": "apollovm.execute",
+ "arguments": {"language": "dart", "source": "...", "nullSafety": true}}
+```
+
+On the MCP tools that *load* code (`execute`, `translate`, `wasm`) a finding
+rejects the source; on the parse-based tools (`parse`, `ast`, `symbols`,
+`types`) nothing is loaded, so the findings are added to `diagnostics` instead.
+See [doc/MCP.md](doc/MCP.md).
+
 > The `⚠️` cells are targets whose language has no equivalent construct: the
 > access is emitted without its null check (`a?.x` becomes `a.x`, `a!` becomes
 > `a`). The generated source compiles, but a null receiver behaves differently

--- a/bin/apollovm.dart
+++ b/bin/apollovm.dart
@@ -40,7 +40,11 @@ void main(List<String> args) async {
     }
   }
 
-  await commandRunner.run(args);
+  // A command returns `false` only when it rejected the source (today: a
+  // `--null-safety` failure), which must be a non-zero exit so a build/CI step
+  // fails. `run` yields `null` when no command executed (`--help`, usage).
+  var ok = await commandRunner.run(args);
+  if (ok == false) exitCode = 1;
 }
 
 void showVersion() {
@@ -69,6 +73,14 @@ abstract class CommandSourceFileBase extends Command<bool> {
       valueHelp: 'dart|java|kotlin|go|javascript|typescript|lua|python',
     );
     argParser.addFlag(
+      'null-safety',
+      help:
+          'Reject source with null-safety errors while loading it, instead of\n'
+          'failing partway through the run.',
+      defaultsTo: false,
+      negatable: false,
+    );
+    argParser.addFlag(
       'pub',
       help:
           'Resolve Dart `package:` imports through the optional package '
@@ -95,6 +107,35 @@ abstract class CommandSourceFileBase extends Command<bool> {
   String? get pubHost => argResults!['pub-host'] as String?;
 
   String? get pubCache => argResults!['pub-cache'] as String?;
+
+  /// Whether `--null-safety` was passed: the VM then rejects a code unit whose
+  /// AST has null-safety errors while loading it.
+  bool get nullSafetyChecks => argResults!['null-safety'] as bool;
+
+  /// Set when [loadCodeUnitReporting] rejected the source for null-safety
+  /// errors, so the caller reports nothing further (it was already printed, and
+  /// it is not a parse failure).
+  bool nullSafetyRejected = false;
+
+  /// Loads [codeUnit] into [vm], reporting a [NullSafetyError] as a clean
+  /// message instead of letting it escape as an unhandled error with a stack
+  /// trace — `--null-safety` is user-facing, so its failure should read like a
+  /// diagnostic.
+  Future<bool> loadCodeUnitReporting<T extends Object>(
+    ApolloVM vm,
+    CodeUnit<T> codeUnit,
+  ) async {
+    try {
+      return await vm.loadCodeUnit(codeUnit);
+    } on NullSafetyError catch (e) {
+      nullSafetyRejected = true;
+      print('** NULL SAFETY: ${e.message}');
+      for (var f in e.findings) {
+        print('   - ${f.message}');
+      }
+      return false;
+    }
+  }
 
   /// Installs the optional Dart package importer on [vm] and pre-loads all
   /// reachable `package:` imports. No-op unless `--pub` is set (and Dart).
@@ -205,7 +246,7 @@ Examples:
       );
     }
 
-    var vm = ApolloVM();
+    var vm = ApolloVM(nullSafetyChecks: nullSafetyChecks);
 
     // A `.wasm` file is a binary module: load its bytes as a `BinaryCodeUnit`
     // (parsed by `ApolloParserWasm` into its exported functions) and run it
@@ -223,9 +264,12 @@ Examples:
       codeUnit = SourceCodeUnit(language, source, id: sourceFilePath);
     }
 
-    var loadOK = await vm.loadCodeUnit(codeUnit);
+    var loadOK = await loadCodeUnitReporting(vm, codeUnit);
 
     if (!loadOK) {
+      // A null-safety rejection was already reported in full; it is not a parse
+      // failure, so do not restate it as one.
+      if (nullSafetyRejected) return false;
       throw StateError(
         "Can't parse source! language: $language ; sourceFilePath: $sourceFilePath",
       );
@@ -322,13 +366,16 @@ Examples:
       );
     }
 
-    var vm = ApolloVM();
+    var vm = ApolloVM(nullSafetyChecks: nullSafetyChecks);
 
     var codeUnit = SourceCodeUnit(language, source, id: sourceFilePath);
 
-    var loadOK = await vm.loadCodeUnit(codeUnit);
+    var loadOK = await loadCodeUnitReporting(vm, codeUnit);
 
     if (!loadOK) {
+      // A null-safety rejection was already reported in full; it is not a parse
+      // failure, so do not restate it as one.
+      if (nullSafetyRejected) return false;
       throw StateError(
         "Can't parse source! language: $language ; sourceFilePath: $sourceFilePath",
       );
@@ -395,13 +442,16 @@ Examples:
       throw StateError('Unsupported compile target: $target');
     }
 
-    var vm = ApolloVM();
+    var vm = ApolloVM(nullSafetyChecks: nullSafetyChecks);
 
     var codeUnit = SourceCodeUnit(language, source, id: sourceFilePath);
 
-    var loadOK = await vm.loadCodeUnit(codeUnit);
+    var loadOK = await loadCodeUnitReporting(vm, codeUnit);
 
     if (!loadOK) {
+      // A null-safety rejection was already reported in full; it is not a parse
+      // failure, so do not restate it as one.
+      if (nullSafetyRejected) return false;
       throw StateError(
         "Can't parse source! language: $language ; sourceFilePath: $sourceFilePath",
       );

--- a/doc/MCP.md
+++ b/doc/MCP.md
@@ -88,7 +88,10 @@ apollovm mcp doctor               # environment & capability checks
 import 'package:apollovm/apollovm_mcp.dart';
 
 // stdio
-final server = serveStdio(limits: const McpLimits(timeoutMs: 3000));
+final server = serveStdio(
+  limits: const McpLimits(timeoutMs: 3000),
+  nullSafetyChecks: true, // default for the tools' `nullSafety` argument
+);
 await server.done;
 
 // HTTP/SSE
@@ -112,7 +115,7 @@ Supported `language` values: `dart`, `java` (`java11`), `kotlin`, `go` (`golang`
 
 ### apollovm.parse
 
-Input: `{ language, source }`
+Input: `{ language, source, nullSafety? }`
 
 Output:
 ```json
@@ -123,9 +126,24 @@ Output:
 }
 ```
 
+### `nullSafety`
+
+Every source tool accepts an optional `nullSafety` boolean.
+
+- On the tools that **load** code (`apollovm.execute`, `apollovm.translate`,
+  `apollovm.wasm`) a null-safety **error** rejects the source before anything
+  runs, and is returned as a diagnostic (never a throw).
+- On the **parse-based** tools (`apollovm.parse`, `apollovm.ast`,
+  `apollovm.symbols`, `apollovm.types`) nothing is loaded, so the findings are
+  simply added to `diagnostics` — the call still succeeds.
+
+`apollovm mcp --null-safety` sets the server-wide default; a per-call
+`nullSafety` always overrides it. Only error-severity findings reject; warnings
+and info are reported but never fatal.
+
 ### apollovm.execute
 
-Input: `{ language, source, function?, className?, args?, timeoutMs? }`
+Input: `{ language, source, function?, className?, args?, timeoutMs?, nullSafety? }`
 (`function` defaults to `main`; `args` is a positional argument list.)
 
 Output:
@@ -144,13 +162,13 @@ Output:
 
 ### apollovm.translate
 
-Input: `{ from, to, source }`
+Input: `{ from, to, source, nullSafety? }`
 
 Output: `{ "generated": "<source in the target language>", "diagnostics": [] }`
 
 ### apollovm.ast
 
-Input: `{ language, source, maxDepth? }`
+Input: `{ language, source, maxDepth?, nullSafety? }`
 
 Output: `{ "ast": <node> }` where each node is
 `{ "node": "<runtimeType>", ...node-specific fields, "children": [...] }`.
@@ -163,7 +181,7 @@ literal `value`s.
 
 ### apollovm.symbols
 
-Input: `{ language, source }`
+Input: `{ language, source, nullSafety? }`
 
 Output:
 ```json
@@ -179,7 +197,7 @@ Output:
 
 ### apollovm.types
 
-Input: `{ language, source }`
+Input: `{ language, source, nullSafety? }`
 
 Output:
 ```json
@@ -190,7 +208,7 @@ Output:
 
 ### apollovm.wasm
 
-Input: `{ language, source }`
+Input: `{ language, source, nullSafety? }`
 
 Output: `{ "modules": [ { "name": "mcp", "base64": "<wasm bytes>" } ] }`.
 Each module's bytes are base64-encoded and begin with the `\0asm` magic

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -61,7 +61,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.22.0';
+  static final String VERSION = '2.23.0';
 
   static int _idCount = 0;
 

--- a/lib/src/mcp/apollo_mcp_server.dart
+++ b/lib/src/mcp/apollo_mcp_server.dart
@@ -36,9 +36,14 @@ final class ApolloMcpServer extends MCPServer with ToolsSupport {
   /// The workspace/repository runtime, present only when an adapter was given.
   final RepoRuntime? _repo;
 
+  /// Server-wide default for the tools' `nullSafety` argument (the
+  /// `--null-safety` flag). A per-call argument always overrides it.
+  final bool nullSafetyChecks;
+
   ApolloMcpServer(
     super.channel, {
     this.limits = const McpLimits(),
+    this.nullSafetyChecks = false,
     RepositoryAdapter? repository,
     RepoConfig repoConfig = const RepoConfig(),
   }) : _repo = repository == null
@@ -78,7 +83,16 @@ final class ApolloMcpServer extends MCPServer with ToolsSupport {
   }
 
   Future<CallToolResult> _handle(String name, CallToolRequest request) async {
-    final args = request.arguments ?? const <String, Object?>{};
+    final requestArgs = request.arguments ?? const <String, Object?>{};
+
+    // Merge the server default into the args here — this is the one dispatch
+    // point shared by the in-process and isolate paths, and `_IsolateJob`
+    // carries only `args`/`limits`, so a field on the server would not reach a
+    // spawned isolate. Spread last so a per-call value wins.
+    final args = <String, Object?>{
+      if (nullSafetyChecks) 'nullSafety': true,
+      ...requestArgs,
+    };
 
     final Map<String, Object?> result;
     if (limits.runsInIsolate(name)) {

--- a/lib/src/mcp/cli/mcp_command.dart
+++ b/lib/src/mcp/cli/mcp_command.dart
@@ -130,8 +130,19 @@ mixin _WorkspaceOptions on Command<bool> {
         'require-line-match',
         help: 'Require every fs.edit to pin its expected line via `atLine`.',
         negatable: false,
+      )
+      ..addFlag(
+        'null-safety',
+        help:
+            'Default the tools\' `nullSafety` argument to true: loading tools\n'
+            'reject source with null-safety errors, and the parse-based tools\n'
+            'report the findings. A per-call argument still overrides it.',
+        negatable: false,
       );
   }
+
+  /// Server-wide default for the tools' `nullSafety` argument.
+  bool get nullSafetyChecks => argResults!['null-safety'] as bool;
 
   RepoConfig get repoConfig => RepoConfig(
     allowWrite: argResults!['allow-write'] as bool,
@@ -201,6 +212,7 @@ Examples:
 
       final transport = HttpSseTransport(
         limits: limits,
+        nullSafetyChecks: nullSafetyChecks,
         repository: repository,
         repoConfig: repoConfig,
       );
@@ -214,6 +226,7 @@ Examples:
 
     final server = serveStdio(
       limits: limits,
+      nullSafetyChecks: nullSafetyChecks,
       repository: repository,
       repoConfig: repoConfig,
     );
@@ -537,6 +550,10 @@ Examples:
             int.tryParse(argResults!['character'] as String? ?? '') ?? 0;
       }
     }
+
+    // `--null-safety` is the same default the server applies at dispatch: set
+    // it unless the invocation already carried an explicit value.
+    if (nullSafetyChecks) args.putIfAbsent('nullSafety', () => true);
 
     final limits = this.limits;
     final result = limits.runsInIsolate(toolName)

--- a/lib/src/mcp/runtime/apollo_runtime.dart
+++ b/lib/src/mcp/runtime/apollo_runtime.dart
@@ -65,7 +65,11 @@ class ApolloRuntime {
   ///
   /// Uses the parser directly (not `loadCodeUnit`) so a parse failure yields
   /// structured line/column diagnostics instead of a thrown [SyntaxError].
-  Future<ParseOutcome> parse(String language, String source) async {
+  Future<ParseOutcome> parse(
+    String language,
+    String source, {
+    bool nullSafety = false,
+  }) async {
     final tooLarge = _checkSource(source);
     if (tooLarge != null) return (root: null, diagnostics: tooLarge);
 
@@ -81,18 +85,48 @@ class ApolloRuntime {
     final codeUnit = SourceCodeUnit(language, source, id: 'mcp');
     final result = await parser.parse(codeUnit);
     if (result.isOK) {
-      return (root: result.root, diagnostics: const <Diagnostic>[]);
+      // This path never loads, so a null-safety problem cannot *reject* the
+      // source here — it is reported instead, which is the useful form for the
+      // inspection tools (`parse`/`ast`/`symbols`/`types`).
+      return (
+        root: result.root,
+        diagnostics: nullSafety
+            ? _nullSafetyDiagnostics(result.root!)
+            : const <Diagnostic>[],
+      );
     }
     return (root: null, diagnostics: [diagnosticFromParseResult(result)]);
+  }
+
+  /// Null-safety findings for [root] as MCP diagnostics.
+  ///
+  /// Best-effort, like the LSP path: an internal analyzer failure must not turn
+  /// a successful parse into a tool error.
+  List<Diagnostic> _nullSafetyDiagnostics(ASTRoot root) {
+    List<NullSafetyDiagnostic> findings;
+    try {
+      findings = NullSafetyAnalyzer().analyze(root);
+    } catch (_) {
+      return const <Diagnostic>[];
+    }
+    return [
+      for (final f in findings)
+        <String, Object?>{
+          'severity': f.severity.name,
+          'message': f.message,
+          'code': f.code,
+        },
+    ];
   }
 
   /// Loads [source] into a fresh [ApolloVM], returning `(vm, null)` on success
   /// or `(null, diagnostics)` on failure.
   Future<(ApolloVM?, List<Diagnostic>?)> _load(
     String language,
-    String source,
-  ) async {
-    final vm = ApolloVM();
+    String source, {
+    bool nullSafety = false,
+  }) async {
+    final vm = ApolloVM(nullSafetyChecks: nullSafety);
     // Reject unknown languages up front: `loadCodeUnit` throws a `StateError`
     // (rather than returning false) when there is no parser for the language.
     if (vm.getParser<String>(language) == null) {
@@ -105,6 +139,19 @@ class ApolloRuntime {
         return (null, [_err('Unsupported language: $language')]);
       }
       return (vm, null);
+    } on NullSafetyError catch (e) {
+      // A tool must return structured diagnostics, never throw.
+      return (
+        null,
+        [
+          for (final f in e.findings)
+            <String, Object?>{
+              'severity': f.severity.name,
+              'message': f.message,
+              'code': f.code,
+            },
+        ],
+      );
     } on SyntaxError catch (e) {
       return (null, [diagnosticFromError(e)]);
     }
@@ -121,6 +168,7 @@ class ApolloRuntime {
     String? className,
     List<Object?> args = const [],
     int? timeoutMs,
+    bool nullSafety = false,
   }) async {
     final tooLarge = _checkSource(source);
     if (tooLarge != null) {
@@ -133,7 +181,11 @@ class ApolloRuntime {
       );
     }
 
-    final (vm, loadDiagnostics) = await _load(language, source);
+    final (vm, loadDiagnostics) = await _load(
+      language,
+      source,
+      nullSafety: nullSafety,
+    );
     if (vm == null) {
       return (
         result: null,
@@ -310,12 +362,17 @@ class ApolloRuntime {
   Future<TranslateOutcome> translate(
     String from,
     String to,
-    String source,
-  ) async {
+    String source, {
+    bool nullSafety = false,
+  }) async {
     final tooLarge = _checkSource(source);
     if (tooLarge != null) return (generated: null, diagnostics: tooLarge);
 
-    final (vm, loadDiagnostics) = await _load(from, source);
+    final (vm, loadDiagnostics) = await _load(
+      from,
+      source,
+      nullSafety: nullSafety,
+    );
     if (vm == null) return (generated: null, diagnostics: loadDiagnostics!);
 
     try {
@@ -335,11 +392,19 @@ class ApolloRuntime {
 
   /// Compiles [source] to WebAssembly, returning each produced module as
   /// `{name, base64}` (the module bytes, base64-encoded for JSON transport).
-  Future<WasmOutcome> compileWasm(String language, String source) async {
+  Future<WasmOutcome> compileWasm(
+    String language,
+    String source, {
+    bool nullSafety = false,
+  }) async {
     final tooLarge = _checkSource(source);
     if (tooLarge != null) return (modules: null, diagnostics: tooLarge);
 
-    final (vm, loadDiagnostics) = await _load(language, source);
+    final (vm, loadDiagnostics) = await _load(
+      language,
+      source,
+      nullSafety: nullSafety,
+    );
     if (vm == null) return (modules: null, diagnostics: loadDiagnostics!);
 
     try {

--- a/lib/src/mcp/tools/apollo_tools.dart
+++ b/lib/src/mcp/tools/apollo_tools.dart
@@ -57,6 +57,17 @@ Schema get _languageSchema =>
 Schema get _sourceSchema =>
     Schema.string(description: 'The source code to process.');
 
+/// Shared `nullSafety` input. On the tools that *load* code it rejects the
+/// source outright; on the parse-based tools it adds the findings to
+/// `diagnostics`. Defaults to the server's `--null-safety` setting.
+Schema get _nullSafetySchema => Schema.bool(
+  description:
+      'Apply null-safety checks. On tools that load code (execute, translate, '
+      'wasm) a null-safety error rejects the source; on the parse-based tools '
+      'the findings are added to `diagnostics`. '
+      'Defaults to the server `--null-safety` setting.',
+);
+
 /// The [Tool] definitions (name, description, JSON input schema) for all seven
 /// ApolloVM tools. These schemas are the single source of truth advertised via
 /// `tools/list`.
@@ -67,7 +78,11 @@ List<Tool> buildTools() => [
         'Parse source code and return parse diagnostics plus a summary of the '
         'top-level classes, functions and imports.',
     inputSchema: ObjectSchema(
-      properties: {'language': _languageSchema, 'source': _sourceSchema},
+      properties: {
+        'language': _languageSchema,
+        'source': _sourceSchema,
+        'nullSafety': _nullSafetySchema,
+      },
       required: ['language', 'source'],
     ),
   ),
@@ -92,6 +107,7 @@ List<Tool> buildTools() => [
         'timeoutMs': Schema.int(
           description: 'Execution timeout override, in milliseconds.',
         ),
+        'nullSafety': _nullSafetySchema,
       },
       required: ['language', 'source'],
     ),
@@ -108,6 +124,7 @@ List<Tool> buildTools() => [
         ),
         'to': Schema.string(description: 'Target language ($_languageValues).'),
         'source': _sourceSchema,
+        'nullSafety': _nullSafetySchema,
       },
       required: ['from', 'to', 'source'],
     ),
@@ -122,6 +139,7 @@ List<Tool> buildTools() => [
         'maxDepth': Schema.int(
           description: 'Maximum AST tree depth to serialize.',
         ),
+        'nullSafety': _nullSafetySchema,
       },
       required: ['language', 'source'],
     ),
@@ -132,7 +150,11 @@ List<Tool> buildTools() => [
         'Parse source code and return its symbol graph: top-level functions '
         'and classes with their fields, methods and constructors.',
     inputSchema: ObjectSchema(
-      properties: {'language': _languageSchema, 'source': _sourceSchema},
+      properties: {
+        'language': _languageSchema,
+        'source': _sourceSchema,
+        'nullSafety': _nullSafetySchema,
+      },
       required: ['language', 'source'],
     ),
   ),
@@ -142,7 +164,11 @@ List<Tool> buildTools() => [
         'Parse source code and return the deduplicated table of types it '
         'references (classified as class/builtin/unknown).',
     inputSchema: ObjectSchema(
-      properties: {'language': _languageSchema, 'source': _sourceSchema},
+      properties: {
+        'language': _languageSchema,
+        'source': _sourceSchema,
+        'nullSafety': _nullSafetySchema,
+      },
       required: ['language', 'source'],
     ),
   ),
@@ -152,7 +178,11 @@ List<Tool> buildTools() => [
         'Compile source code to WebAssembly and return each produced module '
         'as base64-encoded bytes.',
     inputSchema: ObjectSchema(
-      properties: {'language': _languageSchema, 'source': _sourceSchema},
+      properties: {
+        'language': _languageSchema,
+        'source': _sourceSchema,
+        'nullSafety': _nullSafetySchema,
+      },
       required: ['language', 'source'],
     ),
   ),
@@ -190,6 +220,29 @@ int? mcpCoerceInt(Object? value) {
   return null;
 }
 
+/// Nullable bool, coerced the same defensive way as [_intOrNull].
+bool _boolOr(Map<String, Object?> args, String key, bool defaultValue) =>
+    mcpCoerceBool(args[key]) ?? defaultValue;
+
+/// Coerces an arbitrary decoded-JSON [value] to `bool?` without throwing a
+/// `TypeError`. Some clients send booleans as strings (`"true"`) or as `0`/`1`,
+/// so those are accepted; anything else (or `null`) yields `null`.
+bool? mcpCoerceBool(Object? value) {
+  if (value is bool) return value;
+  if (value is num) return value != 0;
+  if (value is String) {
+    switch (value.trim().toLowerCase()) {
+      case 'true':
+      case '1':
+        return true;
+      case 'false':
+      case '0':
+        return false;
+    }
+  }
+  return null;
+}
+
 /// A list of arbitrary elements; a non-list (or missing) value yields `const []`.
 List<Object?> _listOrEmpty(Map<String, Object?> args, String key) {
   final v = args[key];
@@ -210,9 +263,18 @@ Future<Map<String, Object?>> computeTool(
 
   final rt = ApolloRuntime(limits: limits);
 
+  // The server merges its `--null-safety` default into `args` before dispatch
+  // (see `ApolloMcpServer._handle`), so a per-call value always wins here and
+  // the same read works in-process and inside an isolate.
+  final nullSafety = _boolOr(args, 'nullSafety', false);
+
   switch (name) {
     case parseToolName:
-      final o = await rt.parse(_str(args, 'language'), _str(args, 'source'));
+      final o = await rt.parse(
+        _str(args, 'language'),
+        _str(args, 'source'),
+        nullSafety: nullSafety,
+      );
       final root = o.root;
       return <String, Object?>{
         'ok': root != null,
@@ -228,7 +290,11 @@ Future<Map<String, Object?>> computeTool(
       };
 
     case astToolName:
-      final o = await rt.parse(_str(args, 'language'), _str(args, 'source'));
+      final o = await rt.parse(
+        _str(args, 'language'),
+        _str(args, 'source'),
+        nullSafety: nullSafety,
+      );
       if (o.root == null) {
         return <String, Object?>{'diagnostics': o.diagnostics, 'isError': true};
       }
@@ -236,25 +302,39 @@ Future<Map<String, Object?>> computeTool(
       final depth = math.min(requested, limits.maxAstDepth);
       return <String, Object?>{
         'ast': astNodeToJson(o.root!, maxDepth: depth),
+        if (o.diagnostics.isNotEmpty) 'diagnostics': o.diagnostics,
         'isError': false,
       };
 
     case symbolsToolName:
-      final o = await rt.parse(_str(args, 'language'), _str(args, 'source'));
+      final o = await rt.parse(
+        _str(args, 'language'),
+        _str(args, 'source'),
+        nullSafety: nullSafety,
+      );
       if (o.root == null) {
         return <String, Object?>{'diagnostics': o.diagnostics, 'isError': true};
       }
       return <String, Object?>{
         'symbols': symbolsToJson(o.root!),
+        if (o.diagnostics.isNotEmpty) 'diagnostics': o.diagnostics,
         'isError': false,
       };
 
     case typesToolName:
-      final o = await rt.parse(_str(args, 'language'), _str(args, 'source'));
+      final o = await rt.parse(
+        _str(args, 'language'),
+        _str(args, 'source'),
+        nullSafety: nullSafety,
+      );
       if (o.root == null) {
         return <String, Object?>{'diagnostics': o.diagnostics, 'isError': true};
       }
-      return <String, Object?>{...typesToJson(o.root!), 'isError': false};
+      return <String, Object?>{
+        ...typesToJson(o.root!),
+        if (o.diagnostics.isNotEmpty) 'diagnostics': o.diagnostics,
+        'isError': false,
+      };
 
     case executeToolName:
       final rawArgs = _listOrEmpty(args, 'args');
@@ -265,6 +345,7 @@ Future<Map<String, Object?>> computeTool(
         className: _strOrNull(args, 'className'),
         args: rawArgs,
         timeoutMs: _intOrNull(args, 'timeoutMs'),
+        nullSafety: nullSafety,
       );
       return <String, Object?>{
         'result': o.result,
@@ -280,6 +361,7 @@ Future<Map<String, Object?>> computeTool(
         _str(args, 'from'),
         _str(args, 'to'),
         _str(args, 'source'),
+        nullSafety: nullSafety,
       );
       return <String, Object?>{
         'generated': o.generated,
@@ -291,6 +373,7 @@ Future<Map<String, Object?>> computeTool(
       final o = await rt.compileWasm(
         _str(args, 'language'),
         _str(args, 'source'),
+        nullSafety: nullSafety,
       );
       return <String, Object?>{
         'modules': o.modules,

--- a/lib/src/mcp/transport/http_sse_transport.dart
+++ b/lib/src/mcp/transport/http_sse_transport.dart
@@ -45,6 +45,9 @@ class _Session {
 class HttpSseTransport {
   final McpLimits limits;
 
+  /// Server-wide default for the tools' `nullSafety` argument.
+  final bool nullSafetyChecks;
+
   /// Optional workspace/repository backend shared by all sessions (exposes the
   /// `apollovm.fs.*`/`search.*`/`code.*`/`git.*` tools when set).
   final RepositoryAdapter? repository;
@@ -56,6 +59,7 @@ class HttpSseTransport {
 
   HttpSseTransport({
     this.limits = const McpLimits(),
+    this.nullSafetyChecks = false,
     this.repository,
     this.repoConfig = const RepoConfig(),
   });
@@ -139,6 +143,7 @@ class HttpSseTransport {
     final server = ApolloMcpServer(
       channel,
       limits: limits,
+      nullSafetyChecks: nullSafetyChecks,
       repository: repository,
       repoConfig: repoConfig,
     );

--- a/lib/src/mcp/transport/stdio_transport.dart
+++ b/lib/src/mcp/transport/stdio_transport.dart
@@ -22,6 +22,7 @@ import '../mcp_config.dart';
 /// Returns the running server; await its `done` to know when the peer closes.
 ApolloMcpServer serveStdio({
   McpLimits limits = const McpLimits(),
+  bool nullSafetyChecks = false,
   Stream<List<int>>? input,
   StreamSink<List<int>>? output,
   RepositoryAdapter? repository,
@@ -31,6 +32,7 @@ ApolloMcpServer serveStdio({
   return ApolloMcpServer(
     channel,
     limits: limits,
+    nullSafetyChecks: nullSafetyChecks,
     repository: repository,
     repoConfig: repoConfig,
   );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.22.0
+version: 2.23.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/cli/null_safety_flag_test.dart
+++ b/test/cli/null_safety_flag_test.dart
@@ -1,0 +1,127 @@
+@TestOn('vm')
+@Tags(['dart'])
+library;
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+/// `--null-safety` on the source-file commands, exercised through the real CLI.
+///
+/// `CommandRun`/`CommandTranslate`/`CommandCompile` live in `bin/apollovm.dart`,
+/// which a test cannot import, so these spawn the script. The contract under
+/// test is user-facing anyway: the exit status and the printed report.
+late Directory _tmp;
+
+/// A nullable parameter used in arithmetic — a null-safety error.
+const _bad = r'''
+class Foo {
+  static void main(int a, int? b) {
+    print(a);
+    var c = a + b;
+    print(c);
+  }
+}
+''';
+
+const _clean = r'''
+void main() {
+  int? b = 7;
+  print(b ?? 0);
+}
+''';
+
+File _write(String name, String source) =>
+    File('${_tmp.path}/$name')..writeAsStringSync(source);
+
+Future<ProcessResult> _apollovm(List<String> args) => Process.run('dart', [
+  'run',
+  'bin/apollovm.dart',
+  ...args,
+], workingDirectory: Directory.current.path);
+
+void main() {
+  setUpAll(() {
+    _tmp = Directory.systemTemp.createTempSync('apollovm_cli_ns');
+  });
+
+  tearDownAll(() {
+    if (_tmp.existsSync()) _tmp.deleteSync(recursive: true);
+  });
+
+  group('--null-safety', () {
+    test(
+      'is advertised by the source-file commands',
+      () async {
+        for (final command in const ['run', 'translate', 'compile']) {
+          final r = await _apollovm([command, '--help']);
+          expect(
+            r.stdout.toString(),
+            contains('--null-safety'),
+            reason: '`$command --help` should list the flag',
+          );
+        }
+      },
+      timeout: const Timeout(Duration(minutes: 2)),
+    );
+
+    test(
+      'rejects a null-safety error with a clean report and exit 1',
+      () async {
+        final file = _write('bad.dart', _bad);
+        final r = await _apollovm(['run', '--null-safety', file.path]);
+
+        expect(r.exitCode, 1);
+        final out = '${r.stdout}${r.stderr}';
+        expect(out, contains('NULL SAFETY'));
+        expect(out, contains("The operand 'b' can be 'null'"));
+        // A rejection is not a parse failure, and must not be restated as one.
+        expect(out, isNot(contains("Can't parse source")));
+        // Nothing ran, so nothing was printed by the program.
+        expect(out, isNot(contains('\n5')));
+      },
+      timeout: const Timeout(Duration(minutes: 2)),
+    );
+
+    test(
+      'without the flag, the same source is not rejected',
+      () async {
+        final file = _write('bad2.dart', _bad);
+        final r = await _apollovm(['run', file.path]);
+
+        expect(r.exitCode, isNot(1));
+        expect('${r.stdout}${r.stderr}', isNot(contains('NULL SAFETY')));
+      },
+      timeout: const Timeout(Duration(minutes: 2)),
+    );
+
+    test(
+      'a clean program still runs with the flag on',
+      () async {
+        final file = _write('good.dart', _clean);
+        final r = await _apollovm(['run', '--null-safety', file.path]);
+
+        expect(r.exitCode, 0);
+        expect(r.stdout.toString().trim(), '7');
+      },
+      timeout: const Timeout(Duration(minutes: 2)),
+    );
+
+    test(
+      'translate rejects the source too',
+      () async {
+        final file = _write('bad3.dart', _bad);
+        final r = await _apollovm([
+          'translate',
+          '--null-safety',
+          '--target=java',
+          file.path,
+        ]);
+
+        expect(r.exitCode, 1);
+        expect('${r.stdout}${r.stderr}', contains('NULL SAFETY'));
+      },
+      timeout: const Timeout(Duration(minutes: 2)),
+    );
+  });
+}

--- a/test/mcp/mcp_command_test.dart
+++ b/test/mcp/mcp_command_test.dart
@@ -130,4 +130,29 @@ void main() {
       expect(output, contains('apollovm.wasm'));
     });
   });
+
+  group('mcp call --null-safety', () {
+    // The flag is the same server default the serve path applies; `call` builds
+    // its own args map, so it has to set it explicitly.
+    const bad =
+        'class Foo { static void main(int a, int? b) { var c = a + b; } }';
+
+    test('reports the finding on a parse-based tool', () async {
+      final out = await runMcp([
+        'call',
+        'parse',
+        '-l',
+        'dart',
+        '-s',
+        bad,
+        '--null-safety',
+      ]);
+      expect(out, contains('unchecked-nullable-operand'));
+    });
+
+    test('reports nothing without the flag', () async {
+      final out = await runMcp(['call', 'parse', '-l', 'dart', '-s', bad]);
+      expect(out, isNot(contains('unchecked-nullable-operand')));
+    });
+  });
 }

--- a/test/mcp/null_safety_arg_test.dart
+++ b/test/mcp/null_safety_arg_test.dart
@@ -1,0 +1,239 @@
+@TestOn('vm')
+@Tags(['mcp'])
+library;
+
+import 'package:apollovm/apollovm_mcp.dart';
+// `mcpCoerceBool` is an internal helper (like `mcpCoerceInt`, it is not part of
+// the public MCP surface), so it is reached through its source library.
+import 'package:apollovm/src/mcp/tools/apollo_tools.dart' show mcpCoerceBool;
+import 'package:test/test.dart';
+
+/// A nullable parameter used in arithmetic — a null-safety error inside a class
+/// method, which is what the tools should surface.
+const _bad = r'''
+class Foo {
+  static void main(int a, int? b) {
+    print(a);
+    var c = a + b;
+    print(c);
+  }
+}
+''';
+
+const _clean = r'''
+class Foo {
+  static int main(int a, int? b) {
+    return a + (b ?? 0);
+  }
+}
+''';
+
+const _limits = McpLimits();
+
+List<Map<String, Object?>> _diagnostics(Map<String, Object?> result) =>
+    ((result['diagnostics'] as List?) ?? const []).cast<Map<String, Object?>>();
+
+bool _hasNullSafetyFinding(Map<String, Object?> result) =>
+    _diagnostics(result).any((d) => d['code'] == 'unchecked-nullable-operand');
+
+void main() {
+  group('nullSafety argument — tools that load code', () {
+    test(
+      'execute rejects the source, reporting a diagnostic not a throw',
+      () async {
+        final result = await computeTool('apollovm.execute', {
+          'language': 'dart',
+          'source': _bad,
+          'className': 'Foo',
+          'nullSafety': true,
+        }, _limits);
+
+        expect(result['isError'], isTrue);
+        expect(_hasNullSafetyFinding(result), isTrue);
+        // Rejected at load: nothing ran, so nothing was printed.
+        expect((result['output'] as List?) ?? const [], isEmpty);
+      },
+    );
+
+    test('without the argument, execute behaves as before', () async {
+      final result = await computeTool('apollovm.execute', {
+        'language': 'dart',
+        'source': _bad,
+        'className': 'Foo',
+      }, _limits);
+
+      // It still fails, but at *runtime* — not as a null-safety finding.
+      expect(_hasNullSafetyFinding(result), isFalse);
+    });
+
+    test('translate rejects the source', () async {
+      final result = await computeTool('apollovm.translate', {
+        'from': 'dart',
+        'to': 'java',
+        'source': _bad,
+        'nullSafety': true,
+      }, _limits);
+
+      expect(result['isError'], isTrue);
+      expect(result['generated'], isNull);
+      expect(_hasNullSafetyFinding(result), isTrue);
+    });
+
+    test('wasm rejects the source', () async {
+      final result = await computeTool('apollovm.wasm', {
+        'language': 'dart',
+        'source': _bad,
+        'nullSafety': true,
+      }, _limits);
+
+      expect(result['isError'], isTrue);
+      expect(_hasNullSafetyFinding(result), isTrue);
+    });
+
+    test('a clean source is unaffected', () async {
+      final result = await computeTool('apollovm.execute', {
+        'language': 'dart',
+        'source': _clean,
+        'className': 'Foo',
+        'args': [5, null],
+        'nullSafety': true,
+      }, _limits);
+
+      expect(result['isError'], isFalse);
+      expect(result['result'], 5);
+    });
+  });
+
+  group('nullSafety argument — parse-based tools report, never reject', () {
+    test('parse lists the finding but still succeeds', () async {
+      final result = await computeTool('apollovm.parse', {
+        'language': 'dart',
+        'source': _bad,
+        'nullSafety': true,
+      }, _limits);
+
+      // A report, not a failure: the parse itself was fine.
+      expect(result['isError'], isFalse);
+      expect(result['summary'], isNotNull);
+      expect(_hasNullSafetyFinding(result), isTrue);
+    });
+
+    test('parse without the argument reports nothing', () async {
+      final result = await computeTool('apollovm.parse', {
+        'language': 'dart',
+        'source': _bad,
+      }, _limits);
+
+      expect(result['isError'], isFalse);
+      expect(_diagnostics(result), isEmpty);
+    });
+
+    test('ast / symbols / types carry the findings too', () async {
+      for (final tool in const [
+        'apollovm.ast',
+        'apollovm.symbols',
+        'apollovm.types',
+      ]) {
+        final result = await computeTool(tool, {
+          'language': 'dart',
+          'source': _bad,
+          'nullSafety': true,
+        }, _limits);
+
+        expect(result['isError'], isFalse, reason: tool);
+        expect(_hasNullSafetyFinding(result), isTrue, reason: tool);
+      }
+    });
+  });
+
+  group('argument coercion', () {
+    test('accepts a bool, and the string/number forms a client may send', () {
+      expect(mcpCoerceBool(true), isTrue);
+      expect(mcpCoerceBool(false), isFalse);
+      expect(mcpCoerceBool('true'), isTrue);
+      expect(mcpCoerceBool(' TRUE '), isTrue);
+      expect(mcpCoerceBool('false'), isFalse);
+      expect(mcpCoerceBool(1), isTrue);
+      expect(mcpCoerceBool(0), isFalse);
+    });
+
+    test('a missing or unusable value yields null (never throws)', () {
+      expect(mcpCoerceBool(null), isNull);
+      expect(mcpCoerceBool('yes'), isNull);
+      expect(mcpCoerceBool(<String>[]), isNull);
+    });
+
+    test('a string "true" enables the check end to end', () async {
+      final result = await computeTool('apollovm.parse', {
+        'language': 'dart',
+        'source': _bad,
+        'nullSafety': 'true',
+      }, _limits);
+
+      expect(_hasNullSafetyFinding(result), isTrue);
+    });
+
+    test('a garbage value falls back to off', () async {
+      final result = await computeTool('apollovm.parse', {
+        'language': 'dart',
+        'source': _bad,
+        'nullSafety': 'maybe',
+      }, _limits);
+
+      expect(_diagnostics(result), isEmpty);
+    });
+  });
+
+  group('server default (--null-safety)', () {
+    // The server merges its default into `args` at dispatch, so a per-call
+    // value must still win. That merge is what makes the default reach a
+    // spawned isolate at all.
+    Map<String, Object?> merged(
+      bool serverDefault,
+      Map<String, Object?> call,
+    ) => <String, Object?>{if (serverDefault) 'nullSafety': true, ...call};
+
+    test('the default applies when the call omits the argument', () async {
+      final result = await computeTool(
+        'apollovm.parse',
+        merged(true, {'language': 'dart', 'source': _bad}),
+        _limits,
+      );
+      expect(_hasNullSafetyFinding(result), isTrue);
+    });
+
+    test('a per-call `false` overrides a server default of true', () async {
+      final result = await computeTool(
+        'apollovm.parse',
+        merged(true, {'language': 'dart', 'source': _bad, 'nullSafety': false}),
+        _limits,
+      );
+      expect(_diagnostics(result), isEmpty);
+    });
+
+    test('with the default off, an omitted argument stays off', () async {
+      final result = await computeTool(
+        'apollovm.parse',
+        merged(false, {'language': 'dart', 'source': _bad}),
+        _limits,
+      );
+      expect(_diagnostics(result), isEmpty);
+    });
+  });
+
+  group('isolate path', () {
+    // `apollovm.execute` defaults to isolate execution, and `_IsolateJob`
+    // carries only `args`/`limits` — so the argument must survive the boundary.
+    test('the argument crosses into the spawned isolate', () async {
+      final result = await computeToolIsolated('apollovm.execute', {
+        'language': 'dart',
+        'source': _bad,
+        'className': 'Foo',
+        'nullSafety': true,
+      }, _limits);
+
+      expect(result['isError'], isTrue);
+      expect(_hasNullSafetyFinding(result), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
2.22.0 added `ApolloVM(nullSafetyChecks: true)`, but the only way to turn it on was to construct the VM in Dart. It is now reachable from every entry point that actually loads code.

## Inventory

Every `ApolloVM()` construction site was checked, not just the obvious ones:

| site | loads? | action |
|---|---|---|
| `bin/apollovm.dart` — `run`, `translate`, `compile` | yes | `--null-safety` |
| `mcp/runtime/apollo_runtime.dart` `_load` | yes | `nullSafety` arg |
| `mcp/runtime/apollo_runtime.dart` `parse` | **no** — parser only | *reports* findings |
| `lsp/analysis/analyzer.dart` `Analyzer._vm` | **no** — only `getParser` | **left alone** |

## CLI

`--null-safety` added once on the shared `CommandSourceFileBase`, alongside `--pub`, so all three source commands get it:

```
$ apollovm run --null-safety foo.dart
** NULL SAFETY: Can't load `foo.dart` (dart): 1 null-safety error(s).
   - The operand 'b' can be 'null', so it can't be used in an operation
     unconditionally. Use '??', '!' or a null check.
$ echo $?
1
```

Two details worth calling out:

- The rejection **prints as a report** instead of escaping as an unhandled error with a stack trace, and it is **not restated as a parse failure** — the existing `if (!loadOK) throw StateError("Can't parse source")` would otherwise misreport it.
- `main` now maps a command result of `false` to **exit status 1**, so the flag can gate a build. Verified safe: no existing command path returns `false` — the only `false` returns are the new rejections.

## MCP

Every source tool takes an optional `nullSafety` argument, and `--null-safety` on both `mcp serve` and `mcp call` sets the default (a per-call value always wins).

The two tool kinds behave differently **by design**:

- **Tools that load** — `execute`, `translate`, `wasm` — reject the source, returning the findings as diagnostics rather than throwing (an MCP tool must never throw).
- **Parse-based tools** — `parse`, `ast`, `symbols`, `types` — never call `loadCodeUnit`, so "fail the load" would be meaningless. They add the findings to `diagnostics` and still succeed, which is the useful form for inspection: an LLM can see the problem without executing anything.

```
$ apollovm mcp call parse -f foo.dart -l dart --null-safety
{ "ok": true,
  "diagnostics": [ { "severity": "error",
                     "code": "unchecked-nullable-operand",
                     "message": "The operand 'b' can be 'null' ..." } ], ... }
```

**Where the server default is merged matters.** It goes into the tool arguments at `_handle`, the single dispatch point shared by the in-process and isolate paths — `_IsolateJob` carries only `(toolName, args, limits, replyPort)`, so a field on the server object would never reach a spawned isolate, and `apollovm.execute` runs in one by default. It is deliberately **not** stored in `McpLimits`, which is documented as resource/security limits.

Adds `mcpCoerceBool` beside `mcpCoerceInt`, so a client sending `"true"` or `1` is handled rather than crashing the tool on a hard cast — the same class of bug 2.16.0 fixed for the integer arguments.

## Not changed: the LSP

Its `Analyzer` uses its VM only for `getParser` and never loads a code unit, and it already surfaces null-safety findings as diagnostics. Making it throw would be wrong — an editor must report, not refuse to open a file.

## Tests

**2533 passing** (from 2510), plus Chrome `wasm-gc` and `wasm-chrome`.

- **CLI** (`test/cli/null_safety_flag_test.dart`, new): the flag is advertised by all three commands; a finding gives exit 1 with the report and *without* the "can't parse" message; the same source without the flag is not rejected; a clean program still runs; `translate` rejects too. These spawn the real script, since `bin/` cannot be imported.
- **MCP** (`test/mcp/null_safety_arg_test.dart`, new): all three loading tools reject; a clean source is unaffected; the four parse-based tools report while still succeeding; server-default merge and per-call override; `mcpCoerceBool` across `true`/`"true"`/`" TRUE "`/`1`/`0`/garbage/absent; and the argument surviving the **isolate** boundary.
- `mcp call` coverage added to the existing command test — it builds its own args map, so it needed wiring separately (caught by testing it, after the flag was advertised but inert).

🤖 Generated with [Claude Code](https://claude.com/claude-code)