### PR TITLE
apollovm_wasm 1.1.0 — wasm_run ^0.2.0+1

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -49,8 +49,6 @@ jobs:
         run: dart pub get
       - name: Upgrade dependencies
         run: dart pub upgrade
-      - name: wasm_run:setup (install dynamic library)
-        run: dart run wasm_run:setup
       - name: Run tests (VM)
         # Exclude `wasm-gc` tests: this job uses `wasm_run` (wasmtime 14 /
         # wasmi 0.31), which does not support the WebAssembly GC proposal.
@@ -84,8 +82,6 @@ jobs:
         run: dart pub get
       - name: Upgrade dependencies
         run: dart pub upgrade
-      - name: wasm_run:setup (install dynamic library)
-        run: dart run wasm_run:setup
       - name: Run tests (exe)
         # `wasm_run` backend has no WebAssembly GC support; skip `wasm-gc` tests.
         run: dart test --compiler exe --exclude-tags wasm-gc
@@ -135,9 +131,10 @@ jobs:
         run: dart analyze --fatal-infos --fatal-warnings .
       - name: dart doc
         run: dart doc --dry-run
-      - name: wasm_run:setup (install dynamic library)
-        run: dart run wasm_run:setup
       - name: Run tests (VM)
+        # No `wasm_run:setup` step: since `wasm_run` 0.2 that command is gone and
+        # the SDK's build hooks download the native library (into `.dart_tool/lib/`)
+        # as part of `dart test`.
         # `wasm_run` (wasmtime 14 / wasmi 0.31) has no WebAssembly GC support.
         run: dart test --platform vm --exclude-tags wasm-gc
       - name: dart pub publish --dry-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## 2.23.2
+
+### The native Wasm runtime no longer has an install step
+
+`apollovm_wasm` 1.1.0 moves to `wasm_run` 0.2, which dropped `dart run wasm_run:setup` in favor
+of the SDK's build hooks: the native library is downloaded automatically by `dart run`,
+`dart test` and `dart compile`. `mcp doctor` and the Wasm test suite said otherwise, so they now
+just point at `package:apollovm_wasm`.
+
+Nothing changes for `package:apollovm` itself — it still compiles Wasm everywhere and pulls in no
+native toolchain. See the [`apollovm_wasm` changelog][apollovm_wasm_changelog] for the details,
+including a macOS/Apple-Silicon issue in the upstream 0.2.0 binary.
+
+[apollovm_wasm_changelog]: https://pub.dev/packages/apollovm_wasm/changelog
+
 ## 2.23.1
 
 ### A blank `className`/`function` no longer breaks execution

--- a/WASM_BACKEND_PLAN.md
+++ b/WASM_BACKEND_PLAN.md
@@ -20,10 +20,15 @@ The Wasm backend lives almost entirely in:
 ## How to run / verify
 
 ```bash
-dart run wasm_run:setup            # one-time: install the native wasm_run lib
+# The native `wasm_run` lib needs no install step: its build hook downloads it
+# into `.dart_tool/lib/` when `dart test`/`dart run` executes.
 dart test -t wasm -x wasm-gc -x wasm-chrome    # all Wasm backend tests, native runtime
 dart test test/wasm/apollovm_wasm_maps_test.dart -x wasm-gc   # one file
 ```
+
+- On **macOS arm64** the `wasm_run` 0.2 prebuilt library is SIGKILLed (*Code Signature
+  Invalid*) as soon as wasmtime runs JIT-compiled Wasm under the JIT VM. Use
+  `--compiler exe` there: `dart test --compiler exe -t wasm -x wasm-gc -x wasm-chrome`.
 
 - `wasm-gc` / `wasm-chrome` tags need a browser (WasmGC engine); the native
   `wasm_run` runtime (wasmtime/wasmi) has **no GC**, so exclude those tags when

--- a/apollovm_wasm/CHANGELOG.md
+++ b/apollovm_wasm/CHANGELOG.md
@@ -1,3 +1,33 @@
+## 1.1.0
+
+- `wasm_run: ^0.2.0+1` (was `^0.1.0+2`) — a breaking upgrade, absorbed here so that consumers
+  keep the same `WasmRuntimeIO` API:
+
+  - **No install step.** `dart run wasm_run:setup` is gone; the SDK's build hooks download the
+    native library into `.dart_tool/lib/` during `dart run`/`dart test`/`dart compile`. That
+    directory is now searched first, along with `.dart_tool/wasm_run/` (the
+    `wasm_run:build_binaries` output) — walking up to every enclosing package root, so a nested
+    package finds a library fetched by its workspace.
+  - The bindings moved to `flutter_rust_bridge` 2.x, so the symbol that identifies a genuine
+    `wasm_run` library changed (`wire_compile_wasm` → `frb_get_rust_content_hash`); validating
+    the old one rejected every 0.2 library.
+  - `wasm_run` 0.2 initializes its Rust bindings **asynchronously** and no longer finds its own
+    library in a pure-Dart app. `WasmRunLibrary.setUp()` is now awaited once, lazily, on the
+    first module compile — `ensureBooted()`/`isSupported` stay synchronous, as `WasmRuntime`
+    requires, and only probe for the library.
+  - `WASM_RUN_DART_DYNAMIC_LIBRARY` (the variable `wasm_run` itself reads) now overrides the
+    library path. The older `WASM_RUN_LIB_PATH` is still honored, and is finally read as a
+    *path*: it used to be consulted only on platforms with no known library name, and then
+    joined with candidate directories as if it were a file name.
+
+- Requires Dart >= 3.10 (build hooks), matching `wasm_run` 0.2.
+
+- **Known issue (macOS on Apple Silicon).** The upstream `aarch64-apple-darwin` 0.2.0 library is
+  killed by macOS (`SIGKILL`, *Code Signature Invalid*) when wasmtime executes JIT-compiled Wasm
+  inside the JIT Dart VM, i.e. under `dart run`/`dart test`. Compiling and instantiating modules
+  is fine. Use `dart test --compiler exe` / `dart compile exe` there; other platforms are
+  unaffected. See the README.
+
 ## 1.0.0
 
 - Initial release: the native (Dart VM) `WasmRuntime`, extracted from

--- a/apollovm_wasm/README.md
+++ b/apollovm_wasm/README.md
@@ -46,14 +46,15 @@ Add both packages:
 ```yaml
 dependencies:
   apollovm: ^2.0.0
-  apollovm_wasm: ^1.0.0
+  apollovm_wasm: ^1.1.0
 ```
 
-Install the native library once (it is downloaded, not built):
+The native library is downloaded (never built) by the `wasm_run` build hook, which the SDK runs
+for you on `dart run`, `dart test` and `dart compile` — no install step. It lands in
+`.dart_tool/lib/`, and `WASM_RUN_DART_DYNAMIC_LIBRARY` overrides that path if you ship your own.
 
-```shell
-dart run wasm_run:setup
-```
+> **Requires Dart >= 3.10** (build hooks). Earlier `apollovm_wasm` releases used `wasm_run` 0.1,
+> whose `dart run wasm_run:setup` command no longer exists.
 
 Register the runtime, and `WasmRuntime()` returns an engine that executes:
 
@@ -118,6 +119,20 @@ void main() async {
 
 The `wasm_run` backend (wasmtime 14 / wasmi 0.31) does **not** implement the WebAssembly GC
 proposal. Modules that rely on it run in the browser (Chrome 119+), not on this runtime.
+
+## Known issue: macOS on Apple Silicon, JIT mode
+
+The `wasm_run` 0.2.0 prebuilt `aarch64-apple-darwin` library is killed by macOS
+(`SIGKILL`, *Code Signature Invalid*) the moment wasmtime executes JIT-compiled Wasm inside the
+**JIT** Dart VM — i.e. under `dart run` and `dart test`. Compiling and instantiating modules is
+fine; only the call into generated code trips it.
+
+Ahead-of-time compilation is unaffected (its binaries are not hardened-runtime signed), so on
+macOS arm64 run Wasm through `dart test --compiler exe` / `dart compile exe`. The check is a macOS
+code-signing enforcement, so other platforms are not expected to hit it — Linux is verified in CI.
+Tracked upstream at [wasm_run][wasm_run_issues].
+
+[wasm_run_issues]: https://github.com/juancastillo0/wasm_run/issues
 
 ## See Also
 

--- a/apollovm_wasm/lib/src/wasm_runtime_io.dart
+++ b/apollovm_wasm/lib/src/wasm_runtime_io.dart
@@ -16,6 +16,11 @@ class WasmRuntimeIO extends WasmRuntime {
 
   static Object? _lastBootError;
 
+  /// The dynamic library resolved by [boot], or `null` when `wasm_run` is
+  /// expected to resolve it on its own (already loaded into the process, or
+  /// reachable through its default lookup).
+  static String? _wasmRunLibPath;
+
   static void boot() {
     if (_boot) return;
     _boot = true;
@@ -30,19 +35,36 @@ class WasmRuntimeIO extends WasmRuntime {
     }
   }
 
+  /// Symbol exported by every `flutter_rust_bridge` 2.x library: the cheapest
+  /// way to tell a real `wasm_run` library from a same-named impostor.
+  static const _wasmRunLibrarySymbol = 'frb_get_rust_content_hash';
+
   static bool _bootImpl() {
-    if (wasm_run.WasmRunLibrary.isReachable()) {
-      print('** Loading `wasm_run` dynamic library with default resolver.');
+    // Already in the process (a Flutter plugin, or a statically linked host).
+    if (_processProvidesLibrary()) {
+      _wasmRunLibPath = null;
       return true;
     }
 
     var libPath = _wasmRunLibraryFilePath();
 
     if (libPath == null) {
+      // Last resort: let the OS loader resolve the plain name (system
+      // directories, `LD_LIBRARY_PATH`, next to the executable).
+      var libName = _wasmRunLibraryFileName();
+      if (libName != null && _opensValidLibrary(libName)) {
+        print('** Loading `wasm_run` dynamic library by name: $libName');
+        _wasmRunLibPath = libName;
+        return true;
+      }
+
       throw StateError(
         "Unable to locate the `wasm_run` dynamic library. "
-        "You can specify the library path using the environment variable `WASM_RUN_LIB_PATH`. "
-        "Run `dart run wasm_run:setup` to install `wasm_run` dynamic library.",
+        "It is normally downloaded into `.dart_tool/lib/` by the `wasm_run` "
+        "build hook, which the SDK runs on `dart run`/`dart test`/`dart compile` "
+        "— check that the build hooks ran. You can also point at a library "
+        "explicitly with the environment variable "
+        "`WASM_RUN_DART_DYNAMIC_LIBRARY`.",
       );
     }
 
@@ -50,12 +72,29 @@ class WasmRuntimeIO extends WasmRuntime {
 
     var dynLib = DynamicLibrary.open(libPath);
 
-    var ok = dynLib.providesSymbol('wire_compile_wasm');
+    var ok = dynLib.providesSymbol(_wasmRunLibrarySymbol);
     if (!ok) {
       throw StateError("Invalid `wasm_run` dynamic library: $libPath");
     }
 
+    _wasmRunLibPath = libPath;
     return true;
+  }
+
+  static bool _processProvidesLibrary() {
+    try {
+      return DynamicLibrary.process().providesSymbol(_wasmRunLibrarySymbol);
+    } catch (_) {
+      return false;
+    }
+  }
+
+  static bool _opensValidLibrary(String path) {
+    try {
+      return DynamicLibrary.open(path).providesSymbol(_wasmRunLibrarySymbol);
+    } catch (_) {
+      return false;
+    }
   }
 
   WasmRuntimeIO() : super.base();
@@ -80,6 +119,38 @@ class WasmRuntimeIO extends WasmRuntime {
       print(s);
     }
     return _wasmRunDynLibLoaded;
+  }
+
+  /// `wasm_run` 0.2 initializes its Rust bindings asynchronously, so the
+  /// library can only be wired up from an `async` entry point — [boot] alone
+  /// (which must stay synchronous, per [WasmRuntime.ensureBooted]) is not
+  /// enough. Kept as a single future so concurrent loads share one setup.
+  static Future<void>? _librarySetUp;
+
+  static Future<void> _ensureLibrarySetUp() =>
+      _librarySetUp ??= _setUpLibraryImpl();
+
+  static Future<void> _setUpLibraryImpl() async {
+    boot();
+
+    if (!_wasmRunDynLibLoaded) {
+      throw StateError(
+        "Can't set up the `wasm_run` library: ${_lastBootError ?? 'unknown error'}",
+      );
+    }
+
+    // Already configured (by the host application), or reachable through
+    // `wasm_run`'s own lookup: let it use that. Calling `setUp` with an
+    // explicit library after it was configured throws.
+    if (await wasm_run.WasmRunLibrary.isReachable()) {
+      await wasm_run.WasmRunLibrary.setUp();
+      return;
+    }
+
+    var libPath = _wasmRunLibPath;
+    await wasm_run.WasmRunLibrary.setUp(
+      lib: libPath != null ? wasm_run.ExternalLibrary.open(libPath) : null,
+    );
   }
 
   @override
@@ -150,8 +221,10 @@ class WasmRuntimeIO extends WasmRuntime {
     return module;
   }
 
-  Future<wasm_run.WasmModule> _compileModuleImpl(Uint8List wasmModuleBinary) {
-    boot();
+  Future<wasm_run.WasmModule> _compileModuleImpl(
+    Uint8List wasmModuleBinary,
+  ) async {
+    await _ensureLibrarySetUp();
     return wasm_run.compileWasmModule(wasmModuleBinary);
   }
 
@@ -213,23 +286,40 @@ class WasmModuleIO extends WasmModule {
 }
 
 String? _wasmRunLibraryFileName() {
-  if (Platform.isMacOS) {
+  if (Platform.isMacOS || Platform.isIOS) {
     return 'libwasm_run_dart.dylib';
   } else if (Platform.isWindows) {
     return 'wasm_run_dart.dll';
-  } else if (Platform.isLinux) {
+  } else if (Platform.isLinux || Platform.isAndroid) {
     return 'libwasm_run_dart.so';
   }
   return null;
 }
 
+/// The environment variable `wasm_run` itself reads to override the library
+/// path. `WASM_RUN_LIB_PATH` is the older ApolloVM-specific name, still
+/// honored.
+const _libPathEnvVars = ['WASM_RUN_DART_DYNAMIC_LIBRARY', 'WASM_RUN_LIB_PATH'];
+
 String? _wasmRunLibraryFilePath() {
-  var libName =
-      _wasmRunLibraryFileName() ?? Platform.environment['WASM_RUN_LIB_PATH'];
+  for (var envVar in _libPathEnvVars) {
+    var envPath = Platform.environment[envVar];
+    if (envPath != null && envPath.isNotEmpty && File(envPath).existsSync()) {
+      return pack_path.normalize(File(envPath).absolute.path);
+    }
+  }
+
+  var libName = _wasmRunLibraryFileName();
   if (libName == null || libName.isEmpty) return null;
 
   var possibleDirs = [
-    libName,
+    // Where the `wasm_run` build hook (Dart 3.10+) drops the downloaded
+    // binary, and where the `wasm_run:build_binaries` CLI writes by default.
+    for (var pkgRoot in _packageRoots()) ...[
+      pack_path.join(pkgRoot, '.dart_tool', 'lib'),
+      pack_path.join(pkgRoot, '.dart_tool', 'wasm_run'),
+    ],
+    // Next to the executable / working directory (bundled deployments).
     '.',
     '../',
     '../../',
@@ -246,4 +336,37 @@ String? _wasmRunLibraryFilePath() {
   }
 
   return null;
+}
+
+/// Walks up from the current directory and from the running script looking for
+/// a Dart package root (a directory holding `.dart_tool/package_config.json`).
+List<String> _packageRoots() {
+  var roots = <String>[];
+
+  void addRootsFrom(String? from) {
+    if (from == null) return;
+
+    var dir = pack_path.normalize(from);
+
+    while (true) {
+      if (File(
+        pack_path.join(dir, '.dart_tool', 'package_config.json'),
+      ).existsSync()) {
+        if (!roots.contains(dir)) roots.add(dir);
+      }
+
+      var parent = pack_path.dirname(dir);
+      if (parent == dir) break;
+      dir = parent;
+    }
+  }
+
+  addRootsFrom(Directory.current.absolute.path);
+
+  var script = Platform.script;
+  if (script.isScheme('file')) {
+    addRootsFrom(pack_path.dirname(script.toFilePath()));
+  }
+
+  return roots;
 }

--- a/apollovm_wasm/pubspec.yaml
+++ b/apollovm_wasm/pubspec.yaml
@@ -2,7 +2,7 @@ name: apollovm_wasm
 description: >-
   Native (Dart VM) WebAssembly execution for ApolloVM: the wasm_run-backed
   WasmRuntime, kept out of the core package so apollovm stays FFI-free.
-version: 1.0.0
+version: 1.1.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 
@@ -17,7 +17,7 @@ environment:
 
 dependencies:
   apollovm: ^2.0.0
-  wasm_run: ^0.1.0+2
+  wasm_run: ^0.2.0+1
   crypto: ^3.0.7
   path: ^1.9.1
 

--- a/apollovm_wasm/test/apollovm_wasm_test.dart
+++ b/apollovm_wasm/test/apollovm_wasm_test.dart
@@ -33,8 +33,10 @@ void main() {
         runtime.isSupported,
         isTrue,
         reason:
-            'The `wasm_run` dynamic library must be installed: '
-            'run `dart run wasm_run:setup`. Boot error: ${runtime.lastBootError}',
+            'The `wasm_run` dynamic library must be present — it is downloaded '
+            'by the `wasm_run` build hook (`.dart_tool/lib/`), or pointed at by '
+            '`WASM_RUN_DART_DYNAMIC_LIBRARY`. '
+            'Boot error: ${runtime.lastBootError}',
       );
     });
 

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -61,7 +61,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.23.1';
+  static final String VERSION = '2.23.2';
 
   static int _idCount = 0;
 

--- a/lib/src/mcp/cli/mcp_command.dart
+++ b/lib/src/mcp/cli/mcp_command.dart
@@ -645,8 +645,7 @@ Examples:
             ? 'native Wasm runtime available (apollovm.wasm modules are runnable)'
             : 'native Wasm runtime missing — apollovm.wasm still COMPILES; '
                   'running compiled modules needs `package:apollovm_wasm` '
-                  '(call `registerApolloVMWasmRuntime()`) and '
-                  '`dart run wasm_run:setup`',
+                  '(call `registerApolloVMWasmRuntime()`)',
         warnOnly: !runtime,
       );
     } catch (_) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.23.1
+version: 2.23.2
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/wasm/apollovm_wasm_async_test.dart
+++ b/test/wasm/apollovm_wasm_async_test.dart
@@ -56,7 +56,7 @@ Future<void> _testWasm(
   if (!rt.isSupported) {
     fail(
       'Wasm runtime not supported — cannot validate compiled bytes '
-      '(run `dart run wasm_run:setup`).',
+      '(`wasm_run` native library unavailable).',
     );
   }
 

--- a/test/wasm/apollovm_wasm_asyncify_codegen_test.dart
+++ b/test/wasm/apollovm_wasm_asyncify_codegen_test.dart
@@ -106,7 +106,9 @@ void main() {
   group('Wasm Asyncify codegen (generated, real suspension)', () {
     test('async fn awaiting an external host call really suspends', () async {
       if (!rt.isSupported) {
-        fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+        fail(
+          'Wasm runtime not supported (`wasm_run` native library unavailable).',
+        );
       }
 
       // `hostDouble` is NOT a module function => compiled as a suspending host
@@ -137,7 +139,9 @@ void main() {
 
     test('pre/post-await locals survive the suspension', () async {
       if (!rt.isSupported) {
-        fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+        fail(
+          'Wasm runtime not supported (`wasm_run` native library unavailable).',
+        );
       }
 
       // `base` is set before the await and must survive the unwind/rewind.
@@ -220,7 +224,9 @@ void main() {
 
     test('two generated computations interleave by host delay', () async {
       if (!rt.isSupported) {
-        fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+        fail(
+          'Wasm runtime not supported (`wasm_run` native library unavailable).',
+        );
       }
 
       final wasm = await _compile(r'''

--- a/test/wasm/apollovm_wasm_asyncify_prototype_test.dart
+++ b/test/wasm/apollovm_wasm_asyncify_prototype_test.dart
@@ -289,7 +289,9 @@ void main() {
   group('Wasm Asyncify prototype (real suspension)', () {
     test('suspends to the host, awaits a real Future, and rewinds', () async {
       if (!rt.isSupported) {
-        fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+        fail(
+          'Wasm runtime not supported (`wasm_run` native library unavailable).',
+        );
       }
 
       final module = await _loadModule(rt, 'asyncify-1');
@@ -316,7 +318,9 @@ void main() {
 
     test('two suspended computations interleave by host delay', () async {
       if (!rt.isSupported) {
-        fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+        fail(
+          'Wasm runtime not supported (`wasm_run` native library unavailable).',
+        );
       }
 
       // Independent instances => independent linear memory / Asyncify state.

--- a/test/wasm/apollovm_wasm_asyncify_runner_test.dart
+++ b/test/wasm/apollovm_wasm_asyncify_runner_test.dart
@@ -57,7 +57,9 @@ void main() {
         }
       ''');
         if (runner == null) {
-          fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+          fail(
+            'Wasm runtime not supported (`wasm_run` native library unavailable).',
+          );
         }
 
         var awaited = false;

--- a/test/wasm/apollovm_wasm_class_test.dart
+++ b/test/wasm/apollovm_wasm_class_test.dart
@@ -45,7 +45,7 @@ Future<void> _testClassReturn(
 
   var rt = WasmRuntime()..ensureBooted();
   if (!rt.isSupported) {
-    fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+    fail('Wasm runtime not supported (`wasm_run` native library unavailable).');
   }
 
   // 3) Load + run the compiled Wasm.
@@ -93,7 +93,7 @@ Future<void> _testClassPrint(
 
   var rt = WasmRuntime()..ensureBooted();
   if (!rt.isSupported) {
-    fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+    fail('Wasm runtime not supported (`wasm_run` native library unavailable).');
   }
 
   var vmWasm = ApolloVM();

--- a/test/wasm/apollovm_wasm_maps_test.dart
+++ b/test/wasm/apollovm_wasm_maps_test.dart
@@ -38,7 +38,7 @@ Future<void> _testWasmReturn(
 
   var rt = WasmRuntime()..ensureBooted();
   if (!rt.isSupported) {
-    fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+    fail('Wasm runtime not supported (`wasm_run` native library unavailable).');
   }
 
   var vmWasm = ApolloVM();

--- a/test/wasm/apollovm_wasm_object_field_test.dart
+++ b/test/wasm/apollovm_wasm_object_field_test.dart
@@ -38,7 +38,7 @@ Future<void> _testWasmPrints(
 
   var rt = WasmRuntime()..ensureBooted();
   if (!rt.isSupported) {
-    fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+    fail('Wasm runtime not supported (`wasm_run` native library unavailable).');
   }
 
   // 3) Run the compiled Wasm.

--- a/test/wasm/apollovm_wasm_ops_test.dart
+++ b/test/wasm/apollovm_wasm_ops_test.dart
@@ -50,7 +50,7 @@ Future<void> _testWasm(
   if (!rt.isSupported) {
     fail(
       'Wasm runtime not supported — cannot validate compiled bytes '
-      '(run `dart run wasm_run:setup`).',
+      '(`wasm_run` native library unavailable).',
     );
   }
 

--- a/test/wasm/apollovm_wasm_p2_test.dart
+++ b/test/wasm/apollovm_wasm_p2_test.dart
@@ -39,7 +39,7 @@ Future<void> _testWasmPrint(
 
   var rt = WasmRuntime()..ensureBooted();
   if (!rt.isSupported) {
-    fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+    fail('Wasm runtime not supported (`wasm_run` native library unavailable).');
   }
 
   // 3) Load + run the compiled Wasm, capturing its `print` host import.
@@ -94,7 +94,7 @@ Future<void> _testWasmPrintText(
 
   var rt = WasmRuntime()..ensureBooted();
   if (!rt.isSupported) {
-    fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+    fail('Wasm runtime not supported (`wasm_run` native library unavailable).');
   }
 
   // 3) Load + run the compiled Wasm, capturing its `print` host import.
@@ -151,7 +151,7 @@ Future<void> _testWasmReturn(
 
   var rt = WasmRuntime()..ensureBooted();
   if (!rt.isSupported) {
-    fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+    fail('Wasm runtime not supported (`wasm_run` native library unavailable).');
   }
 
   var vmWasm = ApolloVM();

--- a/test/wasm/apollovm_wasm_p3_test.dart
+++ b/test/wasm/apollovm_wasm_p3_test.dart
@@ -38,7 +38,7 @@ Future<void> _testWasmReturn(
 
   var rt = WasmRuntime()..ensureBooted();
   if (!rt.isSupported) {
-    fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+    fail('Wasm runtime not supported (`wasm_run` native library unavailable).');
   }
 
   var vmWasm = ApolloVM();

--- a/test/wasm/apollovm_wasm_polish_test.dart
+++ b/test/wasm/apollovm_wasm_polish_test.dart
@@ -45,7 +45,7 @@ Future<void> _testWasm(
 
   var rt = WasmRuntime()..ensureBooted();
   if (!rt.isSupported) {
-    fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+    fail('Wasm runtime not supported (`wasm_run` native library unavailable).');
   }
 
   var vmWasm = ApolloVM();

--- a/test/wasm/apollovm_wasm_return_paths_test.dart
+++ b/test/wasm/apollovm_wasm_return_paths_test.dart
@@ -50,7 +50,7 @@ Future<void> _testWasm(
 
   var rt = WasmRuntime()..ensureBooted();
   if (!rt.isSupported) {
-    fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+    fail('Wasm runtime not supported (`wasm_run` native library unavailable).');
   }
 
   // 3) Load + execute the compiled Wasm.

--- a/test/wasm/apollovm_wasm_static_method_test.dart
+++ b/test/wasm/apollovm_wasm_static_method_test.dart
@@ -71,7 +71,7 @@ Future<void> _runWasmAndExpect(
 
   var rt = WasmRuntime()..ensureBooted();
   if (!rt.isSupported) {
-    fail('Wasm runtime not supported (run `dart run wasm_run:setup`).');
+    fail('Wasm runtime not supported (`wasm_run` native library unavailable).');
   }
 
   var vmWasm = ApolloVM();


### PR DESCRIPTION
`wasm_run: ^0.2.0+1` was released and is a **breaking** upgrade. This absorbs it in `apollovm_wasm` so consumers keep the same `WasmRuntimeIO` API.

## What broke, and how it is fixed

| Upstream change | Effect here |
|---|---|
| `WasmRunLibrary.isReachable()` became `Future<bool>` | Compile error (`non_bool_condition`) — boot reworked |
| Bindings moved to `flutter_rust_bridge` 2.x | The symbol used to validate a genuine library, `wire_compile_wasm`, no longer exists — every 0.2 library was rejected. Now checks `frb_get_rust_content_hash` |
| `dart run wasm_run:setup` removed; binaries now come from the SDK's build hooks | The library lands in `.dart_tool/lib/`, which is now searched first (walking up to every enclosing package root), along with `.dart_tool/wasm_run/` (the `wasm_run:build_binaries` output). Three CI steps dropped |
| Rust bindings initialize **asynchronously**, and `wasm_run` no longer locates its own library in a pure-Dart app | `WasmRunLibrary.setUp()` is awaited once, lazily, on the first module compile. `ensureBooted()`/`isSupported` stay synchronous — `WasmRuntime` requires that — and only probe for the library |

Also: `WASM_RUN_DART_DYNAMIC_LIBRARY` (the variable `wasm_run` itself reads) now overrides the path, and the older `WASM_RUN_LIB_PATH` is finally read as a *path* — it used to be consulted only on platforms with no known library name, then joined with candidate directories as if it were a file name.

`apollovm` 2.23.2 carries the doc/message side of it: `mcp doctor`, the Wasm tests and `WASM_BACKEND_PLAN.md` no longer tell people to run a command that does not exist.

## Verification

- `apollovm_wasm`: 4/4 tests, analyze `--fatal-infos --fatal-warnings`, `dart doc`, publish dry-run (via `tool/publish_apollovm_wasm.sh`) — all clean. It resolves `apollovm` from pub.dev, so this is the consumer-shaped path.
- Root: **2541 tests passed**, plus format, analyze, `dependency_validator`, `dart doc`, publish dry-run.

## Known issue: macOS on Apple Silicon

The upstream `aarch64-apple-darwin` 0.2.0 binary is killed by macOS (`SIGKILL`, *Code Signature Invalid*) the moment wasmtime executes JIT-compiled Wasm **inside the JIT Dart VM** — i.e. under `dart run` / `dart test`. Compiling and instantiating modules is fine; only the call into generated code trips it. `wasm_run` 0.1.0+2 does not have this problem on the same machine, and AOT (`dart compile exe`, `dart test --compiler exe`) is unaffected — that is how the suites above were run locally.

It is a macOS code-signing enforcement, so other platforms are not expected to hit it; Linux is verified by this PR's CI. Documented in the README and CHANGELOG, and worth reporting upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)