### PR TITLE
apollovm_wasm 1.2.0 — apollovm ^2.25.0, wasm_run ^0.2.0+2 (apollovm 2.25.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## 2.25.1
+
+### apollovm_wasm 1.2.0: the runtime now tracks the core it decodes
+
+No change to this package's code — this release exists to carry the
+`apollovm_wasm` bump, the way `2.23.2` carried `apollovm_wasm 1.1.0`.
+
+`apollovm_wasm` declared `apollovm: ^2.0.0`, but it is not a loosely-coupled
+consumer: it *decodes* what this package's Wasm generator encodes. The
+boxed-`Object` cell layout and its `_boxTag*` values are a contract, and both
+`wasm_runner.dart` and `wasm_generator.dart` carry a comment saying the
+constants must match.
+
+That constraint let pub pair the runtime with any 2.x, including releases whose
+box encoding it was never built against — a mismatch that shows up as a wrong
+value or a trap at run time, not as a resolution failure. It is now
+`apollovm: ^2.25.0`, widened deliberately rather than by default. Its `wasm_run`
+also moves to `^0.2.0+2` (patch, no API change).
+
 ## 2.25.0
 
 ### Wasm: `?.` on a boxed slot no longer refuses to compile

--- a/apollovm_wasm/CHANGELOG.md
+++ b/apollovm_wasm/CHANGELOG.md
@@ -1,3 +1,20 @@
+## 1.2.0
+
+- `apollovm: ^2.25.0` (was `^2.0.0`) — this runtime decodes what the `apollovm` Wasm generator
+  encodes, and the boxed-`Object` cell layout (`[tag@0][typeId@4][payload@8]`) with its
+  `_boxTag*` values is a contract between the two: `wasm_runner.dart` and `wasm_generator.dart`
+  each carry a comment saying the constants must match.
+
+  `^2.0.0` let pub pair this runtime with any `apollovm` 2.x, including releases whose box
+  encoding it was never built or tested against — a mismatch that surfaces as a wrong value or
+  a trap at run time, not as a resolution error. The constraint now tracks the release the
+  runtime is cut against; it is widened deliberately, not by default.
+
+  apollovm 2.25.0 is a case in point: it added `?.` on a boxed slot, which emits box reads this
+  runtime has to agree with.
+
+- `wasm_run: ^0.2.0+2` (was `^0.2.0+1`) — patch upgrade, no API change.
+
 ## 1.1.0
 
 - `wasm_run: ^0.2.0+1` (was `^0.1.0+2`) — a breaking upgrade, absorbed here so that consumers

--- a/apollovm_wasm/pubspec.yaml
+++ b/apollovm_wasm/pubspec.yaml
@@ -2,7 +2,7 @@ name: apollovm_wasm
 description: >-
   Native (Dart VM) WebAssembly execution for ApolloVM: the wasm_run-backed
   WasmRuntime, kept out of the core package so apollovm stays FFI-free.
-version: 1.1.0
+version: 1.2.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 
@@ -16,8 +16,12 @@ environment:
   sdk: '>=3.10.0 <4.0.0'
 
 dependencies:
-  apollovm: ^2.0.0
-  wasm_run: ^0.2.0+1
+  # This runtime decodes values the `apollovm` Wasm generator encodes — the
+  # boxed-`Object` cell layout and its `_boxTag*` values are a contract between
+  # the two. `^2.0.0` allowed pairings that were never built or tested together,
+  # so it tracks the release it is cut against.
+  apollovm: ^2.25.0
+  wasm_run: ^0.2.0+2
   crypto: ^3.0.7
   path: ^1.9.1
 

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -61,7 +61,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.25.0';
+  static final String VERSION = '2.25.1';
 
   static int _idCount = 0;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.25.0
+version: 2.25.1
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 


### PR DESCRIPTION
Updates the `./apollovm_wasm` sub-package and carries the release on the root package, the way `2.23.2` carried `apollovm_wasm 1.1.0`.

```diff
 apollovm_wasm/pubspec.yaml
-version: 1.1.0
+version: 1.2.0

 dependencies:
-  apollovm: ^2.0.0
+  apollovm: ^2.25.0
-  wasm_run: ^0.2.0+1
+  wasm_run: ^0.2.0+2
```

## Why tighten `apollovm`

`apollovm_wasm` is not a loosely-coupled consumer of `apollovm` — it **decodes what the Wasm generator encodes**. The boxed-`Object` cell layout (`[tag@0][typeId@4][payload@8]`) and its `_boxTag*` values are a contract between them, and both `wasm_runner.dart` and `wasm_generator.dart` carry a comment saying the constants *must match*.

`^2.0.0` let pub pair this runtime with any 2.x, including releases whose box encoding it was never built or tested against. That mismatch doesn't fail resolution — it surfaces as a wrong value or a trap at run time, which is the worst place to find it.

The constraint now tracks the release the runtime is cut against, to be widened deliberately rather than by default. **2.25.0 is a live example**: it added `?.` on a boxed slot, emitting box reads this runtime has to agree with.

## Note on what was already fine

Both old constraints (`^2.0.0`, `^0.2.0+1`) *already permitted* the current versions — the sub-package was only resolving stale locally, and `apollovm_wasm/pubspec.lock` is gitignored. So this is a deliberate narrowing plus a patch bump, not a mechanical refresh; a `pub upgrade` alone would have left nothing to commit.

## Verification

- Both packages resolve: `apollovm_wasm` → apollovm **2.25.0**, wasm_run **0.2.0+2**; the root's path dev-dependency still resolves against the local 2.25.1.
- `dart format`, `dart analyze --fatal-infos --fatal-warnings` clean on both; `dart doc --dry-run` on `apollovm_wasm` reports 0 warnings, 0 errors.
- `dart run dependency_validator` clean.
- **2049** root tests pass.
- Both `pub publish --dry-run`s (the sub-package via `tool/publish_apollovm_wasm.sh`) report only the expected uncommitted-changes warning, and `.pubignore` is correctly restored afterwards.

No library code changed in either package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
