### PR TITLE
v2.23.3 - Signature mismatch is no longer reported as a missing entry function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,37 @@
+## 2.23.3
+
+### A signature mismatch is no longer reported as a missing entry function
+
+Calling `apollovm.execute` with arguments that no declaration of the entry name
+accepts reported the same thing as a typo in the name — `Entry function not
+found: main` — leaving the caller with nothing to correct:
+
+```shell
+$ apollovm mcp call apollovm.execute --language dart --args '[1,2,3]' \
+    --source 'int main(int a, String b){ return 1; }'
+{
+  "diagnostics": [
+    { "severity": "error", "message": "Entry function not found: main" }
+  ],
+  "isError": true
+}
+```
+
+`ApolloRuntime.execute` now separates the two causes. When the name exists but
+no overload matches, the diagnostic shows the call that was attempted and every
+declared signature of that name (qualified with the class when it is a method,
+including one reached by the auto-discovery order):
+
+```
+No entry function matching the passed arguments: `main(int, int, int)`.
+A function named `main` exists, but with a different signature:
+`int main(int a, String b)`. Adjust the arguments to match a declared signature.
+```
+
+An explicit `className` that does not exist now reports `Entry class not found:
+Bar (looking for the method `run`)` instead of blaming the method. A name that
+is genuinely absent from the source still reports `Entry function not found`.
+
 ## 2.23.2
 
 ### The native Wasm runtime no longer has an install step

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -61,7 +61,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.23.2';
+  static final String VERSION = '2.23.3';
 
   static int _idCount = 0;
 

--- a/lib/src/mcp/runtime/apollo_runtime.dart
+++ b/lib/src/mcp/runtime/apollo_runtime.dart
@@ -245,10 +245,7 @@ class ApolloRuntime {
       final diagnostics = <Diagnostic>[];
       if (!hasResult) {
         diagnostics.add(
-          _err(
-            "Entry function not found: ${className != null ? '$className.' : ''}"
-            '$function',
-          ),
+          _entryNotFound(vm, language, function, className, args),
         );
       }
 
@@ -279,6 +276,130 @@ class ApolloRuntime {
       );
     }
   }
+
+  /// Builds the diagnostic for an entry point that could not be invoked.
+  ///
+  /// A failed lookup has two very different causes, and the message must say
+  /// which one: there is no declaration with that *name* at all, or one (or
+  /// more) exist but none accepts the passed arguments. The latter is the
+  /// common case for a caller that guessed the parameters, so the declared
+  /// signatures are listed to show what to pass instead.
+  Diagnostic _entryNotFound(
+    ApolloVM vm,
+    String language,
+    String function,
+    String? className,
+    List<Object?> args,
+  ) {
+    final entryName = className != null ? '$className.$function' : function;
+    final namespaces = vm.getLanguageNamespaces(language).namespaces;
+    if (!namespaces.contains('')) namespaces.insert(0, '');
+
+    final signatures = <String>[];
+
+    if (className != null) {
+      var classFound = false;
+      for (var ns in namespaces) {
+        final clazz = vm
+            .getLanguageNamespaces(language)
+            .get(ns)
+            .getClass(className);
+        if (clazz == null) continue;
+        classFound = true;
+        _collectSignatures(
+          clazz.getFunctionWithName(function),
+          signatures,
+          className: className,
+        );
+      }
+
+      if (!classFound) {
+        return _err(
+          'Entry class not found: $className '
+          "(looking for the method `$function`)",
+        );
+      }
+    } else {
+      for (var ns in namespaces) {
+        for (var codeUnit
+            in vm.getLanguageNamespaces(language).get(ns).codeUnits) {
+          final root = codeUnit.root;
+          if (root == null) continue;
+
+          _collectSignatures(root.getFunctionWithName(function), signatures);
+
+          for (var clazz in root.classes) {
+            _collectSignatures(
+              clazz.getFunctionWithName(function),
+              signatures,
+              className: clazz.name,
+            );
+          }
+        }
+      }
+    }
+
+    if (signatures.isEmpty) {
+      return _err('Entry function not found: $entryName');
+    }
+
+    final declared = signatures.map((s) => '`$s`').join(', ');
+
+    final found = signatures.length > 1
+        ? '${signatures.length} functions named `$function` exist, but with '
+              'different signatures'
+        : 'A function named `$function` exists, but with a different signature';
+
+    return _err(
+      'No entry function matching the passed arguments: '
+      '`$entryName(${_argsSignature(args)})`. '
+      '$found: $declared. '
+      'Adjust the arguments to match a declared signature.',
+    );
+  }
+
+  /// Adds the formatted signature of every declaration in [set] to [out].
+  void _collectSignatures(
+    ASTFunctionSet? set,
+    List<String> out, {
+    String? className,
+  }) {
+    if (set == null) return;
+    for (var f in set.functions) {
+      final signature = _signature(f, className: className);
+      if (!out.contains(signature)) out.add(signature);
+    }
+  }
+
+  /// Formats a declaration as `Ret name(T1 a, T2 b)`, qualified with
+  /// [className] when it is a class method.
+  String _signature(ASTInvocableDeclaration f, {String? className}) {
+    final params = [
+      for (var p in f.parameters.allParameters)
+        '${_typeName(p.type)} ${p.name}',
+    ].join(', ');
+
+    final name = className != null ? '$className.${f.name}' : f.name;
+    final returnType = _typeName(f.returnType);
+    final prefix = returnType.isEmpty ? '' : '$returnType ';
+
+    return '$prefix$name($params)';
+  }
+
+  /// The argument types as passed by the caller, e.g. `int, String`.
+  String _argsSignature(List<Object?> args) =>
+      args.map(_argTypeName).join(', ');
+
+  String _argTypeName(Object? arg) {
+    if (arg == null) return 'null';
+    // Generic collections stringify with their (always dynamic, since these
+    // come from JSON) type arguments: not useful noise in the message.
+    if (arg is List) return 'List';
+    if (arg is Map) return 'Map';
+    return arg.runtimeType.toString();
+  }
+
+  String _typeName(ASTType? type) => type?.name ?? '';
 
   /// Normalize class/function name.
   String? _normalizeEntryName(String? entryName) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.23.2
+version: 2.23.3
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/mcp/apollo_runtime_test.dart
+++ b/test/mcp/apollo_runtime_test.dart
@@ -246,6 +246,83 @@ void main() {
     });
   });
 
+  group('entry signature mismatch', () {
+    // A name that exists but rejects the passed arguments must not be reported
+    // as a missing entry: the message has to show what was passed and what is
+    // declared, otherwise the caller has no way to fix the call.
+    const limits = McpLimits(isolateTools: {});
+
+    Future<String> messageOf(Map<String, Object?> input) async {
+      final r = await computeTool('apollovm.execute', input, limits);
+      expect(r['isError'], isTrue);
+      final diag = (r['diagnostics'] as List).first as Map;
+      return '${diag['message']}';
+    }
+
+    test(
+      'a top-level function with a different signature is described',
+      () async {
+        final message = await messageOf({
+          'language': 'dart',
+          'source': 'int main(int a, String b){ return 1; }',
+          'args': [1, 2, 3],
+        });
+        expect(message, contains('No entry function matching'));
+        expect(message, contains('`main(int, int, int)`'));
+        expect(message, contains('`int main(int a, String b)`'));
+        expect(message, isNot(contains('Entry function not found')));
+      },
+    );
+
+    test('a class method mismatch is qualified with the class', () async {
+      final message = await messageOf({
+        'language': 'dart',
+        'source': 'class Foo { int run(int a){ return 7; } }',
+        'function': 'run',
+        'className': 'Foo',
+        'args': ['x', 'y'],
+      });
+      expect(message, contains('`Foo.run(String, String)`'));
+      expect(message, contains('`int Foo.run(int a)`'));
+    });
+
+    test('a method reached by auto-discovery names its class', () async {
+      final message = await messageOf({
+        'language': 'dart',
+        'source': 'class Foo { int run(int a, int b){ return 7; } }',
+        'function': 'run',
+        'args': ['x'],
+      });
+      expect(message, contains('`int Foo.run(int a, int b)`'));
+    });
+
+    test('every declaration of the name is listed', () async {
+      final message = await messageOf({
+        'language': 'dart',
+        'source':
+            'class A { int run(int a){ return 1; } } '
+            'class B { int run(bool x, bool y){ return 2; } }',
+        'function': 'run',
+        'args': [1.5, 2.5, 3.5],
+      });
+      expect(message, contains('2 functions named `run` exist'));
+      expect(message, contains('different signatures'));
+      expect(message, contains('`int A.run(int a)`'));
+      expect(message, contains('`int B.run(bool x, bool y)`'));
+    });
+
+    test('an unknown className is reported as a missing class', () async {
+      final message = await messageOf({
+        'language': 'dart',
+        'source': 'class Foo { int run(int a){ return 7; } }',
+        'function': 'run',
+        'className': 'Bar',
+      });
+      expect(message, contains('Entry class not found: Bar'));
+      expect(message, contains('`run`'));
+    });
+  });
+
   group('McpLimits', () {
     test('defaults, runsInIsolate, copyWith and toString', () {
       const limits = McpLimits();


### PR DESCRIPTION
## A signature mismatch read as a missing function

`apollovm.execute` returned the same diagnostic whether the entry name was absent or existed but rejected the passed arguments, so a caller that guessed the parameters was told to fix the name:

```shell
$ apollovm mcp call apollovm.execute --language dart --args '[1,2,3]' \
    --source 'int main(int a, String b){ return 1; }'
{
  "diagnostics": [
    { "severity": "error", "message": "Entry function not found: main" }
  ],
  "isError": true
}
```

The lookup already had the information needed to say more: `_runEntry` walks the namespaces, top-level functions and class methods, and returns `null` for *any* miss — name, overload or class alike.

## What it says now

`ApolloRuntime.execute` delegates the failure to `_entryNotFound`, which re-runs the lookup by *name only* and reports the three cases separately.

**Name exists, no overload matches** — the attempted call (with the passed argument types) and every declared signature:

```
No entry function matching the passed arguments: `main(int, int, int)`.
A function named `main` exists, but with a different signature:
`int main(int a, String b)`. Adjust the arguments to match a declared signature.
```

Several declarations are all listed, so an overload set or a name shared across classes shows the full menu:

```
No entry function matching the passed arguments: `run(double, double, double)`.
2 functions named `run` exist, but with different signatures:
`int A.run(int a)`, `int B.run(bool x, bool y)`.
```

Signatures are qualified with their class, including for a method reached through the auto-discovery order (no `className` given) — that is the case where the caller cannot otherwise tell *which* class answered.

**An explicit `className` that does not exist** is now reported as such instead of blaming the method:

```
Entry class not found: Bar (looking for the method `run`)
```

**A genuinely absent name** still reports `Entry function not found: main`, unchanged.

## Details

- Argument types come from the values as passed. `List`/`Map` are printed unparameterized on purpose — MCP arguments arrive from JSON, so their type argument is always `dynamic` and `List<dynamic>` is noise.
- Signature formatting mirrors the LSP's `formatInvocable` (`Ret name(T a, T b)`) but is local to the runtime: it adds the class qualifier, and the MCP runtime does not otherwise depend on `apollovm_lsp`.
- Duplicate signatures are collapsed — the same declaration is reachable from more than one namespace.
- The lookup is read-only and runs only on the failure path, so the success path is untouched.

## Tests

`test/mcp/apollo_runtime_test.dart`: new `entry signature mismatch` group — top-level mismatch, a `className`-scoped method mismatch, a method reached by auto-discovery naming its class, multiple declarations all listed with plural wording, and an unknown `className` reported as a missing class. The existing `Entry function not found` assertions (a genuinely missing name) still pass unchanged.

## Verification

- `dart analyze` and `dart format` clean; MCP suite (142 tests) and `test/cli` green; verified end-to-end through the real `apollovm mcp call apollovm.execute`.
- `test/features`, `test/integration`, `test/lsp`, `test/meta`, `test/repository` green.
- A single full-suite `dart test` run gets SIGKILLed locally around ~1990 tests while the `wasm_run` native library is loaded — this reproduces on unmodified `master`, so it is environmental and not from this change. CI covers the full suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)