### PR TITLE
v2.25.1 - The Wasm tests run against the published `apollovm_wasm`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## 2.25.1
+
+### The Wasm tests run against the published `apollovm_wasm`
+
+The native (VM) Wasm engine lives in `apollovm_wasm`, which this package pulls
+back in as a dev-dependency so `test/wasm/**` can execute the modules it
+compiles. That dependency was taken **by path** from the sibling directory:
+
+```yaml
+apollovm_wasm:
+  path: apollovm_wasm
+```
+
+so the tests exercised the working copy rather than the engine users install.
+The two can drift — the runner decodes boxed values using `_boxTag*` constants
+that must match `wasm_generator.dart`, and a path dependency hides a mismatch
+between a released engine and a changed generator until someone else hits it.
+
+It is now the hosted `apollovm_wasm: ^1.1.0`. No library code changed, and this
+is a dev-dependency, so nothing changes for anyone depending on `apollovm`.
+
+Note for contributors: changes to `apollovm_wasm/` are no longer picked up by
+the root package's tests automatically. To test the two together, add a
+temporary `dependency_overrides: {apollovm_wasm: {path: apollovm_wasm}}`, or run
+the sub-package's own suite from `apollovm_wasm/`.
+
 ## 2.25.0
 
 ### Wasm: `?.` on a boxed slot no longer refuses to compile

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -61,7 +61,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.25.0';
+  static final String VERSION = '2.25.1';
 
   static int _idCount = 0;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.25.0
+version: 2.25.1
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 
@@ -42,9 +42,9 @@ dependencies:
 
 dev_dependencies:
   # The native (VM) Wasm engine lives outside this package (see `apollovm_wasm`),
-  # so the Wasm execution tests pull it back in here.
-  apollovm_wasm:
-    path: apollovm_wasm
+  # so the Wasm execution tests pull it back in here. Taken from pub.dev rather
+  # than by path, so the tests run against the engine users actually get.
+  apollovm_wasm: ^1.1.0
   lints: ^6.1.0
   dependency_validator: ^5.0.5
   test: ^1.31.1


### PR DESCRIPTION
Changes the root package's dev-dependency on `apollovm_wasm` from a path to the hosted `^1.1.0`.

```diff
 dev_dependencies:
-  apollovm_wasm:
-    path: apollovm_wasm
+  apollovm_wasm: ^1.1.0
```

## Why it matters

The native (VM) Wasm engine lives in `apollovm_wasm` and is pulled back in here so `test/wasm/**` can *execute* the modules the generator compiles. Taken by path, those tests exercised the working copy rather than the engine users install.

That drift is the kind that hides. `wasm_runner.dart` decodes boxed values using `_boxTag*` constants documented as **"must match `wasm_generator.dart`"**. With a path dependency, a released engine paired with a changed generator looks fine locally and breaks for whoever installs the pair.

## Verified it doesn't quietly introduce a stale core

The obvious risk with a hosted dev-dependency on a package that itself depends on `apollovm` is ending up testing against an older published core. It doesn't happen here: `apollovm_wasm 1.1.0` declares `apollovm: ^2.0.0`, and since `apollovm` *is* the root package, pub resolves it to this working copy — `pubspec.lock` contains no hosted `apollovm` entry. Checked explicitly rather than assumed.

## Verification

- `dart pub get` resolves `apollovm_wasm` to `source: hosted, version: 1.1.0`.
- **2049** non-Wasm tests pass; the Wasm suite passes against the published engine.
- `dart analyze --fatal-infos --fatal-warnings`, `dart run dependency_validator`, `dart format` and `dart pub publish --dry-run` all clean.

No library code changed, and this is a dev-dependency, so nothing changes for anyone depending on `apollovm`. Version bumped to 2.25.1 per the repo's one-PR-one-release convention.

## Trade-off for contributors

Recorded in the CHANGELOG rather than left to be discovered: changes under `apollovm_wasm/` are **no longer picked up by the root package's tests automatically**. To work on the two together, add a temporary

```yaml
dependency_overrides:
  apollovm_wasm:
    path: apollovm_wasm
```

or run the sub-package's own suite from `apollovm_wasm/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
