### PR TITLE
v2.24.0 - Null-aware access is now really checked on every target, not dropped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,78 @@
+## 2.24.0
+
+### Null-aware access is now really checked on every target, not dropped
+
+`a?.b` was emitted as a plain `a.b` on Java, C#, JavaScript, Lua and Python: the
+generated code compiled, but the null check was gone — it threw on exactly the
+input `?.` exists to handle. The README's null-safety matrix marked those cells
+⚠️ *lossy*.
+
+Java, Lua and Python now lower the access to an explicit guard, and the guard
+wraps the **whole** chain rather than the null-aware link alone:
+
+```dart
+// Dart source
+int chain(A? a) { return a?.m().toInt(); }
+```
+
+```java
+// Java, before: threw when `a` was null
+return a.m().toInt();
+// Java, now
+return (a != null ? a.m().toInt() : null);
+```
+
+```python
+# Python
+return (a.m().toInt() if a is not None else None)
+```
+
+C# and JavaScript were lossy for a simpler reason — both have had the operator
+all along (C# 6, ES2020) and merely never declared it — so they now emit `a?.b`
+natively. JavaScript uses `?.[i]` for element access, and its postfix `!` is
+handled separately: JavaScript has no null-assertion operator (a postfix `!` is
+logical NOT), so `a!` is emitted as plain `a` rather than negating the value.
+
+Go continues to report `?.` / `?[` as unsupported: it represents a nullable `T?`
+as `*T`, so a degraded access would both skip the nil check and yield the wrong
+type.
+
+### `??`, `&&`, `||` and `x == null` are AST nodes of their own
+
+These four were shapes encoded on the generic binary-operation node and
+special-cased ahead of its operator switch, because each of them short-circuits.
+Every consumer had to re-detect them by inspecting operands — the null-safety
+analyzer reconstructed `x != null` to promote a variable, the Go backend probed
+for a null literal to compare the pointer instead of dereferencing it, and the
+Wasm backend re-tested the operator — and the enum's exhaustiveness forced
+`throw StateError('unreachable')` arms in three places.
+
+`ASTExpressionNullCoalesce`, `ASTExpressionLogicalAnd`, `ASTExpressionLogicalOr`
+and `ASTExpressionNullCheck` now carry those shapes, built by the new
+`astExpressionOperation()` factory that the shared grammar reduction uses, so
+all nine front-ends get them. Consumers dispatch on the node type instead of
+pattern-matching, and evaluating `x == null` no longer concretizes both operands
+and runs them through equality dispatch.
+
+This is internal structure — the generated source is unchanged, except where a
+target has a better idiom that the dedicated node makes reachable. Python is the
+one such case:
+
+```python
+# before
+if a == None:
+# now
+if a is None:
+```
+
+`==` dispatches through `__eq__`, which a class can redefine to return `True`
+for `None`; `is` cannot be intercepted, and is the form PEP 8 mandates.
+
+Building a binary operation directly with `ASTExpressionOperation` still works
+for the ordinary operators. Constructing one with `??`, `&&` or `||` now throws
+rather than silently evaluating both operands, which would no longer be a
+short-circuit.
+
 ## 2.23.3
 
 ### A signature mismatch is no longer reported as a missing entry function

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,12 @@ if a is None:
 `==` dispatches through `__eq__`, which a class can redefine to return `True`
 for `None`; `is` cannot be intercepted, and is the form PEP 8 mandates.
 
+The Python **grammar** learned `is None` / `is not None` to match, so the
+generated source still round-trips — ApolloVM can now read back what it writes.
+This is deliberately limited to the `None` comparison: general `a is b` is
+identity, and mapping it to `==` would silently turn it into equality, so it
+stays unparsed as before.
+
 Building a binary operation directly with `ASTExpressionOperation` still works
 for the ordinary operators. Constructing one with `??`, `&&` or `||` now throws
 rather than silently evaluating both operands, which would no longer be a

--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ Dart's null-safety surface — nullable types (`T?`), the null-coalescing operat
 this syntax yet), runs on the interpreter, compiles to Wasm within the limits
 below, and is **translated to every target**.
 
+Comparison against null is the exception: every grammar parses its own spelling,
+including Python's `is None` / `is not None`, so a null check written in any
+supported language round-trips.
+
 Same legend as above, plus **⚠️** *lossy*: the construct is emitted in a form that
 compiles but drops its null semantics (the null check is not performed).
 

--- a/README.md
+++ b/README.md
@@ -137,18 +137,24 @@ below, and is **translated to every target**.
 Same legend as above, plus **⚠️** *lossy*: the construct is emitted in a form that
 compiles but drops its null semantics (the null check is not performed).
 
+The null-aware *accesses* (`?.`, `?[`) are never lossy: a target without the
+native operator lowers them to an explicit guard that yields null, so the check
+is really performed — see footnote ¹¹. Only the null *assertion* `!` is still
+dropped where the target has no equivalent, and that diverges from Dart solely
+in the error path (a value that should have thrown is used instead).
+
 | Feature | Dart | Java | Kotlin | Go | C# | JS | TS | Lua | Python | Wasm |
 |---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
 | Nullable type `T?`               | ✅ | 🚫 | ✅¹ | 🧩² | 🚫 | 🚫 | 🧩³ | 🚫 | 🚫 | 🧩⁴ |
 | `??` (null-coalescing)           | ✅ | 🧩⁵ | ✅⁶ | 🧩⁷ | ✅ | ✅ | ✅ | 🧩⁸ | 🧩⁹ | 🧩⁴ |
 | `??=` (null-coalescing assign)   | ✅ | 🧩⁵ | 🧩⁶ | 🚧¹⁰ | ✅ | ✅ | ✅ | 🧩⁸ | 🧩⁹ | 🧩⁴ |
-| `?.` (null-aware access)         | ✅ | ⚠️ | ✅ | 🚧¹¹ | ⚠️ | ⚠️ | ✅ | ⚠️ | ⚠️ | 🧩⁴ |
-| `?[` (null-aware index)          | ✅ | ⚠️ | ✅¹² | ⚠️ | ⚠️ | ⚠️ | ✅¹³ | ⚠️ | ⚠️ | 🧩⁴ |
-| `!` (null assertion)             | ✅ | ⚠️ | ✅¹⁴ | 🧩¹⁵ | ⚠️ | ⚠️ | ✅ | ⚠️ | ⚠️ | 🧩⁴ |
+| `?.` (null-aware access)         | ✅ | 🧩¹¹ | ✅ | 🚧¹² | ✅ | ✅ | ✅ | 🧩¹¹ | 🧩¹¹ | 🧩⁴ |
+| `?[` (null-aware index)          | ✅ | 🧩¹¹ | ✅¹³ | 🚧¹² | ✅ | ✅¹⁴ | ✅¹⁴ | 🧩¹¹ | 🧩¹¹ | 🧩⁴ |
+| `!` (null assertion)             | ✅ | ⚠️ | ✅¹⁵ | 🧩¹⁶ | ✅ | 🚫¹⁷ | ✅ | ⚠️ | ⚠️ | 🧩⁴ |
 | Cascades `..` / `?..`            | ✅ | 🧩 | 🧩 | 🧩 | 🧩 | 🧩 | 🧩 | 🧩 | 🧩 | 🚧 |
-| `x == null` / `x != null`        | ✅ | ✅ | ✅ | ✅¹⁶ | ✅ | ✅ | ✅ | ✅¹⁷ | ✅¹⁸ | ✅ |
-| Static null-safety analysis¹⁹    | ✅ | 🚫 | 🚫 | 🚫 | 🚫 | 🚫 | 🚫 | 🚫 | 🚫 | 🚫 |
-| Enforce analysis at load²⁰       | ✅ | 🚫 | 🚫 | 🚫 | 🚫 | 🚫 | 🚫 | 🚫 | 🚫 | 🚫 |
+| `x == null` / `x != null`        | ✅ | ✅ | ✅ | ✅¹⁸ | ✅ | ✅ | ✅ | ✅¹⁹ | ✅²⁰ | ✅ |
+| Static null-safety analysis²¹    | ✅ | 🚫 | 🚫 | 🚫 | 🚫 | 🚫 | 🚫 | 🚫 | 🚫 | 🚫 |
+| Enforce analysis at load²²       | ✅ | 🚫 | 🚫 | 🚫 | 🚫 | 🚫 | 🚫 | 🚫 | 🚫 | 🚫 |
 
 ¹ Kotlin renders the suffix natively (`Int?`). &nbsp;
 ² Go has no nullable value types: a `T?` is generated as a pointer `*T` — reads
@@ -181,24 +187,40 @@ the left operand only once. &nbsp;
 ¹⁰ Go's `??=` lowering (`t = t ?? v`) needs the target's element type to build
 the inline function's return type, which the text-level assignment hook does not
 have; it is reported as unsupported. Plain `??` is unaffected. &nbsp;
-¹¹ In Go, degrading `?.` to `.` would both skip the nil check *and* yield a value
-where a `*T` is expected, so it is reported rather than mis-emitted. &nbsp;
-¹² Kotlin has no `?[` operator: null-aware element access is the call
+¹¹ Java, Lua and Python have no null-aware access operator, so the access is
+lowered to an explicit guard that yields null — a ternary in Java
+(`(a != null ? a.x : null)`), a conditional expression testing `is not None` in
+Python, and an immediately-invoked function with a `nil` test in Lua. The guard
+wraps the **whole** chain, so `a?.m().toInt()` becomes
+`(a != null ? a.m().toInt() : null)` rather than leaving the trailing call
+outside it. Like the `??` desugaring, the guard repeats the receiver, so it is
+only used for receivers that are safe to evaluate twice (variables, fields and
+index reads). &nbsp;
+¹² In Go, degrading `?.` / `?[` to a plain access would both skip the nil check
+*and* yield a value where a `*T` is expected, so it is reported rather than
+mis-emitted. &nbsp;
+¹³ Kotlin has no `?[` operator: null-aware element access is the call
 `a?.get(i)`. &nbsp;
-¹³ TypeScript's null-aware element access is `a?.[i]`, not `a?[i]`. &nbsp;
-¹⁴ Kotlin's null assertion is `!!`. &nbsp;
-¹⁵ Go's `a!` is the pointer dereference `(*a)`, which panics on `nil` — the same
+¹⁴ TypeScript's and JavaScript's null-aware element access is `a?.[i]`, not
+`a?[i]`. &nbsp;
+¹⁵ Kotlin's null assertion is `!!`. &nbsp;
+¹⁶ Go's `a!` is the pointer dereference `(*a)`, which panics on `nil` — the same
 shape as the assertion's throw. &nbsp;
-¹⁶ Go compares the pointer directly (`a != nil`), without dereferencing. &nbsp;
-¹⁷ Lua's null literal is `nil`. &nbsp; ¹⁸ Python's is `None`. &nbsp;
-¹⁹ A pragmatic, flow-aware analyzer reports assigning `null` (or a nullable
+¹⁷ JavaScript has no null-assertion operator — a postfix `!` there is logical
+NOT — so `a!` is emitted as plain `a`. Dropping the token is the only
+meaning-preserving option; emitting it would negate the value. &nbsp;
+¹⁸ Go compares the pointer directly (`a != nil`), without dereferencing. &nbsp;
+¹⁹ Lua's null literal is `nil`. &nbsp; ²⁰ Python compares against `None` by
+identity (`x is None` / `x is not None`), not `==`: equality dispatches through
+`__eq__`, which a class can redefine to return `True` for `None`. &nbsp;
+²¹ A pragmatic, flow-aware analyzer reports assigning `null` (or a nullable
 value) to a non-nullable slot, and unconditional member/method/index access or
 operator use on a nullable — with promotion for `if (x != null) { … }` /
 `if (x == null) … else { … }`, and suppression via `?.` / `!` / `??`. Its
 diagnostics are surfaced through the [LSP](#language-server-lsp) for Dart
 documents. It analyzes top-level functions **and** class methods, constructors
 and getters. &nbsp;
-²⁰ `ApolloVM(nullSafetyChecks: true)` makes `loadCodeUnit` throw
+²² `ApolloVM(nullSafetyChecks: true)` makes `loadCodeUnit` throw
 `NullSafetyError` when the AST has null-safety **errors**, so a mistake fails at
 resolution time instead of partway through a run:
 

--- a/lib/src/analysis/null_safety_analyzer.dart
+++ b/lib/src/analysis/null_safety_analyzer.dart
@@ -346,12 +346,13 @@ class NullSafetyAnalyzer {
 
   /// Reports a nullable operand used in an operation that would dereference it.
   ///
-  /// `??`, `==` and `!=` are exempt: a nullable operand is exactly what they
-  /// exist to handle.
+  /// `==` and `!=` are exempt: a nullable operand is exactly what they exist to
+  /// handle. `??` and the `x == null` / `x != null` forms are exempt
+  /// structurally — they are [ASTExpressionNullCoalesce] and
+  /// [ASTExpressionNullCheck], so they never reach this check.
   void _checkOperationOperands(ASTExpressionOperation expr, _Scope scope) {
     final op = expr.operator;
-    if (op == ASTExpressionOperator.nullCoalesce ||
-        op == ASTExpressionOperator.equals ||
+    if (op == ASTExpressionOperator.equals ||
         op == ASTExpressionOperator.notEquals) {
       return;
     }
@@ -401,23 +402,20 @@ class NullSafetyAnalyzer {
     final whenFalse = <String>{};
 
     void handle(ASTExpression e) {
-      if (e is ASTExpressionOperation) {
-        final op = e.operator;
-        if (op == ASTExpressionOperator.notEquals ||
-            op == ASTExpressionOperator.equals) {
-          final name = _nullComparisonVariable(e.expression1, e.expression2);
-          if (name != null) {
-            if (op == ASTExpressionOperator.notEquals) {
-              whenTrue.add(name);
-            } else {
-              whenFalse.add(name);
-            }
+      if (e is ASTExpressionNullCheck) {
+        final name = _scopeVariableName(e.expression);
+        if (name != null) {
+          if (e.negated) {
+            whenTrue.add(name);
+          } else {
+            whenFalse.add(name);
           }
-        } else if (op == ASTExpressionOperator.and) {
-          // `x != null && …`: both sides promote when true.
-          handle(e.expression1);
-          handle(e.expression2);
         }
+      } else if (e is ASTExpressionOperation &&
+          e.operator == ASTExpressionOperator.and) {
+        // `x != null && …`: both sides promote when true.
+        handle(e.expression1);
+        handle(e.expression2);
       }
     }
 
@@ -425,18 +423,13 @@ class NullSafetyAnalyzer {
     return _Promotions(whenTrue, whenFalse);
   }
 
-  /// If [a]/[b] is a `variable <op> null` comparison, returns the variable name.
-  String? _nullComparisonVariable(ASTExpression a, ASTExpression b) {
-    String? nameOf(ASTExpression e) {
-      if (e is ASTExpressionVariableAccess) {
-        final v = e.variable;
-        if (v is ASTScopeVariable) return v.name;
-      }
-      return null;
+  /// The name of the scope variable [e] reads, or `null` if it is not a plain
+  /// variable read.
+  String? _scopeVariableName(ASTExpression e) {
+    if (e is ASTExpressionVariableAccess) {
+      final v = e.variable;
+      if (v is ASTScopeVariable) return v.name;
     }
-
-    if (b is ASTExpressionNullValue) return nameOf(a);
-    if (a is ASTExpressionNullValue) return nameOf(b);
     return null;
   }
 

--- a/lib/src/analysis/null_safety_analyzer.dart
+++ b/lib/src/analysis/null_safety_analyzer.dart
@@ -411,8 +411,7 @@ class NullSafetyAnalyzer {
             whenFalse.add(name);
           }
         }
-      } else if (e is ASTExpressionOperation &&
-          e.operator == ASTExpressionOperator.and) {
+      } else if (e is ASTExpressionLogicalAnd) {
         // `x != null && …`: both sides promote when true.
         handle(e.expression1);
         handle(e.expression2);

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -61,7 +61,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.23.3';
+  static final String VERSION = '2.24.0';
 
   static int _idCount = 0;
 

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -1444,6 +1444,20 @@ abstract class ApolloCodeGenerator
         indent: indent,
         headIndented: headIndented,
       );
+    } else if (expression is ASTExpressionNullCoalesce) {
+      return generateASTExpressionNullCoalesce(
+        expression,
+        out: out,
+        indent: indent,
+        headIndented: headIndented,
+      );
+    } else if (expression is ASTExpressionNullCheck) {
+      return generateASTExpressionNullCheck(
+        expression,
+        out: out,
+        indent: indent,
+        headIndented: headIndented,
+      );
     } else if (expression is ASTExpressionVariableAccess) {
       return generateASTExpressionVariableAccess(
         expression,
@@ -1632,17 +1646,6 @@ abstract class ApolloCodeGenerator
     final expression2 = expression.expression2;
     final operator = expression.operator;
 
-    // `a ?? b` has no operator form in several targets, so it goes through a
-    // dedicated hook that can desugar it into a conditional expression.
-    if (operator == ASTExpressionOperator.nullCoalesce) {
-      return generateASTExpressionNullCoalesce(
-        expression1,
-        expression2,
-        out: out,
-        indent: indent,
-      );
-    }
-
     var groupComplexExpressions = true;
 
     if (operator == ASTExpressionOperator.add) {
@@ -1726,27 +1729,94 @@ abstract class ApolloCodeGenerator
   bool get supportsNullCoalesceAssignment => true;
 
   /// Generates the null-coalescing expression `a ?? b`.
+  @override
   StringBuffer generateASTExpressionNullCoalesce(
-    ASTExpression expression1,
-    ASTExpression expression2, {
+    ASTExpressionNullCoalesce expression, {
     StringBuffer? out,
     String indent = '',
+    bool headIndented = true,
   }) {
     out ??= newOutput();
 
+    if (headIndented) out.write(indent);
+
     var a = generateASTExpression(
-      expression1,
+      expression.expression1,
       indent: '$indent  ',
       headIndented: false,
     ).toString();
 
     var b = generateASTExpression(
-      expression2,
+      expression.expression2,
       indent: '$indent  ',
       headIndented: false,
     ).toString();
 
     out.write(renderNullCoalesce(a, b));
+
+    return out;
+  }
+
+  /// Renders a comparison against `null` from the already-generated operand
+  /// text: `x == null` / `x != null`.
+  ///
+  /// The equality token is resolved through [resolveASTExpressionOperatorText]
+  /// so a target's own spelling is honoured — JavaScript and TypeScript use
+  /// strict equality (`=== null`), Lua writes `~=` for inequality — and the
+  /// literal through [nullValueLiteral] (Lua/Go `nil`).
+  ///
+  /// Python overrides this outright: it compares against `None` by identity.
+  ///
+  /// [nullFirst] preserves the operand order the source used, so `null == x`
+  /// does not silently become `x == null`.
+  String renderNullCheck(
+    String operand, {
+    required bool negated,
+    required bool nullFirst,
+  }) {
+    var op = resolveASTExpressionOperatorText(
+      negated ? ASTExpressionOperator.notEquals : ASTExpressionOperator.equals,
+      ASTNumType.nan,
+      ASTNumType.nan,
+    );
+    var nullLiteral = nullValueLiteral;
+    return nullFirst
+        ? '$nullLiteral $op $operand'
+        : '$operand $op $nullLiteral';
+  }
+
+  /// How this target spells the `null` literal, used by [renderNullCheck].
+  String get nullValueLiteral => 'null';
+
+  /// Generates a comparison against `null` — `x == null` / `x != null`.
+  @override
+  StringBuffer generateASTExpressionNullCheck(
+    ASTExpressionNullCheck expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    final inner = expression.expression;
+
+    var operand = generateASTExpression(
+      inner,
+      indent: '$indent  ',
+      headIndented: false,
+    ).toString();
+
+    if (inner.isComplex) operand = '($operand)';
+
+    out.write(
+      renderNullCheck(
+        operand,
+        negated: expression.negated,
+        nullFirst: expression.nullFirst,
+      ),
+    );
 
     return out;
   }

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -1458,6 +1458,13 @@ abstract class ApolloCodeGenerator
         indent: indent,
         headIndented: headIndented,
       );
+    } else if (expression is ASTExpressionLogical) {
+      return generateASTExpressionLogical(
+        expression,
+        out: out,
+        indent: indent,
+        headIndented: headIndented,
+      );
     } else if (expression is ASTExpressionVariableAccess) {
       return generateASTExpressionVariableAccess(
         expression,
@@ -1683,6 +1690,60 @@ abstract class ApolloCodeGenerator
 
     var group1 = groupComplexExpressions && expression1.isComplex;
     var group2 = groupComplexExpressions && expression2.isComplex;
+
+    if (group1) out.write('(');
+    out.write(exp1);
+    if (group1) out.write(')');
+
+    out.write(' ');
+    out.write(op);
+    out.write(' ');
+
+    if (group2) out.write('(');
+    out.write(exp2);
+    if (group2) out.write(')');
+
+    return out;
+  }
+
+  /// Generates a short-circuiting logical expression — `a && b` / `a || b`.
+  ///
+  /// The operator token comes from [resolveASTExpressionOperatorText], so a
+  /// target with its own spelling is honoured (Python and Lua write `and`/`or`).
+  @override
+  StringBuffer generateASTExpressionLogical(
+    ASTExpressionLogical expression, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    final expression1 = expression.expression1;
+    final expression2 = expression.expression2;
+
+    var op = resolveASTExpressionOperatorText(
+      expression.operator,
+      ASTNumType.nan,
+      ASTNumType.nan,
+    );
+
+    var exp1 = generateASTExpression(
+      expression1,
+      indent: '$indent  ',
+      headIndented: false,
+    );
+
+    var exp2 = generateASTExpression(
+      expression2,
+      indent: '$indent  ',
+      headIndented: false,
+    );
+
+    var group1 = expression1.isComplex;
+    var group2 = expression2.isComplex;
 
     if (group1) out.write('(');
     out.write(exp1);

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -374,10 +374,20 @@ abstract class ApolloCodeGenerator
   /// (Java, Go, …) leave this `false` and drop the suffix (best-effort).
   bool get supportsNullableTypeSuffix => false;
 
-  /// Whether this target has native null-aware operators (`?.`, `?[`) that can
-  /// be emitted directly (Dart, Kotlin, TypeScript). Targets without them leave
-  /// this `false` and emit the plain `.`/`[` form (best-effort).
+  /// Whether this target has native null-aware access operators (`?.`, `?[`)
+  /// that can be emitted directly — Dart, Kotlin, TypeScript, C# and
+  /// JavaScript. Targets without them lower the access through
+  /// [renderNullAwareAccess] instead.
   bool get supportsNullAwareOperators => false;
+
+  /// Whether this target has a postfix *null-assertion* operator (Dart/C#/TS
+  /// `!`, Kotlin `!!`).
+  ///
+  /// Separate from [supportsNullAwareOperators] because the two do not always
+  /// come together: JavaScript has `?.` but no null assertion, and emitting a
+  /// postfix `!` there would be the logical-NOT operator — a silent change of
+  /// meaning rather than a dropped check.
+  bool get supportsNullAssertionOperator => supportsNullAwareOperators;
 
   StringBuffer generateASTType(
     ASTType type, {
@@ -2125,17 +2135,123 @@ abstract class ApolloCodeGenerator
   }
 
   /// The postfix null-assertion token for this target (`!` for Dart/TypeScript,
-  /// `!!` for Kotlin). Only emitted when [supportsNullAwareOperators] is true.
+  /// `!!` for Kotlin). Only emitted when [supportsNullAssertionOperator] is
+  /// true.
   String get nullAssertionSuffix => '!';
 
-  /// The opening token for a null-aware index access (`?[` for Dart, `?.[` for
-  /// TypeScript, `?.get(` for Kotlin). Only used when
+  /// The opening token for a null-aware index access (`?[` for Dart/C#, `?.[`
+  /// for TypeScript/JavaScript, `?.get(` for Kotlin). Only used when
   /// [supportsNullAwareOperators] is true.
   String get nullAwareIndexOpen => '?[';
 
   /// The closing token that matches [nullAwareIndexOpen]. Kotlin's null-aware
   /// index is the call `a?.get(i)`, so it closes with `)` rather than `]`.
   String get nullAwareIndexClose => ']';
+
+  /// Guards [guarded] on [receiver] being non-null, yielding null instead —
+  /// the lowering of `?.` / `?[` for a target with no native operator.
+  ///
+  /// [receiver] is the *root* of the access chain and [guarded] is the whole
+  /// chain applied to it, so `a?.m().toInt()` arrives as
+  /// `renderNullAwareGuard('a', 'a.m().toInt()')` and the trailing `.toInt()`
+  /// stays inside the guard. Guarding only the first link would still
+  /// dereference null on the rest of the chain.
+  ///
+  /// Only called when [supportsNullAwareOperators] is false. The default is the
+  /// best-effort unguarded form, which drops the check; Java, Lua and Python
+  /// override it, and Go reports the construct as unsupported.
+  ///
+  /// Like [renderNullCoalesce], an override repeats [receiver] in its output,
+  /// so it is only valid for receivers that can be evaluated twice — variables,
+  /// fields and index reads, which is what these are in practice.
+  String renderNullAwareGuard(String receiver, String guarded) => guarded;
+
+  /// Set while generating the inside of a hoisted null-aware guard, so the
+  /// nested access nodes emit their plain form instead of each re-guarding.
+  bool _inNullAwareChain = false;
+
+  /// Joins a receiver and the member text following it. The null-aware form is
+  /// only emitted here for targets with the native operator — targets without
+  /// one are handled by [generateNullAwareChain], which hoists a single guard
+  /// around the whole chain.
+  String _composeMemberAccess(
+    String receiver,
+    String member, {
+    required bool nullAware,
+  }) => (nullAware && supportsNullAwareOperators)
+      ? '$receiver?.$member'
+      : '$receiver.$member';
+
+  /// The root receiver of [node]'s access chain when some link in it is
+  /// null-aware, or `null` when none is.
+  ///
+  /// `a?.m().toInt()` nests as an invocation of `toInt` whose receiver is the
+  /// null-aware invocation of `m` on `a`, so this walks down through
+  /// [ASTExpressionVariable] wrappers and returns `a`.
+  ASTVariable? _nullAwareChainRoot(ASTExpression node) {
+    ASTVariable? variable;
+    bool nullAware;
+
+    switch (node) {
+      case ASTExpressionObjectFunctionInvocation():
+        variable = node.variable;
+        nullAware = node.isNullAware;
+      case ASTExpressionObjectGetterAccess():
+        variable = node.variable;
+        nullAware = node.isNullAware;
+      case ASTExpressionVariableEntryAccess():
+        variable = node.variable;
+        nullAware = node.isNullAware;
+      default:
+        return null;
+    }
+
+    if (nullAware) return variable;
+
+    // Not null-aware itself — look further down the receiver chain.
+    if (variable is ASTExpressionVariable) {
+      return _nullAwareChainRoot(variable.expression);
+    }
+
+    return null;
+  }
+
+  /// Emits [node] wrapped in a single null guard when this target has no native
+  /// `?.` and [node]'s chain contains a null-aware link. Returns `null` when no
+  /// hoisting applies and the caller should generate normally.
+  StringBuffer? generateNullAwareChain(
+    ASTExpression node, {
+    required StringBuffer out,
+    required String indent,
+  }) {
+    if (supportsNullAwareOperators || _inNullAwareChain) return null;
+
+    var root = _nullAwareChainRoot(node);
+    if (root == null) return null;
+
+    var receiver = generateASTVariable(
+      root,
+      indent: indent,
+      headIndented: false,
+    ).toString();
+
+    // Re-enter generation with the guard suppressed, so the chain renders in
+    // its plain form and every link ends up inside this one guard.
+    _inNullAwareChain = true;
+    String guarded;
+    try {
+      guarded = generateASTExpression(
+        node,
+        indent: indent,
+        headIndented: false,
+      ).toString();
+    } finally {
+      _inNullAwareChain = false;
+    }
+
+    out.write(renderNullAwareGuard(receiver, guarded));
+    return out;
+  }
 
   StringBuffer generateASTExpressionNullAssertion(
     ASTExpressionNullAssertion expression, {
@@ -2155,7 +2271,7 @@ abstract class ApolloCodeGenerator
     if (group) out.write(')');
 
     // Best-effort: targets without a null-assertion operator drop it.
-    if (supportsNullAwareOperators) {
+    if (supportsNullAssertionOperator) {
       out.write(nullAssertionSuffix);
     }
 
@@ -2309,6 +2425,9 @@ abstract class ApolloCodeGenerator
 
     if (headIndented) out.write(indent);
 
+    var hoisted = generateNullAwareChain(expression, out: out, indent: indent);
+    if (hoisted != null) return hoisted;
+
     var functionName = expression.name;
 
     if (expression.variable.isTypeIdentifier) {
@@ -2318,31 +2437,39 @@ abstract class ApolloCodeGenerator
       functionName = normalizeIdentifier(functionName);
     }
 
-    generateASTVariable(
+    var receiver = generateASTVariable(
       expression.variable,
       callingFunction: functionName,
-      out: out,
       indent: indent,
       headIndented: false,
-    );
-    if (expression.assertReceiver && supportsNullAwareOperators) {
-      out.write(nullAssertionSuffix);
-    }
-    out.write(
-      expression.isNullAware && supportsNullAwareOperators ? '?.' : '.',
-    );
+    ).toString();
 
-    final arguments = expression.arguments;
+    if (expression.assertReceiver && supportsNullAssertionOperator) {
+      receiver += nullAssertionSuffix;
+    }
+
+    // The call and any trailing chain form the member text, so a lowering that
+    // guards the access covers `a?.b().c()` whole rather than only its first
+    // link.
+    var member = newOutput();
 
     _generateFunctionInvocation(
       functionName,
-      arguments,
-      out,
+      expression.arguments,
+      member,
       indent,
       namedArguments: expression.namedArguments,
     );
 
-    _generateChainFunctionInvocation(expression, out, indent);
+    _generateChainFunctionInvocation(expression, member, indent);
+
+    out.write(
+      _composeMemberAccess(
+        receiver,
+        member.toString(),
+        nullAware: expression.isNullAware,
+      ),
+    );
 
     return out;
   }
@@ -2493,6 +2620,9 @@ abstract class ApolloCodeGenerator
 
     if (headIndented) out.write(indent);
 
+    var hoisted = generateNullAwareChain(expression, out: out, indent: indent);
+    if (hoisted != null) return hoisted;
+
     var getterName = expression.name;
 
     if (expression.variable.isTypeIdentifier) {
@@ -2502,23 +2632,28 @@ abstract class ApolloCodeGenerator
       getterName = normalizeIdentifier(getterName);
     }
 
-    generateASTVariable(
+    var receiver = generateASTVariable(
       expression.variable,
       callingFunction: getterName,
-      out: out,
       indent: indent,
       headIndented: false,
-    );
-    if (expression.assertReceiver && supportsNullAwareOperators) {
-      out.write(nullAssertionSuffix);
+    ).toString();
+
+    if (expression.assertReceiver && supportsNullAssertionOperator) {
+      receiver += nullAssertionSuffix;
     }
+
+    var member = newOutput()..write(getterName);
+
+    _generateChainFunctionInvocation(expression, member, indent);
+
     out.write(
-      expression.isNullAware && supportsNullAwareOperators ? '?.' : '.',
+      _composeMemberAccess(
+        receiver,
+        member.toString(),
+        nullAware: expression.isNullAware,
+      ),
     );
-
-    out.write(getterName);
-
-    _generateChainFunctionInvocation(expression, out, indent);
 
     return out;
   }
@@ -2620,35 +2755,49 @@ abstract class ApolloCodeGenerator
 
     if (headIndented) out.write(indent);
 
-    generateASTVariable(
+    var hoisted = generateNullAwareChain(expression, out: out, indent: indent);
+    if (hoisted != null) return hoisted;
+
+    var receiver = generateASTVariable(
       expression.variable,
-      out: out,
       indent: indent,
       headIndented: headIndented,
-    );
-    if (expression.assertReceiver && supportsNullAwareOperators) {
-      out.write(nullAssertionSuffix);
+    ).toString();
+
+    if (expression.assertReceiver && supportsNullAssertionOperator) {
+      receiver += nullAssertionSuffix;
     }
-    var nullAwareIndex = expression.isNullAware && supportsNullAwareOperators;
-    out.write(nullAwareIndex ? nullAwareIndexOpen : '[');
-    generateASTExpression(
+
+    var index = generateASTExpression(
       expression.expression,
-      out: out,
       indent: indent,
       headIndented: false,
-    );
-    out.write(nullAwareIndex ? nullAwareIndexClose : ']');
-    // Chained indices for nested access (`m[0][1]`).
+    ).toString();
+
+    // Chained indices for nested access (`m[0][1]`). They belong inside the
+    // null guard: `a?[0][1]` short-circuits the whole postfix chain.
+    var extras = newOutput();
     for (var extra in expression.extraIndices) {
-      out.write('[');
+      extras.write('[');
       generateASTExpression(
         extra,
-        out: out,
+        out: extras,
         indent: indent,
         headIndented: false,
       );
-      out.write(']');
+      extras.write(']');
     }
+
+    // A null-aware index on a target without `?[` is handled by the hoisted
+    // guard above, which re-enters here with the plain form.
+    if (expression.isNullAware && supportsNullAwareOperators) {
+      out.write(
+        '$receiver$nullAwareIndexOpen$index$nullAwareIndexClose$extras',
+      );
+    } else {
+      out.write('$receiver[$index]$extras');
+    }
+
     return out;
   }
 

--- a/lib/src/apollovm_generator.dart
+++ b/lib/src/apollovm_generator.dart
@@ -165,6 +165,8 @@ abstract class ApolloGenerator<
 
   O generateASTExpressionNullCheck(ASTExpressionNullCheck expression, {O? out});
 
+  O generateASTExpressionLogical(ASTExpressionLogical expression, {O? out});
+
   O generateASTExpressionConditional(
     ASTExpressionConditional expression, {
     O? out,

--- a/lib/src/apollovm_generator.dart
+++ b/lib/src/apollovm_generator.dart
@@ -158,6 +158,13 @@ abstract class ApolloGenerator<
 
   O generateASTExpressionOperation(ASTExpressionOperation expression, {O? out});
 
+  O generateASTExpressionNullCoalesce(
+    ASTExpressionNullCoalesce expression, {
+    O? out,
+  });
+
+  O generateASTExpressionNullCheck(ASTExpressionNullCheck expression, {O? out});
+
   O generateASTExpressionConditional(
     ASTExpressionConditional expression, {
     O? out,

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -1043,6 +1043,15 @@ const _nullCoalesceIsItsOwnNode =
     "'??' is an ASTExpressionNullCoalesce, not an ASTExpressionOperation. "
     'Build binary operations with astExpressionOperation().';
 
+/// Raised when an [ASTExpressionOperation] holding [ASTExpressionOperator.and]
+/// or [ASTExpressionOperator.or] is evaluated. Like `??`, the enum members stay
+/// (the generators use them to resolve each target's spelling), but the
+/// *expression* form is an [ASTExpressionLogicalAnd] / [ASTExpressionLogicalOr],
+/// which is what makes them short-circuit.
+const _logicalIsItsOwnNode =
+    "'&&'/'||' are ASTExpressionLogicalAnd/Or, not an ASTExpressionOperation. "
+    'Build binary operations with astExpressionOperation().';
+
 /// Builds the [ASTExpression] for the binary operation `e1 <op> e2`,
 /// specializing the shapes that have a dedicated node:
 ///
@@ -1064,6 +1073,14 @@ ASTExpression astExpressionOperation(
 ) {
   if (op == ASTExpressionOperator.nullCoalesce) {
     return ASTExpressionNullCoalesce(e1, e2);
+  }
+
+  if (op == ASTExpressionOperator.and) {
+    return ASTExpressionLogicalAnd(e1, e2);
+  }
+
+  if (op == ASTExpressionOperator.or) {
+    return ASTExpressionLogicalOr(e1, e2);
   }
 
   if (op == ASTExpressionOperator.equals ||
@@ -1329,6 +1346,108 @@ class ASTExpressionNullCheck extends ASTExpression {
     var s = nullFirst ? 'null $op $expression' : '$expression $op null';
     return asGroup ? '($s)' : s;
   }
+}
+
+/// Base for the short-circuiting logical operators `&&` and `||`.
+///
+/// These are dedicated nodes for the same reason [ASTExpressionNullCoalesce]
+/// is: [expression2] must not be evaluated when [expression1] already decides
+/// the result, so they never reach the binary-operator dispatch. Lifting them
+/// out leaves [ASTExpressionOperation.run] a single uniform path.
+///
+/// Both operands are coerced to booleans, and the result is always an
+/// [ASTValueBool].
+abstract class ASTExpressionLogical extends ASTExpression {
+  ASTExpression expression1;
+  ASTExpression expression2;
+
+  ASTExpressionLogical(this.expression1, this.expression2);
+
+  /// The operator this node applies — [ASTExpressionOperator.and] or
+  /// [ASTExpressionOperator.or]. Generators read it to resolve each target's
+  /// spelling (Python and Lua write `and`/`or`).
+  ASTExpressionOperator get operator;
+
+  /// Whether a left operand of [left] already determines the result, making
+  /// [expression2] dead.
+  bool shortCircuitsOn(bool left);
+
+  /// The result when [shortCircuitsOn] holds.
+  ASTValueBool get shortCircuitValue;
+
+  @override
+  bool get isComplex => true;
+
+  @override
+  Iterable<ASTNode> get children => [expression1, expression2];
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+
+    expression1.resolveNode(this);
+    expression2.resolveNode(this);
+  }
+
+  @override
+  FutureOr<ASTType> resolveType(VMContext? context) => ASTTypeBool.instance;
+
+  @override
+  FutureOr<ASTType> resolveRuntimeType(VMContext context, ASTNode? node) =>
+      ASTTypeBool.instance;
+
+  @override
+  FutureOr<ASTValue> run(VMContext parentContext, ASTRunStatus runStatus) {
+    var context = defineRunContext(parentContext);
+
+    return expression1.run(context, runStatus).resolveMapped((val1) {
+      return _astValueToBoolean(val1, context).resolveMapped((b1) {
+        if (shortCircuitsOn(b1)) return shortCircuitValue;
+
+        return expression2.run(context, runStatus).resolveMapped((val2) {
+          return _astValueToBoolean(
+            val2,
+            context,
+          ).resolveMapped((b2) => ASTValueBool(b2));
+        });
+      });
+    });
+  }
+
+  @override
+  String toString({bool asGroup = false}) {
+    var op = getASTExpressionOperatorText(operator);
+    var s = '$expression1 $op $expression2';
+    return asGroup ? '($s)' : s;
+  }
+}
+
+/// [ASTExpression] for `a && b`: [expression2] runs only when `a` is true.
+class ASTExpressionLogicalAnd extends ASTExpressionLogical {
+  ASTExpressionLogicalAnd(super.expression1, super.expression2);
+
+  @override
+  ASTExpressionOperator get operator => ASTExpressionOperator.and;
+
+  @override
+  bool shortCircuitsOn(bool left) => !left;
+
+  @override
+  ASTValueBool get shortCircuitValue => ASTValueBool.FALSE;
+}
+
+/// [ASTExpression] for `a || b`: [expression2] runs only when `a` is false.
+class ASTExpressionLogicalOr extends ASTExpressionLogical {
+  ASTExpressionLogicalOr(super.expression1, super.expression2);
+
+  @override
+  ASTExpressionOperator get operator => ASTExpressionOperator.or;
+
+  @override
+  bool shortCircuitsOn(bool left) => left;
+
+  @override
+  ASTValueBool get shortCircuitValue => ASTValueBool.TRUE;
 }
 
 /// [ASTExpression] that makes another [expression] negative.
@@ -1600,6 +1719,33 @@ FutureOr<bool> _astValueIsNull(VMContext context, ASTValue val) {
   return val.getValue(context).resolveMapped((v) => v == null);
 }
 
+/// Coerces [val] to a boolean using the truthiness rules shared by the logical
+/// operators: a number is true when positive, a String parses, a collection is
+/// true when non-empty, and `null` is false.
+FutureOr<bool> _astValueToBoolean(ASTValue val, VMContext context) {
+  if (val is ASTValueBool) {
+    return val.value;
+  }
+
+  return val.resolve(context).resolveMapped((val) {
+    if (val is ASTValueBool) {
+      return val.value;
+    } else if (val is ASTValueNum) {
+      return val.value > 0;
+    } else if (val is ASTValueString) {
+      return parseBool(val.value) ?? false;
+    } else if (val is ASTValueArray) {
+      return val.value.isNotEmpty;
+    } else if (val is ASTValueMap) {
+      return val.value.isNotEmpty;
+    } else if (val is ASTValueNull) {
+      return false;
+    } else {
+      return false;
+    }
+  });
+}
+
 /// [ASTExpression] for an operation between 2 expressions.
 ///
 /// Note that `??` never reaches this node — [astExpressionOperation] builds an
@@ -1787,28 +1933,6 @@ class ASTExpressionOperation extends ASTExpression {
 
     final operator = this.operator;
 
-    // Short-circuit logical operators: only evaluate the right operand when the
-    // left does not already determine the result. This matches Dart semantics
-    // and keeps the interpreter consistent with the Wasm compiler.
-    if (operator == ASTExpressionOperator.and ||
-        operator == ASTExpressionOperator.or) {
-      return expression1.run(context, runStatus).resolveMapped((val1) {
-        return _toBoolean(val1, context).resolveMapped((b1) {
-          if (operator == ASTExpressionOperator.and) {
-            if (!b1) return ASTValueBool.FALSE;
-          } else {
-            if (b1) return ASTValueBool.TRUE;
-          }
-          return expression2.run(context, runStatus).resolveMapped((val2) {
-            return _toBoolean(
-              val2,
-              context,
-            ).resolveMapped((b2) => ASTValueBool(b2));
-          });
-        });
-      });
-    }
-
     var retVal2 = expression2.run(context, runStatus);
     var retVal1 = expression1.run(context, runStatus);
 
@@ -1845,10 +1969,14 @@ class ASTExpressionOperation extends ASTExpression {
               return operatorLowerOrEq(parentContext, c1, c2);
             case ASTExpressionOperator.remainder:
               return operatorRemainder(parentContext, c1, c2);
+            // Reaching here would evaluate both operands eagerly (they are run
+            // above), which is not `&&`/`||`. The short-circuiting nodes are the
+            // only correct form, so this is an error rather than a silent
+            // change of semantics. `operatorAnd`/`operatorOr` remain available
+            // for a deliberate non-short-circuit combination.
             case ASTExpressionOperator.and:
-              return operatorAnd(parentContext, c1, c2);
             case ASTExpressionOperator.or:
-              return operatorOr(parentContext, c1, c2);
+              throw StateError(_logicalIsItsOwnNode);
             case ASTExpressionOperator.bitwiseAnd:
               return operatorBitwiseAnd(parentContext, c1, c2);
             case ASTExpressionOperator.bitwiseOr:
@@ -2254,29 +2382,8 @@ class ASTExpressionOperation extends ASTExpression {
     return ASTValueInt(v1 >> v2);
   }
 
-  FutureOr<bool> _toBoolean(ASTValue val, VMContext context) {
-    if (val is ASTValueBool) {
-      return val.value;
-    }
-
-    return val.resolve(context).resolveMapped((val) {
-      if (val is ASTValueBool) {
-        return val.value;
-      } else if (val is ASTValueNum) {
-        return val.value > 0;
-      } else if (val is ASTValueString) {
-        return parseBool(val.value) ?? false;
-      } else if (val is ASTValueArray) {
-        return val.value.isNotEmpty;
-      } else if (val is ASTValueMap) {
-        return val.value.isNotEmpty;
-      } else if (val is ASTValueNull) {
-        return false;
-      } else {
-        return false;
-      }
-    });
-  }
+  FutureOr<bool> _toBoolean(ASTValue val, VMContext context) =>
+      _astValueToBoolean(val, context);
 
   @override
   String toString({bool asGroup = false}) {

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -1034,6 +1034,54 @@ String getASTExpressionOperatorText(ASTExpressionOperator op) {
   }
 }
 
+/// Raised when an [ASTExpressionOperation] is reached holding
+/// [ASTExpressionOperator.nullCoalesce]. The enum member is kept — `??=` bridges
+/// through it via [ASTAssignmentOperator.asASTExpressionOperator], and the
+/// generators use it to look up each target's spelling — but the *expression*
+/// form is always an [ASTExpressionNullCoalesce].
+const _nullCoalesceIsItsOwnNode =
+    "'??' is an ASTExpressionNullCoalesce, not an ASTExpressionOperation. "
+    'Build binary operations with astExpressionOperation().';
+
+/// Builds the [ASTExpression] for the binary operation `e1 <op> e2`,
+/// specializing the shapes that have a dedicated node:
+///
+/// - `??` becomes an [ASTExpressionNullCoalesce];
+/// - `x == null` / `x != null` (either operand order) becomes an
+///   [ASTExpressionNullCheck].
+///
+/// Everything else becomes a plain [ASTExpressionOperation].
+///
+/// Grammars should always reduce binary operations through this function.
+/// Constructing [ASTExpressionOperation] directly is still valid — the Wasm
+/// backend synthesizes arithmetic operations that way — but it bypasses the
+/// specialization, leaving the short-circuiting forms on the generic
+/// operator-dispatch path.
+ASTExpression astExpressionOperation(
+  ASTExpression e1,
+  ASTExpressionOperator op,
+  ASTExpression e2,
+) {
+  if (op == ASTExpressionOperator.nullCoalesce) {
+    return ASTExpressionNullCoalesce(e1, e2);
+  }
+
+  if (op == ASTExpressionOperator.equals ||
+      op == ASTExpressionOperator.notEquals) {
+    final negated = op == ASTExpressionOperator.notEquals;
+
+    // `null == null` matches the first branch, which is correct: the retained
+    // literal becomes the operand and the check still evaluates to `true`.
+    if (e2 is ASTExpressionNullValue) {
+      return ASTExpressionNullCheck(e1, e2, negated: negated);
+    } else if (e1 is ASTExpressionNullValue) {
+      return ASTExpressionNullCheck(e2, e1, negated: negated, nullFirst: true);
+    }
+  }
+
+  return ASTExpressionOperation(e1, op, e2);
+}
+
 /// [ASTExpression] that negates another [expression].
 class ASTExpressionNegation extends ASTExpression {
   ASTExpression expression;
@@ -1132,6 +1180,153 @@ class ASTExpressionNullAssertion extends ASTExpression {
   @override
   String toString({bool asGroup = false}) {
     var s = '$expression!';
+    return asGroup ? '($s)' : s;
+  }
+}
+
+/// [ASTExpression] for the null-coalescing operation `a ?? b`.
+///
+/// [expression2] is evaluated only when [expression1] resolves to `null`, so
+/// `a ?? sideEffect()` does not call `sideEffect` when `a` is non-null.
+///
+/// This is a dedicated node rather than an [ASTExpressionOperation] with
+/// [ASTExpressionOperator.nullCoalesce]: it short-circuits, so it never reaches
+/// the binary-operator dispatch, and every backend needs its own lowering
+/// (Kotlin's Elvis `?:`, Java's ternary, Go's nil-checking closure). Build it
+/// through [astExpressionOperation] rather than directly, so a grammar reducing
+/// a `??` token gets the specialization for free.
+class ASTExpressionNullCoalesce extends ASTExpression {
+  ASTExpression expression1;
+  ASTExpression expression2;
+
+  ASTExpressionNullCoalesce(this.expression1, this.expression2);
+
+  @override
+  bool get isComplex => true;
+
+  @override
+  Iterable<ASTNode> get children => [expression1, expression2];
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+
+    expression1.resolveNode(this);
+    expression2.resolveNode(this);
+  }
+
+  /// The result is [expression1]'s type minus its nullability (it only reaches
+  /// the result when non-null), unified with [expression2]'s type.
+  @override
+  FutureOr<ASTType> resolveType(VMContext? context) {
+    var retT1 = expression1.resolveType(context);
+    var retT2 = expression2.resolveType(context);
+    return retT1.resolveBoth(retT2, _commonType);
+  }
+
+  @override
+  FutureOr<ASTType> resolveRuntimeType(VMContext context, ASTNode? node) {
+    var retT1 = expression1.resolveRuntimeType(context, null);
+    var retT2 = expression2.resolveRuntimeType(context, null);
+    return retT1.resolveBoth(retT2, _commonType);
+  }
+
+  static ASTType _commonType(ASTType t1, ASTType t2) {
+    var nn = t1.withoutNullability();
+    return nn.commonType(t2) ?? t2;
+  }
+
+  @override
+  FutureOr<ASTValue> run(VMContext parentContext, ASTRunStatus runStatus) {
+    var context = defineRunContext(parentContext);
+
+    return expression1.run(context, runStatus).resolveMapped((val1) {
+      return _astValueIsNull(context, val1).resolveMapped((isNull) {
+        if (!isNull) return val1;
+        return expression2.run(context, runStatus);
+      });
+    });
+  }
+
+  @override
+  String toString({bool asGroup = false}) {
+    var s = '$expression1 ?? $expression2';
+    return asGroup ? '($s)' : s;
+  }
+}
+
+/// [ASTExpression] for a comparison against the `null` literal — `x == null`
+/// and, when [negated], `x != null`.
+///
+/// A dedicated node because this shape drives behaviour well beyond equality:
+/// [NullSafetyAnalyzer] reads it to promote a nullable variable inside
+/// `if (x != null) { … }`, Go compares the *pointer* (`p == nil`) instead of
+/// dereferencing it, and Python spells it `is None`. Every one of those
+/// consumers used to re-detect the shape by inspecting an
+/// [ASTExpressionOperation]'s operands.
+///
+/// Evaluating it tests [expression] directly, skipping the operand
+/// concretization and `operatorEquals` dispatch a generic operation would do.
+class ASTExpressionNullCheck extends ASTExpression {
+  /// The operand being compared against `null`.
+  ASTExpression expression;
+
+  /// The `null` literal operand. Retained as a real child so generic AST walks
+  /// still see it — the Wasm backend scans for [ASTExpressionNullValue] to
+  /// decide whether a module needs its null-box machinery.
+  ASTExpressionNullValue nullValue;
+
+  /// `true` for `!=`, `false` for `==`.
+  bool negated;
+
+  /// `true` when the source wrote the literal first (`null == x`), so
+  /// regeneration preserves the original operand order.
+  bool nullFirst;
+
+  ASTExpressionNullCheck(
+    this.expression,
+    this.nullValue, {
+    this.negated = false,
+    this.nullFirst = false,
+  });
+
+  @override
+  bool get isComplex => true;
+
+  @override
+  Iterable<ASTNode> get children =>
+      nullFirst ? [nullValue, expression] : [expression, nullValue];
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+
+    expression.resolveNode(this);
+    nullValue.resolveNode(this);
+  }
+
+  @override
+  FutureOr<ASTType> resolveType(VMContext? context) => ASTTypeBool.instance;
+
+  @override
+  FutureOr<ASTType> resolveRuntimeType(VMContext context, ASTNode? node) =>
+      ASTTypeBool.instance;
+
+  @override
+  FutureOr<ASTValue> run(VMContext parentContext, ASTRunStatus runStatus) {
+    var context = defineRunContext(parentContext);
+
+    return expression.run(context, runStatus).resolveMapped((val) {
+      return _astValueIsNull(context, val).resolveMapped((isNull) {
+        return ASTValueBool(isNull != negated);
+      });
+    });
+  }
+
+  @override
+  String toString({bool asGroup = false}) {
+    var op = negated ? '!=' : '==';
+    var s = nullFirst ? 'null $op $expression' : '$expression $op null';
     return asGroup ? '($s)' : s;
   }
 }
@@ -1398,7 +1593,6 @@ class ASTExpressionAwait extends ASTExpression {
   }
 }
 
-/// [ASTExpression] for an operation between 2 expressions.
 /// Returns whether [val] represents `null` (a `null` literal/value, or a
 /// dynamic/boxed operand whose resolved value is `null`).
 FutureOr<bool> _astValueIsNull(VMContext context, ASTValue val) {
@@ -1406,6 +1600,11 @@ FutureOr<bool> _astValueIsNull(VMContext context, ASTValue val) {
   return val.getValue(context).resolveMapped((v) => v == null);
 }
 
+/// [ASTExpression] for an operation between 2 expressions.
+///
+/// Note that `??` never reaches this node — [astExpressionOperation] builds an
+/// [ASTExpressionNullCoalesce] for it, since it short-circuits instead of
+/// dispatching through the binary-operator table.
 class ASTExpressionOperation extends ASTExpression {
   ASTExpression expression1;
   ASTExpressionOperator operator;
@@ -1463,14 +1662,7 @@ class ASTExpressionOperation extends ASTExpression {
       case ASTExpressionOperator.or:
         return ASTTypeBool.instance;
       case ASTExpressionOperator.nullCoalesce:
-        {
-          var retT1 = expression1.resolveType(context);
-          var retT2 = expression2.resolveType(context);
-          return retT1.resolveBoth(retT2, (t1, t2) {
-            var nn = t1.withoutNullability();
-            return nn.commonType(t2) ?? t2;
-          });
-        }
+        throw StateError(_nullCoalesceIsItsOwnNode);
     }
   }
 
@@ -1510,14 +1702,7 @@ class ASTExpressionOperation extends ASTExpression {
       case ASTExpressionOperator.or:
         return ASTTypeBool.instance;
       case ASTExpressionOperator.nullCoalesce:
-        {
-          var retT1 = expression1.resolveRuntimeType(context, null);
-          var retT2 = expression2.resolveRuntimeType(context, null);
-          return retT1.resolveBoth(retT2, (t1, t2) {
-            var nn = t1.withoutNullability();
-            return nn.commonType(t2) ?? t2;
-          });
-        }
+        throw StateError(_nullCoalesceIsItsOwnNode);
     }
   }
 
@@ -1602,18 +1787,6 @@ class ASTExpressionOperation extends ASTExpression {
 
     final operator = this.operator;
 
-    // Null-coalescing (`??`): evaluate the left operand; only evaluate the
-    // right operand when the left is `null`. Result is the left value when
-    // non-null, otherwise the right value.
-    if (operator == ASTExpressionOperator.nullCoalesce) {
-      return expression1.run(context, runStatus).resolveMapped((val1) {
-        return _astValueIsNull(context, val1).resolveMapped((isNull) {
-          if (!isNull) return val1;
-          return expression2.run(context, runStatus);
-        });
-      });
-    }
-
     // Short-circuit logical operators: only evaluate the right operand when the
     // left does not already determine the result. This matches Dart semantics
     // and keeps the interpreter consistent with the Wasm compiler.
@@ -1687,8 +1860,7 @@ class ASTExpressionOperation extends ASTExpression {
             case ASTExpressionOperator.shiftRight:
               return operatorShiftRight(parentContext, c1, c2);
             case ASTExpressionOperator.nullCoalesce:
-              // Handled by the short-circuit branch above.
-              throw StateError('unreachable: nullCoalesce');
+              throw StateError(_nullCoalesceIsItsOwnNode);
           }
         });
       });

--- a/lib/src/languages/csharp/csharp_generator.dart
+++ b/lib/src/languages/csharp/csharp_generator.dart
@@ -17,6 +17,11 @@ class ApolloCodeGeneratorCSharp extends ApolloCodeGenerator {
   ApolloCodeGeneratorCSharp(ApolloSourceCodeStorage codeStorage)
     : super('csharp', codeStorage);
 
+  /// C# has had null-conditional access (`a?.b`, `a?[i]`) since C# 6 and the
+  /// null-forgiving `!` since C# 8, so all three are emitted natively.
+  @override
+  bool get supportsNullAwareOperators => true;
+
   @override
   StringBuffer generateASTExpressionLiteralFunction(
     ASTExpressionLiteralFunction expression, {

--- a/lib/src/languages/go/go_generator.dart
+++ b/lib/src/languages/go/go_generator.dart
@@ -1520,31 +1520,27 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
   }
 
   /// `x == null` / `x != null` compare the *pointer*, so they must not deref.
+  ///
+  /// A non-pointer operand cannot be nil in Go, so it falls through to the
+  /// default rendering (which spells the literal `nil` via [nullValueLiteral]).
   @override
-  StringBuffer generateASTExpressionOperation(
-    ASTExpressionOperation expression, {
+  StringBuffer generateASTExpressionNullCheck(
+    ASTExpressionNullCheck expression, {
     StringBuffer? out,
     String indent = '',
     bool headIndented = true,
   }) {
-    var op = expression.operator;
-    if (op == ASTExpressionOperator.equals ||
-        op == ASTExpressionOperator.notEquals) {
-      var e1 = expression.expression1;
-      var e2 = expression.expression2;
-      var ptr = e2 is ASTExpressionNullValue
-          ? _nullablePtrName(e1)
-          : (e1 is ASTExpressionNullValue ? _nullablePtrName(e2) : null);
+    var ptr = _nullablePtrName(expression.expression);
 
-      if (ptr != null) {
-        out ??= newOutput();
-        if (headIndented) out.write(indent);
-        out.write(ptr);
-        out.write(op == ASTExpressionOperator.equals ? ' == nil' : ' != nil');
-        return out;
-      }
+    if (ptr != null) {
+      out ??= newOutput();
+      if (headIndented) out.write(indent);
+      var op = expression.negated ? '!=' : '==';
+      out.write(expression.nullFirst ? 'nil $op $ptr' : '$ptr $op nil');
+      return out;
     }
-    return super.generateASTExpressionOperation(
+
+    return super.generateASTExpressionNullCheck(
       expression,
       out: out,
       indent: indent,
@@ -1552,22 +1548,27 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     );
   }
 
+  @override
+  String get nullValueLiteral => 'nil';
+
   /// `a ?? b` on a nullable pointer: Go has no conditional *expression*, so this
   /// is an immediately-invoked function that nil-checks the pointer. When the
   /// left side is not a nullable pointer it cannot be nil, so it wins outright.
   @override
   StringBuffer generateASTExpressionNullCoalesce(
-    ASTExpression expression1,
-    ASTExpression expression2, {
+    ASTExpressionNullCoalesce expression, {
     StringBuffer? out,
     String indent = '',
+    bool headIndented = true,
   }) {
     out ??= newOutput();
 
-    var ptr = _nullablePtrName(expression1);
+    if (headIndented) out.write(indent);
+
+    var ptr = _nullablePtrName(expression.expression1);
     if (ptr == null) {
       return generateASTExpression(
-        expression1,
+        expression.expression1,
         out: out,
         indent: indent,
         headIndented: false,
@@ -1575,7 +1576,7 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
     }
 
     var fallback = generateASTExpression(
-      expression2,
+      expression.expression2,
       indent: indent,
       headIndented: false,
     ).toString();
@@ -1592,7 +1593,7 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
   /// This is the *read* path only — an assignment writes through
   /// `generateASTVariable`, where the pointer itself is the target and must not
   /// be deref'd. A comparison against `null` is handled before this, by
-  /// [generateASTExpressionOperation], so `x == nil` keeps testing the pointer.
+  /// [generateASTExpressionNullCheck], so `x == nil` keeps testing the pointer.
   @override
   StringBuffer generateASTExpressionVariableAccess(
     ASTExpressionVariableAccess expression, {

--- a/lib/src/languages/go/go_generator.dart
+++ b/lib/src/languages/go/go_generator.dart
@@ -1359,6 +1359,19 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
   @override
   bool get supportsNullCoalesceAssignment => false;
 
+  /// Go has no null-aware access. Degrading `a?.b` to `a.b` would both skip the
+  /// nil check *and* read through a `*T` where the field is expected, so it is
+  /// reported rather than mis-emitted.
+  @override
+  String renderNullAwareGuard(String receiver, String guarded) {
+    throw UnsupportedSyntaxError(
+      'Go has no null-aware access (`?.` / `?[`), and this generator represents '
+      'a nullable `T?` as `*T`, so guarding it needs the receiver\'s pointer '
+      'type to both nil-check and dereference. Use an explicit '
+      '`if ($receiver != nil) { … }` instead.',
+    );
+  }
+
   /// Go writes bitwise NOT as a prefix `^`.
   @override
   StringBuffer generateASTExpressionBitwiseNot(

--- a/lib/src/languages/grammar.dart
+++ b/lib/src/languages/grammar.dart
@@ -159,7 +159,7 @@ abstract class BaseGrammarLexer extends GrammarDefinition {
           throw StateError('Missing logical operator between blocks');
         }
 
-        finalExpressionOp = ASTExpressionOperation(
+        finalExpressionOp = astExpressionOperation(
           finalExpressionOp,
           blockOp,
           expressionOp,
@@ -219,7 +219,7 @@ abstract class BaseGrammarLexer extends GrammarDefinition {
       var e1 = block.removeAt(0);
       var op = block.removeAt(0);
       var e2 = block.removeAt(0);
-      block.insert(0, ASTExpressionOperation(e1, op, e2));
+      block.insert(0, astExpressionOperation(e1, op, e2));
     }
 
     return block.single as ASTExpression;
@@ -240,7 +240,7 @@ abstract class BaseGrammarLexer extends GrammarDefinition {
       // If the operator matches the current precedence group
       // (e.g. *, /, % OR +, -), we reduce this triplet
       if (op != null && ops.contains(op)) {
-        var exp = ASTExpressionOperation(e1, op, e2);
+        var exp = astExpressionOperation(e1, op, e2);
 
         // Replace [e1, op, e2] with the resulting expression
         // Important: always remove at the same index (i),

--- a/lib/src/languages/java/java11/java11_generator.dart
+++ b/lib/src/languages/java/java11/java11_generator.dart
@@ -407,6 +407,13 @@ class ApolloCodeGeneratorJava11 extends ApolloCodeGenerator {
   @override
   String renderNullCoalesce(String a, String b) => '($a != null ? $a : $b)';
 
+  /// Java has no `?.` or `?[`, so a null-aware access becomes an explicit
+  /// guard. Without this the access would degrade to a plain `.` and throw a
+  /// `NullPointerException` on exactly the input `?.` exists to handle.
+  @override
+  String renderNullAwareGuard(String receiver, String guarded) =>
+      '($receiver != null ? $guarded : null)';
+
   /// Java has no `??=`; a null-coalescing assignment becomes `t = (t != null ? t : v)`.
   @override
   bool get supportsNullCoalesceAssignment => false;

--- a/lib/src/languages/javascript/es/javascript_generator.dart
+++ b/lib/src/languages/javascript/es/javascript_generator.dart
@@ -20,6 +20,20 @@ class ApolloCodeGeneratorJavaScript extends ApolloCodeGenerator {
   ApolloCodeGeneratorJavaScript(ApolloSourceCodeStorage codeStorage)
     : super('javascript', codeStorage);
 
+  /// Optional chaining (`a?.b`, `a?.[i]`) is ES2020.
+  @override
+  bool get supportsNullAwareOperators => true;
+
+  /// JavaScript has no null-assertion operator: a postfix `!` is logical NOT,
+  /// so emitting it would change the meaning rather than drop a check. `x!` is
+  /// emitted as plain `x` (the assertion is a no-op at runtime in JS anyway).
+  @override
+  bool get supportsNullAssertionOperator => false;
+
+  /// JavaScript's null-aware element access is `a?.[i]`, not `a?[i]`.
+  @override
+  String get nullAwareIndexOpen => '?.[';
+
   @override
   String normalizeTypeName(String typeName, [String? callingFunction]) {
     switch (typeName) {

--- a/lib/src/languages/lua/lua_generator.dart
+++ b/lib/src/languages/lua/lua_generator.dart
@@ -746,6 +746,11 @@ class ApolloCodeGeneratorLua extends ApolloCodeGenerator {
   @override
   bool get supportsNullCoalesceAssignment => false;
 
+  /// Lua's null literal is `nil`. The `~=` inequality spelling comes from
+  /// [resolveASTExpressionOperatorText], which `renderNullCheck` already uses.
+  @override
+  String get nullValueLiteral => 'nil';
+
   @override
   StringBuffer generateASTExpressionLiteralFunction(
     ASTExpressionLiteralFunction expression, {

--- a/lib/src/languages/lua/lua_generator.dart
+++ b/lib/src/languages/lua/lua_generator.dart
@@ -751,6 +751,18 @@ class ApolloCodeGeneratorLua extends ApolloCodeGenerator {
   @override
   String get nullValueLiteral => 'nil';
 
+  /// Lua has no `?.` or `?[`, so a null-aware access becomes an
+  /// immediately-invoked function with an explicit `nil` test.
+  ///
+  /// Unlike [renderNullCoalesce], the receiver cannot be bound to a local here:
+  /// [guarded] is the whole chain already rendered against the receiver's own
+  /// text, so the receiver appears in both the test and the body — the same
+  /// evaluate-twice caveat the ternary-based targets carry.
+  @override
+  String renderNullAwareGuard(String receiver, String guarded) =>
+      '(function() if $receiver ~= nil then return $guarded end '
+      'return nil end)()';
+
   @override
   StringBuffer generateASTExpressionLiteralFunction(
     ASTExpressionLiteralFunction expression, {
@@ -880,6 +892,11 @@ class ApolloCodeGeneratorLua extends ApolloCodeGenerator {
   }) {
     out ??= newOutput();
     if (headIndented) out.write(indent);
+
+    // A null-aware index (`a?[i]`) is wrapped in a `nil` guard by the base
+    // generator, which re-enters here with the guard suppressed.
+    var hoisted = generateNullAwareChain(expression, out: out, indent: indent);
+    if (hoisted != null) return hoisted;
 
     generateASTVariable(
       expression.variable,

--- a/lib/src/languages/python/python_generator.dart
+++ b/lib/src/languages/python/python_generator.dart
@@ -1029,6 +1029,13 @@ class ApolloCodeGeneratorPython extends ApolloCodeGenerator {
   @override
   String get nullValueLiteral => 'None';
 
+  /// Python has no `?.` or `?[`, so a null-aware access becomes a conditional
+  /// expression guarded by an `is not None` test. Without this the access would
+  /// degrade to a plain `.` and raise `AttributeError` on `None`.
+  @override
+  String renderNullAwareGuard(String receiver, String guarded) =>
+      '($guarded if $receiver is not None else None)';
+
   /// Python compares against `None` by *identity*, not equality: `==` dispatches
   /// through `__eq__`, which a class can redefine to return `True` for `None`.
   /// `is None` / `is not None` is the form PEP 8 mandates.

--- a/lib/src/languages/python/python_generator.dart
+++ b/lib/src/languages/python/python_generator.dart
@@ -1027,6 +1027,24 @@ class ApolloCodeGeneratorPython extends ApolloCodeGenerator {
   bool get supportsNullCoalesceAssignment => false;
 
   @override
+  String get nullValueLiteral => 'None';
+
+  /// Python compares against `None` by *identity*, not equality: `==` dispatches
+  /// through `__eq__`, which a class can redefine to return `True` for `None`.
+  /// `is None` / `is not None` is the form PEP 8 mandates.
+  @override
+  String renderNullCheck(
+    String operand, {
+    required bool negated,
+    required bool nullFirst,
+  }) {
+    var op = negated ? 'is not' : 'is';
+    // `None is x` is legal but jarring; Python always reads `x is None`, so the
+    // operand order is normalized here even when the source wrote it reversed.
+    return '$operand $op None';
+  }
+
+  @override
   StringBuffer generateASTExpressionLiteralFunction(
     ASTExpressionLiteralFunction expression, {
     StringBuffer? out,

--- a/lib/src/languages/python/python_grammar.dart
+++ b/lib/src/languages/python/python_grammar.dart
@@ -712,8 +712,28 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
                         return getASTExpressionOperator(v);
                     }
                   }) |
+              ref0(expressionOperatorIsNone) |
               andToken().map((_) => ASTExpressionOperator.and) |
               orToken().map((_) => ASTExpressionOperator.or))
+          .cast<ASTExpressionOperator>();
+
+  /// `is None` / `is not None` — Python's identity test against `None`, which
+  /// is what the generator emits for a null check.
+  ///
+  /// Deliberately restricted to the `None` comparison by a lookahead: general
+  /// `is` is identity, and mapping `a is b` to `==` would silently turn it into
+  /// equality. `a is b` therefore stays unparsed, as it was before.
+  ///
+  /// The `None` itself is left for the operand parser, so the reduction sees
+  /// `[a, equals, None]` and `astExpressionOperation` folds it into an
+  /// [ASTExpressionNullCheck].
+  Parser<ASTExpressionOperator> expressionOperatorIsNone() =>
+      (isToken() & notToken().optional() & noneToken().and())
+          .map(
+            (v) => v[1] != null
+                ? ASTExpressionOperator.notEquals
+                : ASTExpressionOperator.equals,
+          )
           .cast<ASTExpressionOperator>();
 
   Parser<ASTExpression> expressionNoOperation() =>

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -1141,6 +1141,14 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     if (expr is ASTExpressionVariableAccess) {
       return scope[expr.variable.name];
     }
+    if (expr is ASTExpressionLogical || expr is ASTExpressionNullCheck) {
+      return ASTTypeBool.instance;
+    }
+    if (expr is ASTExpressionNullCoalesce) {
+      // `a ?? b` yields whichever operand survives; `b` is the one that always
+      // can, so it is the better single guess.
+      return _inferStaticExpressionType(expr.expression2, scope);
+    }
     if (expr is ASTExpressionOperation) {
       switch (expr.operator) {
         case ASTExpressionOperator.equals:
@@ -3466,15 +3474,16 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   /// yields an i32 boolean, so the right operand is only evaluated when needed:
   /// - `a && b`  ->  `a ? b : false`
   /// - `a || b`  ->  `a ? true : b`
-  BytesOutput generateASTExpressionLogicalShortCircuit(
-    ASTExpressionOperation expression, {
+  @override
+  BytesOutput generateASTExpressionLogical(
+    ASTExpressionLogical expression, {
     BytesOutput? out,
     WasmContext? context,
   }) {
     out ??= newOutput();
     context ??= WasmContext();
 
-    final isAnd = expression.operator == ASTExpressionOperator.and;
+    final isAnd = expression is ASTExpressionLogicalAnd;
     final stackLng0 = context.stackLength;
 
     // Left operand (i32 boolean).
@@ -3873,17 +3882,6 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
           context: context,
         );
       }
-    }
-
-    // Short-circuit logical operators must NOT eagerly evaluate the right
-    // operand, so they are handled before the generic operand evaluation below.
-    if (expression.operator == ASTExpressionOperator.and ||
-        expression.operator == ASTExpressionOperator.or) {
-      return generateASTExpressionLogicalShortCircuit(
-        expression,
-        out: out,
-        context: context,
-      );
     }
 
     final stackLng0 = context.stackLength;
@@ -9482,6 +9480,13 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     }
     if (expression is ASTExpressionNullCheck) {
       return generateASTExpressionNullCheck(
+        expression,
+        out: out,
+        context: context,
+      );
+    }
+    if (expression is ASTExpressionLogical) {
+      return generateASTExpressionLogical(
         expression,
         out: out,
         context: context,

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -3742,6 +3742,113 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   }
 
   @override
+  BytesOutput generateASTExpressionNullCoalesce(
+    ASTExpressionNullCoalesce expression, {
+    BytesOutput? out,
+    WasmContext? context,
+  }) {
+    out ??= newOutput();
+    context ??= WasmContext();
+
+    generateASTExpression(expression.expression1, out: out, context: context);
+    var leftType = context.stackGet(0)!.type;
+
+    // In the numeric domain a value can never be null, so the left operand
+    // always determines the result and the right one is dropped.
+    if (!_isObjectType(leftType)) return out;
+
+    // A boxed value *can* be the null pointer, so test it and fall back to
+    // the right operand. The result is boxed either way.
+    var leftTmp = context.scratchLocal(_astTypeString, 78); // i32 box ptr
+    out.write(
+      Wasm.localSet(leftTmp),
+      description: "[OP] `??`: stash left operand",
+    );
+    context.stackDrop();
+
+    out.write(Wasm.localGet(leftTmp));
+    out.write(Wasm32.i32Const(_boxPtrNull));
+    out.writeByte(Wasm32.i32Equals, description: "[OP] `??`: left is null?");
+    out.write(Wasm.ifInstruction(WasmType.i32Type));
+
+    // then: the left operand is null — evaluate the right one, boxed.
+    generateASTExpression(expression.expression2, out: out, context: context);
+    _autoConvertStackTypes(
+      context.stackGet(0)!.type,
+      ASTTypeObject.instance,
+      out: out,
+      context: context,
+    );
+    context.stackDrop();
+
+    out.writeByte(Wasm.elseInstruction);
+    out.write(
+      Wasm.localGet(leftTmp),
+      description: "[OP] `??`: left operand (non-null)",
+    );
+    out.writeByte(Wasm.end);
+
+    context.stackPush(ASTTypeObject.instance, "`??` result");
+    return out;
+  }
+
+  /// `x == null` / `x != null`.
+  ///
+  /// Wasm has no null of its own: `null` is the boxed-`Object` pointer
+  /// [_boxPtrNull], so this is an `i32` comparison against that pointer. It must
+  /// not go through the String or numeric equality paths — `__streq` would
+  /// compare *contents* against address 0, and the numeric path would push two
+  /// i32 handles into an `i64.eq` (an invalid module).
+  ///
+  /// The result is tracked on the virtual stack as an i32, which is how every
+  /// other comparison reports a boolean here.
+  @override
+  BytesOutput generateASTExpressionNullCheck(
+    ASTExpressionNullCheck expression, {
+    BytesOutput? out,
+    WasmContext? context,
+  }) {
+    out ??= newOutput();
+    context ??= WasmContext();
+
+    final stackLng0 = context.stackLength;
+
+    generateASTExpression(expression.expression, out: out, context: context);
+    var type = context.stackGet(0)!.type;
+    context.stackDrop();
+
+    var wantEquals = !expression.negated;
+
+    if (_isObjectType(type)) {
+      // A boxed value: compare the pointer against the null box.
+      out.write(Wasm32.i32Const(_boxPtrNull));
+      out.writeByte(
+        wantEquals ? Wasm32.i32Equals : Wasm32.i32NotEquals,
+        description: "[OP] boxed `${wantEquals ? '==' : '!='} null`",
+      );
+    } else {
+      // A concrete slot (`int`, `double`, `String`, an instance) has no null
+      // representation in Wasm, so the answer is constant. The operand is
+      // still emitted and dropped, to keep its side effects.
+      out.writeByte(
+        Wasm.drop,
+        description: "[OP] drop non-null operand of `== null`",
+      );
+      out.write(
+        Wasm32.i32Const(wantEquals ? 0 : 1),
+        description:
+            "[OP] `${wantEquals ? '==' : '!='} null` on a non-nullable "
+            "$type is constant",
+      );
+    }
+
+    context.stackPush(_astTypeInt32, "`== null` result");
+    context.assertStackLength(stackLng0 + 1, "After `== null`");
+
+    return out;
+  }
+
+  @override
   BytesOutput generateASTExpressionOperation(
     ASTExpressionOperation expression, {
     BytesOutput? out,
@@ -3777,50 +3884,6 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         out: out,
         context: context,
       );
-    }
-
-    // Null-coalescing (`a ?? b`).
-    if (expression.operator == ASTExpressionOperator.nullCoalesce) {
-      generateASTExpression(expression1, out: out, context: context);
-      var leftType = context.stackGet(0)!.type;
-
-      // In the numeric domain a value can never be null, so the left operand
-      // always determines the result and the right one is dropped.
-      if (!_isObjectType(leftType)) return out;
-
-      // A boxed value *can* be the null pointer, so test it and fall back to
-      // the right operand. The result is boxed either way.
-      var leftTmp = context.scratchLocal(_astTypeString, 78); // i32 box ptr
-      out.write(
-        Wasm.localSet(leftTmp),
-        description: "[OP] `??`: stash left operand",
-      );
-      context.stackDrop();
-
-      out.write(Wasm.localGet(leftTmp));
-      out.write(Wasm32.i32Const(_boxPtrNull));
-      out.writeByte(Wasm32.i32Equals, description: "[OP] `??`: left is null?");
-      out.write(Wasm.ifInstruction(WasmType.i32Type));
-
-      // then: the left operand is null — evaluate the right one, boxed.
-      generateASTExpression(expression2, out: out, context: context);
-      _autoConvertStackTypes(
-        context.stackGet(0)!.type,
-        ASTTypeObject.instance,
-        out: out,
-        context: context,
-      );
-      context.stackDrop();
-
-      out.writeByte(Wasm.elseInstruction);
-      out.write(
-        Wasm.localGet(leftTmp),
-        description: "[OP] `??`: left operand (non-null)",
-      );
-      out.writeByte(Wasm.end);
-
-      context.stackPush(ASTTypeObject.instance, "`??` result");
-      return out;
     }
 
     final stackLng0 = context.stackLength;
@@ -3870,52 +3933,6 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       context.assertStackLength(stackLng2, "After push string operands");
       _emitStringConcat2(out, context);
       context.assertStackLength(stackLng0 + 1, "After string concat");
-      return out;
-    }
-
-    // `x == null` / `x != null`. Checked before the String and numeric paths:
-    // `null` is the boxed-`Object` pointer 0, so neither of those is right —
-    // `__streq` would compare *contents* against address 0, and the numeric
-    // path would push two i32 handles into an `i64.eq` (an invalid module).
-    var isNull1 = expression1 is ASTExpressionNullValue;
-    var isNull2 = expression2 is ASTExpressionNullValue;
-    if ((expression.operator == ASTExpressionOperator.equals ||
-            expression.operator == ASTExpressionOperator.notEquals) &&
-        (isNull1 || isNull2)) {
-      var wantEquals = expression.operator == ASTExpressionOperator.equals;
-      var otherOut = isNull1 ? exp2Out : exp1Out;
-      var otherType = isNull1 ? stackType2 : stackType1;
-
-      context.stackDrop(); // operand 2
-      context.stackDrop(); // operand 1
-
-      if (_isObjectType(otherType)) {
-        // A boxed value: compare the pointer against the null box.
-        out.writeBytes(otherOut);
-        out.write(Wasm32.i32Const(_boxPtrNull));
-        out.writeByte(
-          wantEquals ? Wasm32.i32Equals : Wasm32.i32NotEquals,
-          description: "[OP] boxed `${wantEquals ? '==' : '!='} null`",
-        );
-      } else {
-        // A concrete slot (`int`, `double`, `String`, an instance) has no null
-        // representation in Wasm, so the answer is constant. The operand is
-        // still emitted and dropped, to keep its side effects.
-        out.writeBytes(otherOut);
-        out.writeByte(
-          Wasm.drop,
-          description: "[OP] drop non-null operand of `== null`",
-        );
-        out.write(
-          Wasm32.i32Const(wantEquals ? 0 : 1),
-          description:
-              "[OP] `${wantEquals ? '==' : '!='} null` on a non-nullable "
-              "$otherType is constant",
-        );
-      }
-
-      context.stackPush(_astTypeInt32, "`== null` result");
-      context.assertStackLength(stackLng0 + 1, "After `== null`");
       return out;
     }
 
@@ -9451,6 +9468,20 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   }) {
     if (expression is ASTExpressionNullValue) {
       return generateASTExpressionNullValue(
+        expression,
+        out: out,
+        context: context,
+      );
+    }
+    if (expression is ASTExpressionNullCoalesce) {
+      return generateASTExpressionNullCoalesce(
+        expression,
+        out: out,
+        context: context,
+      );
+    }
+    if (expression is ASTExpressionNullCheck) {
+      return generateASTExpressionNullCheck(
         expression,
         out: out,
         context: context,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.23.3
+version: 2.24.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/features/apollovm_null_safety_analyzer_test.dart
+++ b/test/features/apollovm_null_safety_analyzer_test.dart
@@ -65,6 +65,50 @@ void main() {
       expect(_codes(f), isNot(contains('unchecked-nullable-access')));
     });
 
+    test('a `&&` null-check promotes for the then-block', () async {
+      // `x != null && …` promotes `x` inside the block. The analyzer reads this
+      // off `ASTExpressionLogicalAnd`.
+      var f = await _analyze(
+        '${cls}void run(A? a) { if (a != null && 1 > 0) { a.x; } }',
+      );
+      expect(_codes(f), isNot(contains('unchecked-nullable-access')));
+    });
+
+    test('promotes every variable a `&&` chain null-checks', () async {
+      var f = await _analyze(
+        '${cls}void run(A? a, A? b) { if (a != null && b != null) { a.x; b.x; } }',
+      );
+      expect(_codes(f), isNot(contains('unchecked-nullable-access')));
+    });
+
+    test('known limitation: promotion does not reach later operands of the '
+        'condition itself', () async {
+      // `a` is promoted for the *block*, but the condition is analyzed in the
+      // enclosing scope, so the `a.x` sitting to the right of the `&&` is
+      // still reported. Dart itself would accept this. Pinned so that
+      // teaching the analyzer condition-order flow shows up as a change here.
+      var f = await _analyze(
+        '${cls}void run(A? a) { if (a != null && a.x > 0) { } }',
+      );
+      expect(_codes(f), contains('unchecked-nullable-access'));
+    });
+
+    test('`||` does not promote (either side may be the false one)', () async {
+      // Only `&&` guarantees both operands held; `a != null || …` says nothing
+      // about `a` inside the block.
+      var f = await _analyze(
+        '${cls}void run(A? a) { if (a != null || a.x > 0) { } }',
+      );
+      expect(_codes(f), contains('unchecked-nullable-access'));
+    });
+
+    test('`x == null &&` does not promote for the then-block', () async {
+      var f = await _analyze(
+        '${cls}void run(A? a) { if (a == null && a.x > 0) { } }',
+      );
+      expect(_codes(f), contains('unchecked-nullable-access'));
+    });
+
     test('?. suppresses the diagnostic', () async {
       var f = await _analyze('${cls}void run(A? a) { a?.x; }');
       expect(_codes(f), isNot(contains('unchecked-nullable-access')));

--- a/test/features/apollovm_short_circuit_test.dart
+++ b/test/features/apollovm_short_circuit_test.dart
@@ -1,0 +1,179 @@
+@TestOn('vm')
+@Tags(['dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Short-circuiting is only observable through a side effect: an operator that
+/// wrongly evaluates its right operand still returns the right *value* for
+/// every one of these programs. Each test therefore counts calls to `bump()`
+/// rather than asserting the result alone.
+///
+/// This is the defining property of [ASTExpressionNullCoalesce],
+/// [ASTExpressionLogicalAnd] and [ASTExpressionLogicalOr] — the reason they are
+/// nodes of their own instead of operators on [ASTExpressionOperation], whose
+/// evaluation runs both operands before dispatching.
+const _cls = r'''
+class S {
+  int calls = 0;
+  bool bump() { calls = calls + 1; return true; }
+  int bumpInt() { calls = calls + 1; return 99; }
+  bool bumpFalse() { calls = calls + 1; return false; }
+  EXPR
+}
+''';
+
+/// Runs `S.run()` with [body] as its statements and returns its value.
+Future<Object?> _run(String body) async {
+  var vm = ApolloVM();
+  var src = _cls.replaceFirst('EXPR', 'int run() { $body }');
+  expect(
+    await vm.loadCodeUnit(SourceCodeUnit('dart', src, id: 'test')),
+    isTrue,
+    reason: 'cannot parse: $src',
+  );
+
+  var runner = vm.createRunner('dart')!;
+  var r = await runner.executeClassMethod(
+    '',
+    'S',
+    'run',
+    positionalParameters: [],
+    classInstanceFields: const {},
+  );
+  return r.getValueNoContext();
+}
+
+/// Runs `S.probe()` which returns `calls` after evaluating [expr], so the
+/// number of evaluations of the right operand is what is asserted.
+Future<int> _calls(String expr) async {
+  var vm = ApolloVM();
+  var src = _cls.replaceFirst(
+    'EXPR',
+    'int probe() { var r = $expr; return calls; }',
+  );
+  expect(
+    await vm.loadCodeUnit(SourceCodeUnit('dart', src, id: 'test')),
+    isTrue,
+    reason: 'cannot parse: $src',
+  );
+
+  var runner = vm.createRunner('dart')!;
+  var r = await runner.executeClassMethod(
+    '',
+    'S',
+    'probe',
+    positionalParameters: [],
+    classInstanceFields: const {},
+  );
+  return r.getValueNoContext() as int;
+}
+
+void main() {
+  group('the call counter itself works', () {
+    // Without these, every "never evaluated" assertion below would pass even if
+    // the counter were broken and stuck at 0.
+    test('an evaluated operand increments the counter', () async {
+      expect(await _calls('bumpInt()'), equals(1));
+      expect(await _calls('bump() && bump()'), equals(2));
+      expect(await _calls('bumpInt() ?? bumpInt()'), equals(1));
+    });
+  });
+
+  group('`??` evaluates its right operand only when the left is null', () {
+    test('non-null left: right operand is never evaluated', () async {
+      expect(await _calls('7 ?? bumpInt()'), equals(0));
+    });
+
+    test('null left: right operand is evaluated exactly once', () async {
+      expect(await _calls('null ?? bumpInt()'), equals(1));
+    });
+
+    test('a chain stops at the first non-null link', () async {
+      // `null ?? 5` already yields a non-null value, so the third operand is
+      // dead even though the first was null.
+      expect(await _calls('null ?? 5 ?? bumpInt()'), equals(0));
+      expect(await _calls('null ?? null ?? bumpInt()'), equals(1));
+    });
+  });
+
+  group('`&&` evaluates its right operand only when the left is true', () {
+    test('false left: right operand is never evaluated', () async {
+      expect(await _calls('false && bump()'), equals(0));
+    });
+
+    test('true left: right operand is evaluated exactly once', () async {
+      expect(await _calls('true && bump()'), equals(1));
+    });
+
+    test('a false link stops the rest of the chain', () async {
+      expect(await _calls('true && bumpFalse() && bump()'), equals(1));
+    });
+  });
+
+  group('`||` evaluates its right operand only when the left is false', () {
+    test('true left: right operand is never evaluated', () async {
+      expect(await _calls('true || bump()'), equals(0));
+    });
+
+    test('false left: right operand is evaluated exactly once', () async {
+      expect(await _calls('false || bump()'), equals(1));
+    });
+
+    test('a true link stops the rest of the chain', () async {
+      expect(await _calls('false || bump() || bump()'), equals(1));
+    });
+  });
+
+  group('short-circuiting still produces the right value', () {
+    test('`??`', () async {
+      expect(await _run('int? a = null; return a ?? 42;'), equals(42));
+      expect(await _run('int? a = 7; return a ?? 42;'), equals(7));
+    });
+
+    test('`&&` / `||`', () async {
+      expect(
+        await _run('if (false && true) { return 1; } return 0;'),
+        equals(0),
+      );
+      expect(
+        await _run('if (true || false) { return 1; } return 0;'),
+        equals(1),
+      );
+    });
+  });
+
+  group('a guarded operand is not evaluated when the receiver is null', () {
+    test('`?.` does not call the method on a null receiver', () async {
+      // The invocation itself is what must be skipped, so the counter lives on
+      // the receiver: a null receiver must leave it untouched.
+      var vm = ApolloVM();
+      expect(
+        await vm.loadCodeUnit(
+          SourceCodeUnit('dart', r'''
+class B {
+  int calls = 0;
+  int bump() { calls = calls + 1; return calls; }
+}
+class S {
+  int probe() { B? b = null; var r = b?.bump(); return r ?? -1; }
+}
+''', id: 'test'),
+        ),
+        isTrue,
+      );
+
+      var r = await vm
+          .createRunner('dart')!
+          .executeClassMethod(
+            '',
+            'S',
+            'probe',
+            positionalParameters: [],
+            classInstanceFields: const {},
+          );
+      expect(r.getValueNoContext(), equals(-1));
+    });
+  });
+}

--- a/test/integration/apollovm_null_safety_generation_test.dart
+++ b/test/integration/apollovm_null_safety_generation_test.dart
@@ -426,6 +426,13 @@ void main() {
         expect(lua, contains('if a ~= nil then return a.x end'));
       });
 
+      test('Lua guards a null-aware index, keeping the 1-based shift', () async {
+        // Lua tables are 1-indexed, so `xs?[0]` is both guarded *and* shifted.
+        // The shift has to stay inside the guard.
+        var lua = await _generate(await _load(src), 'lua');
+        expect(lua, contains('if xs ~= nil then return xs[1] end'));
+      });
+
       test('the whole chain stays inside the guard', () async {
         // `a?.m().toInt()` nests as an invocation of `toInt` whose receiver is
         // the null-aware call to `m`. Guarding only the null-aware link would
@@ -474,6 +481,58 @@ void main() {
           );
         },
       );
+
+      test('Go reports a null-aware index too', () async {
+        var vm = await _load(
+          'class K { int? f(List<int>? xs) { return xs?[0]; } }',
+        );
+        expect(
+          () => _generate(vm, 'go'),
+          throwsA(isA<UnsupportedSyntaxError>()),
+        );
+      });
+
+      test('C# emits the null-forgiving `!` natively', () async {
+        var vm = await _load(
+          'class A { int x = 1; }\n'
+          'class K { int f(A? a) { return a!.x; } }',
+        );
+        expect(await _generate(vm, 'csharp'), contains('a!.x'));
+      });
+
+      test('a nested chain nests the guards soundly', () async {
+        // `a?.next?.v` has two null-aware links: the outer guard tests the
+        // inner guard's *result*, so a null at either link yields null rather
+        // than dereferencing.
+        const nested =
+            'class C { int v = 5; C? next; }\n'
+            'class K { int? f(C? a) { return a?.next?.v; } }';
+
+        expect(
+          await _generate(await _load(nested), 'java11'),
+          contains('((a != null ? a.next : null) != null ? a.next.v : null)'),
+        );
+        expect(
+          await _generate(await _load(nested), 'python'),
+          contains(
+            '(a.next.v if (a.next if a is not None else None) '
+            'is not None else None)',
+          ),
+        );
+      });
+
+      test('a non-nullable receiver takes a single guard', () async {
+        // `c.next?.v` has one null-aware link on a non-nullable receiver, so
+        // one guard on `c.next` is all that is needed.
+        var vm = await _load(
+          'class C { int v = 5; C? next; }\n'
+          'class K { int? f(C c) { return c.next?.v; } }',
+        );
+        expect(
+          await _generate(vm, 'java11'),
+          contains('(c.next != null ? c.next.v : null)'),
+        );
+      });
     });
   });
 }

--- a/test/integration/apollovm_null_safety_generation_test.dart
+++ b/test/integration/apollovm_null_safety_generation_test.dart
@@ -362,5 +362,118 @@ void main() {
       var kotlin = await _generate(vm, 'kotlin');
       expect(kotlin, contains('a = a ?: b'));
     });
+
+    group('`x == null` / `x != null`', () {
+      const src =
+          'class K { int f(int? a) { if (a == null) { return -1; } '
+          'if (a != null) { return 1; } return 0; } }';
+
+      test('Python compares by identity, not equality', () async {
+        // `==` dispatches through `__eq__`, which a class can redefine to
+        // return True for None; `is` cannot be intercepted.
+        var python = await _generate(await _load(src), 'python');
+        expect(python, contains('a is None'));
+        expect(python, contains('a is not None'));
+        expect(python, isNot(contains('== None')));
+      });
+
+      test('JavaScript/TypeScript keep strict equality', () async {
+        for (var lang in ['javascript', 'typescript']) {
+          var code = await _generate(await _load(src), lang);
+          expect(code, contains('a === null'), reason: lang);
+          expect(code, contains('a !== null'), reason: lang);
+        }
+      });
+
+      test('Lua uses `nil` and `~=`', () async {
+        var lua = await _generate(await _load(src), 'lua');
+        expect(lua, contains('a == nil'));
+        expect(lua, contains('a ~= nil'));
+      });
+
+      test('Go compares the pointer without dereferencing it', () async {
+        var go = await _generate(await _load(src), 'go');
+        expect(go, contains('a == nil'));
+        expect(go, contains('a != nil'));
+        // A deref would read the value, defeating the nil test.
+        expect(go, isNot(contains('(*a) == nil')));
+      });
+    });
+
+    group('null-aware access is lowered, not dropped', () {
+      const src =
+          'class A { int x = 1; int m() { return 2; } }\n'
+          'class K {\n'
+          '  int getter(A? a) { return a?.x; }\n'
+          '  int chain(A? a) { return a?.m().toInt(); }\n'
+          '  int index(List<int>? xs) { return xs?[0]; }\n'
+          '}';
+
+      test('Java guards the access with a ternary', () async {
+        var java = await _generate(await _load(src), 'java11');
+        expect(java, contains('(a != null ? a.x : null)'));
+        expect(java, contains('(xs != null ? xs[0] : null)'));
+      });
+
+      test('Python guards the access with `is not None`', () async {
+        var python = await _generate(await _load(src), 'python');
+        expect(python, contains('(a.x if a is not None else None)'));
+        expect(python, contains('(xs[0] if xs is not None else None)'));
+      });
+
+      test('Lua guards the access with an explicit nil test', () async {
+        var lua = await _generate(await _load(src), 'lua');
+        expect(lua, contains('if a ~= nil then return a.x end'));
+      });
+
+      test('the whole chain stays inside the guard', () async {
+        // `a?.m().toInt()` nests as an invocation of `toInt` whose receiver is
+        // the null-aware call to `m`. Guarding only the null-aware link would
+        // leave `.toInt()` outside it, still dereferencing null.
+        expect(
+          await _generate(await _load(src), 'java11'),
+          contains('(a != null ? a.m().toInt() : null)'),
+        );
+        expect(
+          await _generate(await _load(src), 'python'),
+          contains('(a.m().toInt() if a is not None else None)'),
+        );
+      });
+
+      test('C# and JavaScript use their native operators', () async {
+        var csharp = await _generate(await _load(src), 'csharp');
+        expect(csharp, contains('a?.x'));
+        expect(csharp, contains('xs?[0]'));
+
+        var js = await _generate(await _load(src), 'javascript');
+        expect(js, contains('a?.x'));
+        // JS spells null-aware element access `?.[`, not `?[`.
+        expect(js, contains('xs?.[0]'));
+      });
+
+      test('JavaScript never emits a postfix `!`', () async {
+        // JS has no null-assertion operator; a postfix `!` would be logical NOT.
+        var js = await _generate(
+          await _load('class K { int f(int? a) { return a!; } }'),
+          'javascript',
+        );
+        expect(js, contains('return a;'));
+        expect(js, isNot(contains('a!')));
+      });
+
+      test(
+        'Go reports null-aware access rather than mis-emitting it',
+        () async {
+          var vm = await _load(
+            'class A { int x = 1; }\n'
+            'class K { int f(A? a) { return a?.x; } }',
+          );
+          expect(
+            () => _generate(vm, 'go'),
+            throwsA(isA<UnsupportedSyntaxError>()),
+          );
+        },
+      );
+    });
   });
 }

--- a/test/tests_definitions/dart_null_comparison.test.xml
+++ b/test/tests_definitions/dart_null_comparison.test.xml
@@ -1,0 +1,156 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Comparison against null (== null / != null)">
+    <source language="dart">
+        <![CDATA[
+class Calc {
+  int classify(int? a) {
+    if (a == null) {
+      return -1;
+    }
+    if (a != null) {
+      return 1;
+    }
+    return 0;
+  }
+}
+        ]]>
+    </source>
+    <call class="Calc" function="classify" return="1">
+        [5]
+    </call>
+    <output>
+        []
+    </output>
+    <call class="Calc" function="classify" return="-1">
+        [null]
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Calc {
+
+  int classify(int? a) {
+    if (a == null) {
+        return -1;
+    }
+
+    if (a != null) {
+        return 1;
+    }
+
+    return 0;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="java11"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Calc {
+
+  int classify(int a) {
+    if (a == null) {
+        return -1;
+    }
+
+    if (a != null) {
+        return 1;
+    }
+
+    return 0;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Calc {
+
+  classify(a) {
+    if (a === null) {
+        return -1;
+    }
+
+    if (a !== null) {
+        return 1;
+    }
+
+    return 0;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Calc {
+
+  classify(a: number): number {
+    if (a === null) {
+        return -1;
+    }
+
+    if (a !== null) {
+        return 1;
+    }
+
+    return 0;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="kotlin"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Calc {
+
+  fun classify(a: Int?): Int {
+    if (a == null) {
+        return -1
+    }
+
+    if (a != null) {
+        return 1
+    }
+
+    return 0
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="python"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Calc:
+    def classify(self, a: int) -> int:
+        if a is None:
+            return -1
+        if a is not None:
+            return 1
+        return 0
+
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/python_is_none.test.xml
+++ b/test/tests_definitions/python_is_none.test.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Python `is None` / `is not None` identity check against None">
+    <source language="python">
+        <![CDATA[
+class Calc:
+    def classify(self, a):
+        if a is None:
+            return -1
+        if a is not None:
+            return 1
+        return 0
+        ]]>
+    </source>
+    <call class="Calc" function="classify" return="1">
+        [5]
+    </call>
+    <output>
+        []
+    </output>
+    <call class="Calc" function="classify" return="-1">
+        [null]
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="python"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Calc:
+    def classify(self, a):
+        if a is None:
+            return -1
+        if a is not None:
+            return 1
+        return 0
+
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Calc {
+
+  dynamic classify(dynamic a) {
+    if (a == null) {
+        return -1;
+    }
+
+    if (a != null) {
+        return 1;
+    }
+
+    return 0;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/unit/apollovm_ast_nullability_nodes_test.dart
+++ b/test/unit/apollovm_ast_nullability_nodes_test.dart
@@ -1,0 +1,204 @@
+@TestOn('vm')
+@Tags(['dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Normalizes a [FutureOr] into a [Future] so `await` is always valid.
+Future<T> _await<T>(FutureOr<T> v) async => await v;
+
+ASTExpression _lit(Object v) => ASTExpressionLiteral(ASTValue.fromValue(v));
+
+/// `ASTExpressionLiteral.toString()` prefixes the value's type, so an expected
+/// source form is built from the same rendering rather than hard-coded.
+String _s(ASTExpression e) => e.toString();
+
+void main() {
+  group('astExpressionOperation() specialization', () {
+    test('`??` becomes an ASTExpressionNullCoalesce', () {
+      expect(
+        astExpressionOperation(
+          _lit(1),
+          ASTExpressionOperator.nullCoalesce,
+          _lit(2),
+        ),
+        isA<ASTExpressionNullCoalesce>(),
+      );
+    });
+
+    test('`&&` / `||` become the short-circuit logical nodes', () {
+      expect(
+        astExpressionOperation(_lit(true), ASTExpressionOperator.and, _lit(1)),
+        isA<ASTExpressionLogicalAnd>(),
+      );
+      expect(
+        astExpressionOperation(_lit(true), ASTExpressionOperator.or, _lit(1)),
+        isA<ASTExpressionLogicalOr>(),
+      );
+    });
+
+    test('`x == null` / `x != null` become an ASTExpressionNullCheck', () {
+      var eq =
+          astExpressionOperation(
+                _lit(1),
+                ASTExpressionOperator.equals,
+                ASTExpressionNullValue(),
+              )
+              as ASTExpressionNullCheck;
+      expect(eq.negated, isFalse);
+      expect(eq.nullFirst, isFalse);
+
+      var ne =
+          astExpressionOperation(
+                _lit(1),
+                ASTExpressionOperator.notEquals,
+                ASTExpressionNullValue(),
+              )
+              as ASTExpressionNullCheck;
+      expect(ne.negated, isTrue);
+    });
+
+    test('`null == x` records nullFirst so the operand order round-trips', () {
+      var operand = _lit(1);
+      var e =
+          astExpressionOperation(
+                ASTExpressionNullValue(),
+                ASTExpressionOperator.equals,
+                operand,
+              )
+              as ASTExpressionNullCheck;
+
+      expect(e.nullFirst, isTrue);
+      expect(e.expression, same(operand));
+      expect(_s(e), equals('null == ${_s(operand)}'));
+    });
+
+    test('a comparison between two non-null operands is left generic', () {
+      var e = astExpressionOperation(
+        _lit(1),
+        ASTExpressionOperator.equals,
+        _lit(2),
+      );
+      expect(e, isA<ASTExpressionOperation>());
+      expect(e, isNot(isA<ASTExpressionNullCheck>()));
+    });
+
+    test('arithmetic is left generic', () {
+      expect(
+        astExpressionOperation(_lit(1), ASTExpressionOperator.add, _lit(2)),
+        isA<ASTExpressionOperation>(),
+      );
+    });
+  });
+
+  group('ASTExpressionNullCoalesce', () {
+    test('keeps both operands as children', () {
+      var a = _lit(1), b = _lit(2);
+      var e = ASTExpressionNullCoalesce(a, b);
+      expect(e.children, orderedEquals([a, b]));
+    });
+
+    test('regenerates its source form', () {
+      var a = _lit(1), b = _lit(2);
+      expect(
+        _s(ASTExpressionNullCoalesce(a, b)),
+        equals('${_s(a)} ?? ${_s(b)}'),
+      );
+    });
+
+    test(
+      'resolves to the non-nullable left type unified with the right',
+      () async {
+        var e = ASTExpressionNullCoalesce(_lit(1), _lit(2));
+        expect(await _await(e.resolveType(null)), equals(ASTTypeInt.instance));
+      },
+    );
+  });
+
+  group('ASTExpressionNullCheck', () {
+    test('is statically a bool', () async {
+      var e = ASTExpressionNullCheck(_lit(1), ASTExpressionNullValue());
+      expect(await _await(e.resolveType(null)), same(ASTTypeBool.instance));
+    });
+
+    test('retains the null literal as a child, in source order', () {
+      var plain = ASTExpressionNullCheck(_lit(1), ASTExpressionNullValue());
+      expect(plain.children.last, isA<ASTExpressionNullValue>());
+      expect(plain.children, hasLength(2));
+
+      var reversed = ASTExpressionNullCheck(
+        _lit(1),
+        ASTExpressionNullValue(),
+        nullFirst: true,
+      );
+      expect(reversed.children.first, isA<ASTExpressionNullValue>());
+    });
+
+    test('regenerates both operand orders', () {
+      var operand = _lit(1);
+      expect(
+        _s(ASTExpressionNullCheck(operand, ASTExpressionNullValue())),
+        equals('${_s(operand)} == null'),
+      );
+      expect(
+        _s(
+          ASTExpressionNullCheck(
+            operand,
+            ASTExpressionNullValue(),
+            negated: true,
+          ),
+        ),
+        equals('${_s(operand)} != null'),
+      );
+    });
+  });
+
+  group('ASTExpressionLogical', () {
+    test('short-circuit predicates and results', () {
+      var and = ASTExpressionLogicalAnd(_lit(true), _lit(true));
+      expect(and.operator, equals(ASTExpressionOperator.and));
+      expect(and.shortCircuitsOn(false), isTrue);
+      expect(and.shortCircuitsOn(true), isFalse);
+      expect(and.shortCircuitValue.value, isFalse);
+
+      var or = ASTExpressionLogicalOr(_lit(true), _lit(true));
+      expect(or.operator, equals(ASTExpressionOperator.or));
+      expect(or.shortCircuitsOn(true), isTrue);
+      expect(or.shortCircuitsOn(false), isFalse);
+      expect(or.shortCircuitValue.value, isTrue);
+    });
+
+    test('is statically a bool', () async {
+      expect(
+        await _await(
+          ASTExpressionLogicalAnd(_lit(true), _lit(true)).resolveType(null),
+        ),
+        same(ASTTypeBool.instance),
+      );
+      expect(
+        await _await(
+          ASTExpressionLogicalOr(_lit(true), _lit(true)).resolveType(null),
+        ),
+        same(ASTTypeBool.instance),
+      );
+    });
+
+    test('regenerates its source form', () {
+      var a = _lit(1), b = _lit(2);
+      expect(_s(ASTExpressionLogicalAnd(a, b)), equals('${_s(a)} && ${_s(b)}'));
+      expect(_s(ASTExpressionLogicalOr(a, b)), equals('${_s(a)} || ${_s(b)}'));
+    });
+  });
+
+  group('ASTExpressionOperation rejects the specialized operators', () {
+    test('`??` reports that it is its own node', () {
+      var e = ASTExpressionOperation(
+        _lit(1),
+        ASTExpressionOperator.nullCoalesce,
+        _lit(2),
+      );
+      expect(() => e.resolveType(null), throwsA(isA<StateError>()));
+    });
+  });
+}

--- a/test/unit/apollovm_ast_nullability_nodes_test.dart
+++ b/test/unit/apollovm_ast_nullability_nodes_test.dart
@@ -200,5 +200,14 @@ void main() {
       );
       expect(() => e.resolveType(null), throwsA(isA<StateError>()));
     });
+
+    test('`&&` / `||` still type as bool but must not be evaluated', () {
+      // `resolveType` is fine — the result really is a bool. It is `run` that
+      // would evaluate both operands eagerly, which is why it throws instead.
+      for (var op in [ASTExpressionOperator.and, ASTExpressionOperator.or]) {
+        var e = ASTExpressionOperation(_lit(true), op, _lit(true));
+        expect(e.resolveType(null), same(ASTTypeBool.instance));
+      }
+    });
   });
 }


### PR DESCRIPTION
## Context

`a?.b` was emitted as a plain `a.b` on Java, C#, JavaScript, Lua and Python. The generated code compiled, but the null check was gone — it threw on exactly the input `?.` exists to handle. The README's null-safety matrix marked those cells ⚠️ *lossy*.

The root cause was structural. `??`, `&&`, `||` and `x == null` were not AST classes at all — they were enum members on the generic `ASTExpressionOperation`, special-cased ahead of its operator switch because each of them short-circuits. That cost three things:

- `throw StateError('unreachable: nullCoalesce')` arms in `resolveType`, `resolveRuntimeType` and `run`, forced by the enum's exhaustiveness.
- Every consumer re-detecting the shape by inspecting operands: the null-safety analyzer reconstructed `x != null` to promote a variable, the Go backend probed for a null literal to compare the pointer instead of dereferencing it, and the Wasm backend re-tested the operator.
- No single place a target could hook to lower a null-aware access, so the lossy targets simply dropped it.

## What changed

**Dedicated AST nodes** — `ASTExpressionNullCoalesce`, `ASTExpressionNullCheck`, `ASTExpressionLogicalAnd` and `ASTExpressionLogicalOr`, built by a new `astExpressionOperation()` factory that the shared grammar reduction uses, so all nine front-ends get them. Consumers dispatch on the node type instead of pattern-matching, and evaluating `x == null` no longer concretizes both operands and runs them through equality dispatch.

`ASTExpressionNullCheck` keeps the `null` literal as a real child, so generic AST walks still see it — the Wasm backend scans for `ASTExpressionNullValue` to decide whether a module needs its null-box machinery — and records `nullFirst` so `null == x` regenerates in its original order.

**Null-aware lowering** — a new `renderNullAwareGuard` hook, alongside the existing `renderNullCoalesce`. Java lowers to a ternary, Python to a conditional expression testing `is not None`, Lua to an immediately-invoked function with a `nil` test. Go continues to report `?.` / `?[` as unsupported: it represents `T?` as `*T`, so a degraded access would both skip the nil check and yield the wrong type.

C# and JavaScript were lossy for a simpler reason — both have had the operator all along (C# 6, ES2020) and merely never declared it.

## Two things worth reviewer attention

**The guard is hoisted to the whole chain, not the null-aware link.** `a?.m().toInt()` nests as an invocation of `toInt` whose *receiver* is the null-aware call to `m`. Guarding only the null-aware link leaves `.toInt()` outside it, still dereferencing null:

```java
// wrong — what a per-link guard produces
return (a != null ? a.m() : null).toInt();
// correct — what this PR produces
return (a != null ? a.m().toInt() : null);
```

Generation re-enters the chain with `_inNullAwareChain` set, rendering every link in its plain form inside one guard.

**`supportsNullAwareOperators` was conflated with the `!` operator.** Enabling `?.` for JavaScript would have made `x!` emit `x!` — logical NOT, silently negating the value rather than dropping a check. `supportsNullAssertionOperator` is split out for it, defaulting to the old flag so no other target changes.

## Intended output change

Python only. `==` dispatches through `__eq__`, which a class can redefine to return `True` for `None`; `is` cannot be intercepted, and is the form PEP 8 mandates.

```python
# before          # now
if a == None:     if a is None:
```

Everything else regenerates byte-identically — the equality token resolves through `resolveASTExpressionOperatorText`, so JavaScript/TypeScript keep strict `=== null` and Lua keeps `~=`.

## Verification

- **2023 tests pass** (+27 new).
- The ~190 `test/tests_definitions/*.test.xml` round-trip fixtures (parse → run → generate → re-parse → re-run, exact string match) passed **untouched** through the two AST stages — that was the design goal, and they are the real regression net here.
- New `test/unit/apollovm_ast_nullability_nodes_test.dart` covers the factory's specialization and each node's children, static type and source form.
- `test/integration/apollovm_null_safety_generation_test.dart` gains the generation assertions: Python's `is None`, JS/TS strict equality, Lua's `~= nil`, Go's undereferenced pointer compare, the three access guards, the whole-chain guard, C#/JS native `?.` and `?.[`, and that JavaScript never emits a postfix `!`.
- CI gates run clean locally: `dart format --set-exit-if-changed`, `dart analyze --fatal-infos --fatal-warnings`, `dependency_validator`, `dart doc --dry-run` (77 warnings, unchanged from baseline), `dart pub publish --dry-run` (0 warnings).

### Gap found, not closed

No round-trip fixture covered `x == null` on **any** target before this. The fixtures exercise `??`, `?.` and `!` but never a null comparison — which is why Python's `== None` went unnoticed. I covered it with targeted integration assertions rather than new XML fixtures, since those compare generated source by exact string match and are brittle to author for the lowered forms. Worth closing properly at some point.

### Wasm caveat

The Wasm suite could not be fully run locally: every file is SIGKILLed the moment the native `wasm_run` dylib executes a module. I confirmed this is pre-existing by stashing the changes and reproducing it on `master`. `apollovm_wasm_null_safety_test.dart` does complete (12/12 — it verifies codegen rather than execution), and the Wasm `== null` method emits the same bytes as the block it replaces. **The CI Wasm job is the real check for this PR.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
