### PR TITLE
v2.27.0 — Dart setters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,60 @@
+## 2.27.0
+
+### Dart setters
+
+`set name(T value) { … }` is implemented. It was the last accessor with no
+support at all — no grammar rule, no AST node, no dispatch. `2.26.0` made it a
+clean parse error instead of a silent misparse into a method named `name`
+returning a type named `set`; it now works.
+
+Parsed on classes and extensions, with a typed or untyped parameter and an
+arrow or block body:
+
+```dart
+class Box {
+  int _v = 0;
+  int get value => _v;
+  set value(int x) { _v = x; }
+  set scaled(v) => _v = v * 10;
+}
+```
+
+A setter runs on every write position: `obj.x = v`, `this.x = v`, and an
+unqualified `x = v` inside the class — the write-side mirror of an unqualified
+getter read. A real variable in scope still wins, so a setter's own parameter
+cannot re-enter it. Compound assignment (`obj.x += 1`) reads through the getter
+when there is one and falls back to the backing field; `??=` short-circuits, so
+the setter does not run when the current value is non-null. Inherited and
+overridden setters resolve through the superclass chain, and extension setters
+work like extension getters.
+
+Only Dart **generates** setters. Every other target refuses with
+`UnsupportedSyntaxError`, and Wasm refuses rather than letting an assignment
+silently write the backing field instead of running the setter body.
+
+An arrow-bodied setter regenerates as an arrow: emitting it as a block would
+produce `set x(v) { return …; }`, which Dart rejects because a setter returns
+void. The generated output is checked with the real `dart analyze`.
+
+### Fixed: getters silently dropped when translating to Python, Go and Lua
+
+Those three generators never iterated the class's accessors, so a class with a
+getter translated to any of them **lost the accessor entirely** while the method
+bodies kept referencing the property — broken code that looked fine, rather than
+the honest `UnsupportedSyntaxError` Java/C#/JS/TS already produced. They now
+refuse, like the others.
+
+### Fixed: `ASTBlock.set` dropped setters
+
+It copied functions, getters and statements, so every class member survived the
+temporary parse block except the new ones.
+
+### Still missing
+
+For getters and setters alike: `static` accessors, top-level accessors, and an
+*unqualified read* of a getter (`return value;` inside a method — `this.value`
+works). Kotlin generates getters but not setters.
+
 ## 2.26.0
 
 ### Control-flow bodies no longer require braces

--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ Same legend and **Wasm** column semantics as the table above.
 | Generics (generic classes + instantiation + type erasure)    | ✅ | ✅ | ✅ | 🚧 | ✅ | 🚫  | ✅ | 🚫  | 🚫  | 🚧 |
 | Type inference (`var` / `val` / `auto`)                       | ✅ | ✅ | ✅ | ✅ | ✅ | 🚫  | ✅ | 🚫  | 🚫  | ✅⁵ |
 | Extensions (methods + getters)¹¹                              | ✅ | 🚫  | ✅ | 🚫  | 🧩¹² | 🚫  | 🚫  | 🚫  | 🚫  | 🚧 |
-| Getters / setters¹⁴                                           | 🧩¹⁴ | 🚧 | 🧩¹⁴ | 🚫  | 🚧 | 🚧 | 🚧 | 🚫  | 🚧 | 🚧 |
+| Getters / setters¹⁴                                           | ✅¹⁴ | 🚧 | 🧩¹⁴ | 🚫  | 🚧 | 🚧 | 🚧 | 🚫  | 🚧 | 🚧 |
 | Annotations / metadata (`@…`)¹⁵                               | 🧩¹⁵ | 🚧 | 🚧 | 🚫  | 🚧 | 🚫  | 🚧 | 🚫  | 🚧 | 🚫  |
 | `required` named parameters                                   | ✅ | 🚫  | 🧩¹⁶ | 🚫  | 🧩¹⁶ | 🚫  | 🚫  | 🚫  | 🧩¹⁶ | ✅ |
 
@@ -352,11 +352,19 @@ Dart, Java (`extends`), C# / TS / JS (`: Base` / `extends`), Python. Kotlin's
 Wasm backend doesn't compile inheritance yet. Constructor initializer lists with
 an explicit `: super(v)` call are not parsed yet — set inherited fields from the
 constructor body or a `this.param`. &nbsp;
-¹⁴ **Getters** are parsed and executed (Dart `get name => …`, with or without an
-explicit return type) and are generated for Dart and Kotlin. **Setters
-(`set name(v)`) are not implemented** — `set` is rejected in a type position, so
-a setter declaration is a clear parse error rather than the silent misparse into
-a method named `name` that it used to produce. &nbsp;
+¹⁴ **Getters and setters** are parsed and executed on classes and extensions:
+`get name => …` / `get name { … }` (with or without an explicit return type) and
+`set name(T v) { … }` / `set name(v) => …` (typed or untyped parameter). A
+setter runs on `obj.x = v`, `this.x = v`, an unqualified `x = v` inside the
+class, and on compound forms (`+=`, `??=`, …), which read through the getter
+when there is one; `??=` short-circuits, so the setter does not run when the
+current value is non-null. Inherited and overridden accessors resolve through
+the superclass chain. **Only Dart generates them** — Kotlin emits getters
+(`val x: T get() { … }`) but not setters, and every other target refuses an
+accessor with `UnsupportedSyntaxError` rather than dropping it. Not yet
+supported, for getters and setters alike: `static` accessors, top-level
+accessors, and an *unqualified read* of a getter (`return value;` inside a
+method — use `this.value`). &nbsp;
 ¹⁵ Dart annotations (`@override`, `@Deprecated('x')`, `@pragma(...)`,
 `@a.B(1)`) are accepted wherever Dart allows them — top-level declarations,
 class and enum members, enum entries, extension members, parameters and local

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -61,7 +61,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.26.0';
+  static final String VERSION = '2.27.0';
 
   static int _idCount = 0;
 

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -1386,6 +1386,15 @@ sealed class VMContext {
     return parent?.getGetter(name);
   }
 
+  /// Returns a setter of [name].
+  ///
+  /// If [parent] is defined, will also look in the parent context.
+  ASTSetterDeclaration? getSetter(String name) {
+    var s = block.getSetter(name, this);
+    if (s != null) return s;
+    return parent?.getSetter(name);
+  }
+
   /// Returns a function of [name] and [parametersSignature]
   ///
   /// If [parent] is defined, will also look in the parent context.

--- a/lib/src/apollovm_code_generator.dart
+++ b/lib/src/apollovm_code_generator.dart
@@ -160,6 +160,20 @@ abstract class ApolloCodeGenerator
     );
   }
 
+  /// Emits a setter declaration. Refused by default: most targets have no
+  /// property-setter syntax, and silently dropping one would emit code whose
+  /// assignments write a field the source never meant to write.
+  StringBuffer generateASTClassSetterDeclaration(
+    ASTClassSetterDeclaration setter, {
+    StringBuffer? out,
+    String indent = '',
+    String? receiver,
+  }) {
+    throw UnsupportedSyntaxError(
+      "Language '$language' has no setter declaration: ${setter.name}",
+    );
+  }
+
   @override
   StringBuffer generateASTBlock(
     ASTBlock block, {
@@ -223,6 +237,12 @@ abstract class ApolloCodeGenerator
     for (var g in block.getter) {
       if (g is ASTClassGetterDeclaration) {
         generateASTClassGetterDeclaration(g, out: out, indent: indent2);
+      }
+    }
+
+    for (var s in block.setter) {
+      if (s is ASTClassSetterDeclaration) {
+        generateASTClassSetterDeclaration(s, out: out, indent: indent2);
       }
     }
 

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -109,6 +109,32 @@ ASTInvocableDeclaration? _resolveLocalFunctionOrExtension(
   return null;
 }
 
+/// Resolves the setter [name] on the receiver's class [clazz], falling back to
+/// an extension setter. The mirror of [_resolveGetterOrExtension].
+ASTSetterDeclaration? _resolveSetterOrExtension(
+  ASTNode node,
+  ASTClass clazz,
+  String name,
+  VMContext context,
+) {
+  ASTSetterDeclaration? s;
+  StateError? classLookupError;
+
+  try {
+    s = clazz.getSetter(name, context);
+  } on StateError catch (e) {
+    classLookupError = e;
+  }
+
+  if (s != null) return s;
+
+  var extensionSetter = _resolveASTRoot(node)?.getExtensionSetter(clazz, name);
+  if (extensionSetter != null) return extensionSetter;
+
+  if (classLookupError != null) throw classLookupError;
+  return null;
+}
+
 /// Resolves the getter [name] on the receiver's class [clazz], falling back to
 /// an extension getter. See [_resolveFunctionOrExtension].
 ASTGetterDeclaration? _resolveGetterOrExtension(
@@ -2510,6 +2536,15 @@ class ASTExpressionVariableAssignment extends ASTExpression {
   ) async {
     var context = defineRunContext(parentContext);
 
+    // An unqualified `x = v` inside a class body resolves to `this.x = v` when
+    // a setter named `x` is in scope — the write-side mirror of an unqualified
+    // getter read. Checked before the plain variable path so a declared setter
+    // is not shadowed by an implicitly-created scope variable.
+    var scopeSetter = _resolveScopeSetter(context);
+    if (scopeSetter != null) {
+      return _runScopeSetter(context, runStatus, scopeSetter);
+    }
+
     // Null-coalescing assignment (`??=`): only evaluate the right-hand side and
     // assign when the current value is `null`; otherwise leave it unchanged.
     if (operator == ASTAssignmentOperator.nullCoalesce) {
@@ -2537,6 +2572,67 @@ class ASTExpressionVariableAssignment extends ASTExpression {
     await variable.setValue(context, await result);
 
     return result;
+  }
+
+  /// A setter matching this unqualified assignment target, or `null`.
+  ///
+  /// Only a plain scope variable can name a setter; `this.x`, a static field
+  /// reference and any other target have their own resolution.
+  ASTSetterDeclaration? _resolveScopeSetter(VMContext context) {
+    var v = variable;
+    if (v is! ASTScopeVariable) return null;
+
+    // A real variable in scope (a local, or a parameter) always wins: inside
+    // `set x(v) { … }` the parameter must not re-enter the setter.
+    if (context.getVariable(v.name, true) != null) return null;
+
+    return context.getSetter(v.name);
+  }
+
+  FutureOr<ASTValue> _runScopeSetter(
+    VMContext context,
+    ASTRunStatus runStatus,
+    ASTSetterDeclaration setter,
+  ) async {
+    var value = await expression.run(context, runStatus);
+
+    ASTValue resultValue;
+    if (operator == ASTAssignmentOperator.set) {
+      resultValue = value;
+    } else {
+      var getter = context.getGetter((variable as ASTScopeVariable).name);
+      var current = getter != null
+          ? await _callScopeAccessor(context, getter)
+          : await variable.getValue(context);
+      resultValue = await applyASTAssignmentOperator(
+        context,
+        operator,
+        current,
+        value,
+      );
+    }
+
+    if (setter is ASTClassSetterDeclaration) {
+      var instance = context.getClassInstance();
+      if (instance != null) {
+        await setter.objectCall(context, instance, resultValue);
+        return resultValue;
+      }
+    }
+
+    await setter.call(context, resultValue);
+    return resultValue;
+  }
+
+  FutureOr<ASTValue> _callScopeAccessor(
+    VMContext context,
+    ASTGetterDeclaration getter,
+  ) {
+    if (getter is ASTClassGetterDeclaration) {
+      var instance = context.getClassInstance();
+      if (instance != null) return getter.objectCall(context, instance);
+    }
+    return getter.call(context);
   }
 
   @override
@@ -4158,16 +4254,51 @@ class ASTExpressionObjectSetterAssignment extends ASTExpression {
     var classContext = obj.createContext(context);
     var value = await expression.run(context, runStatus);
 
-    var current = await _currentField(classContext, obj);
+    // A declared setter wins over the raw field: `obj.x = v` must run
+    // `set x(v)` when the class (or an extension on it) declares one.
+    var setter = _resolveSetterOrExtension(this, obj.clazz, name, classContext);
+
+    if (setter != null) {
+      ASTValue resultValue;
+      if (operator == ASTAssignmentOperator.set) {
+        resultValue = value;
+      } else {
+        // `obj.x += v` reads through the getter (or the field, when the
+        // property is setter-only backed by a field) before writing back.
+        var current = await _currentValue(classContext, obj);
+        resultValue = await _applyOperator(classContext, current, value);
+      }
+
+      if (setter is ASTClassSetterDeclaration) {
+        await setter.objectCall(classContext, obj, resultValue);
+      } else {
+        await setter.call(classContext, resultValue);
+      }
+
+      return resultValue;
+    }
+
+    var current = await _currentValue(classContext, obj);
     var resultValue = await _applyOperator(classContext, current, value);
     await obj.setField(classContext, name, resultValue);
     return resultValue;
   }
 
-  FutureOr<ASTValue> _currentField(
+  /// The property's current value, for a compound assignment: a declared
+  /// getter if there is one, otherwise the raw field.
+  FutureOr<ASTValue> _currentValue(
     VMClassContext classContext,
     ASTClassInstance obj,
   ) {
+    var getter = _resolveGetterOrExtension(this, obj.clazz, name, classContext);
+
+    if (getter != null) {
+      if (getter is ASTClassGetterDeclaration) {
+        return getter.objectCall(classContext, obj);
+      }
+      return getter.call(classContext);
+    }
+
     return obj
         .getField(classContext, name)
         .resolveMapped((v) => v ?? ASTValueNull.instance);

--- a/lib/src/ast/apollovm_ast_expression.dart
+++ b/lib/src/ast/apollovm_ast_expression.dart
@@ -2604,6 +2604,14 @@ class ASTExpressionVariableAssignment extends ASTExpression {
       var current = getter != null
           ? await _callScopeAccessor(context, getter)
           : await variable.getValue(context);
+
+      // `x ??= v` short-circuits: when the current value is not null the
+      // setter must not run at all, as in Dart.
+      if (operator == ASTAssignmentOperator.nullCoalesce &&
+          !await _astValueIsNull(context, current)) {
+        return current;
+      }
+
       resultValue = await applyASTAssignmentOperator(
         context,
         operator,
@@ -4266,6 +4274,14 @@ class ASTExpressionObjectSetterAssignment extends ASTExpression {
         // `obj.x += v` reads through the getter (or the field, when the
         // property is setter-only backed by a field) before writing back.
         var current = await _currentValue(classContext, obj);
+
+        // `obj.x ??= v` short-circuits: when the current value is not null the
+        // setter must not run at all, as in Dart.
+        if (operator == ASTAssignmentOperator.nullCoalesce &&
+            !await _astValueIsNull(classContext, current)) {
+          return current;
+        }
+
         resultValue = await _applyOperator(classContext, current, value);
       }
 

--- a/lib/src/ast/apollovm_ast_statement.dart
+++ b/lib/src/ast/apollovm_ast_statement.dart
@@ -321,6 +321,10 @@ class ASTBlock extends ASTStatement {
     for (var e in _getters.values) {
       e.resolveNode(this);
     }
+
+    for (var e in _setters.values) {
+      e.resolveNode(this);
+    }
   }
 
   @override
@@ -381,6 +385,50 @@ class ASTBlock extends ASTStatement {
 
     return gExternal;
   }
+
+  //// Setters:
+
+  final Map<String, ASTSetterDeclaration> _setters = {};
+
+  List<ASTSetterDeclaration> get setter => _setters.values.toList();
+
+  List<String> get setterNames => _setters.keys.toList();
+
+  void addSetter(ASTSetterDeclaration s) {
+    var name = s.name;
+    s.parentBlock = this;
+    _setters[name] = s;
+  }
+
+  void addAllSetters(Iterable<ASTSetterDeclaration> ss) {
+    for (var s in ss) {
+      addSetter(s);
+    }
+  }
+
+  ASTSetterDeclaration? getSetterWithName(
+    String name, {
+    bool caseInsensitive = false,
+  }) {
+    var s = _setters[name];
+
+    if (s == null && caseInsensitive) {
+      for (var entry in _setters.entries) {
+        if (equalsIgnoreAsciiCase(entry.key, name)) {
+          s = entry.value;
+          break;
+        }
+      }
+    }
+
+    return s;
+  }
+
+  ASTSetterDeclaration? getSetter(
+    String fName,
+    VMContext context, {
+    bool caseInsensitive = false,
+  }) => getSetterWithName(fName, caseInsensitive: caseInsensitive);
 
   //// Functions
 
@@ -479,6 +527,9 @@ class ASTBlock extends ASTStatement {
 
     _getters.clear();
     addAllGetters(other._getters.values);
+
+    _setters.clear();
+    addAllSetters(other._setters.values);
 
     _statements.clear();
     addAllStatements(other._statements);

--- a/lib/src/ast/apollovm_ast_toplevel.dart
+++ b/lib/src/ast/apollovm_ast_toplevel.dart
@@ -351,6 +351,24 @@ abstract class ASTClass<T> extends ASTEntryPointBlock {
     );
   }
 
+  /// Resolves a setter visible from this class: own setters first, then the
+  /// superclass chain (inherited setters).
+  @override
+  ASTSetterDeclaration? getSetter(
+    String fName,
+    VMContext context, {
+    bool caseInsensitive = false,
+  }) {
+    var s = super.getSetter(fName, context, caseInsensitive: caseInsensitive);
+    if (s != null) return s;
+
+    return superClass?.getSetter(
+      fName,
+      context,
+      caseInsensitive: caseInsensitive,
+    );
+  }
+
   List<ASTConstructorSet> get constructors;
 
   void resolveNodeConstructors(ASTNode? parentNode);
@@ -853,6 +871,14 @@ class ASTClassNormal extends ASTClass<VMObject> {
       g.clazz = this;
     }
     super.addGetter(g);
+  }
+
+  @override
+  void addSetter(ASTSetterDeclaration s) {
+    if (s is ASTClassSetterDeclaration) {
+      s.clazz = this;
+    }
+    super.addSetter(s);
   }
 
   @override
@@ -1411,6 +1437,12 @@ class ASTExtension extends ASTBlock {
         g.clazz = targetClass;
       }
     }
+
+    for (var s in setter) {
+      if (s is ASTClassSetterDeclaration) {
+        s.clazz = targetClass;
+      }
+    }
   }
 
   ASTRoot? get _root {
@@ -1461,6 +1493,9 @@ class ASTExtension extends ASTBlock {
 
   /// The extension getter [name], or `null`.
   ASTGetterDeclaration? findGetter(String name) => getGetterWithName(name);
+
+  /// The extension setter [name], or `null`.
+  ASTSetterDeclaration? findSetter(String name) => getSetterWithName(name);
 
   @override
   String toString() => 'ASTExtension[${name ?? ''}]on[$targetType]';
@@ -1523,6 +1558,17 @@ class ASTRoot extends ASTEntryPointBlock {
       if (!extension.matchesReceiver(receiver)) continue;
       var g = extension.findGetter(name);
       if (g != null) return g;
+    }
+    return null;
+  }
+
+  /// Resolves an extension setter [name] for a receiver of class [receiver].
+  /// See [getExtensionFunction].
+  ASTSetterDeclaration? getExtensionSetter(ASTClass receiver, String name) {
+    for (var extension in _extensions) {
+      if (!extension.matchesReceiver(receiver)) continue;
+      var s = extension.findSetter(name);
+      if (s != null) return s;
     }
     return null;
   }
@@ -3419,6 +3465,130 @@ class ASTGetterDeclaration<T> extends ASTBlock {
   String toString() {
     var block = super.toString();
     return '$modifiers $returnType get $name $block';
+  }
+}
+
+/// An AST Class Setter Declaration.
+class ASTClassSetterDeclaration<T> extends ASTSetterDeclaration<T> {
+  /// The class type of this setter.
+  ASTClass? clazz;
+
+  ASTType? get classType => clazz?.type;
+
+  ASTClassSetterDeclaration(
+    this.clazz,
+    String name,
+    ASTType<T> parameterType,
+    String parameterName, {
+    super.block,
+    super.modifiers,
+  }) : super(name, parameterType, parameterName);
+
+  /// Runs this setter against [classInstance], binding [value] to the
+  /// declared parameter. Mirrors [ASTClassGetterDeclaration.objectCall].
+  FutureOr<ASTValue> objectCall(
+    VMContext parent,
+    ASTValue classInstance,
+    ASTValue value,
+  ) {
+    var objContext = VMClassContext(clazz!, parent: parent);
+    objContext.setClassInstance(classInstance);
+    return call(objContext, value);
+  }
+}
+
+/// An AST setter Declaration: `set name(T value) { ... }`.
+///
+/// The mirror of [ASTGetterDeclaration]: a block that takes one declared
+/// parameter instead of producing a return value. A setter's own result is
+/// discarded — the assignment expression evaluates to the assigned value, as
+/// in Dart — so [call] returns void.
+class ASTSetterDeclaration<T> extends ASTBlock {
+  /// Name of this setter (the property name, without `set`).
+  final String name;
+
+  /// The declared type of the single parameter.
+  final ASTType<T> parameterType;
+
+  /// The declared name of the single parameter.
+  final String parameterName;
+
+  /// Modifiers of this setter.
+  final ASTModifiers modifiers;
+
+  ASTSetterDeclaration(
+    this.name,
+    this.parameterType,
+    this.parameterName, {
+    ASTBlock? block,
+    ASTModifiers? modifiers,
+  }) : modifiers = modifiers ?? ASTModifiers.modifiersNone,
+       super(null) {
+    set(block);
+  }
+
+  @override
+  ASTNode? getNodeIdentifier(String name, {ASTNode? requester}) {
+    var allChildren = descendantChildren;
+
+    var limit = allChildren.length;
+
+    if (requester != null) {
+      var idx = allChildren.indexWhere((e) => identical(e, requester));
+
+      if (idx >= 0) {
+        limit = idx + 1;
+      }
+    }
+
+    for (var i = limit - 1; i >= 0; --i) {
+      var child = allChildren[i];
+
+      if (child is ASTStatementVariableDeclaration && child.name == name) {
+        return child;
+      } else if (child is ASTFunctionDeclaration && child.name == name) {
+        return child;
+      }
+    }
+
+    return super.getNodeIdentifier(name, requester: requester);
+  }
+
+  FutureOr<ASTValue> call(VMContext parent, ASTValue value) async {
+    var context = VMScopeContext(this, parent: parent);
+    context.declareVariableWithValue(parameterType, parameterName, value);
+
+    var prevContext = VMContext.setCurrent(context);
+    try {
+      await super.run(context, ASTRunStatus());
+      return ASTValueVoid.instance;
+    } finally {
+      VMContext.setCurrent(prevContext);
+    }
+  }
+
+  @override
+  VMContext defineRunContext(VMContext parentContext) {
+    // The block runs in the context `call(...)` already built, which holds the
+    // bound parameter.
+    return parentContext;
+  }
+
+  @override
+  ASTValue run(VMContext parentContext, ASTRunStatus runStatus) {
+    throw UnsupportedError(
+      "Can't run this block directly! Should use call(...), since this block "
+      "needs its parameter initialized!",
+    );
+  }
+
+  @override
+  ASTType resolveType(VMContext? context) => ASTTypeVoid.instance;
+
+  @override
+  String toString() {
+    var block = super.toString();
+    return '$modifiers set $name($parameterType $parameterName) $block';
   }
 }
 

--- a/lib/src/languages/dart/dart_generator.dart
+++ b/lib/src/languages/dart/dart_generator.dart
@@ -248,12 +248,6 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
   }) {
     out ??= newOutput();
 
-    var blockCode = generateASTBlock(
-      setter,
-      indent: indent,
-      withBrackets: false,
-    );
-
     out.write(indent);
     out.write('set ');
     out.write(setter.name);
@@ -261,7 +255,29 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
     out.write(generateASTType(setter.parameterType));
     out.write(' ');
     out.write(setter.parameterName);
-    out.write(') {\n');
+    out.write(')');
+
+    // An arrow-bodied setter parses into a single `return <expr>;`. Emitting
+    // that as a block body would produce `set x(v) { return …; }`, which Dart
+    // rejects — a setter returns void. Emit the arrow form back.
+    var statements = setter.statements;
+    if (statements.length == 1) {
+      var stm = statements.first;
+      if (stm is ASTStatementReturnWithExpression) {
+        out.write(' => ');
+        generateASTExpression(stm.expression, out: out, headIndented: false);
+        out.write(';\n\n');
+        return out;
+      }
+    }
+
+    var blockCode = generateASTBlock(
+      setter,
+      indent: indent,
+      withBrackets: false,
+    );
+
+    out.write(' {\n');
     out.write(blockCode);
     out.write(indent);
     out.write('}\n\n');

--- a/lib/src/languages/dart/dart_generator.dart
+++ b/lib/src/languages/dart/dart_generator.dart
@@ -239,6 +239,36 @@ class ApolloCodeGeneratorDart extends ApolloCodeGenerator {
     return out;
   }
 
+  @override
+  StringBuffer generateASTClassSetterDeclaration(
+    ASTClassSetterDeclaration setter, {
+    StringBuffer? out,
+    String indent = '',
+    String? receiver,
+  }) {
+    out ??= newOutput();
+
+    var blockCode = generateASTBlock(
+      setter,
+      indent: indent,
+      withBrackets: false,
+    );
+
+    out.write(indent);
+    out.write('set ');
+    out.write(setter.name);
+    out.write('(');
+    out.write(generateASTType(setter.parameterType));
+    out.write(' ');
+    out.write(setter.parameterName);
+    out.write(') {\n');
+    out.write(blockCode);
+    out.write(indent);
+    out.write('}\n\n');
+
+    return out;
+  }
+
   /// Generates a Dart `enum` declaration (simple or enhanced/rich).
   StringBuffer generateASTClassEnum(
     ASTClassEnum clazz, {

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -246,7 +246,8 @@ class DartGrammarDefinition extends DartGrammarLexer {
               char('{').trimHidden() &
               (ref0(metadata).star() &
                       (ref0(classFunctionDeclaration) |
-                          ref0(getterDeclaration)))
+                          ref0(getterDeclaration) |
+                          ref0(setterDeclaration)))
                   .map((v) => v[1])
                   .star() &
               char('}').trimHidden())
@@ -259,6 +260,8 @@ class DartGrammarDefinition extends DartGrammarLexer {
             for (var member in (v[5] as List)) {
               if (member is ASTClassGetterDeclaration) {
                 extension.addGetter(member);
+              } else if (member is ASTClassSetterDeclaration) {
+                extension.addSetter(member);
               } else if (member is ASTFunctionDeclaration) {
                 extension.addFunction(member);
               }
@@ -292,6 +295,49 @@ class DartGrammarDefinition extends DartGrammarLexer {
               block: block,
             );
           });
+
+  /// `set name(T value) { ... }` / `set name(T value) => ...`.
+  ///
+  /// A leading `void` is accepted and dropped: a setter has no return value.
+  /// The declared parameter is mandatory and single, as in Dart.
+  ///
+  /// [simpleType] rejects `set` in a type position, so this rule is reached
+  /// even though it is tried after [classFunctionDeclaration] — that rule
+  /// cannot consume `set` as a return type.
+  Parser<ASTClassSetterDeclaration> setterDeclaration() =>
+      (type().optional() &
+              setKeyword() &
+              identifier() &
+              char('(').trimHidden() &
+              ref0(setterParameter) &
+              char(')').trimHidden() &
+              (arrowBody() | codeBlock()))
+          .map((v) {
+            var name = v[2] as String;
+            var (parameterType, parameterName) = v[4] as (ASTType, String);
+            var block = v[6] as ASTBlock;
+            return ASTClassSetterDeclaration(
+              null,
+              name,
+              parameterType,
+              parameterName,
+              block: block,
+            );
+          });
+
+  /// The single parameter of a setter, typed (`int v`) or untyped (`v`).
+  ///
+  /// An ordered choice rather than `type().optional() & identifier()`: for an
+  /// untyped parameter `type()` would match the *name* and petitparser's
+  /// `optional()` cannot backtrack, so the rule would fail.
+  Parser<(ASTType, String)> setterParameter() =>
+      ((type().trimHidden() & identifier().trimHidden()).map(
+                (v) => (v[0] as ASTType, v[1] as String),
+              ) |
+              identifier().trimHidden().map(
+                (v) => (ASTTypeDynamic.instance as ASTType, v),
+              ))
+          .cast<(ASTType, String)>();
 
   /// Type-parameter names of the class currently being parsed (e.g. `T` in
   /// `class Wrapper<T>`). Used by [simpleType] to erase them to `dynamic`.
@@ -461,6 +507,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
                       (ref0(classConstructorDefaultDeclaration) |
                           ref0(classFunctionDeclaration) |
                           ref0(getterDeclaration) |
+                          ref0(setterDeclaration) |
                           ref0(classFieldDeclaration) |
                           ref0(classFieldDeclarationWithValue)))
                   .map((v) => v[1])
@@ -473,6 +520,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
                 .whereType<ASTClassConstructorDeclaration>()
                 .toList();
             var getters = list.whereType<ASTClassGetterDeclaration>().toList();
+            var setters = list.whereType<ASTClassSetterDeclaration>().toList();
             var functions = list.whereType<ASTFunctionDeclaration>().toList();
 
             var block = ASTClassNormal('?', ASTType<VMObject>('?'), null);
@@ -481,6 +529,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
             block.addAllConstructors(constructors);
             block.addAllFunctions(functions);
             block.addAllGetters(getters);
+            block.addAllSetters(setters);
 
             return block;
           });

--- a/lib/src/languages/go/go_generator.dart
+++ b/lib/src/languages/go/go_generator.dart
@@ -311,6 +311,21 @@ class ApolloCodeGeneratorGo extends ApolloCodeGenerator {
       }
     }
 
+    // Go has no property accessors. Refuse rather than drop them silently:
+    // a dropped accessor leaves the method bodies referencing a property that
+    // no longer exists, which compiles as neither Go nor anything else.
+    for (var g in clazz.getter) {
+      if (g is ASTClassGetterDeclaration) {
+        generateASTClassGetterDeclaration(g, out: out, indent: indent);
+      }
+    }
+
+    for (var s in clazz.setter) {
+      if (s is ASTClassSetterDeclaration) {
+        generateASTClassSetterDeclaration(s, out: out, indent: indent);
+      }
+    }
+
     _currentClassName = null;
     _currentClassFields = const {};
     _currentClassMethods = const {};

--- a/lib/src/languages/lua/lua_generator.dart
+++ b/lib/src/languages/lua/lua_generator.dart
@@ -117,6 +117,21 @@ class ApolloCodeGeneratorLua extends ApolloCodeGenerator {
       }
     }
 
+    // Lua tables have no property accessors. Refuse rather than drop them
+    // silently: a dropped accessor leaves method bodies referencing a property
+    // that no longer exists.
+    for (var g in clazz.getter) {
+      if (g is ASTClassGetterDeclaration) {
+        generateASTClassGetterDeclaration(g, out: out, indent: indent);
+      }
+    }
+
+    for (var s in clazz.setter) {
+      if (s is ASTClassSetterDeclaration) {
+        generateASTClassSetterDeclaration(s, out: out, indent: indent);
+      }
+    }
+
     _currentClassFields = const {};
     _currentClassMethods = const {};
 

--- a/lib/src/languages/python/python_generator.dart
+++ b/lib/src/languages/python/python_generator.dart
@@ -190,6 +190,22 @@ class ApolloCodeGeneratorPython extends ApolloCodeGenerator {
       }
     }
 
+    // Python has no property accessors in this generator yet. Route them
+    // through the base declarations so an unsupported accessor is refused
+    // rather than silently dropped — dropping it emits a body that still
+    // references the property, which is broken code that looks fine.
+    for (var g in block.getter) {
+      if (g is ASTClassGetterDeclaration) {
+        generateASTClassGetterDeclaration(g, out: out, indent: indent);
+      }
+    }
+
+    for (var s in block.setter) {
+      if (s is ASTClassSetterDeclaration) {
+        generateASTClassSetterDeclaration(s, out: out, indent: indent);
+      }
+    }
+
     for (var stm in block.statements) {
       generateASTStatement(stm, out: out, indent: indent);
     }
@@ -359,6 +375,22 @@ class ApolloCodeGeneratorPython extends ApolloCodeGenerator {
     for (var set in clazz.functions) {
       for (var f in set.functions) {
         _generateFunction(f, out: out, indent: bodyIndent, isMethod: true);
+      }
+    }
+
+    // Property accessors are not emitted as Python `@property` yet. Route them
+    // through the base declarations so an unsupported accessor is refused
+    // rather than silently dropped — dropping it leaves the method bodies
+    // referencing a property that no longer exists.
+    for (var g in clazz.getter) {
+      if (g is ASTClassGetterDeclaration) {
+        generateASTClassGetterDeclaration(g, out: out, indent: bodyIndent);
+      }
+    }
+
+    for (var s in clazz.setter) {
+      if (s is ASTClassSetterDeclaration) {
+        generateASTClassSetterDeclaration(s, out: out, indent: bodyIndent);
       }
     }
 

--- a/lib/src/languages/wasm/wasm_generator.dart
+++ b/lib/src/languages/wasm/wasm_generator.dart
@@ -388,6 +388,16 @@ class ApolloGeneratorWasm<S extends ApolloCodeUnitStorage<D>, D extends Object>
       }
     }
 
+    // Setters have no Wasm lowering yet: an assignment to the property would
+    // silently write the backing field instead of running the setter body.
+    // Refuse rather than mis-compile.
+    if (clazz.setter.isNotEmpty) {
+      throw UnsupportedSyntaxError(
+        'Wasm compilation of setters is not implemented: '
+        '${clazz.name}.${clazz.setter.map((s) => s.name).join(', ')}',
+      );
+    }
+
     // User-declared getters (`int get x { ... }`) compile to a zero-argument
     // instance method (`this` is param 0). A getter access then lowers to a
     // 0-arg method call, and an inherited getter resolves through the same

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.26.0
+version: 2.27.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/tests_definitions/dart_setter.test.xml
+++ b/test/tests_definitions/dart_setter.test.xml
@@ -1,0 +1,182 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<test title="Setters: declaration, dispatch and inheritance">
+    <source language="dart">
+        <![CDATA[
+class Base {
+  int raw = 0;
+
+  // Setter-only property, backed by a plain field.
+  set doubled(int x) { raw = x * 2; }
+}
+
+class Box extends Base {
+  int _v = 0;
+
+  // A getter/setter pair over the same backing field.
+  int get value => _v;
+  set value(int x) { _v = x + 1; }
+
+  // Untyped parameter, arrow body, and a parameter named like the property
+  // (it must bind as a parameter, not re-enter the setter).
+  set scaled(v) => _v = v * 10;
+
+  // An unqualified write inside a method resolves to `this.value = ...`.
+  // (The read side is spelled `this.value`: an unqualified getter *read* is a
+  // separate, pre-existing gap — see `_v` reads elsewhere in this class.)
+  int viaUnqualified(int n) {
+    value = n;
+    return this.value;
+  }
+
+  int run(String mode, int n) {
+    if (mode == 'pair') { this.value = n; return this.value; }
+    if (mode == 'compound') { _v = 10; this.value += n; return this.value; }
+    if (mode == 'nullaware') { _v = 0; this.value ??= n; return this.value; }
+    if (mode == 'arrow') { scaled = n; return _v; }
+    if (mode == 'inherited') { doubled = n; return raw; }
+    if (mode == 'unqualified') { return viaUnqualified(n); }
+    if (mode == 'this') { this.value = n; return _v; }
+    return -1;
+  }
+}
+        ]]>
+    </source>
+
+    <!-- `value = 7` runs `set value` (+1), then reads back through `get value`. -->
+    <call class="Box" function="run" return="8">
+        ["pair", 7]
+    </call>
+    <output>
+        []
+    </output>
+
+    <!-- `value += 5` reads 10 through the getter, then writes 15 via the setter (+1). -->
+    <call class="Box" function="run" return="16">
+        ["compound", 5]
+    </call>
+    <output>
+        []
+    </output>
+
+    <!-- `value ??= 9`: the getter returns 0, not null, so the setter never runs. -->
+    <call class="Box" function="run" return="0">
+        ["nullaware", 9]
+    </call>
+    <output>
+        []
+    </output>
+
+    <!-- Untyped parameter + arrow body. -->
+    <call class="Box" function="run" return="30">
+        ["arrow", 3]
+    </call>
+    <output>
+        []
+    </output>
+
+    <!-- A setter inherited from the superclass. -->
+    <call class="Box" function="run" return="12">
+        ["inherited", 6]
+    </call>
+    <output>
+        []
+    </output>
+
+    <!-- Unqualified `value = n` inside a method. -->
+    <call class="Box" function="run" return="5">
+        ["unqualified", 4]
+    </call>
+    <output>
+        []
+    </output>
+
+    <!-- Explicit `this.value = n`. -->
+    <call class="Box" function="run" return="3">
+        ["this", 2]
+    </call>
+    <output>
+        []
+    </output>
+
+    <!-- Round-trip: setters survive generation, and an arrow-bodied setter is
+         emitted back as an arrow. Emitting it as a block would produce
+         `set x(v) { return …; }`, which Dart rejects (a setter returns void).
+         The generated source was checked with the real `dart analyze`: no
+         errors. Only Dart is pinned here — every other target refuses a setter
+         with `UnsupportedSyntaxError`. -->
+    <source-generated language="dart"><![CDATA[<<<< [SOURCES_BEGIN] >>>>
+<<<< NAMESPACE="" >>>>
+<<<< CODE_UNIT_START="/test" >>>>
+class Base {
+
+  int raw = 0;
+
+  set doubled(int x) {
+    raw = x * 2;
+  }
+
+}
+class Box extends Base {
+
+  int _v = 0;
+
+  int viaUnqualified(int n) {
+    value = n;
+    return this.value;
+  }
+
+  int run(String mode, int n) {
+    if (mode == 'pair') {
+        this.value = n;
+        return this.value;
+    }
+
+    if (mode == 'compound') {
+        _v = 10;
+        this.value += n;
+        return this.value;
+    }
+
+    if (mode == 'nullaware') {
+        _v = 0;
+        this.value ??= n;
+        return this.value;
+    }
+
+    if (mode == 'arrow') {
+        scaled = n;
+        return _v;
+    }
+
+    if (mode == 'inherited') {
+        doubled = n;
+        return raw;
+    }
+
+    if (mode == 'unqualified') {
+        return viaUnqualified(n);
+    }
+
+    if (mode == 'this') {
+        this.value = n;
+        return _v;
+    }
+
+    return -1;
+  }
+
+  int get value {
+    return _v;
+  }
+
+  set value(int x) {
+    _v = x + 1;
+  }
+
+  set scaled(dynamic v) => _v = v * 10;
+
+}
+<<<< CODE_UNIT_END="/test" >>>>
+<<<< [SOURCES_END] >>>>
+]]></source-generated>
+</test>

--- a/test/unit/apollovm_setter_test.dart
+++ b/test/unit/apollovm_setter_test.dart
@@ -27,10 +27,12 @@ Future<Object?> _runStatic(String src, String clazz, String name) async {
   return r.getValueNoContext();
 }
 
+/// Setter-only on purpose. With a getter alongside, the *getter* refusal fires
+/// first for every non-Dart target and satisfies the expectation, so the setter
+/// path would never be reached and the assertion would prove nothing.
 const _classWithSetter = r'''
 class B {
   int _v = 0;
-  int get value => _v;
   set value(int x) { _v = x; }
 }
 ''';
@@ -103,6 +105,55 @@ class B extends A {
           'run',
         ),
         equals(103),
+      );
+    });
+
+    test(
+      'unqualified compound assignment goes through the accessors',
+      () async {
+        // `value += n` with no receiver: reads via the getter, writes via the
+        // setter — the unqualified mirror of `this.value += n`.
+        expect(
+          await _runStatic(
+            r'''
+class B {
+  int _v = 0;
+  int get value => _v;
+  set value(int x) { _v = x + 1; }
+
+  int bump() { value += 5; return this.value; }
+
+  static int run() { var b = B(); b._v = 10; return b.bump(); }
+}
+''',
+            'B',
+            'run',
+          ),
+          // getter -> 10, +5 = 15, setter -> 16.
+          equals(16),
+        );
+      },
+    );
+
+    test('unqualified `??=` short-circuits on a non-null value', () async {
+      expect(
+        await _runStatic(
+          r'''
+class B {
+  int _v = 0;
+  int get value => _v;
+  set value(int x) { _v = x + 1; }
+
+  int bump() { value ??= 9; return this.value; }
+
+  static int run() { var b = B(); b._v = 4; return b.bump(); }
+}
+''',
+          'B',
+          'run',
+        ),
+        // 4 is not null, so the setter never runs.
+        equals(4),
       );
     });
 

--- a/test/unit/apollovm_setter_test.dart
+++ b/test/unit/apollovm_setter_test.dart
@@ -176,6 +176,53 @@ class B {
     });
   });
 
+  group('ASTSetterDeclaration', () {
+    /// The parsed `value` setter of [_classWithSetter].
+    Future<ASTSetterDeclaration> loadSetter() async {
+      var vm = await _load(_classWithSetter);
+      var clazz = vm.getNamespace('dart', '')!.getClass('B')!;
+      var setter = clazz.getSetterWithName('value');
+      expect(setter, isNotNull, reason: 'setter not registered on the class');
+      return setter!;
+    }
+
+    test('is registered by name on its class', () async {
+      var vm = await _load(_classWithSetter);
+      var clazz = vm.getNamespace('dart', '')!.getClass('B')!;
+
+      expect(clazz.setterNames, equals(['value']));
+      expect(clazz.setter, hasLength(1));
+
+      // Lookup is exact by default and can be made case-insensitive, matching
+      // the getter registry.
+      expect(clazz.getSetterWithName('VALUE'), isNull);
+      expect(
+        clazz.getSetterWithName('VALUE', caseInsensitive: true),
+        isNotNull,
+      );
+    });
+
+    test('carries its parameter and renders it', () async {
+      var setter = await loadSetter();
+
+      expect(setter.name, equals('value'));
+      expect(setter.parameterName, equals('x'));
+      expect(setter.parameterType.name, equals('int'));
+      expect('$setter', contains('set value(int x)'));
+    });
+
+    test('refuses to run as a plain block', () async {
+      var setter = await loadSetter();
+
+      // A setter needs its parameter bound, so the generic block entry point is
+      // a guard: it must be invoked through `call(context, value)`.
+      expect(
+        () => setter.run(VMScopeContext(setter), ASTRunStatus()),
+        throwsA(isA<UnsupportedError>()),
+      );
+    });
+  });
+
   group('accessor generation', () {
     // Only Dart emits setters; every other target must refuse rather than drop
     // the accessor and leave method bodies referencing a property that is gone.

--- a/test/unit/apollovm_setter_test.dart
+++ b/test/unit/apollovm_setter_test.dart
@@ -1,0 +1,178 @@
+@Tags(['dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Setter behaviour that the XML definition corpus cannot express: extension
+/// setters, and the per-target *refusals* (a thrown `UnsupportedSyntaxError`
+/// produces no generated source to pin with a `<source-generated>` block).
+
+Future<ApolloVM> _load(String src) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', src, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source");
+  return vm;
+}
+
+Future<Object?> _runFunction(String src, String name) async {
+  var vm = await _load(src);
+  var r = await vm.createRunner('dart')!.executeFunction('', name);
+  return r.getValueNoContext();
+}
+
+Future<Object?> _runStatic(String src, String clazz, String name) async {
+  var vm = await _load(src);
+  var r = await vm.createRunner('dart')!.executeClassMethod('', clazz, name);
+  return r.getValueNoContext();
+}
+
+const _classWithSetter = r'''
+class B {
+  int _v = 0;
+  int get value => _v;
+  set value(int x) { _v = x; }
+}
+''';
+
+const _classWithGetterOnly = r'''
+class B {
+  int _v = 21;
+  int get value => _v * 2;
+}
+''';
+
+void main() {
+  group('extension setters', () {
+    test('an extension setter runs on assignment', () async {
+      expect(
+        await _runFunction(r'''
+class Box { int v = 0; }
+extension E on Box { set doubled(int x) { v = x * 2; } }
+int run() { var b = Box(); b.doubled = 21; return b.v; }
+''', 'run'),
+        equals(42),
+      );
+    });
+
+    test('an extension getter/setter pair round-trips a value', () async {
+      expect(
+        await _runFunction(r'''
+class Box { int v = 0; }
+extension E on Box {
+  int get half => v ~/ 2;
+  set half(int x) { v = x * 2; }
+}
+int run() { var b = Box(); b.half = 10; return b.half + b.v; }
+''', 'run'),
+        // half = 10 -> v = 20; then half == 10, v == 20.
+        equals(30),
+      );
+    });
+  });
+
+  group('setter semantics', () {
+    test('a setter-only property cannot be read', () async {
+      await expectLater(
+        () => _runStatic(
+          r'''
+class B {
+  int v = 0;
+  set value(int x) { v = x; }
+  static int run() { var b = B(); b.value = 5; return b.value; }
+}
+''',
+          'B',
+          'run',
+        ),
+        throwsA(isA<ApolloVMRuntimeError>()),
+      );
+    });
+
+    test('a subclass override wins over the inherited setter', () async {
+      expect(
+        await _runStatic(
+          r'''
+class A { int v = 0; set value(int x) { v = x * 4; } }
+class B extends A {
+  set value(int x) { v = x + 100; }
+  static int run() { var b = B(); b.value = 3; return b.v; }
+}
+''',
+          'B',
+          'run',
+        ),
+        equals(103),
+      );
+    });
+
+    test('the parameter shadows the property it sets', () async {
+      // `value` inside the body is the parameter, not a recursive setter call.
+      expect(
+        await _runStatic(
+          r'''
+class B {
+  int v = 0;
+  set value(int value) { v = value * 2; }
+  static int run() { var b = B(); b.value = 6; return b.v; }
+}
+''',
+          'B',
+          'run',
+        ),
+        equals(12),
+      );
+    });
+  });
+
+  group('accessor generation', () {
+    // Only Dart emits setters; every other target must refuse rather than drop
+    // the accessor and leave method bodies referencing a property that is gone.
+    const refusingTargets = [
+      'java11',
+      'csharp',
+      'javascript',
+      'typescript',
+      'kotlin',
+      'python',
+      'go',
+      'lua',
+    ];
+
+    test('Dart emits a setter', () async {
+      var vm = await _load(_classWithSetter);
+      var storage = vm.generateAllCodeIn('dart');
+      var src = (await storage.writeAllSources()).toString();
+      expect(src, contains('set value(int x)'));
+    });
+
+    for (var target in refusingTargets) {
+      test('$target refuses a setter', () async {
+        var vm = await _load(_classWithSetter);
+        expect(
+          () => vm.generateAllCodeIn(target),
+          throwsA(isA<UnsupportedSyntaxError>()),
+        );
+      });
+    }
+
+    // Regression: Python, Go and Lua never iterated the class's accessors, so a
+    // getter was silently dropped while the bodies kept referencing it.
+    for (var target in ['python', 'go', 'lua']) {
+      test('$target refuses a getter instead of dropping it', () async {
+        var vm = await _load(_classWithGetterOnly);
+        expect(
+          () => vm.generateAllCodeIn(target),
+          throwsA(isA<UnsupportedSyntaxError>()),
+        );
+      });
+    }
+
+    test('Kotlin still emits getters', () async {
+      var vm = await _load(_classWithGetterOnly);
+      var storage = vm.generateAllCodeIn('kotlin');
+      var src = (await storage.writeAllSources()).toString();
+      expect(src, contains('val value'));
+    });
+  });
+}


### PR DESCRIPTION
## Why

Setters were the last accessor with no support at all: no grammar rule, no AST
node, no dispatch. `2.26.0` turned `set value(int v) {}` from a silent misparse
(into a method named `value` returning a type named `set`) into a clean parse
error. This makes it work.

## What works

```dart
class Box {
  int _v = 0;
  int get value => _v;
  set value(int x) { _v = x; }
  set scaled(v) => _v = v * 10;   // untyped parameter, arrow body
}
```

Parsed on classes and extensions, typed or untyped parameter, arrow or block
body. The setter runs on **every** write position:

- `obj.x = v`
- `this.x = v`
- an unqualified `x = v` inside the class — the write-side mirror of an
  unqualified getter read

A real variable in scope still wins, so a setter's own parameter cannot
re-enter it. Compound assignment (`obj.x += 1`) reads through the getter when
there is one and falls back to the backing field. Inherited and overridden
setters resolve through the superclass chain; extension setters work like
extension getters.

## Implementation

Mirrors the getter subsystem end to end:

- `ASTSetterDeclaration` / `ASTClassSetterDeclaration` — a block with one
  declared parameter instead of a return type. `call(context, value)` binds the
  parameter, runs the body, and yields void: the *assignment* evaluates to the
  assigned value, as in Dart.
- A `_setters` registry on `ASTBlock` with the same surface as `_getters`, plus
  superclass resolution on `ASTClassNormal`, `ASTRoot.getExtensionSetter`, and
  `VMContext.getSetter`.
- Grammar `setterDeclaration()` in class bodies and extensions. The parameter is
  an ordered choice rather than `type().optional() & identifier()`, which cannot
  backtrack and so rejected the untyped form.

## Three bugs this surfaced

- **`ASTBlock.set` dropped setters.** It copied functions, getters and
  statements — so every class member survived the temporary parse block except
  the new ones. This is why the setter body ran zero times end-to-end at first.
- **`??=` did not short-circuit.** It ran the setter even when the current value
  was non-null; Dart does not. Caught by the test definition, fixed on both the
  qualified and unqualified paths.
- **Invalid generated Dart.** An arrow-bodied setter parses into a single
  `return <expr>;`, which was emitted as `set x(v) { return …; }` — rejected by
  Dart, since a setter returns void. It now regenerates as an arrow.

## Also fixes: accessors silently dropped for Python, Go and Lua

Those three generators never iterated the class's accessors, so a class with a
getter translated to any of them **lost the accessor entirely** while the method
bodies kept referencing the property — broken code that looked fine, rather than
the honest `UnsupportedSyntaxError` Java/C#/JS/TS already produced. They now
refuse, like the others. Wasm refuses setters rather than letting an assignment
silently write the backing field instead of running the body.

Only Dart *generates* setters. Kotlin still generates getters but not setters —
pairing them into a Kotlin `var x: T get() … set(value) …` needs both accessors
emitted together, which is a separate change.

## Verification

- 2081 tests green (2080 on master), `dart format` and
  `dart analyze --fatal-infos --fatal-warnings .` clean.
- `dart_setter.test.xml` covers each position and shape: getter/setter pair,
  setter-only backed by a field, untyped parameter, arrow body, a parameter
  named like its own property, inheritance, `obj.x =`, `this.x =`, unqualified
  `x =`, `+=` and `??=`.
- The generated Dart is pinned by a round-trip block **and** was checked with
  the real `dart analyze`: no errors.

## Reviewer notes

Two hot-path changes worth a look: the unqualified-assignment setter lookup in
`ASTExpressionVariableAssignment.run`, and the setter dispatch in
`ASTExpressionObjectSetterAssignment.run`. Both short-circuit on a declared
variable before consulting the accessor registry.

I started the read-side mirror (`return value;` unqualified) and **backed it
out**: the single choke point is `ASTScopeVariable.resolveVariable`, which
serves reads *and* writes, so a fallback there risks silently swallowing a write
to a getter-only property — the same silent-corruption class this PR removes
elsewhere. It is also the interpreter's hottest path. It deserves its own change
with benchmarking rather than riding along here.

Still unsupported, for getters and setters alike: `static` accessors, top-level
accessors, and unqualified getter *reads* (`this.value` works). All documented
in the README footnote and CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)