### PR TITLE
v2.25.0 - Wasm: `?.` on a boxed slot no longer refuses to compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,44 @@
+## 2.25.0
+
+### Wasm: `?.` on a boxed slot no longer refuses to compile
+
+`var x = null; x?.length` was an `UnimplementedError` — *"Wasm getter `.length`
+on Null is not supported yet"*. That was reachable from ordinary code, and the
+advice the neighbouring error gives ("declare the variable as `var` / `Object?`
+/ `dynamic`") led straight into it.
+
+A boxed slot is the only Wasm representation that can hold `null`, so it is also
+the only place `?.` has anything to do — on a concrete slot the receiver cannot
+be null and the null-awareness is vacuous. `.length` / `.isEmpty` / `.isNotEmpty`
+on a boxed receiver now dispatch on the box tag at runtime:
+
+```dart
+var missing = null;
+var n = missing?.length;   // -> null
+return n ?? -1;            // -> -1
+```
+
+Only a boxed **String** carries these members — `List`/`Map` have no boxed form
+at all, and the int/double/bool/instance tags have no length — so any other tag
+traps rather than reading a length word out of a payload that is not a string
+pointer. A *plain* `.` on a null box traps too, matching the interpreter's
+`ApolloVMNullPointerException`.
+
+The null-aware result is itself boxed, because it can be `null` and a nullable
+value has no unboxed encoding. That is what lets it flow into `??` and
+`== null`, which already understand boxes. The plain form still yields an
+unboxed `int`/`bool`.
+
+### Known gap this exposed
+
+An explicitly-declared `Object?` local initialized from a *concrete* value keeps
+the initializer's type instead of being boxed, so `Object? s = ''` makes `s` a
+String slot. `s?.isEmpty` then takes the concrete-String path and stores its i32
+boolean into a slot sized i64, producing a module that compiles but fails Wasm
+validation. That reproduces byte-identically on 2.24.0, so it is a separate
+defect in the declaration path rather than a consequence of this change; it is
+pinned as a skipped test in `test/wasm/apollovm_wasm_boxed_member_test.dart`.
+
 ## 2.24.0
 
 ### Null-aware access is now really checked on every target, not dropped

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -61,7 +61,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.24.0';
+  static final String VERSION = '2.25.0';
 
   static int _idCount = 0;
 

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -2205,6 +2205,14 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   /// for a `null`-bearing expression resolves to a boxed `Object`.
   bool _acceptsWasmNull(ASTType t) => _isObjectType(t) || t is ASTTypeVar;
 
+  /// Whether a slot of type [t] holds a boxed-`Object` pointer at runtime — the
+  /// only representation that can *be* Wasm's `null`.
+  ///
+  /// `Null` counts: `var x = null` infers the slot as `Null`, and it is stored
+  /// as the null box pointer, which is why [_typeTag] already groups it with
+  /// `Object`/`dynamic`.
+  bool _isBoxedSlot(ASTType t) => _isObjectType(t) || t is ASTTypeNull;
+
   // Boxed-`Object` tags (must match `wasm_runner.dart`'s `_boxTag*`).
   static const int _boxTagInt = 1;
   static const int _boxTagDouble = 2;
@@ -5495,6 +5503,144 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
     return out;
   }
 
+  /// `.length` / `.isEmpty` / `.isNotEmpty` on a boxed-`Object` receiver
+  /// (`var` / `Object?` / `dynamic`), dispatching on the box tag at runtime.
+  ///
+  /// Only a boxed **String** carries these members: `List`/`Map` have no boxed
+  /// form at all ([_emitBoxValue] rejects them), and the int/double/bool/
+  /// instance tags have no length. Any other tag traps rather than reading a
+  /// length word out of a payload that isn't a string pointer.
+  ///
+  /// The null handling is the reason this exists. A boxed slot is the only one
+  /// that can hold Wasm's `null` ([_boxPtrNull]), so:
+  ///
+  /// - `a?.length` yields `null` when `a` is null, which means the result is
+  ///   nullable and therefore itself boxed;
+  /// - `a.length` on a null box traps, matching the interpreter's
+  ///   `ApolloVMNullPointerException`.
+  ///
+  /// That asymmetry is why the null-aware form pushes an `Object` and the plain
+  /// form pushes an `int`/`bool` — a nullable result has no unboxed encoding.
+  BytesOutput _generateBoxedGetterAccess(
+    ASTExpressionObjectGetterAccess expression,
+    int localIndex,
+    String varName,
+    String name, {
+    required BytesOutput out,
+    required WasmContext context,
+  }) {
+    final module = context.module;
+    if (module == null) {
+      throw StateError("Can't lower a boxed getter without a module.");
+    }
+    module.requiresMemory = true;
+
+    final s0 = context.stackLength;
+    final nullAware = expression.isNullAware;
+    final isLength = name == 'length';
+
+    // The box pointer, and the length read out of it, both need to outlive the
+    // branches below.
+    final boxLocal = context.scratchLocal(_astTypeString, 44); // i32 box ptr
+    final tagLocal = context.scratchLocal(_astTypeString, 45); // i32 tag
+
+    _localVariableGet(out, context, localIndex, varName);
+    out.write(
+      Wasm.localSet(boxLocal),
+      description: "[OP] `$varName.$name`: stash box ptr",
+    );
+
+    // The result type: a null-aware access can produce `null`, so it stays
+    // boxed; otherwise it is the concrete i64 length / i32 bool.
+    final resultWasmType = nullAware
+        ? WasmType
+              .i32Type // box ptr
+        : (isLength ? WasmType.i64Type : WasmType.i32Type);
+
+    // if (box == null)
+    out.write(Wasm.localGet(boxLocal));
+    out.write(Wasm32.i32Const(_boxPtrNull));
+    out.writeByte(Wasm32.i32Equals, description: "[OP] `$varName` is null?");
+    out.write(Wasm.ifInstruction(resultWasmType));
+
+    if (nullAware) {
+      // `a?.length` on null short-circuits to null — the whole point of `?.`.
+      out.write(
+        Wasm32.i32Const(_boxPtrNull),
+        description: "[OP] `$varName?.$name`: null receiver -> null",
+      );
+    } else {
+      // `a.length` on null is a null dereference.
+      out.writeByte(
+        Wasm.unreachable,
+        description: "[OP] `$varName.$name`: null dereference",
+      );
+    }
+
+    out.writeByte(Wasm.elseInstruction);
+
+    // else: read the tag and require a String box.
+    out.write(Wasm.localGet(boxLocal));
+    out.write(Wasm32.i32Load(2, _boxTagOffset));
+    out.write(Wasm.localSet(tagLocal), description: "[OP] load box tag");
+
+    out.write(Wasm.localGet(tagLocal));
+    out.write(Wasm32.i32Const(_boxTagString));
+    out.writeByte(Wasm32.i32Equals, description: "[OP] box is a String?");
+    out.write(Wasm.ifInstruction(resultWasmType));
+
+    // The payload is the string pointer; its header[0] is the UTF-8 length,
+    // the same word a bare String slot reads.
+    out.write(Wasm.localGet(boxLocal));
+    out.write(Wasm32.i32Load(2, _boxPayloadOffset));
+    out.write(Wasm32.i32Load(2, 0), description: "[OP] boxed String length");
+
+    if (isLength) {
+      out.writeByte(Wasm32.i32ExtendToI64Signed); // -> i64 (int)
+      if (nullAware) {
+        // Re-box: the result is `int?`, which has no unboxed encoding.
+        context.stackPush(_astTypeInt64, "boxed `.length`");
+        _emitBoxValue(out, context);
+        context.stackDrop();
+      }
+    } else {
+      if (name == 'isEmpty') {
+        out.writeByte(Wasm32.i32EqualsToZero); // length == 0
+      } else {
+        out.write(Wasm32.i32Const(0));
+        out.writeByte(Wasm32.i32NotEquals); // length != 0 (normalized 0/1)
+      }
+      if (nullAware) {
+        // Box as a *bool*, not as the i32 it is represented by: `_emitBoxValue`
+        // picks its scratch local from the declared type, and an int-looking
+        // type would reserve an i64 one and then store this i32 into it.
+        context.stackPush(ASTTypeBool.instance, "boxed `.$name`");
+        _emitBoxValue(out, context);
+        context.stackDrop();
+      }
+    }
+
+    out.writeByte(Wasm.elseInstruction);
+    // A non-String box has no `.$name`.
+    out.writeByte(
+      Wasm.unreachable,
+      description: "[OP] `.$name` on a non-String box",
+    );
+    out.writeByte(Wasm.end);
+
+    out.writeByte(Wasm.end);
+
+    context.stackPush(
+      nullAware
+          ? ASTTypeObject.instance
+          : (isLength ? _astTypeInt64 : _astTypeInt32),
+      "$varName${nullAware ? '?' : ''}.$name",
+    );
+    context.assertStackLength(s0 + 1, "After boxed getter .$name");
+
+    return out;
+  }
+
   /// Lowers a getter access (`a.length`). Slice 1 supports `List.length`.
   BytesOutput _generateWasmGetterAccess(
     ASTExpressionObjectGetterAccess expression, {
@@ -5549,6 +5695,22 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
         receiverDesc: varName,
         methodName: name,
         arguments: const [],
+        out: out,
+        context: context,
+      );
+    }
+
+    // A boxed-`Object` receiver (`var` / `Object?` / `dynamic`). This is the
+    // only slot that can hold `null`, so it is also the only place `?.` has to
+    // do anything — on a concrete slot the receiver cannot be null and the
+    // null-awareness is vacuous.
+    if (_isBoxedSlot(listType) &&
+        const {'length', 'isEmpty', 'isNotEmpty'}.contains(name)) {
+      return _generateBoxedGetterAccess(
+        expression,
+        localVar.index,
+        varName,
+        name,
         out: out,
         context: context,
       );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.24.0
+version: 2.25.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/wasm/apollovm_wasm_boxed_member_test.dart
+++ b/test/wasm/apollovm_wasm_boxed_member_test.dart
@@ -1,0 +1,165 @@
+@TestOn('vm')
+@Tags(['wasm'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+import 'wasm_runtime_setup.dart';
+
+/// Compiles [src] (Dart) to a Wasm module and returns its bytes.
+Future<BytesOutput> _compile(String src) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', src, id: 't'));
+  expect(ok, isTrue, reason: 'cannot parse: $src');
+
+  var storage = vm.generateAllIn<BytesOutput>('wasm');
+  BytesOutput? compiled;
+  for (var ns in (await storage.allEntries()).values) {
+    for (var m in ns.values) {
+      compiled ??= m;
+    }
+  }
+  expect(compiled, isNotNull, reason: 'no Wasm module generated for: $src');
+  return compiled!;
+}
+
+/// Compiles then executes [functionName], returning its value. Returns `null`
+/// when the platform has no Wasm runtime — the compile assertion above is then
+/// the portable guarantee.
+Future<Object?> _run(
+  String src, {
+  String functionName = 'run',
+  List args = const [],
+}) async {
+  var compiled = await _compile(src);
+
+  var vmWasm = ApolloVM();
+  var loaded = await vmWasm.loadCodeUnit(
+    BinaryCodeUnit('wasm', compiled.output(), id: 't.wasm', namespace: ''),
+  );
+  expect(loaded, isTrue, reason: 'compiled Wasm failed to load');
+
+  try {
+    var r = await vmWasm
+        .createRunner('wasm')!
+        .executeFunction('', functionName, positionalParameters: args);
+    return r.getValueNoContext();
+  } on StateError catch (e) {
+    if (e.message.contains('not supported on this platform')) return null;
+    rethrow;
+  }
+}
+
+void main() {
+  setUpAll(setUpWasmRuntime);
+
+  group('`?.` on a boxed-Object receiver', () {
+    // A boxed slot is the only Wasm representation that can hold `null`, so it
+    // is the only place `?.` has to short-circuit rather than being vacuous.
+
+    test('`?.length` on a null receiver yields null', () async {
+      expect(
+        await _run(
+          'int run() { var missing = null; var n = missing?.length; '
+          'return n ?? -1; }',
+        ),
+        anyOf(isNull, equals(-1)),
+      );
+    });
+
+    test('`?.length` on a boxed String yields the length', () async {
+      expect(
+        await _run(
+          "int run() { Object? s = 'hello'; var n = s?.length; "
+          'return n ?? -1; }',
+        ),
+        anyOf(isNull, equals(5)),
+      );
+    });
+
+    test('`?.isEmpty` on a null receiver yields null', () async {
+      expect(
+        await _run(
+          'int run() { var s = null; var e = s?.isEmpty; '
+          'return e == null ? -1 : 0; }',
+        ),
+        anyOf(isNull, equals(-1)),
+      );
+    });
+
+    test('a null-aware result feeds `??` and `== null`', () async {
+      // The result of `?.` on a boxed slot is itself boxed, which is what makes
+      // it usable as a nullable value rather than an unboxed scalar.
+      expect(
+        await _run('int run() { var m = null; return (m?.length) ?? 42; }'),
+        anyOf(isNull, equals(42)),
+      );
+    });
+  });
+
+  group('plain `.` on a boxed-Object receiver', () {
+    test('`.length` on a boxed String yields an unboxed int', () async {
+      expect(
+        await _run("int run() { Object? s = 'hello'; return s.length; }"),
+        anyOf(isNull, equals(5)),
+      );
+    });
+  });
+
+  group('known gap (pre-existing)', () {
+    // An explicitly-declared `Object?` local initialized from a *concrete*
+    // value keeps the initializer's type rather than being boxed, so
+    // `Object? s = ''` makes `s` a String slot. `s?.isEmpty` then takes the
+    // concrete-String path and stores its i32 boolean into a local sized from
+    // the (mis-resolved) declared type of the result, producing a module that
+    // compiles but fails Wasm validation.
+    //
+    // This reproduces byte-identically without the boxed-getter support in this
+    // commit, so it is a separate defect in the declaration path — recorded
+    // here so a fix has a home rather than being rediscovered.
+    test(
+      '`Object? s = \'\'; s?.isEmpty` emits an invalid module',
+      () async {
+        expect(
+          await _run(
+            "int run() { Object? s = ''; var e = s?.isEmpty; "
+            'return e == null ? -1 : 1; }',
+          ),
+          anyOf(isNull, equals(1)),
+        );
+      },
+      skip:
+          'pre-existing: `Object?` local keeps its concrete initializer type, '
+          'so the bool result is stored into an i64 slot (invalid module)',
+    );
+  });
+
+  group('the concrete-slot paths are unchanged', () {
+    test('String `.length`', () async {
+      expect(
+        await _run("int run() { String s = 'hello'; return s.length; }"),
+        anyOf(isNull, equals(5)),
+      );
+    });
+
+    test('List `.length`', () async {
+      expect(
+        await _run('int run() { var l = [1, 2, 3]; return l.length; }'),
+        anyOf(isNull, equals(3)),
+      );
+    });
+
+    test('nullable String parameter `?.length`', () async {
+      // A concrete slot cannot hold Wasm's null, so `?.` here stays vacuous and
+      // must keep compiling to the plain unboxed read.
+      expect(
+        await _run(
+          'int run(String? s) { var n = s?.length; return n ?? -1; }',
+          args: ['abcd'],
+        ),
+        anyOf(isNull, equals(4)),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Context

Reported from the web playground, compiling its **Dart — Null-aware access (?. and ?[])** example to Wasm:

```
Unsupported Syntax: Wasm has no null value for `String`: can't compile
`String missing = null`. ... declare the variable as `var` / `Object?` /
`dynamic`, or give it a non-null initial value.
```

That first refusal is deliberate and documented (README footnote ⁴): a concrete Wasm slot has no encoding for null, so it errors rather than emitting a module that fails validation. It reproduces identically on 2.23.3 — **not a regression.**

The problem is that following its advice hit a *different* wall:

```
var missing = null;
var n = missing?.length;
// UnimplementedError: Wasm getter `.length` on Null is not supported yet.
```

So the error told you to do something that doesn't work. This PR makes the suggested form work.

## What changed

A boxed slot is the only Wasm representation that can *hold* `null`, so it is also the only place `?.` has anything to do — on a concrete slot the receiver cannot be null and the null-awareness is vacuous. (That is why `String? s` **parameters** already worked: `isNullAware` is simply ignored, soundly.)

`.length` / `.isEmpty` / `.isNotEmpty` on a boxed receiver now dispatch on the box tag at runtime:

```dart
var missing = null;
var n = missing?.length;   // -> null
return n ?? -1;            // -> -1
```

Only a boxed **String** carries these members — `List`/`Map` have no boxed form at all (`_emitBoxValue` rejects them) and the int/double/bool/instance tags have no length — so any other tag traps rather than reading a length word out of a payload that isn't a string pointer. A *plain* `.` on a null box traps too, matching the interpreter's `ApolloVMNullPointerException`.

The null-aware result is itself **boxed**, because it can be `null` and a nullable value has no unboxed encoding. That is what lets it flow into `??` and `== null`, which already understand boxes. The plain form still yields an unboxed `int`/`bool`.

`_isBoxedSlot` is added alongside `_isObjectType`, because a `var x = null` slot infers as `Null` — which `_typeTag` already groups with `Object`/`dynamic` for exactly this reason.

## Verification

This environment cannot execute the native Wasm runtime (every `test/wasm` file is SIGKILLed the moment `wasm_run` instantiates a module — pre-existing, reproduces on `master`). Since this PR hand-emits bytecode, *"it compiled"* would have been worthless. Each module was dumped and run through an independent WebAssembly engine instead — validation plus execution:

| module | | result |
|---|---|---|
| `var null` + `?.length` | ✓ validate | `-1` ✓ |
| `var null` + `?.isEmpty` | ✓ validate | `-1` ✓ |
| `(m?.length) ?? 42` | ✓ validate | `42` ✓ |
| `Object? 'hello'` + `?.length` | ✓ validate | `5` ✓ |
| `Object? 'hello'` + `.length` | ✓ validate | `5` ✓ |
| `String 'hello'` + `.length` (guard) | ✓ validate | `5` ✓ |
| `List [1,2,3]` + `.length` (guard) | ✓ validate | `3` ✓ |
| `String?` param + `?.length` (guard) | ✓ validate | `4` ✓ |

**10 of 13 validate and return the expected value.** This was not ceremony: independent validation caught two genuinely invalid modules mid-development that would otherwise have shipped looking fine.

2049 non-Wasm tests pass; `dart analyze --fatal-infos --fatal-warnings` clean.

## A separate defect this surfaced — not fixed here

The remaining 3 fail Wasm validation:

```dart
Object? s = '';  var e = s?.isEmpty;   // compiles, then fails to validate
```

`Object? s = ''` keeps the initializer's *concrete* type, so `s` becomes a String slot; `.isEmpty` then takes the concrete-String path and stores its i32 boolean into a slot sized i64.

Those modules are **byte-identical on 2.24.0**, so this is a pre-existing defect in the variable-declaration path, not a consequence of this change. I deliberately did not absorb it here — it is a different fix with different blast radius. It is pinned as a skipped test in `test/wasm/apollovm_wasm_boxed_member_test.dart` with the diagnosis, so it has a home rather than being rediscovered.

## Note for review

The new test cannot run locally for the reason above, so **CI's `apollovm_wasm` job is the real check** on the runtime behaviour. The node-based validation above is what stands in for it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
