### PR TITLE
v2.26.0 — unbraced control-flow bodies, Python inline suites, and a batch of Dart syntax gaps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,107 @@
+## 2.26.0
+
+### Control-flow bodies no longer require braces
+
+`for (var e in l) print('- $e');` is ordinary Dart, and it did not parse. Only
+the plain `if` accepted an unbraced single-statement body — every loop, every
+`if`/`else` and every `else if` demanded `{ }`.
+
+All seven remaining rules now accept either form, in **Dart, Java 11, Kotlin,
+C#, JavaScript and TypeScript**: `for`, `for-in`/`for-each`, `while`,
+`do`/`while`, `if`/`else`, the `else if` chain, and the final `else`. A braced
+body is still tried first, so nothing about existing sources changes.
+
+`singleLineStatement` was also far too narrow — `return …;` or an expression
+statement, nothing else — so even the `if` that already supported it rejected
+`if (x) break;`, `if (x) throw e;` and a nested `if`. It is now the language's
+full statement set minus declarations and bare blocks.
+
+A dangling `else` binds to the **nearest** `if`, matching every target
+language. Python gets the equivalent construct, the **inline suite**
+(`if x: return 1`, `def f(): pass`, `while c: i += 1; j += 1`), for every
+`suite()` position: `if`/`elif`/`else`, `for`, `while`, `try`, `def`, `class`
+and `case`.
+
+**Go is deliberately excluded** — its spec defines `Block = "{" StatementList "}"`
+and every control-flow statement takes a `Block` — and Lua has no such form. A
+single-statement body translated to either is emitted braced / `do`…`end`.
+
+Not supported, on purpose: the *empty* statement as a body (`while (c) ;`),
+`for (;;)`, and `;`-separated statements on an ordinary (non-suite) Python line.
+
+### Fixed: a `else`-prefix miscompile, latent until now
+
+`BaseGrammarLexer.token()` is a prefix matcher with no word-boundary guard, so
+`string('else')` matches the start of an identifier such as `elseCount`. That
+was unreachable while every `else` arm was preceded by a mandatory braced
+block, and would have become a **silent miscompile** the moment bodies could be
+unbraced:
+
+```dart
+if (a) x();
+elseCount = 1;   // `else` matches; `Count = 1;` becomes the else arm
+```
+
+The branch and loop rules of all six C-style grammars now use whole-word
+keyword tokens. Also covers Kotlin's `when` entry labels and `if` expression.
+
+### Other grammar fixes
+
+- **Java and C#**: `if (a) {} else if (b) {}` with no trailing `else` failed to
+  parse — both made the final `else` non-optional, unlike every other language.
+- **Python**: a `do`/`while` translated to Python emitted literal
+  `do { … } while (c);`. It now lowers to `while True: … if not (c): break`.
+- **Lua**: compound assignment was emitted verbatim (`a += 1`), which is not
+  valid Lua. It now lowers to `a = a + 1`.
+- **Go**: removed a dead `codeBlockOrSingleLineBlock` cluster that was defined
+  but never referenced.
+
+### New Dart syntax
+
+- **Interpolation inside triple-quoted strings**. `'''Hello $name'''` yielded
+  the *literal* text `$name` — wrong output, not an error. Raw `r'''…'''` is
+  unaffected.
+- **`assert(c)` / `assert(c, m)`** as a real statement. It previously parsed as
+  a call to a user function named `assert` and failed later with a confusing
+  message. A failed assertion throws and is catchable. Every target emits its
+  own idiom (Java `assert c : m;`, Python `assert c, m`, Kotlin
+  `assert(c) { m }`, C# `Debug.Assert`, Lua's built-in, JS/TS/Go lowered to an
+  explicit check). Wasm refuses to compile it rather than mis-compile it.
+- **`required` named parameters** on plain, constructor-typed and `this.`
+  forms. `({required int a})` was a hard parse failure. Dart output keeps the
+  modifier; other targets express required-ness by the absence of a default.
+- **Annotations** — `@override`, `@Deprecated('x')`, `@pragma(...)`, `@a.B(1)`
+  — at every position Dart allows. There was no `@` in any grammar in the repo,
+  so one `@override` broke the whole class body; this matters beyond
+  hand-written sources, since `lib/src/pub` loads real pub packages. Parsed and
+  discarded for now.
+- **`late`** on locals and fields (accepted and dropped).
+- **`const` at use sites**: `const Foo()`, `const []`, `const {}`. `const [1]`
+  used to *silently misparse* as an index read on a variable named `const`.
+- **Arrow and `async` bodies on local and anonymous functions**:
+  `int f(int x) => x * 2;` inside a function, and `(x) async => …`.
+- **`catch (e, s)`** now binds the stack trace. It was parsed and thrown away,
+  so any handler that referenced `s` failed. ApolloVM has no stack traces, so
+  it binds to an empty string; targets whose `catch` header has no second
+  variable declare it as the handler's first statement.
+- **Compound assignment `%= &= |= ^= <<= >>=`**. In JS/TS `%=` was already in
+  the grammar but missing from the shared operator enum, so it surfaced as a
+  `SyntaxError`.
+- **Untyped getters** (`get twice => …`) now parse. They failed because
+  `type().optional()` greedily ate `get` and petitparser's `optional()` cannot
+  backtrack.
+
+### Fixed: `set` no longer misparses into a method
+
+`simpleType()` accepted any identifier, so `set value(int v) {}` silently became
+a **method** named `value` returning a type named `set`, failing much later with
+a confusing error. `get`/`set` are now rejected in a type position, turning that
+into a parse error at the `set`.
+
+Full setter support remains unimplemented: it would mirror the entire getter
+subsystem plus assignment dispatch, and getters are generated for only 2 of 9
+targets. This change converts a silent misparse into a clear error.
+
 ## 2.25.1
 
 ### apollovm_wasm 1.2.0: the runtime now tracks the core it decodes

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ The **Wasm** column shows what the on-the-fly WebAssembly compiler currently sup
 | Feature | Dart | Java | Kotlin | Go | C# | JS | TS | Lua | Python | Wasm |
 |---|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|:--:|
 | `if` / `else if` / `else`        | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| Unbraced single-statement body¹⁴ | ✅ | ✅ | ✅ | 🚫 | ✅ | ✅ | ✅ | 🚫  | ✅ | ✅ |
 | `for` (C-style)                  | ✅ | ✅ | 🚫  | ✅ | ✅ | ✅ | ✅ | 🧩¹ | 🚫 | ✅ |
 | `for-each` / `for-in`            | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | `while`                          | ✅ | ✅ | ✅ | 🧩⁸ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
@@ -93,7 +94,8 @@ The **Wasm** column shows what the on-the-fly WebAssembly compiler currently sup
 | Arithmetic (`+ - * / %`)         | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Comparison / logical             | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Bitwise (`& \| ^ << >> ~`)       | ✅ | ✅ | 🧩⁵ | 🧩¹¹ | ✅ | ✅ | ✅ | 🧩⁶ | ✅ | ✅ |
-| `++` / `--`, compound assign     | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `++` / `--`, compound assign¹⁵   | ✅ | ✅ | 🧩¹⁵ | ✅ | ✅ | ✅ | ✅ | 🧩¹⁵ | ✅ | ✅ |
+| `assert`¹⁶                       | ✅ | ✅ | ✅ | 🧩¹⁶ | ✅ | 🧩¹⁶ | 🧩¹⁶ | ✅ | ✅ | 🚧 |
 | Lambdas / closures               | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Named / keyword arguments        | ✅ | 🚫  | ✅ | 🚫 | ✅ | 🚫  | 🚫  | 🚫  | ✅ | ✅ |
 | Parameter default values         | ✅ | 🚫  | ✅ | 🚫 | ✅ | 🚫  | 🚫  | 🚫  | ✅ | ✅ |
@@ -124,7 +126,23 @@ with nested-index parsing being extended per grammar. &nbsp;
 ¹³ The null *literal* and its per-language spelling (`null` / `nil` / `None`).
 Wasm has no null value of its own and represents it as a boxed pointer, so it is
 `🧩` — see [Null safety](#null-safety) for the operators (`??`, `?.`, `!`, …) and
-the Wasm limits.
+the Wasm limits. &nbsp;
+¹⁴ A control-flow body may be a single statement without braces
+(`for (var e in l) print(e);`), on `if`/`else`/`else if` and on every loop. A
+dangling `else` binds to the nearest `if`, as in each target language. Python's
+equivalent is the inline suite (`if x: return 1`), including the `;`-joined form.
+Go is `🚫` by its own spec (`Block = "{" StatementList "}"`) and Lua has no such
+form; a single-statement body translated to either is emitted braced /
+`do`…`end`. The *empty* statement as a body (`while (c) ;`) is not supported. &nbsp;
+¹⁵ Compound assignment covers `= += -= *= /= ~/= %= &= |= ^= <<= >>= ??=`.
+Kotlin has no compound form for the bitwise/shift operators and Lua has none at
+all, so those are lowered to `x = x OP y` (`🧩`). &nbsp;
+¹⁶ Each target uses its own idiom: Dart `assert(c, m);`, Java `assert c : m;`,
+Python `assert c, m`, Kotlin `assert(c) { m }`, C# `Debug.Assert(c, m)`, Lua's
+built-in `assert(c, m)`. JS/TS have no throwing `assert` and Go has none at all,
+so they are lowered to an explicit check (`if (!(c)) throw m;` /
+`if !(c) { panic(m) }`) — `🧩`. A failed assertion throws and is catchable like
+any other exception. Wasm refuses to compile `assert` rather than mis-compile it.
 
 ### Null safety
 
@@ -288,6 +306,9 @@ Same legend and **Wasm** column semantics as the table above.
 | Generics (generic classes + instantiation + type erasure)    | ✅ | ✅ | ✅ | 🚧 | ✅ | 🚫  | ✅ | 🚫  | 🚫  | 🚧 |
 | Type inference (`var` / `val` / `auto`)                       | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚫  | 🚫  | ✅⁵ |
 | Extensions (methods + getters)¹¹                              | ✅ | 🚫  | ✅ | 🚫  | 🧩¹² | 🚫  | 🚫  | 🚫  | 🚫  | 🚧 |
+| Getters / setters¹⁴                                           | 🧩¹⁴ | 🚧 | 🧩¹⁴ | 🚫  | 🚧 | 🚧 | 🚧 | 🚫  | 🚧 | 🚧 |
+| Annotations / metadata (`@…`)¹⁵                               | 🧩¹⁵ | 🚧 | 🚧 | 🚫  | 🚧 | 🚫  | 🚧 | 🚫  | 🚧 | 🚫  |
+| `required` named parameters                                   | ✅ | 🚫  | 🧩¹⁶ | 🚫  | 🧩¹⁶ | 🚫  | 🚫  | 🚫  | 🧩¹⁶ | ✅ |
 
 ¹ Lua is table-based: "fields" are table entries (`obj.x`), "constructors" are factory/`setmetatable`
 idioms, methods are `function Obj:method`. &nbsp;
@@ -330,7 +351,22 @@ Dart, Java (`extends`), C# / TS / JS (`: Base` / `extends`), Python. Kotlin's
 `class B : A()` base clause and Go embedding aren't parsed yet (`🚧`), and the
 Wasm backend doesn't compile inheritance yet. Constructor initializer lists with
 an explicit `: super(v)` call are not parsed yet — set inherited fields from the
-constructor body or a `this.param`.
+constructor body or a `this.param`. &nbsp;
+¹⁴ **Getters** are parsed and executed (Dart `get name => …`, with or without an
+explicit return type) and are generated for Dart and Kotlin. **Setters
+(`set name(v)`) are not implemented** — `set` is rejected in a type position, so
+a setter declaration is a clear parse error rather than the silent misparse into
+a method named `name` that it used to produce. &nbsp;
+¹⁵ Dart annotations (`@override`, `@Deprecated('x')`, `@pragma(...)`,
+`@a.B(1)`) are accepted wherever Dart allows them — top-level declarations,
+class and enum members, enum entries, extension members, parameters and local
+variable declarations — and are then **discarded**, so they do not survive a
+round-trip. Their arguments are skipped as a balanced parenthesis group, so an
+annotation using syntax ApolloVM does not model yet still cannot break the
+declaration it precedes. &nbsp;
+¹⁶ Only Dart spells a mandatory named parameter with a `required` modifier. The
+other targets that have named parameters express it by the absence of a default
+value, so the modifier is dropped when generating for them.
 
 > Per-language behavior is normalized to a shared AST, so types and constructs map
 > cleanly when translating between languages (e.g. C# `string` ⇄ Dart `String`,

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -1181,8 +1181,7 @@ final class VMClassContext<T> extends VMContext {
   /// The class of this context.
   ASTClass<T> clazz;
 
-  VMClassContext(this.clazz, {VMContext? parent, VMTypeResolver? typeResolver})
-    : super(clazz, parent: parent, typeResolver: typeResolver);
+  VMClassContext(this.clazz, {super.parent, super.typeResolver}) : super(clazz);
 
   ASTValue<T>? _classInstance;
 

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -61,7 +61,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.25.1';
+  static final String VERSION = '2.26.0';
 
   static int _idCount = 0;
 

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -696,6 +696,13 @@ abstract class ApolloCodeGenerator
         indent: indent,
         headIndented: headIndented,
       );
+    } else if (statement is ASTStatementAssert) {
+      return generateASTStatementAssert(
+        statement,
+        out: out,
+        indent: indent,
+        headIndented: headIndented,
+      );
     } else if (statement is ASTStatementTryCatch) {
       return generateASTStatementTryCatch(
         statement,
@@ -969,6 +976,47 @@ abstract class ApolloCodeGenerator
       headIndented: false,
     );
     out.write(';');
+
+    return out;
+  }
+
+  /// `assert(cond)` / `assert(cond, message)`.
+  ///
+  /// The default is Dart's call syntax, which is also Lua's built-in `assert`.
+  /// Targets that spell it differently override this: Java `assert c : m;`,
+  /// Python `assert c, m`, Kotlin `assert(c) { m }`, C# `Debug.Assert(...)`,
+  /// and JS/TS/Go — which have no throwing `assert` — lower it to an explicit
+  /// check.
+  StringBuffer generateASTStatementAssert(
+    ASTStatementAssert statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+
+    if (headIndented) out.write(indent);
+
+    out.write('assert(');
+    generateASTExpression(
+      statement.condition,
+      out: out,
+      indent: indent,
+      headIndented: false,
+    );
+
+    var message = statement.message;
+    if (message != null) {
+      out.write(', ');
+      generateASTExpression(
+        message,
+        out: out,
+        indent: indent,
+        headIndented: false,
+      );
+    }
+
+    out.write(');');
 
     return out;
   }

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -1042,6 +1042,18 @@ abstract class ApolloCodeGenerator
       out.write(' ');
       out.write(generateASTCatchClauseHeader(catchClause));
       out.write(' {\n');
+
+      // Targets whose `catch` header has no second variable declare it as the
+      // handler's first statement instead, so a body that reads it still
+      // compiles after translation.
+      var stackTraceName = catchClause.stackTraceName;
+      if (stackTraceName != null) {
+        var binding = renderCatchStackTraceBinding(stackTraceName);
+        if (binding != null) {
+          out.write('$indent  $binding\n');
+        }
+      }
+
       out.write(
         generateASTBlock(
           catchClause.block,
@@ -1074,6 +1086,15 @@ abstract class ApolloCodeGenerator
     var name = catchClause.variableName ?? 'e';
     return 'catch ($name)';
   }
+
+  /// A statement binding the catch stack-trace variable [name], for targets
+  /// whose `catch` header cannot declare a second variable. `null` means the
+  /// target binds it in the header itself (Dart's `catch (e, s)`).
+  ///
+  /// ApolloVM has no stack traces, so the value is the empty string — see
+  /// [ASTCatchClause.stackTraceName]. The base form suits JavaScript and
+  /// TypeScript.
+  String? renderCatchStackTraceBinding(String name) => "let $name = '';";
 
   @override
   StringBuffer generateASTBranchIfBlock(

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -1195,11 +1195,7 @@ abstract class ApolloCodeGenerator
         headIndented: false,
       );
       out.write(')');
-      braced = writeASTBranchBody(
-        branchElseIf.block,
-        out: out,
-        indent: indent,
-      );
+      braced = writeASTBranchBody(branchElseIf.block, out: out, indent: indent);
     }
 
     var blockElse = branch.blockElse;

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -390,6 +390,10 @@ abstract class ApolloCodeGenerator
   }) {
     out ??= newOutput();
 
+    if (parameter.isRequired && supportsRequiredParameters) {
+      out.write('required ');
+    }
+
     if (parameter is ASTConstructorParameterDeclaration &&
         parameter.thisParameter) {
       out.write('this.');
@@ -405,6 +409,11 @@ abstract class ApolloCodeGenerator
 
     return out;
   }
+
+  /// Whether this target spells a mandatory named parameter with a `required`
+  /// modifier. Only Dart does; the others express it by the absence of a
+  /// default value, so the modifier is dropped there.
+  bool get supportsRequiredParameters => false;
 
   /// The separator emitted between a parameter and its default value in a
   /// declaration (e.g. ` = ` in Dart/Kotlin/C#/Java, `=` in Python).

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -251,6 +251,66 @@ abstract class ApolloCodeGenerator
     return out;
   }
 
+  /// Writes a branch (`if`/`else`/`else if`) body, starting at the `)` or
+  /// `else` the caller has just written.
+  ///
+  /// Returns `true` when the body was emitted as a braced block, leaving the
+  /// closing `}` for the caller (which may need to continue it with ` else`)
+  /// and the cursor at [indent]. Returns `false` when the body was a single
+  /// statement emitted unbraced (`if (c) return 0;`), in which case the line
+  /// is already terminated and a following `else` must start a fresh one.
+  bool writeASTBranchBody(
+    ASTBlock block, {
+    required StringBuffer out,
+    required String indent,
+  }) {
+    if (block is ASTSingleLineStatementBlock) {
+      out.write(' ');
+      generateASTStatement(
+        block.statements.single,
+        out: out,
+        indent: indent,
+        headIndented: false,
+      );
+      out.write('\n');
+      return false;
+    }
+
+    out.write(' {\n');
+    generateASTBlock(block, out: out, indent: '$indent  ', withBrackets: false);
+    out.write(indent);
+    return true;
+  }
+
+  /// Writes a loop body, starting at the `)` (or `do`) the caller has just
+  /// written. Returns `true` when it was emitted as a braced block, leaving
+  /// the closing `}` for the caller.
+  ///
+  /// Loops differ from branches in two ways that must be preserved: the block
+  /// is passed [indent] unchanged ([generateASTBlock] adds the inner level),
+  /// and no trailing newline is written — the enclosing block adds it.
+  bool writeASTLoopBody(
+    ASTBlock block, {
+    required StringBuffer out,
+    required String indent,
+  }) {
+    if (block is ASTSingleLineStatementBlock) {
+      out.write(' ');
+      generateASTStatement(
+        block.statements.single,
+        out: out,
+        indent: indent,
+        headIndented: false,
+      );
+      return false;
+    }
+
+    out.write(' {\n');
+    out.write(generateASTBlock(block, indent: indent, withBrackets: false));
+    out.write(indent);
+    return true;
+  }
+
   @override
   StringBuffer generateASTStatementImport(
     ASTStatementImport import, {
@@ -705,17 +765,11 @@ abstract class ApolloCodeGenerator
       headIndented: false,
     );
 
-    out.write(') {\n');
+    out.write(')');
 
-    var blockCode = generateASTBlock(
-      forLoop.loopBlock,
-      indent: indent,
-      withBrackets: false,
-    );
-
-    out.write(blockCode);
-    out.write(indent);
-    out.write('}');
+    if (writeASTLoopBody(forLoop.loopBlock, out: out, indent: indent)) {
+      out.write('}');
+    }
 
     return out;
   }
@@ -746,17 +800,11 @@ abstract class ApolloCodeGenerator
       headIndented: false,
     );
 
-    out.write(') {\n');
+    out.write(')');
 
-    var blockCode = generateASTBlock(
-      forEach.loopBlock,
-      indent: indent,
-      withBrackets: false,
-    );
-
-    out.write(blockCode);
-    out.write(indent);
-    out.write('}');
+    if (writeASTLoopBody(forEach.loopBlock, out: out, indent: indent)) {
+      out.write('}');
+    }
 
     return out;
   }
@@ -781,17 +829,11 @@ abstract class ApolloCodeGenerator
       headIndented: false,
     );
 
-    out.write(' ) {\n');
+    out.write(' )');
 
-    var blockCode = generateASTBlock(
-      whileLoop.loopBlock,
-      indent: indent,
-      withBrackets: false,
-    );
-
-    out.write(blockCode);
-    out.write(indent);
-    out.write('}');
+    if (writeASTLoopBody(whileLoop.loopBlock, out: out, indent: indent)) {
+      out.write('}');
+    }
 
     return out;
   }
@@ -806,17 +848,13 @@ abstract class ApolloCodeGenerator
 
     if (headIndented) out.write(indent);
 
-    out.write('do {\n');
+    out.write('do');
 
-    var blockCode = generateASTBlock(
-      doWhileLoop.loopBlock,
-      indent: indent,
-      withBrackets: false,
-    );
-
-    out.write(blockCode);
-    out.write(indent);
-    out.write('} while (');
+    if (writeASTLoopBody(doWhileLoop.loopBlock, out: out, indent: indent)) {
+      out.write('} while (');
+    } else {
+      out.write(' while (');
+    }
 
     generateASTExpression(
       doWhileLoop.conditionExpression,
@@ -998,21 +1036,9 @@ abstract class ApolloCodeGenerator
       indent: indent,
       headIndented: false,
     );
-    out.write(') ');
+    out.write(')');
 
-    final block = branch.block;
-
-    if (block is ASTSingleLineStatementBlock) {
-      generateASTSingleLineStatementBlock(block, out: out);
-    } else {
-      out.write('{\n');
-      generateASTBlock(
-        block,
-        out: out,
-        indent: '$indent  ',
-        withBrackets: false,
-      );
-      out.write(indent);
+    if (writeASTBranchBody(branch.block, out: out, indent: indent)) {
       out.write('}\n');
     }
 
@@ -1037,28 +1063,21 @@ abstract class ApolloCodeGenerator
       indent: indent,
       headIndented: false,
     );
-    out.write(') {\n');
-    generateASTBlock(
-      branch.blockIf,
-      out: out,
-      indent: '$indent  ',
-      withBrackets: false,
-    );
-    out.write(indent);
+    out.write(')');
+
+    var braced = writeASTBranchBody(branch.blockIf, out: out, indent: indent);
 
     var blockElse = branch.blockElse;
 
     if (blockElse != null) {
-      out.write('} else {\n');
-      generateASTBlock(
-        blockElse,
-        out: out,
-        indent: '$indent  ',
-        withBrackets: false,
-      );
-      out.write(indent);
-      out.write('}\n');
-    } else {
+      // An unbraced `if` arm has already ended its line, so `else` starts a
+      // fresh one instead of continuing a `}`.
+      out.write(braced ? '} else' : '${indent}else');
+
+      if (writeASTBranchBody(blockElse, out: out, indent: indent)) {
+        out.write('}\n');
+      }
+    } else if (braced) {
       out.write('}\n');
     }
 
@@ -1083,47 +1102,37 @@ abstract class ApolloCodeGenerator
       indent: indent,
       headIndented: false,
     );
-    out.write(') {\n');
-    generateASTBlock(
-      branch.blockIf,
-      out: out,
-      indent: '$indent  ',
-      withBrackets: false,
-    );
+    out.write(')');
+
+    var braced = writeASTBranchBody(branch.blockIf, out: out, indent: indent);
 
     for (var branchElseIf in branch.blocksElseIf) {
-      out.write(indent);
-      out.write('} else if (');
+      // A braced arm left the cursor at `indent` with its `}` still pending;
+      // an unbraced one ended its line, so indent the `else if` here.
+      out.write(braced ? '} else if (' : '${indent}else if (');
       generateASTExpression(
         branchElseIf.condition,
         out: out,
         indent: indent,
         headIndented: false,
       );
-      out.write(') {\n');
-      generateASTBlock(
+      out.write(')');
+      braced = writeASTBranchBody(
         branchElseIf.block,
         out: out,
-        indent: '$indent  ',
-        withBrackets: false,
+        indent: indent,
       );
     }
-
-    out.write(indent);
 
     var blockElse = branch.blockElse;
 
     if (blockElse != null) {
-      out.write('} else {\n');
-      generateASTBlock(
-        blockElse,
-        out: out,
-        indent: '$indent  ',
-        withBrackets: false,
-      );
-      out.write(indent);
-      out.write('}\n');
-    } else {
+      out.write(braced ? '} else' : '${indent}else');
+
+      if (writeASTBranchBody(blockElse, out: out, indent: indent)) {
+        out.write('}\n');
+      }
+    } else if (braced) {
       out.write('}\n');
     }
 

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -1324,7 +1324,8 @@ abstract class ApolloCodeGenerator
   ///
   /// A `??=` against a target without that operator is lowered to
   /// `= target ?? value`, so only [renderNullCoalesce] has to be defined per
-  /// language.
+  /// language. Any other compound operator the target does not spell (see
+  /// [supportsAssignmentOperator]) is lowered to `= target OP value`.
   void _writeAssignment(
     StringBuffer out,
     ASTAssignmentOperator operator,
@@ -1338,11 +1339,41 @@ abstract class ApolloCodeGenerator
       return;
     }
 
+    if (operator != ASTAssignmentOperator.set &&
+        operator != ASTAssignmentOperator.nullCoalesce &&
+        !supportsAssignmentOperator(operator)) {
+      out.write(' = ');
+      out.write(target);
+      out.write(' ');
+      // The operand types are not available here (both sides are already
+      // rendered text). `num` is the neutral choice: it only matters for
+      // division, and `~/=` has an explicit spelling in every target that
+      // needs this lowering.
+      out.write(
+        resolveASTExpressionOperatorText(
+          operator.asASTExpressionOperator!,
+          ASTNumType.num,
+          ASTNumType.num,
+        ),
+      );
+      out.write(' ');
+      out.write(value);
+      return;
+    }
+
     out.write(' ');
     out.write(resolveASTAssignmentOperatorText(operator));
     out.write(' ');
     out.write(value);
   }
+
+  /// Whether this target spells [operator] as a compound assignment
+  /// (`x OP= y`). When false, it is lowered to `x = x OP y`.
+  ///
+  /// Kotlin has no `&=`/`|=`/`^=`/`<<=`/`>>=` — its bitwise operators are the
+  /// infix functions `and`/`or`/`shl`/`shr` — and Lua has no compound
+  /// assignment at all.
+  bool supportsAssignmentOperator(ASTAssignmentOperator operator) => true;
 
   @override
   StringBuffer generateASTExpressionVariableEntryAssignment(

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -916,6 +916,81 @@ class ASTExpressionVariableEntryAccess extends ASTExpression {
   }
 }
 
+/// Reads [val] as an `int` for a bitwise/shift operation, or throws.
+int _assignmentBitwiseOperand(VMContext context, ASTValue val, String op) {
+  if (val.type is ASTTypeInt) {
+    return val.getValue(context) as int;
+  }
+
+  var message = "Can't perform '$op' operation with type: ${val.type}";
+  if (val.type is ASTTypeNull) {
+    throw ApolloVMNullPointerException(message);
+  }
+  throw UnsupportedError(message);
+}
+
+/// Applies a compound assignment operator: the `current OP value` half of
+/// `target OP= value`.
+///
+/// Shared by every assignment target — plain variables, container entries and
+/// object setters — so the operator set is defined once instead of in a switch
+/// per target. [ASTAssignmentOperator.set] and
+/// [ASTAssignmentOperator.nullCoalesce] are handled by their callers, which
+/// must short-circuit before reading [current].
+FutureOr<ASTValue> applyASTAssignmentOperator(
+  VMContext context,
+  ASTAssignmentOperator operator,
+  ASTValue current,
+  ASTValue value,
+) {
+  switch (operator) {
+    case ASTAssignmentOperator.sum:
+      return current + value;
+    case ASTAssignmentOperator.subtract:
+      return current - value;
+    case ASTAssignmentOperator.multiply:
+      return current * value;
+    case ASTAssignmentOperator.divide:
+      return current / value;
+    case ASTAssignmentOperator.divideAsInt:
+      return current ~/ value;
+    case ASTAssignmentOperator.remainder:
+      return current % value;
+    case ASTAssignmentOperator.bitwiseAnd:
+      return ASTValueInt(
+        _assignmentBitwiseOperand(context, current, '&') &
+            _assignmentBitwiseOperand(context, value, '&'),
+      );
+    case ASTAssignmentOperator.bitwiseOr:
+      return ASTValueInt(
+        _assignmentBitwiseOperand(context, current, '|') |
+            _assignmentBitwiseOperand(context, value, '|'),
+      );
+    case ASTAssignmentOperator.bitwiseXor:
+      return ASTValueInt(
+        _assignmentBitwiseOperand(context, current, '^') ^
+            _assignmentBitwiseOperand(context, value, '^'),
+      );
+    case ASTAssignmentOperator.shiftLeft:
+      return ASTValueInt(
+        _assignmentBitwiseOperand(context, current, '<<') <<
+            _assignmentBitwiseOperand(context, value, '<<'),
+      );
+    case ASTAssignmentOperator.shiftRight:
+      return ASTValueInt(
+        _assignmentBitwiseOperand(context, current, '>>') >>
+            _assignmentBitwiseOperand(context, value, '>>'),
+      );
+    case ASTAssignmentOperator.set:
+      return value;
+    case ASTAssignmentOperator.nullCoalesce:
+      throw StateError(
+        'nullCoalesce must be short-circuited by the caller: it must not '
+        'evaluate the right-hand side when the current value is non-null.',
+      );
+  }
+}
+
 enum ASTExpressionOperator {
   add,
   subtract,
@@ -2452,41 +2527,12 @@ class ASTExpressionVariableAssignment extends ASTExpression {
 
     FutureOr<ASTValue> result;
 
-    switch (operator) {
-      case ASTAssignmentOperator.set:
-        {
-          result = value;
-          break;
-        }
-      case ASTAssignmentOperator.sum:
-        {
-          result = variableValue + value;
-          break;
-        }
-      case ASTAssignmentOperator.subtract:
-        {
-          result = variableValue - value;
-          break;
-        }
-      case ASTAssignmentOperator.divide:
-        {
-          result = variableValue / value;
-          break;
-        }
-      case ASTAssignmentOperator.divideAsInt:
-        {
-          result = variableValue ~/ value;
-          break;
-        }
-      case ASTAssignmentOperator.multiply:
-        {
-          result = variableValue * value;
-          break;
-        }
-      case ASTAssignmentOperator.nullCoalesce:
-        // Handled by the short-circuit branch above.
-        throw StateError('unreachable: nullCoalesce');
-    }
+    result = applyASTAssignmentOperator(
+      context,
+      operator,
+      variableValue,
+      value,
+    );
 
     await variable.setValue(context, await result);
 
@@ -2494,38 +2540,8 @@ class ASTExpressionVariableAssignment extends ASTExpression {
   }
 
   @override
-  String toString({bool asGroup = false}) {
-    switch (operator) {
-      case ASTAssignmentOperator.set:
-        {
-          return '$variable = $expression';
-        }
-      case ASTAssignmentOperator.sum:
-        {
-          return '$variable += $expression';
-        }
-      case ASTAssignmentOperator.subtract:
-        {
-          return '$variable -= $expression';
-        }
-      case ASTAssignmentOperator.multiply:
-        {
-          return '$variable *= $expression';
-        }
-      case ASTAssignmentOperator.divide:
-        {
-          return '$variable /= $expression';
-        }
-      case ASTAssignmentOperator.divideAsInt:
-        {
-          return '$variable ~/= $expression';
-        }
-      case ASTAssignmentOperator.nullCoalesce:
-        {
-          return '$variable ??= $expression';
-        }
-    }
-  }
+  String toString({bool asGroup = false}) =>
+      '$variable ${getASTAssignmentOperatorText(operator)} $expression';
 }
 
 /// [ASTExpression] that assigns to a container entry: `m[k] = v` (map) or
@@ -2622,17 +2638,10 @@ class ASTExpressionVariableEntryAssignment extends ASTExpression {
           ? await container.readKey(context, key as Object)
           : await container.readIndex(context, (key as num).toInt());
       var current = ASTValue.fromValue(currentRaw);
-      result = await switch (operator) {
-        ASTAssignmentOperator.sum => current + value,
-        ASTAssignmentOperator.subtract => current - value,
-        ASTAssignmentOperator.divide => current / value,
-        ASTAssignmentOperator.divideAsInt => current ~/ value,
-        ASTAssignmentOperator.multiply => current * value,
-        ASTAssignmentOperator.set => value,
-        // `m[k] ??= v`: keep the current value unless it is null.
-        ASTAssignmentOperator.nullCoalesce =>
-          (await _astValueIsNull(context, current)) ? value : current,
-      };
+      // `m[k] ??= v`: keep the current value unless it is null.
+      result = operator == ASTAssignmentOperator.nullCoalesce
+          ? ((await _astValueIsNull(context, current)) ? value : current)
+          : await applyASTAssignmentOperator(context, operator, current, value);
     }
 
     var resultRaw = await result.getValue(context);
@@ -2650,15 +2659,7 @@ class ASTExpressionVariableEntryAssignment extends ASTExpression {
 
   @override
   String toString({bool asGroup = false}) {
-    var op = switch (operator) {
-      ASTAssignmentOperator.set => '=',
-      ASTAssignmentOperator.sum => '+=',
-      ASTAssignmentOperator.subtract => '-=',
-      ASTAssignmentOperator.multiply => '*=',
-      ASTAssignmentOperator.divide => '/=',
-      ASTAssignmentOperator.divideAsInt => '~/=',
-      ASTAssignmentOperator.nullCoalesce => '??=',
-    };
+    var op = getASTAssignmentOperatorText(operator);
     var keys = [keyExpression, ...extraKeys].map((k) => '[$k]').join();
     return '$variable$keys $op $expression';
   }
@@ -4108,26 +4109,15 @@ class ASTExpressionObjectSetterAssignment extends ASTExpression {
     ASTValue current,
     ASTValue value,
   ) {
-    switch (operator) {
-      case ASTAssignmentOperator.set:
-        return value;
-      case ASTAssignmentOperator.sum:
-        return current + value;
-      case ASTAssignmentOperator.subtract:
-        return current - value;
-      case ASTAssignmentOperator.multiply:
-        return current * value;
-      case ASTAssignmentOperator.divide:
-        return current / value;
-      case ASTAssignmentOperator.divideAsInt:
-        return current ~/ value;
-      case ASTAssignmentOperator.nullCoalesce:
-        // `obj.field ??= v`: keep the current value unless it is null.
-        return _astValueIsNull(
-          context,
-          current,
-        ).resolveMapped((isNull) => isNull ? value : current);
+    if (operator == ASTAssignmentOperator.nullCoalesce) {
+      // `obj.field ??= v`: keep the current value unless it is null.
+      return _astValueIsNull(
+        context,
+        current,
+      ).resolveMapped((isNull) => isNull ? value : current);
     }
+
+    return applyASTAssignmentOperator(context, operator, current, value);
   }
 
   @override

--- a/lib/src/ast/apollovm_ast_statement.dart
+++ b/lib/src/ast/apollovm_ast_statement.dart
@@ -1881,8 +1881,9 @@ class ASTStatementAssert extends ASTStatement {
   ASTType resolveType(VMContext? context) => ASTTypeVoid.instance;
 
   @override
-  String toString() =>
-      message == null ? 'assert($condition) ;' : 'assert($condition, $message) ;';
+  String toString() => message == null
+      ? 'assert($condition) ;'
+      : 'assert($condition, $message) ;';
 }
 
 /// A single `catch` clause of an [ASTStatementTryCatch].

--- a/lib/src/ast/apollovm_ast_statement.dart
+++ b/lib/src/ast/apollovm_ast_statement.dart
@@ -1872,12 +1872,24 @@ class ASTStatementAssert extends ASTStatement {
 ///
 /// [exceptionType] is the matched type (`null` = catch-all); [variableName] is
 /// the bound variable (`null` = no variable); [block] is the handler body.
+///
+/// [stackTraceName] is Dart's second catch variable (`catch (e, s)`). ApolloVM
+/// interprets the AST and has no stack traces of its own, so the variable is
+/// bound to an empty string — enough for a program that passes it around or
+/// prints it to run, without leaking VM internals or making output differ
+/// between targets.
 class ASTCatchClause {
   final ASTType? exceptionType;
   final String? variableName;
+  final String? stackTraceName;
   final ASTBlock block;
 
-  ASTCatchClause(this.exceptionType, this.variableName, this.block);
+  ASTCatchClause(
+    this.exceptionType,
+    this.variableName,
+    this.block, {
+    this.stackTraceName,
+  });
 
   void resolveNode(ASTNode? parentNode) {
     exceptionType?.resolveNode(parentNode);
@@ -1897,6 +1909,14 @@ class ASTCatchClause {
         exceptionType ?? ASTTypeDynamic.instance,
         name,
         caught,
+      );
+    }
+    var stackTraceName = this.stackTraceName;
+    if (stackTraceName != null) {
+      context.declareVariableWithValue(
+        ASTTypeString.instance,
+        stackTraceName,
+        ASTValueString(''),
       );
     }
     var prevContext = VMContext.setCurrent(context);

--- a/lib/src/ast/apollovm_ast_statement.dart
+++ b/lib/src/ast/apollovm_ast_statement.dart
@@ -605,14 +605,23 @@ enum ASTAssignmentOperator {
   multiply('*'),
   divide('/'),
   divideAsInt('~/'),
+  remainder('%'),
   sum('+'),
   subtract('-'),
+  bitwiseAnd('&'),
+  bitwiseOr('|'),
+  bitwiseXor('^'),
+  shiftLeft('<<'),
+  shiftRight('>>'),
   nullCoalesce('??');
 
   final String symbol;
 
   const ASTAssignmentOperator(this.symbol);
 
+  /// The binary operator this compound assignment applies, or `null` for
+  /// [set]. Used to lower `x OP= y` to `x = x OP y` — both by the Wasm backend
+  /// and by text targets that lack the compound form.
   ASTExpressionOperator? get asASTExpressionOperator {
     switch (this) {
       case sum:
@@ -625,9 +634,21 @@ enum ASTAssignmentOperator {
         return ASTExpressionOperator.divide;
       case divideAsInt:
         return ASTExpressionOperator.divideAsInt;
+      case remainder:
+        return ASTExpressionOperator.remainder;
+      case bitwiseAnd:
+        return ASTExpressionOperator.bitwiseAnd;
+      case bitwiseOr:
+        return ASTExpressionOperator.bitwiseOr;
+      case bitwiseXor:
+        return ASTExpressionOperator.bitwiseXor;
+      case shiftLeft:
+        return ASTExpressionOperator.shiftLeft;
+      case shiftRight:
+        return ASTExpressionOperator.shiftRight;
       case nullCoalesce:
         return ASTExpressionOperator.nullCoalesce;
-      default:
+      case set:
         return null;
     }
   }
@@ -645,10 +666,22 @@ ASTAssignmentOperator getASTAssignmentOperator(String op) {
       return ASTAssignmentOperator.divide;
     case '~/=':
       return ASTAssignmentOperator.divideAsInt;
+    case '%=':
+      return ASTAssignmentOperator.remainder;
     case '+=':
       return ASTAssignmentOperator.sum;
     case '-=':
       return ASTAssignmentOperator.subtract;
+    case '&=':
+      return ASTAssignmentOperator.bitwiseAnd;
+    case '|=':
+      return ASTAssignmentOperator.bitwiseOr;
+    case '^=':
+      return ASTAssignmentOperator.bitwiseXor;
+    case '<<=':
+      return ASTAssignmentOperator.shiftLeft;
+    case '>>=':
+      return ASTAssignmentOperator.shiftRight;
     case '??=':
       return ASTAssignmentOperator.nullCoalesce;
     default:
@@ -656,24 +689,8 @@ ASTAssignmentOperator getASTAssignmentOperator(String op) {
   }
 }
 
-String getASTAssignmentOperatorText(ASTAssignmentOperator op) {
-  switch (op) {
-    case ASTAssignmentOperator.set:
-      return '=';
-    case ASTAssignmentOperator.multiply:
-      return '*=';
-    case ASTAssignmentOperator.divide:
-      return '/=';
-    case ASTAssignmentOperator.divideAsInt:
-      return '~/=';
-    case ASTAssignmentOperator.sum:
-      return '+=';
-    case ASTAssignmentOperator.subtract:
-      return '-=';
-    case ASTAssignmentOperator.nullCoalesce:
-      return '??=';
-  }
-}
+String getASTAssignmentOperatorText(ASTAssignmentOperator op) =>
+    op == ASTAssignmentOperator.set ? '=' : '${op.symbol}=';
 
 ASTAssignmentOperator getASTAssignmentDirectOperator(String op) {
   op = op.trim();

--- a/lib/src/ast/apollovm_ast_statement.dart
+++ b/lib/src/ast/apollovm_ast_statement.dart
@@ -1815,6 +1815,59 @@ class ASTStatementThrow extends ASTStatement {
   String toString() => 'throw $expression ;';
 }
 
+/// An `assert(condition)` / `assert(condition, message)` statement.
+///
+/// ApolloVM has no debug/release split, so the condition is always evaluated —
+/// matching `dart run`'s default. A false condition throws [message] (or a
+/// default text) as an [ApolloVMThrownException], so it is catchable exactly
+/// like a `throw`.
+class ASTStatementAssert extends ASTStatement {
+  ASTExpression condition;
+
+  ASTExpression? message;
+
+  ASTStatementAssert(this.condition, [this.message]);
+
+  @override
+  Iterable<ASTNode> get children => [condition, ?message];
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+    condition.resolveNode(parentNode);
+    message?.resolveNode(parentNode);
+  }
+
+  @override
+  FutureOr<ASTValue> run(VMContext parentContext, ASTRunStatus runStatus) {
+    return condition.run(parentContext, runStatus).resolveMapped((value) {
+      var ok = value.getValue(parentContext);
+
+      return ok.resolveMapped((ok) {
+        if (ok == true) return ASTValueVoid.instance;
+
+        var message = this.message;
+        if (message == null) {
+          // A fixed text, not the condition's `toString()`: that renders the
+          // AST (`n != (int) 5`), not the source, and would differ per target.
+          throw ApolloVMThrownException(ASTValueString('Assertion failed'));
+        }
+
+        return message.run(parentContext, runStatus).resolveMapped((msg) {
+          throw ApolloVMThrownException(msg);
+        });
+      });
+    });
+  }
+
+  @override
+  ASTType resolveType(VMContext? context) => ASTTypeVoid.instance;
+
+  @override
+  String toString() =>
+      message == null ? 'assert($condition) ;' : 'assert($condition, $message) ;';
+}
+
 /// A single `catch` clause of an [ASTStatementTryCatch].
 ///
 /// [exceptionType] is the matched type (`null` = catch-all); [variableName] is

--- a/lib/src/ast/apollovm_ast_toplevel.dart
+++ b/lib/src/ast/apollovm_ast_toplevel.dart
@@ -2522,9 +2522,9 @@ class ASTClassFunctionDeclaration<T> extends ASTFunctionDeclaration<T> {
     String name,
     ASTFunctionParametersDeclaration parameters,
     ASTType<T> returnType, {
-    ASTBlock? block,
-    ASTModifiers? modifiers,
-  }) : super(name, parameters, returnType, block: block, modifiers: modifiers);
+    super.block,
+    super.modifiers,
+  }) : super(name, parameters, returnType);
 
   FutureOr<ASTValue<T>> objectCall(
     VMContext parent,
@@ -3303,9 +3303,9 @@ class ASTClassGetterDeclaration<T> extends ASTGetterDeclaration<T> {
     String name,
 
     ASTType<T> returnType, {
-    ASTBlock? block,
-    ASTModifiers? modifiers,
-  }) : super(name, returnType, block: block, modifiers: modifiers);
+    super.block,
+    super.modifiers,
+  }) : super(name, returnType);
 
   FutureOr<ASTValue<T>> objectCall(
     VMContext parent,

--- a/lib/src/ast/apollovm_ast_toplevel.dart
+++ b/lib/src/ast/apollovm_ast_toplevel.dart
@@ -1774,8 +1774,20 @@ class ASTParameterDeclaration<T> with ASTNode implements ASTTypedNode {
   /// the parameter has no default. Set by the parser after construction.
   ASTExpression? defaultValue;
 
-  ASTParameterDeclaration(ASTType<T> type, this.name, {this.defaultValue})
-    : _type = type;
+  /// Whether the declaration was marked `required` (Dart named parameters).
+  ///
+  /// Not enforced at run time — ApolloVM has no static checker — but preserved
+  /// so Dart output keeps the modifier. Emitting `{int a}` for
+  /// `{required int a}` produces source ApolloVM re-parses happily but
+  /// `dart analyze` rejects.
+  final bool isRequired;
+
+  ASTParameterDeclaration(
+    ASTType<T> type,
+    this.name, {
+    this.defaultValue,
+    this.isRequired = false,
+  }) : _type = type;
 
   @override
   Iterable<ASTNode> get children =>
@@ -1850,6 +1862,7 @@ class ASTConstructorParameterDeclaration<T> extends ASTParameterDeclaration {
     this.index,
     this.optional, {
     this.thisParameter = false,
+    super.isRequired,
   });
 
   @override
@@ -1890,6 +1903,7 @@ class ASTFunctionParameterDeclaration<T> extends ASTParameterDeclaration<T> {
     this.index,
     this.optional, {
     this.unmodifiable = false,
+    super.isRequired,
   });
 }
 

--- a/lib/src/ast/apollovm_ast_variable.dart
+++ b/lib/src/ast/apollovm_ast_variable.dart
@@ -139,8 +139,8 @@ class ASTClassFieldWithInitialValue<T> extends ASTClassField<T> {
     String name,
     this._initialValueExpression,
     bool finalValue, {
-    ASTModifiers? modifiers,
-  }) : super(type, name, finalValue, modifiers: modifiers);
+    super.modifiers,
+  }) : super(type, name, finalValue);
 
   ASTExpression get initialValue => _initialValueExpression;
 

--- a/lib/src/languages/csharp/csharp_generator.dart
+++ b/lib/src/languages/csharp/csharp_generator.dart
@@ -535,6 +535,32 @@ class ApolloCodeGeneratorCSharp extends ApolloCodeGenerator {
   }
 
   @override
+  /// C# has no `assert` keyword: `System.Diagnostics.Debug.Assert(cond, msg)`.
+  @override
+  StringBuffer generateASTStatementAssert(
+    ASTStatementAssert statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    out.write('Debug.Assert(');
+    generateASTExpression(statement.condition, out: out, headIndented: false);
+
+    var message = statement.message;
+    if (message != null) {
+      out.write(', ');
+      generateASTExpression(message, out: out, headIndented: false);
+    }
+
+    out.write(');');
+
+    return out;
+  }
+
+  @override
   StringBuffer generateASTStatementForEach(
     ASTStatementForEach forEach, {
     StringBuffer? out,

--- a/lib/src/languages/csharp/csharp_generator.dart
+++ b/lib/src/languages/csharp/csharp_generator.dart
@@ -70,6 +70,9 @@ class ApolloCodeGeneratorCSharp extends ApolloCodeGenerator {
   }
 
   @override
+  String? renderCatchStackTraceBinding(String name) => 'string $name = "";';
+
+  @override
   String normalizeTypeFunction(String typeName, String functionName) {
     switch (typeName) {
       case 'int':

--- a/lib/src/languages/csharp/csharp_generator.dart
+++ b/lib/src/languages/csharp/csharp_generator.dart
@@ -557,17 +557,11 @@ class ApolloCodeGeneratorCSharp extends ApolloCodeGenerator {
       headIndented: false,
     );
 
-    out.write(') {\n');
+    out.write(')');
 
-    var blockCode = generateASTBlock(
-      forEach.loopBlock,
-      indent: indent,
-      withBrackets: false,
-    );
-
-    out.write(blockCode);
-    out.write(indent);
-    out.write('}');
+    if (writeASTLoopBody(forEach.loopBlock, out: out, indent: indent)) {
+      out.write('}');
+    }
 
     return out;
   }

--- a/lib/src/languages/csharp/csharp_grammar.dart
+++ b/lib/src/languages/csharp/csharp_grammar.dart
@@ -551,7 +551,7 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
 
   Parser<ASTStatementDoWhileLoop> statementDoWhileLoop() =>
       (keywordToken('do') &
-              codeBlock() &
+              ref0(codeBlockOrSingleLineBlock) &
               string('while').trimHidden() &
               char('(').trimHidden() &
               ref0(expression) &
@@ -648,7 +648,7 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
               char(';').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var initExp = v[2];
             var condExp = v[3];
@@ -666,7 +666,7 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
               inToken().trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var variableType = v[2];
             var variableName = v[3];
@@ -686,7 +686,7 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var condExp = v[2];
             var block = v[4];
@@ -758,9 +758,9 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock() &
+              ref0(codeBlockOrSingleLineBlock) &
               keywordToken('else') &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var condition = v[2];
             var blockIf = v[4];
@@ -773,9 +773,10 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock() &
+              ref0(codeBlockOrSingleLineBlock) &
               ref0(branchElseIfs).plus() &
-              (keywordToken('else') & codeBlock()).optional())
+              (keywordToken('else') & ref0(codeBlockOrSingleLineBlock))
+                  .optional())
           .map((v) {
             var condition = v[2];
             var blockIf = v[4];
@@ -796,7 +797,7 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var condition = v[3];
             var blockIf = v[5];

--- a/lib/src/languages/csharp/csharp_grammar.dart
+++ b/lib/src/languages/csharp/csharp_grammar.dart
@@ -531,7 +531,7 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
           .map((v) => ASTStatementContinue());
 
   Parser<ASTStatementDoWhileLoop> statementDoWhileLoop() =>
-      (string('do').trimHidden() &
+      (keywordToken('do') &
               codeBlock() &
               string('while').trimHidden() &
               char('(').trimHidden() &
@@ -740,7 +740,7 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
               ref0(expression) &
               char(')').trimHidden() &
               codeBlock() &
-              string('else').trimHidden() &
+              keywordToken('else') &
               codeBlock())
           .map((v) {
             var condition = v[2];
@@ -756,13 +756,12 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
               char(')').trimHidden() &
               codeBlock() &
               ref0(branchElseIfs).plus() &
-              string('else').trimHidden() &
-              codeBlock())
+              (keywordToken('else') & codeBlock()).optional())
           .map((v) {
             var condition = v[2];
             var blockIf = v[4];
             var blockElseIfs = v[5] as List;
-            var blockElse = v[7];
+            var blockElse = v[6]?[1];
 
             return ASTBranchIfElseIfsElseBlock(
               condition,
@@ -773,8 +772,8 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
           });
 
   Parser<ASTBranchIfBlock> branchElseIfs() =>
-      (string('else').trimHidden() &
-              string('if').trimHidden() &
+      (keywordToken('else') &
+              keywordToken('if') &
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &

--- a/lib/src/languages/csharp/csharp_grammar.dart
+++ b/lib/src/languages/csharp/csharp_grammar.dart
@@ -490,17 +490,36 @@ class CSharpGrammarDefinition extends CSharpGrammarLexer {
             return ASTBlock(null)..addAllStatements(statements);
           });
 
+  /// A control-flow body: either a braced block or a single unbraced
+  /// statement (`foreach (var e in l) print(e);`). [codeBlock] is tried first,
+  /// so a body starting with `{` is always a block.
   Parser<ASTBlock> codeBlockOrSingleLineBlock() =>
-      ((codeBlock() | singleLineCodeBlock())).cast<ASTBlock>();
+      (ref0(codeBlock) | ref0(singleLineCodeBlock)).cast<ASTBlock>();
 
   Parser<ASTSingleLineStatementBlock> singleLineCodeBlock() =>
-      (singleLineStatement().trimHidden()).map((v) {
+      ref0(singleLineStatement).trimHidden().map((v) {
         var statements = v;
         return ASTSingleLineStatementBlock(null)..addStatement(statements);
       });
 
+  /// The [statement] alternation minus [statementVariableDeclaration], which
+  /// is illegal as an unbraced body. The relative order must match
+  /// [statement]. Every alternative must be a `ref0`, otherwise the cycle back
+  /// through [branch] recurses forever while *building* the grammar.
   Parser<ASTStatement> singleLineStatement() =>
-      (statementReturn() | statementExpression()).cast<ASTStatement>();
+      (ref0(statementTryCatch) |
+              ref0(statementThrow) |
+              ref0(statementSwitch) |
+              ref0(branch) |
+              ref0(statementBreak) |
+              ref0(statementContinue) |
+              ref0(statementReturn) |
+              ref0(statementDoWhileLoop) |
+              ref0(statementForLoop) |
+              ref0(statementForEach) |
+              ref0(statementWhileLoop) |
+              ref0(statementExpression))
+          .cast<ASTStatement>();
 
   Parser<ASTStatement> statement() =>
       (statementTryCatch() |

--- a/lib/src/languages/dart/dart_generator.dart
+++ b/lib/src/languages/dart/dart_generator.dart
@@ -25,6 +25,9 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
   bool get supportsNullAwareOperators => true;
 
   @override
+  bool get supportsRequiredParameters => true;
+
+  @override
   String normalizeTypeName(String typeName, [String? callingFunction]) {
     switch (typeName) {
       case 'Integer':

--- a/lib/src/languages/dart/dart_generator.dart
+++ b/lib/src/languages/dart/dart_generator.dart
@@ -433,6 +433,8 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
     var f = expression.function;
     generateFunctionParametersNames(f, out: out);
 
+    if (f.modifiers.isAsync) out.write(' async');
+
     // Dart anonymous functions: `(params) => expr` or `(params) { body }`
     // (no `=>` before a block body, unlike JavaScript).
     var single = singleReturnExpression(f);

--- a/lib/src/languages/dart/dart_generator.dart
+++ b/lib/src/languages/dart/dart_generator.dart
@@ -40,12 +40,19 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
   @override
   String generateASTCatchClauseHeader(ASTCatchClause catchClause) {
     var name = catchClause.variableName ?? 'e';
+    var stackTrace = catchClause.stackTraceName;
+    var bind = stackTrace != null ? '$name, $stackTrace' : name;
     var type = catchClause.exceptionType;
     if (type != null) {
-      return 'on ${generateASTType(type)} catch ($name)';
+      return 'on ${generateASTType(type)} catch ($bind)';
     }
-    return 'catch ($name)';
+    return 'catch ($bind)';
   }
+
+  /// Dart declares the stack trace in the header (`catch (e, s)`), so there is
+  /// no separate binding statement.
+  @override
+  String? renderCatchStackTraceBinding(String name) => null;
 
   @override
   String normalizeTypeFunction(String typeName, String functionName) {

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -449,15 +449,18 @@ class DartGrammarDefinition extends DartGrammarLexer {
 
   Parser<ASTClassField> classFieldDeclaration() =>
       (staticToken().trimHidden().optional() &
+              // Dart's modifier order is `static late final`. `late` is
+              // accepted and dropped.
+              lateKeyword().optional() &
               (finalToken() | constToken()).optional() &
               type().trimHidden() &
               identifier().trimHidden() &
               char(';').trimHidden())
           .map((v) {
             var isStatic = v[0] != null;
-            var finalValue = v[1] != null;
-            var type = v[2] as ASTType;
-            var name = v[3] as String;
+            var finalValue = v[2] != null;
+            var type = v[3] as ASTType;
+            var name = v[4] as String;
             return ASTClassField(
               type,
               name,
@@ -468,6 +471,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
 
   Parser<ASTClassField> classFieldDeclarationWithValue() =>
       (staticToken().trimHidden().optional() &
+              lateKeyword().optional() &
               (finalToken() | constToken()).optional() &
               type() &
               identifier() &
@@ -476,10 +480,10 @@ class DartGrammarDefinition extends DartGrammarLexer {
               char(';').trimHidden())
           .map((v) {
             var isStatic = v[0] != null;
-            var finalValue = v[1] != null;
-            var type = v[2] as ASTType;
-            var name = v[3] as String;
-            var expression = v[5] as ASTExpression;
+            var finalValue = v[2] != null;
+            var type = v[3] as ASTType;
+            var name = v[4] as String;
+            var expression = v[6] as ASTExpression;
             type.associateToType(expression);
             return ASTClassFieldWithInitialValue(
               type,
@@ -955,18 +959,22 @@ class DartGrammarDefinition extends DartGrammarLexer {
   /// `(params) { body }`. Parameters may be typed (`(int a)`) or untyped
   /// (`(a)`). Captures the enclosing scope at runtime.
   Parser<ASTExpression> expressionAnonymousFunction() =>
-      (anonFunctionParameters() & (anonArrowBody() | codeBlock())).map((v) {
-        var parameters = v[0] as ASTFunctionParametersDeclaration;
-        var block = v[1] as ASTBlock;
-        var f = ASTFunctionDeclaration(
-          '',
-          parameters,
-          ASTTypeDynamic.instance,
-          block: block,
-          modifiers: ASTModifiers.modifierStatic,
-        );
-        return ASTExpressionLiteralFunction(f);
-      });
+      (anonFunctionParameters() &
+              asyncToken().optional() &
+              (anonArrowBody() | codeBlock()))
+          .map((v) {
+            var parameters = v[0] as ASTFunctionParametersDeclaration;
+            var isAsync = v[1] != null;
+            var block = v[2] as ASTBlock;
+            var f = ASTFunctionDeclaration(
+              '',
+              parameters,
+              ASTTypeDynamic.instance,
+              block: block,
+              modifiers: ASTModifiers(isStatic: true, isAsync: isAsync),
+            );
+            return ASTExpressionLiteralFunction(f);
+          });
 
   /// `=> expr` body for an anonymous function (no trailing `;`, unlike a
   /// declaration's [arrowBody]).
@@ -1020,27 +1028,32 @@ class DartGrammarDefinition extends DartGrammarLexer {
       (type().optional() &
               identifier() &
               functionParametersDeclaration() &
-              codeBlock())
+              asyncToken().optional() &
+              (arrowBody() | codeBlock()))
           .map((v) {
             var returnType = v[0] as ASTType? ?? ASTTypeDynamic.instance;
             var parameters = v[2];
             var name = v[1];
-            var block = v[3];
+            var isAsync = v[3] != null;
+            var block = v[4];
             return ASTStatementFunctionDeclaration(
               ASTFunctionDeclaration(
                 name,
                 parameters,
                 returnType,
                 block: block,
-                modifiers: ASTModifiers.modifierStatic,
+                modifiers: ASTModifiers(isStatic: true, isAsync: isAsync),
               ),
             );
           });
 
   Parser<ASTStatementVariableDeclaration> statementVariableDeclaration() =>
       (
-          // var definition:
-          (
+          // `late` is accepted and dropped: ApolloVM has no lazy-initialization
+          // semantics, and `late int x = 1;` runs the same as `int x = 1;`.
+          lateKeyword().optional() &
+              // var definition:
+              (
               // final Type name:
               ((finalToken() | constToken()).trimHidden() &
                       type() &
@@ -1054,7 +1067,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
               (char('=').trimHidden() & ref0(expression)).optional() &
               char(';').trimHidden())
           .map((v) {
-            var varDef = v[0] as List;
+            var varDef = v[1] as List;
 
             bool unmodifiable;
             ASTType type;
@@ -1081,7 +1094,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
               throw StateError("Invalid var definition: $varDef");
             }
 
-            var valueOpt = v[1];
+            var valueOpt = v[2];
             var value = valueOpt != null ? valueOpt[1] as ASTExpression : null;
             if (value != null) type.associateToType(value);
             return ASTStatementVariableDeclaration(
@@ -1326,6 +1339,18 @@ class DartGrammarDefinition extends DartGrammarLexer {
             }
           });
 
+  /// A `const` collection literal at a use site. `const` carries no extra
+  /// semantics in ApolloVM, so it is consumed and discarded — the same as
+  /// `new` in [expressionFunctionInvocation].
+  Parser<ASTExpression> expressionConstCollection() =>
+      (constKeyword() &
+              (expressionListEmptyLiteral() |
+                      expressionListLiteral() |
+                      expressionMapEmptyLiteral() |
+                      expressionMapLiteral())
+                  .cast<ASTExpression>())
+          .map((v) => v[1] as ASTExpression);
+
   Parser<ASTExpression> expressionNoOperation() =>
       (expressionCascade() |
               expressionAwait() |
@@ -1333,6 +1358,11 @@ class DartGrammarDefinition extends DartGrammarLexer {
               expressionNegate() |
               expressionBitwiseNot() |
               expressionLiteral() |
+              // `const [1, 2]`, `const {}`. Must come *before*
+              // `expressionVariableEntryAccess` below, which would otherwise
+              // read `const [1]` as an index access on a variable named
+              // `const`.
+              expressionConstCollection() |
               // `(expr).m().field` — needs at least one trailing segment, so it
               // cannot shadow the plain group-invocation rule below.
               expressionGroupInvocationChain() |
@@ -1486,10 +1516,10 @@ class DartGrammarDefinition extends DartGrammarLexer {
           });
 
   Parser<ASTExpressionFunctionInvocation> expressionFunctionInvocation() =>
-      // Optional `new` prefix for class instantiation (`new User()`); the
-      // keyword is consumed and discarded — `new User()` and `User()` both
-      // resolve to the class constructor via `ASTRoot.getFunction`.
-      (newToken().optional() &
+      // Optional `new`/`const` prefix for class instantiation (`new User()`,
+      // `const Point(1, 2)`); the keyword is consumed and discarded — all three
+      // spellings resolve to the class constructor via `ASTRoot.getFunction`.
+      ((newToken() | constKeyword()).optional() &
               (identifier() & char('!').optional() & (string('?.') | char('.')))
                   .optional() &
               identifier() &
@@ -2269,17 +2299,30 @@ class DartGrammarDefinition extends DartGrammarLexer {
           });
 
   Parser<ASTType> simpleType() =>
-      // Guard against the `await` contextual keyword being read as a type name
-      // (so `await x;` parses as an await expression, not a `await x` variable
-      // declaration).
-      (awaitToken().not() & identifier()).map((v) {
-        var name = v[1] as String;
-        // A class type parameter (`T`) is erased to `dynamic`.
-        if (_classTypeParameters.contains(name)) {
-          return ASTTypeDynamic.instance;
-        }
-        return getTypeByName(name);
-      });
+      // Guard the contextual keywords that would otherwise be read as a type
+      // name: `await x;` must parse as an await expression rather than an
+      // `await x` variable declaration, and `get`/`set` must not be swallowed
+      // as the return type of an accessor. Without the `set` guard,
+      // `set value(int v) {}` silently becomes a *method* named `value`
+      // returning a type named `set`; without the `get` guard an untyped
+      // getter (`get twice => …`) fails, because `type().optional()` eats
+      // `get` and petitparser's `optional()` cannot backtrack.
+      //
+      // `var`/`final`/`const`/`void`/`dynamic` must stay accepted here:
+      // [getTypeByName] maps them, and rules like `for (final e in l)` depend
+      // on it.
+      (awaitToken().not() &
+              getToken().not() &
+              setKeyword().not() &
+              identifier())
+          .map((v) {
+            var name = v[3] as String;
+            // A class type parameter (`T`) is erased to `dynamic`.
+            if (_classTypeParameters.contains(name)) {
+              return ASTTypeDynamic.instance;
+            }
+            return getTypeByName(name);
+          });
 
   Parser<ASTTypeArray> arrayTyped() =>
       (array3DTyped() | array2DTyped() | array1DTyped()).cast<ASTTypeArray>();

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -764,6 +764,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
   Parser<ASTStatement> statement() =>
       (statementTryCatch() |
               statementThrow() |
+              statementAssert() |
               statementSwitch() |
               branch() |
               statementBreak() |
@@ -847,6 +848,25 @@ class DartGrammarDefinition extends DartGrammarLexer {
   Parser<ASTStatementThrow> statementThrow() =>
       (string('throw').trimHidden() & ref0(expression) & char(';').trimHidden())
           .map((v) => ASTStatementThrow(v[1] as ASTExpression));
+
+  /// `assert(cond)` / `assert(cond, message)`, with an optional trailing comma.
+  ///
+  /// Must precede [statementExpression] in [statement]: without this rule
+  /// `assert(x);` parses as a call to a user function named `assert` and fails
+  /// much later with a confusing "can't find function" error.
+  Parser<ASTStatementAssert> statementAssert() =>
+      (assertKeyword() &
+              char('(').trimHidden() &
+              ref0(expression) &
+              (char(',').trimHidden() & ref0(expression)).optional() &
+              char(',').trimHidden().optional() &
+              char(')').trimHidden() &
+              char(';').trimHidden())
+          .map((v) {
+            var condition = v[2] as ASTExpression;
+            var message = (v[3] as List?)?[1] as ASTExpression?;
+            return ASTStatementAssert(condition, message);
+          });
 
   Parser<ASTStatementTryCatch> statementTryCatch() =>
       (string('try').trimHidden() &

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -741,7 +741,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
 
   Parser<ASTStatementDoWhileLoop> statementDoWhileLoop() =>
       (keywordToken('do') &
-              codeBlock() &
+              ref0(codeBlockOrSingleLineBlock) &
               string('while').trimHidden() &
               char('(').trimHidden() &
               ref0(expression) &
@@ -860,7 +860,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
               char(';').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var initExp = v[2];
             var condExp = v[3];
@@ -877,7 +877,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
               string('in').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var variableType = v[2];
             var variableName = v[3];
@@ -897,7 +897,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var condExp = v[2];
             var block = v[4];
@@ -1115,9 +1115,9 @@ class DartGrammarDefinition extends DartGrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock() &
+              ref0(codeBlockOrSingleLineBlock) &
               keywordToken('else') &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var condition = v[2];
             var blockIf = v[4];
@@ -1130,9 +1130,10 @@ class DartGrammarDefinition extends DartGrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock() &
+              ref0(codeBlockOrSingleLineBlock) &
               ref0(branchElseIfs).plus() &
-              (keywordToken('else') & codeBlock()).optional())
+              (keywordToken('else') & ref0(codeBlockOrSingleLineBlock))
+                  .optional())
           .map((v) {
             var condition = v[2];
             var blockIf = v[4];
@@ -1153,7 +1154,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var condition = v[3];
             var blockIf = v[5];

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -96,13 +96,43 @@ class DartGrammarDefinition extends DartGrammarLexer {
       (ref0(statementImport) | ref0(statementExport)).cast<ASTStatement>();
 
   Parser topLevelDefinition() =>
-      (typeAliasDeclaration() |
-              enumDeclaration() |
-              extensionDeclaration() |
-              classDeclaration() |
-              functionDeclaration() |
-              statementVariableDeclaration())
+      (ref0(metadata).star() &
+              (typeAliasDeclaration() |
+                  enumDeclaration() |
+                  extensionDeclaration() |
+                  classDeclaration() |
+                  functionDeclaration() |
+                  statementVariableDeclaration()))
+          // Unwrap: `compilationUnit` type-switches over the definitions, so a
+          // wrapper list here would make every top-level definition vanish.
+          .map((v) => v[1])
           .plus();
+
+  /// Metadata / annotation: `@override`, `@Deprecated('x')`,
+  /// `@pragma('vm:prefer-inline')`, `@foo.Bar(1, n: 2)`.
+  ///
+  /// Parsed and discarded. [ASTAnnotation] exists but is never populated, so
+  /// annotations do not survive a round-trip; preserving them is the natural
+  /// next step and needs no grammar change.
+  Parser metadata() =>
+      (char('@').trimHidden() &
+              identifier() &
+              (char('.').trimHidden() & identifier()).star() &
+              ref0(balancedParenGroup).optional())
+          .trimHidden();
+
+  /// A balanced `( … )` group, skipped without interpreting its contents.
+  ///
+  /// Annotation arguments are discarded anyway, and skipping them structurally
+  /// means an annotation using syntax ApolloVM does not model yet still never
+  /// breaks the declaration it precedes. (A parenthesis inside a string
+  /// literal in the arguments would confuse the balance count — rare enough to
+  /// accept.)
+  Parser balancedParenGroup() =>
+      (char('(') &
+              (ref0(balancedParenGroup) | pattern('^()')).star() &
+              char(')'))
+          .trimHidden();
 
   Parser<ASTFunctionDeclaration> functionDeclaration() =>
       (type().optional() &
@@ -214,7 +244,10 @@ class DartGrammarDefinition extends DartGrammarLexer {
               onToken().trimHidden() &
               type() &
               char('{').trimHidden() &
-              (ref0(classFunctionDeclaration) | ref0(getterDeclaration))
+              (ref0(metadata).star() &
+                      (ref0(classFunctionDeclaration) |
+                          ref0(getterDeclaration)))
+                  .map((v) => v[1])
                   .star() &
               char('}').trimHidden())
           .map((v) {
@@ -358,10 +391,12 @@ class DartGrammarDefinition extends DartGrammarLexer {
               // Enhanced/rich enum body: `;` then class members (fields, a
               // `const` constructor, methods) — reusing class-member parsing.
               (char(';').trimHidden() &
-                      (ref0(classConstructorDefaultDeclaration) |
-                              ref0(classFunctionDeclaration) |
-                              ref0(classFieldDeclaration) |
-                              ref0(classFieldDeclarationWithValue))
+                      (ref0(metadata).star() &
+                              (ref0(classConstructorDefaultDeclaration) |
+                                  ref0(classFunctionDeclaration) |
+                                  ref0(classFieldDeclaration) |
+                                  ref0(classFieldDeclarationWithValue)))
+                          .map((v) => v[1])
                           .star())
                   .optional() &
               char('}').trimHidden())
@@ -394,15 +429,16 @@ class DartGrammarDefinition extends DartGrammarLexer {
           });
 
   Parser<ASTEnumEntry> enumEntry() =>
-      (identifier().trimHidden() &
+      (ref0(metadata).star() &
+              identifier().trimHidden() &
               ((char('=').trimHidden() & ref0(expression)) |
                       (char('(').trimHidden() &
                           expressionSequence().optional() &
                           char(')').trimHidden()))
                   .optional())
           .map((v) {
-            var name = v[0] as String;
-            var suffix = v[1] as List?;
+            var name = v[1] as String;
+            var suffix = v[2] as List?;
             ASTExpression? value;
             List<ASTExpression>? arguments;
             if (suffix != null) {
@@ -421,11 +457,13 @@ class DartGrammarDefinition extends DartGrammarLexer {
 
   Parser<ASTBlock> classCodeBlock() =>
       (char('{').trimHidden() &
-              (ref0(classConstructorDefaultDeclaration) |
-                      ref0(classFunctionDeclaration) |
-                      ref0(getterDeclaration) |
-                      ref0(classFieldDeclaration) |
-                      ref0(classFieldDeclarationWithValue))
+              (ref0(metadata).star() &
+                      (ref0(classConstructorDefaultDeclaration) |
+                          ref0(classFunctionDeclaration) |
+                          ref0(getterDeclaration) |
+                          ref0(classFieldDeclaration) |
+                          ref0(classFieldDeclarationWithValue)))
+                  .map((v) => v[1])
                   .star() &
               char('}').trimHidden())
           .map((v) {
@@ -612,29 +650,39 @@ class DartGrammarDefinition extends DartGrammarLexer {
 
   Parser<ASTConstructorParameterDeclaration>
   constructorThisParameterDeclaration() =>
-      (thisToken().trim() &
+      (ref0(metadata).star() &
+              requiredKeyword().optional() &
+              thisToken().trim() &
               char('.') &
               identifier() &
               parameterDefaultValue().optional())
           .map((v) {
             return ASTConstructorParameterDeclaration(
               ASTTypeConstructorThis.instance,
-              v[2],
+              v[4],
               -1,
               false,
               thisParameter: true,
-            )..defaultValue = v[3] as ASTExpression?;
+              isRequired: v[1] != null,
+            )..defaultValue = v[5] as ASTExpression?;
           });
 
   Parser<ASTConstructorParameterDeclaration>
   constructorTypedParameterDeclaration() =>
-      ((finalToken() | constToken()).trim().optional() &
+      (ref0(metadata).star() &
+              requiredKeyword().optional() &
+              (finalToken() | constToken()).trim().optional() &
               type().trim() &
               identifier() &
               parameterDefaultValue().optional())
           .map((v) {
-            return ASTConstructorParameterDeclaration(v[1], v[2], -1, false)
-              ..defaultValue = v[3] as ASTExpression?;
+            return ASTConstructorParameterDeclaration(
+              v[3],
+              v[4],
+              -1,
+              false,
+              isRequired: v[1] != null,
+            )..defaultValue = v[5] as ASTExpression?;
           });
 
   Parser<ASTFunctionDeclaration> classFunctionDeclaration() =>
@@ -1049,9 +1097,15 @@ class DartGrammarDefinition extends DartGrammarLexer {
 
   Parser<ASTStatementVariableDeclaration> statementVariableDeclaration() =>
       (
-          // `late` is accepted and dropped: ApolloVM has no lazy-initialization
-          // semantics, and `late int x = 1;` runs the same as `int x = 1;`.
-          lateKeyword().optional() &
+          // Metadata attaches to the *declaration*, deliberately not to
+          // `statement()`: attempting a metadata parse at every statement
+          // position would move the farthest-failure offset that
+          // `apollovm_dart_parse_error_position_test` pins on a stray `@`.
+          ref0(metadata).star() &
+              // `late` is accepted and dropped: ApolloVM has no
+              // lazy-initialization semantics, and `late int x = 1;` runs the
+              // same as `int x = 1;`.
+              lateKeyword().optional() &
               // var definition:
               (
               // final Type name:
@@ -1067,7 +1121,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
               (char('=').trimHidden() & ref0(expression)).optional() &
               char(';').trimHidden())
           .map((v) {
-            var varDef = v[1] as List;
+            var varDef = v[2] as List;
 
             bool unmodifiable;
             ASTType type;
@@ -1094,7 +1148,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
               throw StateError("Invalid var definition: $varDef");
             }
 
-            var valueOpt = v[2];
+            var valueOpt = v[3];
             var value = valueOpt != null ? valueOpt[1] as ASTExpression : null;
             if (value != null) type.associateToType(value);
             return ASTStatementVariableDeclaration(
@@ -2205,18 +2259,21 @@ class DartGrammarDefinition extends DartGrammarLexer {
           });
 
   Parser<ASTFunctionParameterDeclaration> parameterDeclaration() =>
-      ((finalToken() | constToken()).trim().optional() &
+      (ref0(metadata).star() &
+              requiredKeyword().optional() &
+              (finalToken() | constToken()).trim().optional() &
               type().trim() &
               identifier() &
               parameterDefaultValue().optional())
           .map((v) {
             return ASTFunctionParameterDeclaration(
-              v[1],
-              v[2],
+              v[3],
+              v[4],
               -1,
               false,
-              unmodifiable: v[0] != null,
-            )..defaultValue = v[3] as ASTExpression?;
+              unmodifiable: v[2] != null,
+              isRequired: v[1] != null,
+            )..defaultValue = v[5] as ASTExpression?;
           });
 
   Parser<ASTType> type() =>

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -2182,13 +2182,21 @@ class DartGrammarDefinition extends DartGrammarLexer {
             );
           });
 
+  /// Longest-first: `<<=` must be tried before `<`-anything, and every
+  /// two-character form before the bare `=`.
   Parser<ASTAssignmentOperator> assigmentOperator() =>
       (string('??=') |
+              string('~/=') |
+              string('<<=') |
+              string('>>=') |
               string('+=') |
               string('-=') |
               string('*=') |
               string('/=') |
-              string('~/=') |
+              string('%=') |
+              string('&=') |
+              string('|=') |
+              string('^=') |
               char('='))
           .trimHidden()
           .map((v) {

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -719,7 +719,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
           .map((v) => ASTStatementContinue());
 
   Parser<ASTStatementDoWhileLoop> statementDoWhileLoop() =>
-      (string('do').trimHidden() &
+      (keywordToken('do') &
               codeBlock() &
               string('while').trimHidden() &
               char('(').trimHidden() &
@@ -1095,7 +1095,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
               ref0(expression) &
               char(')').trimHidden() &
               codeBlock() &
-              string('else').trimHidden() &
+              keywordToken('else') &
               codeBlock())
           .map((v) {
             var condition = v[2];
@@ -1111,7 +1111,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
               char(')').trimHidden() &
               codeBlock() &
               ref0(branchElseIfs).plus() &
-              (string('else').trimHidden() & codeBlock()).optional())
+              (keywordToken('else') & codeBlock()).optional())
           .map((v) {
             var condition = v[2];
             var blockIf = v[4];
@@ -1127,8 +1127,8 @@ class DartGrammarDefinition extends DartGrammarLexer {
           });
 
   Parser<ASTBranchIfBlock> branchElseIfs() =>
-      (string('else').trimHidden() &
-              string('if').trimHidden() &
+      (keywordToken('else') &
+              keywordToken('if') &
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -676,17 +676,38 @@ class DartGrammarDefinition extends DartGrammarLexer {
             return ASTBlock(null)..addAllStatements(statements);
           });
 
+  /// A control-flow body: either a braced block or a single unbraced
+  /// statement (`for (var e in l) print(e);`). [codeBlock] is tried first, so
+  /// a body starting with `{` is always a block.
   Parser<ASTBlock> codeBlockOrSingleLineBlock() =>
-      ((codeBlock() | singleLineCodeBlock())).cast<ASTBlock>();
+      (ref0(codeBlock) | ref0(singleLineCodeBlock)).cast<ASTBlock>();
 
   Parser<ASTSingleLineStatementBlock> singleLineCodeBlock() =>
-      (singleLineStatement().trimHidden()).map((v) {
+      ref0(singleLineStatement).trimHidden().map((v) {
         var statements = v;
         return ASTSingleLineStatementBlock(null)..addStatement(statements);
       });
 
+  /// The [statement] alternation minus declarations (illegal as an unbraced
+  /// body) and [statementBlock] (already covered by [codeBlock]). The relative
+  /// order must match [statement]: `break`/`continue`/`throw` before
+  /// [statementExpression], `do`-`while` before `while`, `for` before
+  /// `for`-`in`. Every alternative must be a `ref0`, otherwise the cycle back
+  /// through [branch] recurses forever while *building* the grammar.
   Parser<ASTStatement> singleLineStatement() =>
-      (statementReturn() | statementExpression()).cast<ASTStatement>();
+      (ref0(statementTryCatch) |
+              ref0(statementThrow) |
+              ref0(statementSwitch) |
+              ref0(branch) |
+              ref0(statementBreak) |
+              ref0(statementContinue) |
+              ref0(statementDoWhileLoop) |
+              ref0(statementForLoop) |
+              ref0(statementForEach) |
+              ref0(statementWhileLoop) |
+              ref0(statementReturn) |
+              ref0(statementExpression))
+          .cast<ASTStatement>();
 
   Parser<ASTStatement> statement() =>
       (statementTryCatch() |

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -902,8 +902,14 @@ class DartGrammarDefinition extends DartGrammarLexer {
             var type = v[1] as ASTType;
             var catchPart = v[2] as List?;
             var varName = catchPart != null ? catchPart[2] as String : null;
+            var stackTraceName = (catchPart?[3] as List?)?[1] as String?;
             var block = v[3] as ASTBlock;
-            return ASTCatchClause(type, varName, block);
+            return ASTCatchClause(
+              type,
+              varName,
+              block,
+              stackTraceName: stackTraceName,
+            );
           });
 
   /// Dart `catch (e[, st]) { }` (untyped catch-all).
@@ -916,8 +922,14 @@ class DartGrammarDefinition extends DartGrammarLexer {
               codeBlock())
           .map((v) {
             var varName = v[2] as String;
+            var stackTraceName = (v[3] as List?)?[1] as String?;
             var block = v[5] as ASTBlock;
-            return ASTCatchClause(null, varName, block);
+            return ASTCatchClause(
+              null,
+              varName,
+              block,
+              stackTraceName: stackTraceName,
+            );
           });
 
   Parser<ASTStatement> statementSimple() =>

--- a/lib/src/languages/dart/dart_grammar_lexer.dart
+++ b/lib/src/languages/dart/dart_grammar_lexer.dart
@@ -127,6 +127,19 @@ abstract class DartGrammarLexer extends BaseGrammarLexer {
 
   Parser awaitToken() => _keywordToken('await');
 
+  // Whole-word forms of keywords used as *optional* prefixes. The `ref1(token,
+  // …)` variants above are plain prefix matchers, which would read `constValue`
+  // as `const Value` and `lateBinding` as `late Binding`.
+  Parser constKeyword() => _keywordToken('const');
+
+  Parser lateKeyword() => _keywordToken('late');
+
+  Parser requiredKeyword() => _keywordToken('required');
+
+  Parser setKeyword() => _keywordToken('set');
+
+  Parser assertKeyword() => _keywordToken('assert');
+
   Parser _keywordToken(String word) =>
       (string(word) & ref0(identifierPartLexicalToken).not())
           .map((v) => v[0])
@@ -193,6 +206,8 @@ abstract class DartGrammarLexer extends BaseGrammarLexer {
       (string("'''") &
               (string(r"\'").map((_) => "'") |
                       stringContentQuotedLexicalTokenEscaped() |
+                      ref0(stringVariable) |
+                      ref0(stringExpression) |
                       any())
                   .starLazy(string("'''")) &
               string("'''"))
@@ -208,6 +223,8 @@ abstract class DartGrammarLexer extends BaseGrammarLexer {
       (string('"""') &
               (string(r'\"').map((_) => '"') |
                       stringContentQuotedLexicalTokenEscaped() |
+                      ref0(stringVariable) |
+                      ref0(stringExpression) |
                       any())
                   .starLazy(string('"""')) &
               string('"""'))

--- a/lib/src/languages/go/go_generator.dart
+++ b/lib/src/languages/go/go_generator.dart
@@ -943,6 +943,37 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
   }
 
   @override
+  /// Go has no `assert`; the idiom is an explicit check plus `panic`.
+  @override
+  StringBuffer generateASTStatementAssert(
+    ASTStatementAssert statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    out.write('if !(');
+    generateASTExpression(statement.condition, out: out, headIndented: false);
+    out.write(') {\n');
+    out.write('$indent  panic(');
+
+    var message = statement.message;
+    if (message != null) {
+      generateASTExpression(message, out: out, headIndented: false);
+    } else {
+      out.write('"Assertion failed"');
+    }
+
+    out.write(')\n');
+    out.write(indent);
+    out.write('}');
+
+    return out;
+  }
+
+  @override
   StringBuffer generateASTStatementForEach(
     ASTStatementForEach forEach, {
     StringBuffer? out,

--- a/lib/src/languages/go/go_grammar.dart
+++ b/lib/src/languages/go/go_grammar.dart
@@ -395,23 +395,16 @@ class GoGrammarDefinition extends GoGrammarLexer {
         );
       });
 
+  /// Go always requires braces: the spec defines `Block = "{" StatementList "}"`
+  /// and every control-flow statement takes a `Block`, never a single statement.
+  /// So — unlike the other C-style grammars — there is deliberately no
+  /// `codeBlockOrSingleLineBlock` here.
   Parser<ASTBlock> codeBlock() =>
       (char('{').trimHidden() & ref0(statement).star() & char('}').trimHidden())
           .map((v) {
             var statements = (v[1] as List).cast<ASTStatement>().toList();
             return ASTBlock(null)..addAllStatements(statements);
           });
-
-  Parser<ASTBlock> codeBlockOrSingleLineBlock() =>
-      ((codeBlock() | singleLineCodeBlock())).cast<ASTBlock>();
-
-  Parser<ASTSingleLineStatementBlock> singleLineCodeBlock() =>
-      (singleLineStatement().trimHidden()).map((v) {
-        return ASTSingleLineStatementBlock(null)..addStatement(v);
-      });
-
-  Parser<ASTStatement> singleLineStatement() =>
-      (statementReturn() | statementExpression()).cast<ASTStatement>();
 
   // -----------------------------------------------------------------
   // Statements.

--- a/lib/src/languages/java/java11/java11_generator.dart
+++ b/lib/src/languages/java/java11/java11_generator.dart
@@ -67,6 +67,9 @@ class ApolloCodeGeneratorJava11 extends ApolloCodeGenerator {
   }
 
   @override
+  String? renderCatchStackTraceBinding(String name) => 'String $name = "";';
+
+  @override
   String normalizeTypeFunction(String typeName, String functionName) {
     switch (typeName) {
       case 'int':

--- a/lib/src/languages/java/java11/java11_generator.dart
+++ b/lib/src/languages/java/java11/java11_generator.dart
@@ -104,6 +104,31 @@ class ApolloCodeGeneratorJava11 extends ApolloCodeGenerator {
 
   /// Java for-each uses `for (Type x : coll)` (colon), not the default
   /// `for (var x in coll)`.
+  /// Java spells it `assert cond : message;` — a statement, not a call.
+  @override
+  StringBuffer generateASTStatementAssert(
+    ASTStatementAssert statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    out.write('assert ');
+    generateASTExpression(statement.condition, out: out, headIndented: false);
+
+    var message = statement.message;
+    if (message != null) {
+      out.write(' : ');
+      generateASTExpression(message, out: out, headIndented: false);
+    }
+
+    out.write(';');
+
+    return out;
+  }
+
   @override
   StringBuffer generateASTStatementForEach(
     ASTStatementForEach forEach, {

--- a/lib/src/languages/java/java11/java11_generator.dart
+++ b/lib/src/languages/java/java11/java11_generator.dart
@@ -135,17 +135,11 @@ class ApolloCodeGeneratorJava11 extends ApolloCodeGenerator {
       headIndented: false,
     );
 
-    out.write(') {\n');
+    out.write(')');
 
-    var blockCode = generateASTBlock(
-      forEach.loopBlock,
-      indent: indent,
-      withBrackets: false,
-    );
-
-    out.write(blockCode);
-    out.write(indent);
-    out.write('}');
+    if (writeASTLoopBody(forEach.loopBlock, out: out, indent: indent)) {
+      out.write('}');
+    }
 
     return out;
   }

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -440,7 +440,7 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
 
   Parser<ASTStatementDoWhileLoop> statementDoWhileLoop() =>
       (keywordToken('do') &
-              codeBlock() &
+              ref0(codeBlockOrSingleLineBlock) &
               string('while').trimHidden() &
               char('(').trimHidden() &
               ref0(expression) &
@@ -537,7 +537,7 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
               char(';').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var initExp = v[2];
             var condExp = v[3];
@@ -554,7 +554,7 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
               char(':').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var variableType = v[2];
             var variableName = v[3];
@@ -574,7 +574,7 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var condExp = v[2];
             var block = v[4];
@@ -646,9 +646,9 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock() &
+              ref0(codeBlockOrSingleLineBlock) &
               keywordToken('else') &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var condition = v[2];
             var blockIf = v[4];
@@ -661,9 +661,10 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock() &
+              ref0(codeBlockOrSingleLineBlock) &
               ref0(branchElseIfs).plus() &
-              (keywordToken('else') & codeBlock()).optional())
+              (keywordToken('else') & ref0(codeBlockOrSingleLineBlock))
+                  .optional())
           .map((v) {
             var condition = v[2];
             var blockIf = v[4];
@@ -684,7 +685,7 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var condition = v[3];
             var blockIf = v[5];

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -420,7 +420,7 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
           .map((v) => ASTStatementContinue());
 
   Parser<ASTStatementDoWhileLoop> statementDoWhileLoop() =>
-      (string('do').trimHidden() &
+      (keywordToken('do') &
               codeBlock() &
               string('while').trimHidden() &
               char('(').trimHidden() &
@@ -628,7 +628,7 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
               ref0(expression) &
               char(')').trimHidden() &
               codeBlock() &
-              string('else').trimHidden() &
+              keywordToken('else') &
               codeBlock())
           .map((v) {
             var condition = v[2];
@@ -644,13 +644,12 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
               char(')').trimHidden() &
               codeBlock() &
               ref0(branchElseIfs).plus() &
-              string('else').trimHidden() &
-              codeBlock())
+              (keywordToken('else') & codeBlock()).optional())
           .map((v) {
             var condition = v[2];
             var blockIf = v[4];
             var blockElseIfs = v[5] as List;
-            var blockElse = v[7];
+            var blockElse = v[6]?[1];
 
             return ASTBranchIfElseIfsElseBlock(
               condition,
@@ -661,8 +660,8 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
           });
 
   Parser<ASTBranchIfBlock> branchElseIfs() =>
-      (string('else').trimHidden() &
-              string('if').trimHidden() &
+      (keywordToken('else') &
+              keywordToken('if') &
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &

--- a/lib/src/languages/java/java11/java11_grammar.dart
+++ b/lib/src/languages/java/java11/java11_grammar.dart
@@ -379,17 +379,36 @@ class Java11GrammarDefinition extends Java11GrammarLexer {
             return ASTBlock(null)..addAllStatements(statements);
           });
 
+  /// A control-flow body: either a braced block or a single unbraced
+  /// statement (`for (var e : l) print(e);`). [codeBlock] is tried first, so
+  /// a body starting with `{` is always a block.
   Parser<ASTBlock> codeBlockOrSingleLineBlock() =>
-      ((codeBlock() | singleLineCodeBlock())).cast<ASTBlock>();
+      (ref0(codeBlock) | ref0(singleLineCodeBlock)).cast<ASTBlock>();
 
   Parser<ASTSingleLineStatementBlock> singleLineCodeBlock() =>
-      (singleLineStatement().trimHidden()).map((v) {
+      ref0(singleLineStatement).trimHidden().map((v) {
         var statements = v;
         return ASTSingleLineStatementBlock(null)..addStatement(statements);
       });
 
+  /// The [statement] alternation minus [statementVariableDeclaration], which
+  /// is illegal as an unbraced body. The relative order must match
+  /// [statement]. Every alternative must be a `ref0`, otherwise the cycle back
+  /// through [branch] recurses forever while *building* the grammar.
   Parser<ASTStatement> singleLineStatement() =>
-      (statementReturn() | statementExpression()).cast<ASTStatement>();
+      (ref0(statementTryCatch) |
+              ref0(statementThrow) |
+              ref0(statementSwitch) |
+              ref0(branch) |
+              ref0(statementBreak) |
+              ref0(statementContinue) |
+              ref0(statementReturn) |
+              ref0(statementDoWhileLoop) |
+              ref0(statementForLoop) |
+              ref0(statementForEach) |
+              ref0(statementWhileLoop) |
+              ref0(statementExpression))
+          .cast<ASTStatement>();
 
   Parser<ASTStatement> statement() =>
       (statementTryCatch() |

--- a/lib/src/languages/javascript/es/javascript_generator.dart
+++ b/lib/src/languages/javascript/es/javascript_generator.dart
@@ -308,6 +308,35 @@ class ApolloCodeGeneratorJavaScript extends ApolloCodeGenerator {
   }
 
   @override
+  /// JavaScript has no built-in throwing `assert` (`console.assert` only logs),
+  /// so it is lowered to an explicit check that preserves the semantics.
+  @override
+  StringBuffer generateASTStatementAssert(
+    ASTStatementAssert statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    out.write('if (!(');
+    generateASTExpression(statement.condition, out: out, headIndented: false);
+    out.write(')) throw ');
+
+    var message = statement.message;
+    if (message != null) {
+      generateASTExpression(message, out: out, headIndented: false);
+    } else {
+      out.write("'Assertion failed'");
+    }
+
+    out.write(';');
+
+    return out;
+  }
+
+  @override
   StringBuffer generateASTStatementForEach(
     ASTStatementForEach forEach, {
     StringBuffer? out,

--- a/lib/src/languages/javascript/es/javascript_generator.dart
+++ b/lib/src/languages/javascript/es/javascript_generator.dart
@@ -329,17 +329,11 @@ class ApolloCodeGeneratorJavaScript extends ApolloCodeGenerator {
       headIndented: false,
     );
 
-    out.write(') {\n');
+    out.write(')');
 
-    var blockCode = generateASTBlock(
-      forEach.loopBlock,
-      indent: indent,
-      withBrackets: false,
-    );
-
-    out.write(blockCode);
-    out.write(indent);
-    out.write('}');
+    if (writeASTLoopBody(forEach.loopBlock, out: out, indent: indent)) {
+      out.write('}');
+    }
 
     return out;
   }

--- a/lib/src/languages/javascript/es/javascript_grammar.dart
+++ b/lib/src/languages/javascript/es/javascript_grammar.dart
@@ -283,7 +283,7 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
           .map((v) => ASTStatementContinue());
 
   Parser<ASTStatementDoWhileLoop> statementDoWhileLoop() =>
-      (string('do').trimHidden() &
+      (keywordToken('do') &
               codeBlock() &
               string('while').trimHidden() &
               char('(').trimHidden() &
@@ -622,7 +622,7 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
               ref0(expression) &
               char(')').trimHidden() &
               codeBlock() &
-              elseToken().trimHidden() &
+              keywordToken('else') &
               codeBlock())
           .map((v) {
             return ASTBranchIfElseBlock(v[2], v[4], v[6]);
@@ -635,7 +635,7 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
               char(')').trimHidden() &
               codeBlock() &
               ref0(branchElseIfs).plus() &
-              (elseToken().trimHidden() & codeBlock()).optional())
+              (keywordToken('else') & codeBlock()).optional())
           .map((v) {
             var condition = v[2];
             var blockIf = v[4];
@@ -651,8 +651,8 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
           });
 
   Parser<ASTBranchIfBlock> branchElseIfs() =>
-      (elseToken().trimHidden() &
-              ifToken().trimHidden() &
+      (keywordToken('else') &
+              keywordToken('if') &
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &

--- a/lib/src/languages/javascript/es/javascript_grammar.dart
+++ b/lib/src/languages/javascript/es/javascript_grammar.dart
@@ -240,16 +240,36 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
             return ASTBlock(null)..addAllStatements(statements);
           });
 
+  /// A control-flow body: either a braced block or a single unbraced
+  /// statement (`for (var e of l) print(e);`). [codeBlock] is tried first, so
+  /// a body starting with `{` is always a block.
   Parser<ASTBlock> codeBlockOrSingleLineBlock() =>
-      ((codeBlock() | singleLineCodeBlock())).cast<ASTBlock>();
+      (ref0(codeBlock) | ref0(singleLineCodeBlock)).cast<ASTBlock>();
 
   Parser<ASTSingleLineStatementBlock> singleLineCodeBlock() =>
-      (singleLineStatement().trimHidden()).map((v) {
+      ref0(singleLineStatement).trimHidden().map((v) {
         return ASTSingleLineStatementBlock(null)..addStatement(v);
       });
 
+  /// The [statement] alternation minus declarations (illegal as an unbraced
+  /// body) and [statementBlock] (already covered by [codeBlock]). The relative
+  /// order must match [statement]. Every alternative must be a `ref0`,
+  /// otherwise the cycle back through [branch] recurses forever while
+  /// *building* the grammar.
   Parser<ASTStatement> singleLineStatement() =>
-      (statementReturn() | statementExpression()).cast<ASTStatement>();
+      (ref0(statementTryCatch) |
+              ref0(statementThrow) |
+              ref0(statementSwitch) |
+              ref0(branch) |
+              ref0(statementBreak) |
+              ref0(statementContinue) |
+              ref0(statementDoWhileLoop) |
+              ref0(statementForLoop) |
+              ref0(statementForEach) |
+              ref0(statementWhileLoop) |
+              ref0(statementReturn) |
+              ref0(statementExpression))
+          .cast<ASTStatement>();
 
   Parser<ASTStatement> statement() =>
       (statementTryCatch() |

--- a/lib/src/languages/javascript/es/javascript_grammar.dart
+++ b/lib/src/languages/javascript/es/javascript_grammar.dart
@@ -304,7 +304,7 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
 
   Parser<ASTStatementDoWhileLoop> statementDoWhileLoop() =>
       (keywordToken('do') &
-              codeBlock() &
+              ref0(codeBlockOrSingleLineBlock) &
               string('while').trimHidden() &
               char('(').trimHidden() &
               ref0(expression) &
@@ -403,7 +403,7 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
               char(';').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             return ASTStatementForLoop(v[2], v[3], v[5], v[7]);
           });
@@ -416,7 +416,7 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
               ofToken().trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var variableName = v[3] as String;
             var iterableExp = v[5] as ASTExpression;
@@ -434,7 +434,7 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             return ASTStatementWhileLoop(v[2], v[4]);
           });
@@ -641,9 +641,9 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock() &
+              ref0(codeBlockOrSingleLineBlock) &
               keywordToken('else') &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             return ASTBranchIfElseBlock(v[2], v[4], v[6]);
           });
@@ -653,9 +653,10 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock() &
+              ref0(codeBlockOrSingleLineBlock) &
               ref0(branchElseIfs).plus() &
-              (keywordToken('else') & codeBlock()).optional())
+              (keywordToken('else') & ref0(codeBlockOrSingleLineBlock))
+                  .optional())
           .map((v) {
             var condition = v[2];
             var blockIf = v[4];
@@ -676,7 +677,7 @@ class JavaScriptGrammarDefinition extends JavaScriptGrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             return ASTBranchIfBlock(v[3], v[5]);
           });

--- a/lib/src/languages/kotlin/kotlin_generator.dart
+++ b/lib/src/languages/kotlin/kotlin_generator.dart
@@ -133,6 +133,9 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
   }
 
   @override
+  String? renderCatchStackTraceBinding(String name) => 'var $name = ""';
+
+  @override
   String normalizeTypeFunction(String typeName, String functionName) {
     switch (typeName) {
       case 'int':

--- a/lib/src/languages/kotlin/kotlin_generator.dart
+++ b/lib/src/languages/kotlin/kotlin_generator.dart
@@ -800,6 +800,21 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
   }
 
   @override
+  /// Kotlin's bitwise/shift operators are infix functions (`and`, `or`, `xor`,
+  /// `shl`, `shr`) with no compound-assignment form, so `x &= y` is lowered to
+  /// `x = x and y`.
+  @override
+  bool supportsAssignmentOperator(ASTAssignmentOperator operator) =>
+      switch (operator) {
+        ASTAssignmentOperator.bitwiseAnd ||
+        ASTAssignmentOperator.bitwiseOr ||
+        ASTAssignmentOperator.bitwiseXor ||
+        ASTAssignmentOperator.shiftLeft ||
+        ASTAssignmentOperator.shiftRight => false,
+        _ => true,
+      };
+
+  @override
   String resolveASTExpressionOperatorText(
     ASTExpressionOperator operator,
     ASTNumType aNumType,

--- a/lib/src/languages/kotlin/kotlin_generator.dart
+++ b/lib/src/languages/kotlin/kotlin_generator.dart
@@ -632,17 +632,11 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
       headIndented: false,
     );
 
-    out.write(') {\n');
+    out.write(')');
 
-    var blockCode = generateASTBlock(
-      forEach.loopBlock,
-      indent: indent,
-      withBrackets: false,
-    );
-
-    out.write(blockCode);
-    out.write(indent);
-    out.write('}');
+    if (writeASTLoopBody(forEach.loopBlock, out: out, indent: indent)) {
+      out.write('}');
+    }
 
     return out;
   }

--- a/lib/src/languages/kotlin/kotlin_generator.dart
+++ b/lib/src/languages/kotlin/kotlin_generator.dart
@@ -611,6 +611,33 @@ class ApolloCodeGeneratorKotlin extends ApolloCodeGenerator {
   }
 
   @override
+  /// Kotlin's `assert` takes the message as a trailing lambda:
+  /// `assert(cond) { message }`.
+  @override
+  StringBuffer generateASTStatementAssert(
+    ASTStatementAssert statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    out.write('assert(');
+    generateASTExpression(statement.condition, out: out, headIndented: false);
+    out.write(')');
+
+    var message = statement.message;
+    if (message != null) {
+      out.write(' { ');
+      generateASTExpression(message, out: out, headIndented: false);
+      out.write(' }');
+    }
+
+    return out;
+  }
+
+  @override
   StringBuffer generateASTStatementForEach(
     ASTStatementForEach forEach, {
     StringBuffer? out,

--- a/lib/src/languages/kotlin/kotlin_grammar.dart
+++ b/lib/src/languages/kotlin/kotlin_grammar.dart
@@ -637,7 +637,7 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
   Parser<ASTStatementDoWhileLoop> statementDoWhileLoop() =>
       (string('do') &
               ref0(identifierPartLexicalToken).not() &
-              codeBlock().trimHidden() &
+              ref0(codeBlockOrSingleLineBlock).trimHidden() &
               whileToken().trimHidden() &
               char('(').trimHidden() &
               ref0(expression) &
@@ -724,7 +724,7 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
               inToken().trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var variableName = v[2];
             var iterableExp = v[4];
@@ -743,7 +743,7 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var condExp = v[2];
             var block = v[4];
@@ -834,9 +834,9 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock() &
+              ref0(codeBlockOrSingleLineBlock) &
               keywordToken('else') &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var condition = v[2];
             var blockIf = v[4];
@@ -849,9 +849,10 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock() &
+              ref0(codeBlockOrSingleLineBlock) &
               ref0(branchElseIfs).plus() &
-              (keywordToken('else') & codeBlock()).optional())
+              (keywordToken('else') & ref0(codeBlockOrSingleLineBlock))
+                  .optional())
           .map((v) {
             var condition = v[2];
             var blockIf = v[4];
@@ -872,7 +873,7 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var condition = v[3];
             var blockIf = v[5];

--- a/lib/src/languages/kotlin/kotlin_grammar.dart
+++ b/lib/src/languages/kotlin/kotlin_grammar.dart
@@ -576,17 +576,35 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
             return ASTBlock(null)..addAllStatements(statements);
           });
 
+  /// A control-flow body: either a braced block or a single unbraced
+  /// statement (`for (e in l) print(e)`). [codeBlock] is tried first, so a
+  /// body starting with `{` is always a block.
   Parser<ASTBlock> codeBlockOrSingleLineBlock() =>
-      ((codeBlock() | singleLineCodeBlock())).cast<ASTBlock>();
+      (ref0(codeBlock) | ref0(singleLineCodeBlock)).cast<ASTBlock>();
 
   Parser<ASTSingleLineStatementBlock> singleLineCodeBlock() =>
-      (singleLineStatement().trimHidden()).map((v) {
+      ref0(singleLineStatement).trimHidden().map((v) {
         var statements = v;
         return ASTSingleLineStatementBlock(null)..addStatement(statements);
       });
 
+  /// The [statement] alternation minus [statementVariableDeclaration], which
+  /// is illegal as an unbraced body. The relative order must match
+  /// [statement]. Every alternative must be a `ref0`, otherwise the cycle back
+  /// through [branch] recurses forever while *building* the grammar.
   Parser<ASTStatement> singleLineStatement() =>
-      (statementReturn() | statementExpression()).cast<ASTStatement>();
+      (ref0(statementTryCatch) |
+              ref0(statementThrow) |
+              ref0(statementWhen) |
+              ref0(branch) |
+              ref0(statementBreak) |
+              ref0(statementContinue) |
+              ref0(statementDoWhileLoop) |
+              ref0(statementForEach) |
+              ref0(statementWhileLoop) |
+              ref0(statementReturn) |
+              ref0(statementExpression))
+          .cast<ASTStatement>();
 
   Parser<ASTStatement> statement() =>
       (statementTryCatch() |

--- a/lib/src/languages/kotlin/kotlin_grammar.dart
+++ b/lib/src/languages/kotlin/kotlin_grammar.dart
@@ -658,7 +658,7 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
           });
 
   Parser<ASTExpression?> whenEntryLabel() =>
-      ((elseToken().trimHidden()).map((v) => null) |
+      ((keywordToken('else')).map((v) => null) |
               ref0(expression).map((v) => v as ASTExpression?))
           .cast<ASTExpression?>();
 
@@ -817,7 +817,7 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
               ref0(expression) &
               char(')').trimHidden() &
               codeBlock() &
-              elseToken().trimHidden() &
+              keywordToken('else') &
               codeBlock())
           .map((v) {
             var condition = v[2];
@@ -833,7 +833,7 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
               char(')').trimHidden() &
               codeBlock() &
               ref0(branchElseIfs).plus() &
-              (elseToken().trimHidden() & codeBlock()).optional())
+              (keywordToken('else') & codeBlock()).optional())
           .map((v) {
             var condition = v[2];
             var blockIf = v[4];
@@ -849,8 +849,8 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
           });
 
   Parser<ASTBranchIfBlock> branchElseIfs() =>
-      (elseToken().trimHidden() &
-              ifToken().trimHidden() &
+      (keywordToken('else') &
+              keywordToken('if') &
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
@@ -879,7 +879,7 @@ class KotlinGrammarDefinition extends KotlinGrammarLexer {
               ref0(expression) &
               char(')').trimHidden() &
               ref0(expressionOperationChain) &
-              elseToken().trimHidden() &
+              keywordToken('else') &
               ref0(expression))
           .map(
             (v) => ASTExpressionConditional(

--- a/lib/src/languages/lua/lua_generator.dart
+++ b/lib/src/languages/lua/lua_generator.dart
@@ -693,6 +693,12 @@ class ApolloCodeGeneratorLua extends ApolloCodeGenerator {
   // -----------------------------------------------------------------
   // Expressions and operators.
   // -----------------------------------------------------------------
+
+  /// Lua has no compound assignment at all: every `x OP= y` is lowered to
+  /// `x = x OP y`. (Before this, `a += 1` was emitted verbatim — invalid Lua.)
+  @override
+  bool supportsAssignmentOperator(ASTAssignmentOperator operator) => false;
+
   @override
   String resolveASTExpressionOperatorText(
     ASTExpressionOperator operator,

--- a/lib/src/languages/lua/lua_generator.dart
+++ b/lib/src/languages/lua/lua_generator.dart
@@ -379,6 +379,33 @@ class ApolloCodeGeneratorLua extends ApolloCodeGenerator {
   }
 
   @override
+  /// Lua's `assert(v, message)` is a built-in, so only the trailing `;` — which
+  /// Lua does not use — differs from the base form.
+  @override
+  StringBuffer generateASTStatementAssert(
+    ASTStatementAssert statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    out.write('assert(');
+    generateASTExpression(statement.condition, out: out, headIndented: false);
+
+    var message = statement.message;
+    if (message != null) {
+      out.write(', ');
+      generateASTExpression(message, out: out, headIndented: false);
+    }
+
+    out.write(')');
+
+    return out;
+  }
+
+  @override
   StringBuffer generateASTStatementForEach(
     ASTStatementForEach forEach, {
     StringBuffer? out,

--- a/lib/src/languages/python/python_generator.dart
+++ b/lib/src/languages/python/python_generator.dart
@@ -770,6 +770,31 @@ class ApolloCodeGeneratorPython extends ApolloCodeGenerator {
     return out;
   }
 
+  /// Python spells it `assert cond, message` — a statement, not a call.
+  @override
+  StringBuffer generateASTStatementAssert(
+    ASTStatementAssert statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    out.write('assert ');
+    generateASTExpression(statement.condition, out: out, headIndented: false);
+
+    var message = statement.message;
+    if (message != null) {
+      out.write(', ');
+      generateASTExpression(message, out: out, headIndented: false);
+    }
+
+    out.write('\n');
+
+    return out;
+  }
+
   @override
   StringBuffer generateASTStatementThrow(
     ASTStatementThrow statement, {

--- a/lib/src/languages/python/python_generator.dart
+++ b/lib/src/languages/python/python_generator.dart
@@ -837,6 +837,14 @@ class ApolloCodeGeneratorPython extends ApolloCodeGenerator {
         }
       }
       out.write(':\n');
+
+      // Python's `except` header has no second variable, so a Dart
+      // `catch (e, s)` binds the stack trace as the handler's first statement.
+      var stackTraceName = catchClause.stackTraceName;
+      if (stackTraceName != null) {
+        out.write('$indent$_tab$stackTraceName = ""\n');
+      }
+
       _writeSuite(catchClause.block, out, '$indent$_tab');
     }
 

--- a/lib/src/languages/python/python_generator.dart
+++ b/lib/src/languages/python/python_generator.dart
@@ -956,6 +956,44 @@ class ApolloCodeGeneratorPython extends ApolloCodeGenerator {
     return out;
   }
 
+  /// Python has no `do`-`while`, so it becomes the standard idiom:
+  ///
+  ///     while True:
+  ///         <body>
+  ///         if not (<cond>):
+  ///             break
+  ///
+  /// Without this the base generator would emit C-style `do { ... } while (c);`,
+  /// which is not Python at all.
+  @override
+  StringBuffer generateASTStatementDoWhileLoop(
+    ASTStatementDoWhileLoop doWhileLoop, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    var bodyIndent = '$indent$_tab';
+
+    out.write('while True:\n');
+    _writeSuite(doWhileLoop.loopBlock, out, bodyIndent);
+
+    out.write(bodyIndent);
+    out.write('if not (');
+    generateASTExpression(
+      doWhileLoop.conditionExpression,
+      out: out,
+      headIndented: false,
+    );
+    out.write('):\n');
+    out.write('$bodyIndent$_tab');
+    out.write('break\n');
+
+    return out;
+  }
+
   /// A C-style `for (init; cond; cont)` (e.g. from another language) becomes a
   /// `while` loop, the faithful Python translation.
   @override

--- a/lib/src/languages/python/python_grammar.dart
+++ b/lib/src/languages/python/python_grammar.dart
@@ -380,12 +380,51 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
   // ---------------------------------------------------------------------------
   // Suites (indented blocks).
   // ---------------------------------------------------------------------------
+  /// A suite is either the usual indented block or an inline one on the
+  /// header's own line (`if x: return 1`). The two are decidable on a single
+  /// character — an indented suite starts with NEWLINE, an inline one with a
+  /// statement token — so the ordered choice is unambiguous.
   Parser<ASTBlock> suite() =>
+      (ref0(indentedSuite) | ref0(inlineSuite)).cast<ASTBlock>();
+
+  Parser<ASTBlock> indentedSuite() =>
       (newlineToken() & indentToken() & ref0(suiteBody) & dedentToken()).map((
         v,
       ) {
         return v[2] as ASTBlock;
       });
+
+  /// `<simple_stmt> (';' <simple_stmt>)* [';'] NEWLINE` on the header's own
+  /// logical line: `if x: return 1`, `while c: i += 1; j += 1`, `def f(): pass`.
+  ///
+  /// Only *simple* statements are allowed, matching CPython — `if x: if y: pass`
+  /// is a SyntaxError there too.
+  Parser<ASTBlock> inlineSuite() =>
+      ((ref0(passStatement) | ref0(simpleStatement)).cast<ASTStatement?>() &
+              (char(';').trimHidden() & ref0(simpleStatement))
+                  .map((v) => v[1] as ASTStatement)
+                  .star() &
+              char(';').trimHidden().optional() &
+              newlineToken())
+          .map((v) {
+            var first = v[0] as ASTStatement?;
+            var rest = (v[1] as List).cast<ASTStatement>();
+
+            // `pass` contributes no statement, so `def f(): pass` yields an
+            // empty block just as the indented form does.
+            var statements = resolveScopeBindings([?first, ...rest]);
+
+            if (statements.length == 1) {
+              return ASTSingleLineStatementBlock(null)
+                ..addStatement(statements.first);
+            }
+
+            return ASTBlock(null)..addAllStatements(statements);
+          });
+
+  /// `pass` as an inline suite body. Yields no statement.
+  Parser<ASTStatement?> passStatement() =>
+      passToken().trimHidden().map((_) => null);
 
   Parser<ASTBlock> suiteBody() =>
       (ref0(passBody) | ref0(statementsBody)).cast<ASTBlock>();
@@ -407,17 +446,20 @@ class PythonGrammarDefinition extends PythonGrammarLexer {
               simpleStatementLine())
           .cast<ASTStatement>();
 
+  /// A simple statement: one that cannot contain a suite. Shared by
+  /// [simpleStatementLine] and [inlineSuite].
+  Parser<ASTStatement> simpleStatement() =>
+      (statementBreak() |
+              statementContinue() |
+              statementReturn() |
+              statementRaise() |
+              statementVariableDeclaration() |
+              statementExpression())
+          .cast<ASTStatement>();
+
   /// A simple (single-line) statement terminated by NEWLINE.
   Parser<ASTStatement> simpleStatementLine() =>
-      ((statementBreak() |
-                      statementContinue() |
-                      statementReturn() |
-                      statementRaise() |
-                      statementVariableDeclaration() |
-                      statementExpression())
-                  .cast<ASTStatement>() &
-              newlineToken())
-          .map((v) => v[0] as ASTStatement);
+      (ref0(simpleStatement) & newlineToken()).map((v) => v[0] as ASTStatement);
 
   Parser<ASTStatementBreak> statementBreak() =>
       breakToken().trimHidden().map((_) => ASTStatementBreak());

--- a/lib/src/languages/typescript/ts/typescript_generator.dart
+++ b/lib/src/languages/typescript/ts/typescript_generator.dart
@@ -582,6 +582,35 @@ class ApolloCodeGeneratorTypeScript extends ApolloCodeGenerator {
   }
 
   @override
+  /// TypeScript has no built-in throwing `assert`, so it is lowered to an
+  /// explicit check that preserves the semantics.
+  @override
+  StringBuffer generateASTStatementAssert(
+    ASTStatementAssert statement, {
+    StringBuffer? out,
+    String indent = '',
+    bool headIndented = true,
+  }) {
+    out ??= newOutput();
+    if (headIndented) out.write(indent);
+
+    out.write('if (!(');
+    generateASTExpression(statement.condition, out: out, headIndented: false);
+    out.write(')) throw ');
+
+    var message = statement.message;
+    if (message != null) {
+      generateASTExpression(message, out: out, headIndented: false);
+    } else {
+      out.write("'Assertion failed'");
+    }
+
+    out.write(';');
+
+    return out;
+  }
+
+  @override
   StringBuffer generateASTStatementForEach(
     ASTStatementForEach forEach, {
     StringBuffer? out,

--- a/lib/src/languages/typescript/ts/typescript_generator.dart
+++ b/lib/src/languages/typescript/ts/typescript_generator.dart
@@ -603,17 +603,11 @@ class ApolloCodeGeneratorTypeScript extends ApolloCodeGenerator {
       headIndented: false,
     );
 
-    out.write(') {\n');
+    out.write(')');
 
-    var blockCode = generateASTBlock(
-      forEach.loopBlock,
-      indent: indent,
-      withBrackets: false,
-    );
-
-    out.write(blockCode);
-    out.write(indent);
-    out.write('}');
+    if (writeASTLoopBody(forEach.loopBlock, out: out, indent: indent)) {
+      out.write('}');
+    }
 
     return out;
   }

--- a/lib/src/languages/typescript/ts/typescript_grammar.dart
+++ b/lib/src/languages/typescript/ts/typescript_grammar.dart
@@ -581,16 +581,36 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
             return ASTBlock(null)..addAllStatements(statements);
           });
 
+  /// A control-flow body: either a braced block or a single unbraced
+  /// statement (`for (var e of l) print(e);`). [codeBlock] is tried first, so
+  /// a body starting with `{` is always a block.
   Parser<ASTBlock> codeBlockOrSingleLineBlock() =>
-      ((codeBlock() | singleLineCodeBlock())).cast<ASTBlock>();
+      (ref0(codeBlock) | ref0(singleLineCodeBlock)).cast<ASTBlock>();
 
   Parser<ASTSingleLineStatementBlock> singleLineCodeBlock() =>
-      (singleLineStatement().trimHidden()).map((v) {
+      ref0(singleLineStatement).trimHidden().map((v) {
         return ASTSingleLineStatementBlock(null)..addStatement(v);
       });
 
+  /// The [statement] alternation minus declarations (illegal as an unbraced
+  /// body) and [statementBlock] (already covered by [codeBlock]). The relative
+  /// order must match [statement]. Every alternative must be a `ref0`,
+  /// otherwise the cycle back through [branch] recurses forever while
+  /// *building* the grammar.
   Parser<ASTStatement> singleLineStatement() =>
-      (statementReturn() | statementExpression()).cast<ASTStatement>();
+      (ref0(statementTryCatch) |
+              ref0(statementThrow) |
+              ref0(statementSwitch) |
+              ref0(branch) |
+              ref0(statementBreak) |
+              ref0(statementContinue) |
+              ref0(statementDoWhileLoop) |
+              ref0(statementForLoop) |
+              ref0(statementForEach) |
+              ref0(statementWhileLoop) |
+              ref0(statementReturn) |
+              ref0(statementExpression))
+          .cast<ASTStatement>();
 
   Parser<ASTStatement> statement() =>
       (statementTryCatch() |

--- a/lib/src/languages/typescript/ts/typescript_grammar.dart
+++ b/lib/src/languages/typescript/ts/typescript_grammar.dart
@@ -624,7 +624,7 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
           .map((v) => ASTStatementContinue());
 
   Parser<ASTStatementDoWhileLoop> statementDoWhileLoop() =>
-      (string('do').trimHidden() &
+      (keywordToken('do') &
               codeBlock() &
               string('while').trimHidden() &
               char('(').trimHidden() &
@@ -978,7 +978,7 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
               ref0(expression) &
               char(')').trimHidden() &
               codeBlock() &
-              elseToken().trimHidden() &
+              keywordToken('else') &
               codeBlock())
           .map((v) {
             return ASTBranchIfElseBlock(v[2], v[4], v[6]);
@@ -991,7 +991,7 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
               char(')').trimHidden() &
               codeBlock() &
               ref0(branchElseIfs).plus() &
-              (elseToken().trimHidden() & codeBlock()).optional())
+              (keywordToken('else') & codeBlock()).optional())
           .map((v) {
             var condition = v[2];
             var blockIf = v[4];
@@ -1007,8 +1007,8 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
           });
 
   Parser<ASTBranchIfBlock> branchElseIfs() =>
-      (elseToken().trimHidden() &
-              ifToken().trimHidden() &
+      (keywordToken('else') &
+              keywordToken('if') &
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &

--- a/lib/src/languages/typescript/ts/typescript_grammar.dart
+++ b/lib/src/languages/typescript/ts/typescript_grammar.dart
@@ -645,7 +645,7 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
 
   Parser<ASTStatementDoWhileLoop> statementDoWhileLoop() =>
       (keywordToken('do') &
-              codeBlock() &
+              ref0(codeBlockOrSingleLineBlock) &
               string('while').trimHidden() &
               char('(').trimHidden() &
               ref0(expression) &
@@ -746,7 +746,7 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
               char(';').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             return ASTStatementForLoop(v[2], v[3], v[5], v[7]);
           });
@@ -759,7 +759,7 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
               ofToken().trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             var variableName = v[3] as String;
             var iterableExp = v[5] as ASTExpression;
@@ -777,7 +777,7 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             return ASTStatementWhileLoop(v[2], v[4]);
           });
@@ -997,9 +997,9 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock() &
+              ref0(codeBlockOrSingleLineBlock) &
               keywordToken('else') &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             return ASTBranchIfElseBlock(v[2], v[4], v[6]);
           });
@@ -1009,9 +1009,10 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock() &
+              ref0(codeBlockOrSingleLineBlock) &
               ref0(branchElseIfs).plus() &
-              (keywordToken('else') & codeBlock()).optional())
+              (keywordToken('else') & ref0(codeBlockOrSingleLineBlock))
+                  .optional())
           .map((v) {
             var condition = v[2];
             var blockIf = v[4];
@@ -1032,7 +1033,7 @@ class TypeScriptGrammarDefinition extends TypeScriptGrammarLexer {
               char('(').trimHidden() &
               ref0(expression) &
               char(')').trimHidden() &
-              codeBlock())
+              ref0(codeBlockOrSingleLineBlock))
           .map((v) {
             return ASTBranchIfBlock(v[3], v[5]);
           });

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -12643,12 +12643,11 @@ class _WasmMethodFunction extends ASTFunctionDeclaration {
     String name,
     ASTFunctionParametersDeclaration parameters,
     ASTType returnType, {
-    ASTBlock? block,
+    super.block,
   }) : super(
          name,
          parameters,
          returnType,
-         block: block,
          modifiers: ASTModifiers(isPrivate: true),
        );
 }
@@ -12669,8 +12668,8 @@ class _WasmStaticMethodFunction extends ASTFunctionDeclaration {
     String name,
     ASTFunctionParametersDeclaration parameters,
     ASTType returnType, {
-    ASTBlock? block,
-  }) : super(name, parameters, returnType, block: block);
+    super.block,
+  }) : super(name, parameters, returnType);
 }
 
 /// Module-level Wasm codegen state shared across all functions: the function

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -5144,24 +5144,19 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
   }
 
   /// Maps a compound-assignment operator (`+=`, …) to its binary operator.
+  ///
+  /// The mapping lives on the enum, so `%=` and the bitwise/shift forms come
+  /// for free — `ASTExpressionOperation` already compiles all of them.
   ASTExpressionOperator _compoundToOperator(ASTAssignmentOperator op) {
     switch (op) {
-      case ASTAssignmentOperator.sum:
-        return ASTExpressionOperator.add;
-      case ASTAssignmentOperator.subtract:
-        return ASTExpressionOperator.subtract;
-      case ASTAssignmentOperator.multiply:
-        return ASTExpressionOperator.multiply;
-      case ASTAssignmentOperator.divide:
-        return ASTExpressionOperator.divide;
-      case ASTAssignmentOperator.divideAsInt:
-        return ASTExpressionOperator.divideAsInt;
       case ASTAssignmentOperator.set:
         throw ArgumentError("`set` is not a compound operator");
       case ASTAssignmentOperator.nullCoalesce:
         throw UnimplementedError(
           "Wasm `??=` (null-coalescing assignment) is not supported yet.",
         );
+      default:
+        return op.asASTExpressionOperator!;
     }
   }
 

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -8629,6 +8629,12 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       );
     } else if (statement is ASTStatementReturn) {
       return generateASTStatementReturn(statement, out: out, context: context);
+    } else if (statement is ASTStatementAssert) {
+      // Refuse rather than mis-compile: `assert` throws on failure, and the
+      // Wasm backend has no exception lowering for a bare throw.
+      throw UnsupportedSyntaxError(
+        'Wasm compilation of `assert` is not implemented: $statement',
+      );
     }
 
     throw UnsupportedError("Can't handle statement: $statement");

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -7282,6 +7282,14 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       // inferred from the thrown values for an untyped `catch (e)`).
       final clauseVarTypes = <ASTType?>[];
       for (final c in s.catches) {
+        // A bound stack-trace variable (`catch (e, s)`) has no Wasm
+        // representation: refuse rather than silently dropping the binding and
+        // leaving the body referencing an undeclared name.
+        if (c.stackTraceName != null) {
+          ok = false;
+          return cur;
+        }
+
         var varType = c.exceptionType;
         // A declared catch-all type (`Exception`/`Throwable`/`Error`/`Object`/
         // `dynamic`, from Java/Kotlin/C# `catch (Exception e)` or Dart

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.25.1
+version: 2.26.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 
@@ -50,8 +50,8 @@ dev_dependencies:
   test: ^1.31.1
   pubspec: ^2.3.0
   xml: ^6.6.1
-  build_web_compilers: ^4.8.0
-  build_runner: ^2.15.0
+  build_web_compilers: ^4.8.5
+  build_runner: ^2.15.1
 
 executables:
   apollovm:

--- a/test/cli/null_safety_flag_test.dart
+++ b/test/cli/null_safety_flag_test.dart
@@ -50,20 +50,16 @@ void main() {
   });
 
   group('--null-safety', () {
-    test(
-      'is advertised by the source-file commands',
-      () async {
-        for (final command in const ['run', 'translate', 'compile']) {
-          final r = await _apollovm([command, '--help']);
-          expect(
-            r.stdout.toString(),
-            contains('--null-safety'),
-            reason: '`$command --help` should list the flag',
-          );
-        }
-      },
-      timeout: const Timeout(Duration(minutes: 2)),
-    );
+    test('is advertised by the source-file commands', () async {
+      for (final command in const ['run', 'translate', 'compile']) {
+        final r = await _apollovm([command, '--help']);
+        expect(
+          r.stdout.toString(),
+          contains('--null-safety'),
+          reason: '`$command --help` should list the flag',
+        );
+      }
+    }, timeout: const Timeout(Duration(minutes: 2)));
 
     test(
       'rejects a null-safety error with a clean report and exit 1',
@@ -83,45 +79,33 @@ void main() {
       timeout: const Timeout(Duration(minutes: 2)),
     );
 
-    test(
-      'without the flag, the same source is not rejected',
-      () async {
-        final file = _write('bad2.dart', _bad);
-        final r = await _apollovm(['run', file.path]);
+    test('without the flag, the same source is not rejected', () async {
+      final file = _write('bad2.dart', _bad);
+      final r = await _apollovm(['run', file.path]);
 
-        expect(r.exitCode, isNot(1));
-        expect('${r.stdout}${r.stderr}', isNot(contains('NULL SAFETY')));
-      },
-      timeout: const Timeout(Duration(minutes: 2)),
-    );
+      expect(r.exitCode, isNot(1));
+      expect('${r.stdout}${r.stderr}', isNot(contains('NULL SAFETY')));
+    }, timeout: const Timeout(Duration(minutes: 2)));
 
-    test(
-      'a clean program still runs with the flag on',
-      () async {
-        final file = _write('good.dart', _clean);
-        final r = await _apollovm(['run', '--null-safety', file.path]);
+    test('a clean program still runs with the flag on', () async {
+      final file = _write('good.dart', _clean);
+      final r = await _apollovm(['run', '--null-safety', file.path]);
 
-        expect(r.exitCode, 0);
-        expect(r.stdout.toString().trim(), '7');
-      },
-      timeout: const Timeout(Duration(minutes: 2)),
-    );
+      expect(r.exitCode, 0);
+      expect(r.stdout.toString().trim(), '7');
+    }, timeout: const Timeout(Duration(minutes: 2)));
 
-    test(
-      'translate rejects the source too',
-      () async {
-        final file = _write('bad3.dart', _bad);
-        final r = await _apollovm([
-          'translate',
-          '--null-safety',
-          '--target=java',
-          file.path,
-        ]);
+    test('translate rejects the source too', () async {
+      final file = _write('bad3.dart', _bad);
+      final r = await _apollovm([
+        'translate',
+        '--null-safety',
+        '--target=java',
+        file.path,
+      ]);
 
-        expect(r.exitCode, 1);
-        expect('${r.stdout}${r.stderr}', contains('NULL SAFETY'));
-      },
-      timeout: const Timeout(Duration(minutes: 2)),
-    );
+      expect(r.exitCode, 1);
+      expect('${r.stdout}${r.stderr}', contains('NULL SAFETY'));
+    }, timeout: const Timeout(Duration(minutes: 2)));
   });
 }

--- a/test/features/apollovm_correctness_batch_test.dart
+++ b/test/features/apollovm_correctness_batch_test.dart
@@ -92,9 +92,10 @@ void main() {
 
   // Previously `~/=` (Dart) and `//=` (Python, rewritten to `~/=`) matched the
   // grammar but had no case in `getASTAssignmentOperator`, so the `.map` action
-  // threw an uncaught `UnsupportedError` out of `loadCodeUnit`. `~/=` is now a
-  // supported compound operator, and any still-unsupported compound operator
-  // (e.g. JS/TS `%=`) surfaces as a clean `SyntaxError`, not a raw crash.
+  // threw an uncaught `UnsupportedError` out of `loadCodeUnit`. `%=` had the
+  // same shape in JavaScript/TypeScript: listed in the grammar, missing from
+  // the enum. `ASTAssignmentOperator` now covers the full set
+  // (`%= &= |= ^= <<= >>=` alongside the originals), so all of them parse.
   group('Compound assignment operators', () {
     test('Dart `~/=` parses and truncates', () async {
       expect(
@@ -118,21 +119,29 @@ void main() {
       );
     });
 
-    test(
-      'an unsupported compound op (`%=`) is a clean SyntaxError, not a crash',
-      () async {
-        await expectLater(
-          () => ApolloVM().loadCodeUnit(
-            SourceCodeUnit(
-              'javascript',
-              'function run() { var x = 10; x %= 3; return x; }',
-              id: 'test',
-            ),
-          ),
-          throwsA(isA<SyntaxError>()),
-        );
-      },
-    );
+    test('JavaScript `%=` parses and takes the remainder', () async {
+      expect(
+        await _runFunc(
+          'javascript',
+          'function run() { var x = 10; x %= 3; return x; }',
+          'run',
+        ),
+        equals(1),
+      );
+    });
+
+    test('Dart bitwise and shift compound operators', () async {
+      expect(
+        await _runFunc(
+          'dart',
+          'int run() { int x = 23; x &= 12; x |= 1; x ^= 2; '
+              'x <<= 3; x >>= 1; return x; }',
+          'run',
+        ),
+        // 23&12=4, |1=5, ^2=7, <<3=56, >>1=28.
+        equals(28),
+      );
+    });
   });
 
   // `Enum.values` used to be built with a `dynamic` element type while its

--- a/test/tests_definitions/csharp_if_elseif_no_else.test.xml
+++ b/test/tests_definitions/csharp_if_elseif_no_else.test.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="if / else-if chain with no trailing else">
+    <source language="csharp">
+        <![CDATA[
+
+          class Bar {
+            static public void Main(object[] args) {
+              var a = args[0] ;
+
+              if (a < 10) {
+                print("small");
+              }
+              else if (a < 100) {
+                print("medium");
+              }
+
+              print("done");
+            }
+          }
+
+        ]]>
+    </source>
+    <call class="Bar" function="Main">
+        [
+          [5]
+        ]
+    </call>
+    <output>
+        ["small", "done"]
+    </output>
+
+    <call class="Bar" function="Main">
+        [
+          [50]
+        ]
+    </call>
+    <output>
+        ["medium", "done"]
+    </output>
+
+    <call class="Bar" function="Main">
+        [
+          [500]
+        ]
+    </call>
+    <output>
+        ["done"]
+    </output>
+</test>

--- a/test/tests_definitions/csharp_single_line_bodies.test.xml
+++ b/test/tests_definitions/csharp_single_line_bodies.test.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Unbraced single-statement control-flow bodies">
+    <source language="csharp">
+        <![CDATA[
+
+          class Bar {
+            static public void Run(object[] args) {
+              var l = args[0];
+              var a = args[1];
+              var b = args[2];
+
+              foreach (var e in l) print("- " + e) ;
+
+              for (var i = 0; i < 3; ++i) print("i: " + i);
+
+              var i = 0;
+              while (i < 3) i = i + 1;
+              print("while: " + i);
+
+              do i = i - 1; while (i > 0);
+              print("do: " + i);
+
+              if (a) print("x"); else print("y");
+
+              if (a) print("A"); else if (b) print("B"); else print("C");
+
+              if (a) if (b) print("ab"); else print("a!b");
+
+              foreach (var e in l) if (e > 2) print("gt2: " + e);
+
+              foreach (var e in l) { print("braced: " + e); }
+
+              if (a) print("guard");
+              var elseCount = 1;
+              print("elseCount: " + elseCount);
+            }
+          }
+
+        ]]>
+    </source>
+    <call class="Bar" function="Run">
+        [
+          [[1, 2, 3], true, false]
+        ]
+    </call>
+    <output>
+        ["- 1", "- 2", "- 3", "i: 0", "i: 1", "i: 2", "while: 3", "do: 0", "x", "A", "a!b", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "guard", "elseCount: 1"]
+    </output>
+
+    <call class="Bar" function="Run">
+        [
+          [[1, 2, 3], false, true]
+        ]
+    </call>
+    <output>
+        ["- 1", "- 2", "- 3", "i: 0", "i: 1", "i: 2", "while: 3", "do: 0", "y", "B", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "elseCount: 1"]
+    </output>
+
+    <call class="Bar" function="Run">
+        [
+          [[1, 2, 3], false, false]
+        ]
+    </call>
+    <output>
+        ["- 1", "- 2", "- 3", "i: 0", "i: 1", "i: 2", "while: 3", "do: 0", "y", "C", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "elseCount: 1"]
+    </output>
+</test>

--- a/test/tests_definitions/dart_annotations.test.xml
+++ b/test/tests_definitions/dart_annotations.test.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Annotations are parsed and discarded">
+    <source language="dart">
+        <![CDATA[
+enum Color {
+  @Deprecated('use green')
+  red,
+  green,
+}
+
+class Base {
+  int seed() { return 1; }
+}
+
+@Deprecated('legacy')
+class Impl extends Base {
+  @Deprecated('x')
+  int field = 10;
+
+  @pragma('vm:prefer-inline')
+  static int staticField = 20;
+
+  @override
+  int seed() { return 2; }
+
+  @Deprecated('m')
+  int scaled(@Deprecated('p') int factor) {
+    return field * factor;
+  }
+}
+
+@pragma('vm:entry-point')
+int topLevel(@Deprecated('n') int n) {
+  @Deprecated('local')
+  var bump = 5;
+  return n + bump;
+}
+
+int run() {
+  var i = Impl();
+  @Deprecated('r')
+  var total = i.seed() + i.scaled(3) + Impl.staticField + topLevel(7);
+  return total;
+}
+        ]]>
+    </source>
+    <call function="run" return="64">
+        []
+    </call>
+    <output>
+        []
+    </output>
+</test>

--- a/test/tests_definitions/dart_assert.test.xml
+++ b/test/tests_definitions/dart_assert.test.xml
@@ -23,21 +23,21 @@ class Checks {
 }
         ]]>
     </source>
-    <call class="Checks" function="run" returnType="String" return="ok: 3">
+    <call class="Checks" function="run" return="ok: 3">
         [3]
     </call>
     <output>
         []
     </output>
 
-    <call class="Checks" function="run" returnType="String" return="caught: too big: 42">
+    <call class="Checks" function="run" return="caught: too big: 42">
         [42]
     </call>
     <output>
         []
     </output>
 
-    <call class="Checks" function="run" returnType="String" return="bare: Assertion failed">
+    <call class="Checks" function="run" return="bare: Assertion failed">
         [5]
     </call>
     <output>
@@ -62,6 +62,65 @@ class Checks {
       return 'bare: $e';
     }
     return 'ok: $n';
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <!-- JS/TS have no throwing `assert`, so it lowers to an explicit check.
+         These round-trip and re-execute, pinning that the lowering preserves
+         the semantics (including the caught message).
+
+         The other targets emit their own idiom — Java `assert c : m;`, Python
+         `assert c, m`, Kotlin `assert(c) { m }`, C# `Debug.Assert`, Lua's
+         built-in, Go `panic` — which is correct for their real toolchains but
+         not re-executable inside ApolloVM (`Debug`/`assert` are not VM
+         builtins, and those grammars do not parse their own assert form yet). -->
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Checks {
+
+  static run(n) {
+    if (!(n >= 0)) throw 'Assertion failed';
+    try {
+      if (!(n < 10)) throw `too big: ${n}`;
+    } catch (e) {
+      return `caught: ${e}`;
+    }
+    try {
+      if (!(n !== 5)) throw 'Assertion failed';
+    } catch (e) {
+      return `bare: ${e}`;
+    }
+    return `ok: ${n}`;
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Checks {
+
+  static run(n: number): string {
+    if (!(n >= 0)) throw 'Assertion failed';
+    try {
+      if (!(n < 10)) throw `too big: ${n}`;
+    } catch (e) {
+      return `caught: ${e}`;
+    }
+    try {
+      if (!(n !== 5)) throw 'Assertion failed';
+    } catch (e) {
+      return `bare: ${e}`;
+    }
+    return `ok: ${n}`;
   }
 
 }

--- a/test/tests_definitions/dart_assert.test.xml
+++ b/test/tests_definitions/dart_assert.test.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="assert statement">
+    <source language="dart">
+        <![CDATA[
+class Checks {
+  static String run(int n) {
+    assert(n >= 0);
+
+    try {
+      assert(n < 10, 'too big: $n');
+    } catch (e) {
+      return 'caught: $e';
+    }
+
+    try {
+      assert(n != 5);
+    } catch (e) {
+      return 'bare: $e';
+    }
+
+    return 'ok: $n';
+  }
+}
+        ]]>
+    </source>
+    <call class="Checks" function="run" returnType="String" return="ok: 3">
+        [3]
+    </call>
+    <output>
+        []
+    </output>
+
+    <call class="Checks" function="run" returnType="String" return="caught: too big: 42">
+        [42]
+    </call>
+    <output>
+        []
+    </output>
+
+    <call class="Checks" function="run" returnType="String" return="bare: Assertion failed">
+        [5]
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Checks {
+
+  static String run(int n) {
+    assert(n >= 0);
+    try {
+      assert(n < 10, 'too big: $n');
+    } catch (e) {
+      return 'caught: $e';
+    }
+    try {
+      assert(n != 5);
+    } catch (e) {
+      return 'bare: $e';
+    }
+    return 'ok: $n';
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/dart_catch_stack_trace.test.xml
+++ b/test/tests_definitions/dart_catch_stack_trace.test.xml
@@ -8,9 +8,11 @@ class Traces {
       if (n > 0) { throw 'boom'; }
       return 'none';
     } on String catch (e, s) {
-      // `s` is bound but empty: ApolloVM has no stack traces. Reading it
-      // proves the binding exists without making output target-dependent.
-      return 'typed:$e:${s.isEmpty}';
+      // `s` is bound but empty: ApolloVM has no stack traces. Interpolating it
+      // proves the binding exists without making the output target-dependent
+      // (and without needing a bool/int → string conversion helper, which not
+      // every target's runtime provides).
+      return 'typed:$e:[$s]';
     }
   }
 
@@ -19,13 +21,13 @@ class Traces {
       if (n > 0) { throw 'bang'; }
       return 'none';
     } catch (e, s) {
-      return 'bare:$e:${s.isEmpty}';
+      return 'bare:$e:[$s]';
     }
   }
 }
         ]]>
     </source>
-    <call class="Traces" function="typed" returnType="String" return="typed:boom:true">
+    <call class="Traces" function="typed" returnType="String" return="typed:boom:[]">
         [1]
     </call>
     <output>
@@ -39,10 +41,121 @@ class Traces {
         []
     </output>
 
-    <call class="Traces" function="bare" returnType="String" return="bare:bang:true">
+    <call class="Traces" function="bare" returnType="String" return="bare:bang:[]">
         [1]
     </call>
     <output>
         []
     </output>
+
+    <!-- Only Dart can declare the stack trace in the `catch` header. Every
+         other target binds it as the handler's first statement, so a body that
+         reads it still compiles; these blocks pin each of those spellings. -->
+    <source-generated language="java11"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Traces {
+
+  static String typed(int n) {
+    try {
+      if (n > 0) {
+          throw "boom";
+      }
+
+      return "none";
+    } catch (String e) {
+      String s = "";
+      return "typed:" + e + ":[" + s + "]";
+    }
+  }
+
+  static String bare(int n) {
+    try {
+      if (n > 0) {
+          throw "bang";
+      }
+
+      return "none";
+    } catch (Exception e) {
+      String s = "";
+      return "bare:" + e + ":[" + s + "]";
+    }
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="csharp"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Traces {
+
+  static String typed(int n) {
+    try {
+      if (n > 0) {
+          throw "boom";
+      }
+
+      return "none";
+    } catch (String e) {
+      string s = "";
+      return "typed:" + e + ":[" + s + "]";
+    }
+  }
+
+  static String bare(int n) {
+    try {
+      if (n > 0) {
+          throw "bang";
+      }
+
+      return "none";
+    } catch (Exception e) {
+      string s = "";
+      return "bare:" + e + ":[" + s + "]";
+    }
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="kotlin"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Traces {
+
+  fun typed(n: Int): String {
+    try {
+      if (n > 0) {
+          throw "boom";
+      }
+
+      return "none"
+    } catch (e: String) {
+      var s = ""
+      return "typed:$e:[$s]"
+    }
+  }
+
+  fun bare(n: Int): String {
+    try {
+      if (n > 0) {
+          throw "bang";
+      }
+
+      return "none"
+    } catch (e: Throwable) {
+      var s = ""
+      return "bare:$e:[$s]"
+    }
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
 </test>

--- a/test/tests_definitions/dart_catch_stack_trace.test.xml
+++ b/test/tests_definitions/dart_catch_stack_trace.test.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="catch binds the stack-trace variable">
+    <source language="dart">
+        <![CDATA[
+class Traces {
+  static String typed(int n) {
+    try {
+      if (n > 0) { throw 'boom'; }
+      return 'none';
+    } on String catch (e, s) {
+      // `s` is bound but empty: ApolloVM has no stack traces. Reading it
+      // proves the binding exists without making output target-dependent.
+      return 'typed:$e:${s.isEmpty}';
+    }
+  }
+
+  static String bare(int n) {
+    try {
+      if (n > 0) { throw 'bang'; }
+      return 'none';
+    } catch (e, s) {
+      return 'bare:$e:${s.isEmpty}';
+    }
+  }
+}
+        ]]>
+    </source>
+    <call class="Traces" function="typed" returnType="String" return="typed:boom:true">
+        [1]
+    </call>
+    <output>
+        []
+    </output>
+
+    <call class="Traces" function="typed" returnType="String" return="none">
+        [0]
+    </call>
+    <output>
+        []
+    </output>
+
+    <call class="Traces" function="bare" returnType="String" return="bare:bang:true">
+        [1]
+    </call>
+    <output>
+        []
+    </output>
+</test>

--- a/test/tests_definitions/dart_compound_assign.test.xml
+++ b/test/tests_definitions/dart_compound_assign.test.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Compound assignment operators">
+    <source language="dart">
+        <![CDATA[
+class Acc {
+  int v = 0;
+
+  static int run(int n) {
+    // Locals.
+    var a = n;
+    a %= 7;
+    a &= 12;
+    a |= 1;
+    a ^= 2;
+    a <<= 3;
+    a >>= 1;
+
+    // A field target.
+    var acc = Acc();
+    acc.v = n;
+    acc.v %= 5;
+    acc.v <<= 2;
+
+    // A map entry target.
+    var m = {'k': n};
+    m['k'] %= 6;
+    m['k'] &= 14;
+
+    return a + acc.v + m['k'];
+  }
+}
+        ]]>
+    </source>
+    <!-- Verified against real Dart: a=12, acc.v=12, m['k']=4. -->
+    <call class="Acc" function="run" return="28">
+        [23]
+    </call>
+    <output>
+        []
+    </output>
+</test>

--- a/test/tests_definitions/dart_getter_untyped.test.xml
+++ b/test/tests_definitions/dart_getter_untyped.test.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Getter without an explicit return type">
+    <source language="dart">
+        <![CDATA[
+class Box {
+  int v = 21;
+
+  get twice => v * 2;
+
+  int get tripled => v * 3;
+
+  static int run() {
+    var b = Box();
+    return b.twice + b.tripled;
+  }
+}
+        ]]>
+    </source>
+    <call class="Box" function="run" return="105">
+        []
+    </call>
+    <output>
+        []
+    </output>
+</test>

--- a/test/tests_definitions/dart_late_const.test.xml
+++ b/test/tests_definitions/dart_late_const.test.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="`late` declarations and `const` at use sites">
+    <source language="dart">
+        <![CDATA[
+class Point {
+  int x = 0;
+  int y = 0;
+  static late final String label;
+  late int scratch;
+
+  Point(this.x, this.y);
+
+  int sum() => x + y;
+}
+
+int run() {
+  late int a = 1;
+  late final int b = 2;
+
+  var p = const Point(3, 4);
+  var q = new Point(5, 6);
+
+  var empty = const [];
+  var one = const [10];
+  var many = const [20, 30];
+  var m = const {'k': 40};
+  var em = const {};
+
+  return a + b + p.sum() + q.sum() +
+      empty.length + one[0] + many[1] + m['k'] + em.length;
+}
+        ]]>
+    </source>
+    <call function="run" return="101">
+        []
+    </call>
+    <output>
+        []
+    </output>
+</test>

--- a/test/tests_definitions/dart_local_arrow_async.test.xml
+++ b/test/tests_definitions/dart_local_arrow_async.test.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Arrow and async bodies on local and anonymous functions">
+    <source language="dart">
+        <![CDATA[
+int apply(int v, Function f) {
+  return f(v);
+}
+
+Future<int> run(int n) async {
+  int twice(int x) => x * 2;
+
+  int thrice(int x) {
+    return x * 3;
+  }
+
+  Future<int> boosted(int x) async {
+    return x + 100;
+  }
+
+  var lambda = (int x) => x + 1;
+  var lambdaAsync = (int x) async => x + 7;
+
+  var a = twice(n);
+  var b = thrice(n);
+  var c = await boosted(n);
+  var d = apply(n, lambda);
+  var e = await lambdaAsync(n);
+
+  return a + b + c + d + e;
+}
+        ]]>
+    </source>
+    <call function="run" return="148">
+        [5]
+    </call>
+    <output>
+        []
+    </output>
+</test>

--- a/test/tests_definitions/dart_multiline_interpolation.test.xml
+++ b/test/tests_definitions/dart_multiline_interpolation.test.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="String interpolation inside triple-quoted strings">
+    <source language="dart">
+        <![CDATA[
+String run(String name, int a, int b) {
+  var s1 = '''Hello $name, ${a + b}!''';
+  var s2 = """Bye $name, ${a * b}.""";
+  var s3 = r'''Raw $name stays literal''';
+  return '$s1|$s2|$s3';
+}
+        ]]>
+    </source>
+    <call function="run" returnType="String" return="Hello Ana, 7!|Bye Ana, 12.|Raw $name stays literal">
+        ["Ana", 3, 4]
+    </call>
+    <output>
+        []
+    </output>
+</test>

--- a/test/tests_definitions/dart_required_named_params.test.xml
+++ b/test/tests_definitions/dart_required_named_params.test.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="`required` named parameters">
+    <source language="dart">
+        <![CDATA[
+class Point {
+  int x = 0;
+  int y = 0;
+  String tag = '';
+
+  Point({required this.x, required this.y, this.tag = 'p'});
+
+  String show() => '$tag($x,$y)';
+}
+
+String area({required int w, required int h, int scale = 1}) {
+  return 'a=${w * h * scale}';
+}
+
+String run() {
+  var p = Point(x: 3, y: 4);
+  var q = Point(y: 6, x: 5, tag: 'q');
+  return '${p.show()}|${q.show()}|${area(w: 2, h: 3)}|${area(h: 3, w: 2, scale: 10)}';
+}
+        ]]>
+    </source>
+    <call function="run" returnType="String" return="p(3,4)|q(5,6)|a=6|a=60">
+        []
+    </call>
+    <output>
+        []
+    </output>
+
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+  String area({required int w, required int h, int scale = 1}) {
+    return 'a=${(w * h) * scale}';
+  }
+
+  String run() {
+    var p = Point(x: 3, y: 4);
+    var q = Point(y: 6, x: 5, tag: 'q');
+    return '${p.show()}|${q.show()}|${area(w: 2, h: 3)}|${area(h: 3, w: 2, scale: 10)}';
+  }
+
+class Point {
+
+  int x = 0;
+  int y = 0;
+  String tag = '';
+
+  Point({required this.x, required this.y, this.tag = 'p'});
+
+  String show() {
+    return '$tag($x,$y)';
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/dart_single_line_bodies.test.xml
+++ b/test/tests_definitions/dart_single_line_bodies.test.xml
@@ -2,54 +2,325 @@
 <test title="Unbraced single-statement control-flow bodies">
     <source language="dart">
         <![CDATA[
-void run(bool a, bool b) {
-  var l = [1, 2, 3];
+class Flow {
+  static void run(bool a, bool b) {
+    var l = [1, 2, 3];
 
-  for (var e in l) print('- $e') ;
+    for (var e in l) print('- $e') ;
 
-  for (var i = 0; i < 3; ++i) print('i: $i');
+    for (var i = 0; i < 3; ++i) print('i: $i');
 
-  var i = 0;
-  while (i < 3) i = i + 1;
-  print('while: $i');
+    var i = 0;
+    while (i < 3) i = i + 1;
+    print('while: $i');
 
-  do i = i - 1; while (i > 0);
-  print('do: $i');
+    do i = i - 1; while (i > 0);
+    print('do: $i');
 
-  if (a) print('x'); else print('y');
+    if (a) print('x'); else print('y');
 
-  if (a) print('A'); else if (b) print('B'); else print('C');
+    if (a) print('A'); else if (b) print('B'); else print('C');
 
-  if (a) if (b) print('ab'); else print('a!b');
+    if (a) if (b) print('ab'); else print('a!b');
 
-  for (var e in l) if (e > 2) print('gt2: $e');
+    for (var e in l) if (e > 2) print('gt2: $e');
 
-  for (var e in l) { print('braced: $e'); }
+    for (var e in l) { print('braced: $e'); }
 
-  if (a) print('guard');
-  var elseCount = 1;
-  print('elseCount: $elseCount');
+    if (a) print('guard');
+    var elseCount = 1;
+    print('elseCount: $elseCount');
+  }
 }
         ]]>
     </source>
-    <call function="run">
+    <call class="Flow" function="run">
         [true, false]
     </call>
     <output>
         ["- 1", "- 2", "- 3", "i: 0", "i: 1", "i: 2", "while: 3", "do: 0", "x", "A", "a!b", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "guard", "elseCount: 1"]
     </output>
 
-    <call function="run">
+    <call class="Flow" function="run">
         [false, true]
     </call>
     <output>
         ["- 1", "- 2", "- 3", "i: 0", "i: 1", "i: 2", "while: 3", "do: 0", "y", "B", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "elseCount: 1"]
     </output>
 
-    <call function="run">
+    <call class="Flow" function="run">
         [false, false]
     </call>
     <output>
         ["- 1", "- 2", "- 3", "i: 0", "i: 1", "i: 2", "while: 3", "do: 0", "y", "C", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "elseCount: 1"]
     </output>
+
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Flow {
+
+  static void run(bool a, bool b) {
+    var l = <int>[1, 2, 3];
+    for (var e in l) print('- $e');
+    for (var i = 0; i < 3 ; ++i) print('i: $i');
+    var i = 0;
+    while( i < 3 ) i = i + 1;
+    print('while: $i');
+    do i = i - 1; while (i > 0);
+    print('do: $i');
+    if (a) print('x');
+    else print('y');
+
+    if (a) print('A');
+    else if (b) print('B');
+    else print('C');
+
+    if (a) if (b) print('ab');
+    else print('a!b');
+
+
+    for (var e in l) if (e > 2) print('gt2: $e');
+
+    for (var e in l) {
+      print('braced: $e');
+    }
+    if (a) print('guard');
+
+    var elseCount = 1;
+    print('elseCount: $elseCount');
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="java11"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Flow {
+
+  static void run(bool a, bool b) {
+    var l = new ArrayList<int>(){{
+      add(1);
+      add(2);
+      add(3);
+    }};
+    for (var e : l) print("- " + e);
+    for (var i = 0; i < 3 ; ++i) print("i: " + i);
+    var i = 0;
+    while( i < 3 ) i = i + 1;
+    print("while: " + i);
+    do i = i - 1; while (i > 0);
+    print("do: " + i);
+    if (a) print("x");
+    else print("y");
+
+    if (a) print("A");
+    else if (b) print("B");
+    else print("C");
+
+    if (a) if (b) print("ab");
+    else print("a!b");
+
+
+    for (var e : l) if (e > 2) print("gt2: " + e);
+
+    for (var e : l) {
+      print("braced: " + e);
+    }
+    if (a) print("guard");
+
+    var elseCount = 1;
+    print("elseCount: " + elseCount);
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="csharp"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Flow {
+
+  static void run(bool a, bool b) {
+    var l = new List<int>(){1, 2, 3};
+    foreach (var e in l) print("- " + e);
+    for (var i = 0; i < 3 ; ++i) print("i: " + i);
+    var i = 0;
+    while( i < 3 ) i = i + 1;
+    print("while: " + i);
+    do i = i - 1; while (i > 0);
+    print("do: " + i);
+    if (a) print("x");
+    else print("y");
+
+    if (a) print("A");
+    else if (b) print("B");
+    else print("C");
+
+    if (a) if (b) print("ab");
+    else print("a!b");
+
+
+    foreach (var e in l) if (e > 2) print("gt2: " + e);
+
+    foreach (var e in l) {
+      print("braced: " + e);
+    }
+    if (a) print("guard");
+
+    var elseCount = 1;
+    print("elseCount: " + elseCount);
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="javascript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Flow {
+
+  static run(a, b) {
+    let l = [1, 2, 3];
+    for (const e of l) print(`- ${e}`);
+    for (let i = 0; i < 3 ; ++i) print(`i: ${i}`);
+    let i = 0;
+    while( i < 3 ) i = i + 1;
+    print(`while: ${i}`);
+    do i = i - 1; while (i > 0);
+    print(`do: ${i}`);
+    if (a) print('x');
+    else print('y');
+
+    if (a) print('A');
+    else if (b) print('B');
+    else print('C');
+
+    if (a) if (b) print('ab');
+    else print('a!b');
+
+
+    for (const e of l) if (e > 2) print(`gt2: ${e}`);
+
+    for (const e of l) {
+      print(`braced: ${e}`);
+    }
+    if (a) print('guard');
+
+    let elseCount = 1;
+    print(`elseCount: ${elseCount}`);
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <source-generated language="typescript"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Flow {
+
+  static run(a: boolean, b: boolean): void {
+    let l = [1, 2, 3];
+    for (const e of l) print(`- ${e}`);
+    for (let i = 0; i < 3 ; ++i) print(`i: ${i}`);
+    let i = 0;
+    while( i < 3 ) i = i + 1;
+    print(`while: ${i}`);
+    do i = i - 1; while (i > 0);
+    print(`do: ${i}`);
+    if (a) print('x');
+    else print('y');
+
+    if (a) print('A');
+    else if (b) print('B');
+    else print('C');
+
+    if (a) if (b) print('ab');
+    else print('a!b');
+
+
+    for (const e of l) if (e > 2) print(`gt2: ${e}`);
+
+    for (const e of l) {
+      print(`braced: ${e}`);
+    }
+    if (a) print('guard');
+
+    let elseCount = 1;
+    print(`elseCount: ${elseCount}`);
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <!-- Python has no unbraced form: every single-statement body normalizes
+         back to a properly indented suite. -->
+    <source-generated language="python"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Flow:
+    def run(self, a: bool, b: bool) -> None:
+        l: List[int] = [1, 2, 3]
+        for e in l:
+            print(f'- {e}')
+        i: int = 0
+        while i < 3:
+            print(f'i: {i}')
+            i += 1
+        i: int = 0
+        while i < 3:
+            i = i + 1
+        print(f'while: {i}')
+        while True:
+            i = i - 1
+            if not (i > 0):
+                break
+        print(f'do: {i}')
+        if a:
+            print('x')
+        else:
+            print('y')
+        if a:
+            print('A')
+        elif b:
+            print('B')
+        else:
+            print('C')
+        if a:
+            if b:
+                print('ab')
+            else:
+                print('a!b')
+        for e in l:
+            if e > 2:
+                print(f'gt2: {e}')
+        for e in l:
+            print(f'braced: {e}')
+        if a:
+            print('guard')
+        elseCount: int = 1
+        print(f'elseCount: {elseCount}')
+
+
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+
+    <!-- Go and Kotlin are deliberately absent: the harness re-parses and
+         re-executes every generated source, and both hit pre-existing
+         generator gaps unrelated to unbraced bodies (Go emits `++i` in a
+         `for` header, which its own grammar rejects; Kotlin emits a C-style
+         `for`, which Kotlin has no syntax for). Both were checked by hand and
+         do emit braced bodies, which is the behaviour this test would pin. -->
 </test>

--- a/test/tests_definitions/dart_single_line_bodies.test.xml
+++ b/test/tests_definitions/dart_single_line_bodies.test.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Unbraced single-statement control-flow bodies">
+    <source language="dart">
+        <![CDATA[
+void run(bool a, bool b) {
+  var l = [1, 2, 3];
+
+  for (var e in l) print('- $e') ;
+
+  for (var i = 0; i < 3; ++i) print('i: $i');
+
+  var i = 0;
+  while (i < 3) i = i + 1;
+  print('while: $i');
+
+  do i = i - 1; while (i > 0);
+  print('do: $i');
+
+  if (a) print('x'); else print('y');
+
+  if (a) print('A'); else if (b) print('B'); else print('C');
+
+  if (a) if (b) print('ab'); else print('a!b');
+
+  for (var e in l) if (e > 2) print('gt2: $e');
+
+  for (var e in l) { print('braced: $e'); }
+
+  if (a) print('guard');
+  var elseCount = 1;
+  print('elseCount: $elseCount');
+}
+        ]]>
+    </source>
+    <call function="run">
+        [true, false]
+    </call>
+    <output>
+        ["- 1", "- 2", "- 3", "i: 0", "i: 1", "i: 2", "while: 3", "do: 0", "x", "A", "a!b", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "guard", "elseCount: 1"]
+    </output>
+
+    <call function="run">
+        [false, true]
+    </call>
+    <output>
+        ["- 1", "- 2", "- 3", "i: 0", "i: 1", "i: 2", "while: 3", "do: 0", "y", "B", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "elseCount: 1"]
+    </output>
+
+    <call function="run">
+        [false, false]
+    </call>
+    <output>
+        ["- 1", "- 2", "- 3", "i: 0", "i: 1", "i: 2", "while: 3", "do: 0", "y", "C", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "elseCount: 1"]
+    </output>
+</test>

--- a/test/tests_definitions/java11_if_elseif_no_else.test.xml
+++ b/test/tests_definitions/java11_if_elseif_no_else.test.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="if / else-if chain with no trailing else">
+    <source language="java11">
+        <![CDATA[
+
+          class Bar {
+            static public void main(Object[] args) {
+              var a = args[0] ;
+
+              if (a < 10) {
+                print("small");
+              }
+              else if (a < 100) {
+                print("medium");
+              }
+
+              print("done");
+            }
+          }
+
+        ]]>
+    </source>
+    <call class="Bar" function="main">
+        [
+          [5]
+        ]
+    </call>
+    <output>
+        ["small", "done"]
+    </output>
+
+    <call class="Bar" function="main">
+        [
+          [50]
+        ]
+    </call>
+    <output>
+        ["medium", "done"]
+    </output>
+
+    <call class="Bar" function="main">
+        [
+          [500]
+        ]
+    </call>
+    <output>
+        ["done"]
+    </output>
+</test>

--- a/test/tests_definitions/java11_single_line_bodies.test.xml
+++ b/test/tests_definitions/java11_single_line_bodies.test.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Unbraced single-statement control-flow bodies">
+    <source language="java11">
+        <![CDATA[
+
+          class Bar {
+            static public void run(Object[] args) {
+              var l = args[0];
+              var a = args[1];
+              var b = args[2];
+
+              for (var e : l) print("- " + e) ;
+
+              for (var i = 0; i < 3; ++i) print("i: " + i);
+
+              var i = 0;
+              while (i < 3) i = i + 1;
+              print("while: " + i);
+
+              do i = i - 1; while (i > 0);
+              print("do: " + i);
+
+              if (a) print("x"); else print("y");
+
+              if (a) print("A"); else if (b) print("B"); else print("C");
+
+              if (a) if (b) print("ab"); else print("a!b");
+
+              for (var e : l) if (e > 2) print("gt2: " + e);
+
+              for (var e : l) { print("braced: " + e); }
+
+              if (a) print("guard");
+              var elseCount = 1;
+              print("elseCount: " + elseCount);
+            }
+          }
+
+        ]]>
+    </source>
+    <call class="Bar" function="run">
+        [
+          [[1, 2, 3], true, false]
+        ]
+    </call>
+    <output>
+        ["- 1", "- 2", "- 3", "i: 0", "i: 1", "i: 2", "while: 3", "do: 0", "x", "A", "a!b", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "guard", "elseCount: 1"]
+    </output>
+
+    <call class="Bar" function="run">
+        [
+          [[1, 2, 3], false, true]
+        ]
+    </call>
+    <output>
+        ["- 1", "- 2", "- 3", "i: 0", "i: 1", "i: 2", "while: 3", "do: 0", "y", "B", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "elseCount: 1"]
+    </output>
+
+    <call class="Bar" function="run">
+        [
+          [[1, 2, 3], false, false]
+        ]
+    </call>
+    <output>
+        ["- 1", "- 2", "- 3", "i: 0", "i: 1", "i: 2", "while: 3", "do: 0", "y", "C", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "elseCount: 1"]
+    </output>
+</test>

--- a/test/tests_definitions/javascript_single_line_bodies.test.xml
+++ b/test/tests_definitions/javascript_single_line_bodies.test.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Unbraced single-statement control-flow bodies">
+    <source language="javascript">
+        <![CDATA[
+
+          function run(l, a, b) {
+            for (var e of l) print("- " + e) ;
+
+            for (var i = 0; i < 3; ++i) print("i: " + i);
+
+            var i = 0;
+            while (i < 3) i = i + 1;
+            print("while: " + i);
+
+            do i = i - 1; while (i > 0);
+            print("do: " + i);
+
+            if (a) print("x"); else print("y");
+
+            if (a) print("A"); else if (b) print("B"); else print("C");
+
+            if (a) if (b) print("ab"); else print("a!b");
+
+            for (var e of l) if (e > 2) print("gt2: " + e);
+
+            for (var e of l) { print("braced: " + e); }
+
+            if (a) print("guard");
+            var elseCount = 1;
+            print("elseCount: " + elseCount);
+          }
+
+        ]]>
+    </source>
+    <call function="run">
+        [[1, 2, 3], true, false]
+    </call>
+    <output>
+        ["- 1", "- 2", "- 3", "i: 0", "i: 1", "i: 2", "while: 3", "do: 0", "x", "A", "a!b", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "guard", "elseCount: 1"]
+    </output>
+
+    <call function="run">
+        [[1, 2, 3], false, true]
+    </call>
+    <output>
+        ["- 1", "- 2", "- 3", "i: 0", "i: 1", "i: 2", "while: 3", "do: 0", "y", "B", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "elseCount: 1"]
+    </output>
+
+    <call function="run">
+        [[1, 2, 3], false, false]
+    </call>
+    <output>
+        ["- 1", "- 2", "- 3", "i: 0", "i: 1", "i: 2", "while: 3", "do: 0", "y", "C", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "elseCount: 1"]
+    </output>
+</test>

--- a/test/tests_definitions/kotlin_single_line_bodies.test.xml
+++ b/test/tests_definitions/kotlin_single_line_bodies.test.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Unbraced single-statement control-flow bodies">
+    <source language="kotlin">
+        <![CDATA[
+
+          fun run(l: Any, a: Boolean, b: Boolean) {
+            for (e in l) print("- " + e) ;
+
+            var i = 0;
+            while (i < 3) i = i + 1;
+            print("while: " + i);
+
+            do i = i - 1; while (i > 0);
+            print("do: " + i);
+
+            if (a) print("x"); else print("y");
+
+            if (a) print("A"); else if (b) print("B"); else print("C");
+
+            if (a) if (b) print("ab"); else print("a!b");
+
+            for (e in l) if (e > 2) print("gt2: " + e);
+
+            for (e in l) { print("braced: " + e); }
+
+            if (a) print("guard");
+            var elseCount = 1;
+            print("elseCount: " + elseCount);
+          }
+
+        ]]>
+    </source>
+    <call function="run">
+        [[1, 2, 3], true, false]
+    </call>
+    <output>
+        ["- 1", "- 2", "- 3", "while: 3", "do: 0", "x", "A", "a!b", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "guard", "elseCount: 1"]
+    </output>
+
+    <call function="run">
+        [[1, 2, 3], false, true]
+    </call>
+    <output>
+        ["- 1", "- 2", "- 3", "while: 3", "do: 0", "y", "B", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "elseCount: 1"]
+    </output>
+
+    <call function="run">
+        [[1, 2, 3], false, false]
+    </call>
+    <output>
+        ["- 1", "- 2", "- 3", "while: 3", "do: 0", "y", "C", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "elseCount: 1"]
+    </output>
+</test>

--- a/test/tests_definitions/python_inline_suite.test.xml
+++ b/test/tests_definitions/python_inline_suite.test.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Inline suites on the header's own line">
+    <source language="python">
+        <![CDATA[
+class Flow:
+    def classify(self, n):
+        if n < 0: return 'neg'
+        elif n == 0: return 'zero'
+        else: return 'pos'
+
+    def noop(self): pass
+
+    def run(self, l, a):
+        for e in l: print(f'- {e}')
+
+        i = 0
+        while i < 3: i = i + 1
+        print(f'while: {i}')
+
+        if a: print('x')
+        else: print('y')
+
+        for e in l:
+            if e > 2: print(f'gt2: {e}')
+
+        if a: print('p1'); print('q1')
+        else: print('p2'); print('q2')
+
+        print(self.classify(-5))
+        print(self.classify(0))
+        print(self.classify(7))
+        self.noop()
+        print('done')
+        ]]>
+    </source>
+    <call class="Flow" function="run">
+        [[1, 2, 3], true]
+    </call>
+    <output>
+        ["- 1", "- 2", "- 3", "while: 3", "x", "gt2: 3", "p1", "q1", "neg", "zero", "pos", "done"]
+    </output>
+
+    <call class="Flow" function="run">
+        [[1, 2, 3], false]
+    </call>
+    <output>
+        ["- 1", "- 2", "- 3", "while: 3", "y", "gt2: 3", "p2", "q2", "neg", "zero", "pos", "done"]
+    </output>
+
+    <!-- A one-statement inline suite becomes an `ASTSingleLineStatementBlock`,
+         so it emits an unbraced Dart body; a `;`-joined one stays a block. -->
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Flow {
+
+  dynamic classify(dynamic n) {
+    if (n < 0) return 'neg';
+    else if (n == 0) return 'zero';
+    else return 'pos';
+
+  }
+
+  void noop() {
+  }
+
+  void run(dynamic l, dynamic a) {
+    for (var e in l) print('- ${e}');
+    var i = 0;
+    while( i < 3 ) i = i + 1;
+    print('while: ${i}');
+    if (a) print('x');
+    else print('y');
+
+    for (var e in l) {
+      if (e > 2) print('gt2: ${e}');
+
+    }
+    if (a) {
+        print('p1');
+        print('q1');
+    } else {
+        print('p2');
+        print('q2');
+    }
+
+    print(this.classify(-5));
+    print(this.classify(0));
+    print(this.classify(7));
+    this.noop();
+    print('done');
+  }
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/tests_definitions/typescript_single_line_bodies.test.xml
+++ b/test/tests_definitions/typescript_single_line_bodies.test.xml
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Unbraced single-statement control-flow bodies">
+    <source language="typescript">
+        <![CDATA[
+
+          function run(l: any, a: boolean, b: boolean): void {
+            for (var e of l) print("- " + e) ;
+
+            for (var i = 0; i < 3; ++i) print("i: " + i);
+
+            var i = 0;
+            while (i < 3) i = i + 1;
+            print("while: " + i);
+
+            do i = i - 1; while (i > 0);
+            print("do: " + i);
+
+            if (a) print("x"); else print("y");
+
+            if (a) print("A"); else if (b) print("B"); else print("C");
+
+            if (a) if (b) print("ab"); else print("a!b");
+
+            for (var e of l) if (e > 2) print("gt2: " + e);
+
+            for (var e of l) { print("braced: " + e); }
+
+            if (a) print("guard");
+            var elseCount = 1;
+            print("elseCount: " + elseCount);
+          }
+
+        ]]>
+    </source>
+    <call function="run">
+        [[1, 2, 3], true, false]
+    </call>
+    <output>
+        ["- 1", "- 2", "- 3", "i: 0", "i: 1", "i: 2", "while: 3", "do: 0", "x", "A", "a!b", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "guard", "elseCount: 1"]
+    </output>
+
+    <call function="run">
+        [[1, 2, 3], false, true]
+    </call>
+    <output>
+        ["- 1", "- 2", "- 3", "i: 0", "i: 1", "i: 2", "while: 3", "do: 0", "y", "B", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "elseCount: 1"]
+    </output>
+
+    <call function="run">
+        [[1, 2, 3], false, false]
+    </call>
+    <output>
+        ["- 1", "- 2", "- 3", "i: 0", "i: 1", "i: 2", "while: 3", "do: 0", "y", "C", "gt2: 3", "braced: 1", "braced: 2", "braced: 3", "elseCount: 1"]
+    </output>
+</test>

--- a/test/unit/apollovm_assert_emission_test.dart
+++ b/test/unit/apollovm_assert_emission_test.dart
@@ -1,0 +1,153 @@
+@Tags(['dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Generation-only coverage for constructs whose per-language *output* cannot
+/// be pinned by the round-trip harness in `test/tests_definitions/`.
+///
+/// The harness re-parses and re-executes every generated source, which is the
+/// stronger check — but it can only cover targets whose own grammar parses what
+/// their generator emits. Java's `assert c : m;`, Python's `assert c, m`,
+/// C#'s `Debug.Assert` and Kotlin's `assert(c) { m }` are correct for those
+/// languages' real toolchains, yet ApolloVM neither parses them back nor
+/// provides `Debug`/`assert` as VM builtins. Same for the Kotlin and Lua
+/// compound-assignment lowering: no other grammar accepts `&=` to begin with.
+///
+/// So these assert on the emitted text directly.
+
+Future<String> _generate(String dartSource, String language) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(
+    SourceCodeUnit('dart', dartSource, id: 'test'),
+  );
+  expect(ok, isTrue, reason: "Can't load Dart source");
+
+  var storage = vm.generateAllCodeIn(language);
+  await storage.writeAllSources();
+
+  var out = StringBuffer();
+  for (var ns in await storage.getNamespaces()) {
+    for (var id in await storage.getNamespaceCodeUnitsIDs(ns)) {
+      out.writeln(await storage.getNamespaceCodeUnit(ns, id));
+    }
+  }
+  return out.toString();
+}
+
+const _assertSource = r'''
+class Checks {
+  static void run(int n) {
+    assert(n >= 0);
+    assert(n < 10, 'too big');
+  }
+}
+''';
+
+const _compoundSource = r'''
+class Bits {
+  static int run(int n) {
+    var a = n;
+    a %= 7;
+    a &= 12;
+    a |= 1;
+    a ^= 2;
+    a <<= 3;
+    a >>= 1;
+    return a;
+  }
+}
+''';
+
+void main() {
+  group('assert emission', () {
+    // Each entry: the target language, the bare form, and the form with a
+    // message.
+    const cases = <String, (String, String)>{
+      'dart': ('assert(n >= 0);', "assert(n < 10, 'too big');"),
+      'java11': ('assert n >= 0;', 'assert n < 10 : "too big";'),
+      'python': ('assert n >= 0', "assert n < 10, 'too big'"),
+      'kotlin': ('assert(n >= 0)', 'assert(n < 10) { "too big" }'),
+      'csharp': ('Debug.Assert(n >= 0);', 'Debug.Assert(n < 10, "too big");'),
+      // Lua's `assert(v, message)` is a built-in, so no `;`.
+      'lua': ('assert(n >= 0)', 'assert(n < 10, "too big")'),
+      // No throwing `assert` exists: lowered to an explicit check.
+      'javascript': (
+        "if (!(n >= 0)) throw 'Assertion failed';",
+        "if (!(n < 10)) throw 'too big';",
+      ),
+      'typescript': (
+        "if (!(n >= 0)) throw 'Assertion failed';",
+        "if (!(n < 10)) throw 'too big';",
+      ),
+    };
+
+    for (var entry in cases.entries) {
+      var language = entry.key;
+      var (bare, withMessage) = entry.value;
+
+      test('$language emits its own idiom', () async {
+        var code = await _generate(_assertSource, language);
+        expect(
+          code,
+          contains(bare),
+          reason: 'bare assert in $language:\n$code',
+        );
+        expect(
+          code,
+          contains(withMessage),
+          reason: 'assert with message in $language:\n$code',
+        );
+      });
+    }
+
+    test('go has no assert: lowered to a check plus panic', () async {
+      var code = await _generate(_assertSource, 'go');
+      expect(code, contains('if !(n >= 0) {'));
+      expect(code, contains('panic("Assertion failed")'));
+      expect(code, contains('if !(n < 10) {'));
+      expect(code, contains('panic("too big")'));
+    });
+  });
+
+  group('compound assignment emission', () {
+    test('targets with the compound form keep it', () async {
+      for (var language in ['dart', 'java11', 'csharp', 'javascript']) {
+        var code = await _generate(_compoundSource, language);
+        for (var op in ['a %= 7', 'a &= 12', 'a |= 1', 'a <<= 3', 'a >>= 1']) {
+          expect(code, contains(op), reason: '$op in $language:\n$code');
+        }
+      }
+    });
+
+    test('kotlin lowers bitwise/shift to its infix functions', () async {
+      var code = await _generate(_compoundSource, 'kotlin');
+
+      // Kotlin *does* have `%=`.
+      expect(code, contains('a %= 7'));
+
+      // It has no compound form for the bitwise/shift operators.
+      expect(code, contains('a = a and 12'));
+      expect(code, contains('a = a or 1'));
+      expect(code, contains('a = a xor 2'));
+      expect(code, contains('a = a shl 3'));
+      expect(code, contains('a = a shr 1'));
+    });
+
+    test('lua has no compound assignment at all', () async {
+      var code = await _generate(_compoundSource, 'lua');
+
+      expect(code, contains('a = a % 7'));
+      expect(code, contains('a = a & 12'));
+      expect(code, contains('a = a | 1'));
+      expect(code, contains('a = a ~ 2'));
+      expect(code, contains('a = a << 3'));
+      expect(code, contains('a = a >> 1'));
+
+      // Regression: the generator used to emit `a += 1`, which is not Lua.
+      expect(code, isNot(contains('+=')));
+      expect(code, isNot(contains('&=')));
+    });
+  });
+}

--- a/test/wasm/apollovm_wasm_boxed_member_test.dart
+++ b/test/wasm/apollovm_wasm_boxed_member_test.dart
@@ -44,7 +44,7 @@ Future<Object?> _run(
     var r = await vmWasm
         .createRunner('wasm')!
         .executeFunction('', functionName, positionalParameters: args);
-    return r.getValueNoContext();
+    return await r.getValueNoContext();
   } on StateError catch (e) {
     if (e.message.contains('not supported on this platform')) return null;
     rethrow;

--- a/test/wasm/apollovm_wasm_null_safety_test.dart
+++ b/test/wasm/apollovm_wasm_null_safety_test.dart
@@ -44,7 +44,7 @@ Future<Object?> _compileAndMaybeRun(
     var r = await vmWasm
         .createRunner('wasm')!
         .executeFunction('', functionName, positionalParameters: args);
-    return r.getValueNoContext();
+    return await r.getValueNoContext();
   } on StateError catch (e) {
     // No Wasm runtime on this platform — codegen already verified above.
     if (e.message.contains('not supported on this platform')) return null;


### PR DESCRIPTION
## Why

`for (var e in l) print('- $e') ;` is ordinary Dart, and it did not parse.

Only the plain `if` accepted an unbraced single-statement body. Every loop,
every `if`/`else` and every `else if` demanded `{ }`. A survey of the Dart
grammar while fixing that turned up a further batch of gaps — several of them
**silent misparses** that produced wrong programs rather than errors.

## Unbraced control-flow bodies

All seven remaining rules now accept either form, in **Dart, Java 11, Kotlin,
C#, JavaScript and TypeScript**: `for`, `for-in`/`for-each`, `while`,
`do`/`while`, `if`/`else`, the `else if` chain and the final `else`. A braced
body is still the first alternative, so nothing about existing sources changes.

`singleLineStatement` was also far too narrow — `return …;` or an expression
statement, nothing else — so even the `if` that already supported it rejected
`if (x) break;`, `if (x) throw e;` and a nested `if`. It is now each language's
full statement set minus declarations and bare blocks.

A dangling `else` binds to the **nearest** `if`, matching every target language.
PEG ordered choice gets this right on its own; the test pins it with two calls
whose output changes if the binding ever flips.

**Python** gains the equivalent construct, the inline suite (`if x: return 1`,
`def f(): pass`, `while c: i += 1; j += 1`), at every `suite()` position. No
change to the indentation preprocessor was needed.

**Go is deliberately excluded** — its spec defines
`Block = "{" StatementList "}"` — and Lua has no such form. A single-statement
body translated to either is emitted braced / `do`…`end`.

Not supported, on purpose: the *empty* statement as a body (`while (c) ;`),
`for (;;)`, and `;`-separated statements on an ordinary (non-suite) Python line.

## The one that would have shipped broken

`BaseGrammarLexer.token()` is a prefix matcher with no word-boundary guard, so
`string('else')` matches the start of an identifier like `elseCount`. That was
unreachable while every `else` arm followed a mandatory braced block, and would
have become a **silent miscompile** the moment bodies could be unbraced:

```dart
if (a) x();
elseCount = 1;   // `else` matches; `Count = 1;` becomes the else arm
```

Fixed first, in its own commit, before anything depended on it. Also covers
Kotlin's `when` entry labels and `if` expression.

## Bugs found and fixed along the way

- **Java and C#**: `if (a) {} else if (b) {}` with no trailing `else` failed to
  parse — both made the final `else` non-optional, unlike every other language.
- **Python**: a `do`/`while` translated to Python emitted literal
  `do { … } while (c);`. Reproduced against the *unchanged* braced path to
  confirm it predated this work. Now lowers to `while True: … if not (c): break`.
- **Lua**: compound assignment was emitted verbatim (`a += 1`), which Lua does
  not have, while the README claimed support. Now lowers to `a = a + 1`.
- **`const [1]`** silently misparsed as an index read on a variable named `const`.
- **`set value(int v) {}`** silently became a *method* named `value` returning a
  type named `set`, failing much later with a confusing error. Now a clean parse
  error at the `set` — and the same guard makes untyped getters
  (`get twice => …`) parse, which previously failed because `type().optional()`
  ate `get` and petitparser's `optional()` cannot backtrack.
- **Go**: removed a dead `codeBlockOrSingleLineBlock` cluster, defined but never
  referenced.

## New Dart syntax

- **Interpolation inside triple-quoted strings** — `'''Hello $name'''` yielded
  the *literal* text `$name`. Wrong output, not an error.
- **`assert(c)` / `assert(c, m)`** as a real statement (it parsed as a call to a
  user function named `assert`). Each target emits its own idiom: Java
  `assert c : m;`, Python `assert c, m`, Kotlin `assert(c) { m }`, C#
  `Debug.Assert`, Lua's built-in, JS/TS/Go lowered to an explicit check. Wasm
  refuses to compile it rather than mis-compile it.
- **`required` named parameters** on plain, constructor-typed and `this.` forms.
  `({required int a})` was a hard parse failure.
- **Annotations** (`@override`, `@Deprecated('x')`, `@pragma(...)`, `@a.B(1)`)
  at every position Dart allows. There was no `@` in *any* grammar in the repo,
  so a single `@override` broke the whole class body — which matters beyond
  hand-written sources, since `lib/src/pub` loads real pub packages. Parsed and
  discarded for now.
- **`late`** on locals and fields (accepted and dropped).
- **`const` at use sites**: `const Foo()`, `const []`, `const {}`.
- **Arrow and `async` bodies on local and anonymous functions**.
- **`catch (e, s)`** now binds the stack trace — it was parsed and thrown away,
  so any handler referencing `s` failed. ApolloVM has no stack traces, so it
  binds to an empty string; targets whose `catch` header has no second variable
  declare it as the handler's first statement.
- **Compound assignment `%= &= |= ^= <<= >>=`**. In JS/TS `%=` was already in
  the grammar but missing from the shared operator enum, so it surfaced as a
  `SyntaxError` — a test had pinned that accidental behaviour as intended.

## Verification

- **2068 tests green** (baseline on `master` was 2049), `dart analyze` clean.
- The braced codegen output is **byte-identical** to before — the whole existing
  `<source-generated>` corpus still matches exactly, which is what confirms the
  generator refactor.
- The Dart definition pins round-trip fidelity through **dart, java11, csharp,
  javascript, typescript and python**: the harness regenerates, re-parses and
  re-executes each and compares output.
- Compound-assignment expectations are verified against **real Dart**, not
  hand-computed.

## Reviewer notes

- Go and Kotlin are absent from that cross-language block: both hit pre-existing
  generator gaps unrelated to this work (Go emits `++i` in a `for` header, which
  its own grammar rejects; Kotlin emits a C-style `for`, which Kotlin has no
  syntax for). Their braced output was checked by hand and the exclusion is
  documented in the test file.
- The version-bump commit carries `pubspec.yaml`, which also had two
  **pre-existing uncommitted** dev-dependency bumps in the working tree
  (`build_web_compilers ^4.8.5`, `build_runner ^2.15.1`).
- Full setter support stays out of scope: it would mirror the entire getter
  subsystem plus assignment dispatch, and getters are generated for only 2 of 9
  targets. This PR converts the silent misparse into a clear error.
- `>>>` / `>>>=` stay out of scope: `ASTExpressionOperator` has no unsigned
  shift, so that is a new binary operator end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)