### PR TITLE
Binary AST serialization (`.avma`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,97 @@
+## 2.28.0
+
+### Binary AST serialization
+
+A parsed AST can now be saved as a compact binary image (`.avma`) and loaded
+back without running a parser. Parsing dominates the cost of loading code, so an
+application can parse once — at build time, or on first run — and afterwards
+load the same code unit by decoding bytes.
+
+Measured on a ~4 KB Dart program: decoding is about **11× faster** than parsing
+and the image is about **two thirds** the size of the source. For a very small
+unit the fixed header and pools cost more than the source is worth; the saving
+appears once there is a program to speak of.
+
+```dart
+import 'package:apollovm/apollovm_serialization.dart';
+
+var image = vm.saveCodeUnitAST(codeUnit);   // Uint8List
+await ApolloVM().loadCodeUnitAST(image);    // no parser involved
+```
+
+`vm.saveAllAST()` / `vm.loadAllAST()` do the same for a whole VM, bundling every
+loaded code unit into one archive. The CLI gained
+`apollovm compile --target=ast`, and `apollovm run` recognizes an image by its
+magic bytes — not its extension — taking the language from the image itself.
+
+Everything is `Uint8List` in and `Uint8List` out, so file access stays with the
+caller and the whole feature works unchanged on the web. The Chrome suite covers
+it, including the places where a JavaScript double behaves unlike a VM `int`.
+
+Loading a decoded unit needs no new path: `ApolloVM.loadCodeUnit` only reaches
+for a parser when a unit has no AST yet, so namespace registration, the
+null-safety check and incremental-resolution invalidation all behave exactly as
+they do for parsed source. Nothing derivable is stored — parent links,
+scope-variable resolution, superclass and extension targets and the `this.field`
+constructor-parameter promotion are re-established by one `resolveNode` call
+after decoding, exactly as every grammar does after a parse.
+
+Nodes holding live Dart state are refused with an error naming where in the
+program they were found: external functions and getters, which carry a closure,
+and runtime values such as a class instance or a pending future. All of them are
+injected by the VM at run time rather than produced by a parser, so a parsed AST
+never contains them and the same bindings are re-injected after a binary load.
+
+Coverage is enforced by a test that scans `lib/src/ast/` and requires every
+concrete `AST*` class to be registered, pooled as a type, encoded inline by a
+parent, or listed as refused with a written reason — so adding a node kind and
+forgetting its codec fails the build rather than silently dropping a field.
+
+### Binary AST integrity
+
+Every image carries a CRC-32, verified on load. **It detects corruption, not
+tampering:** anyone who can modify a file can recompute the checksum in
+microseconds. Only a signature made with a key the attacker does not have makes
+an image tamper-evident, and an unsigned image deserves exactly as much trust as
+the source it came from — loading one and running it is equivalent to running
+arbitrary code from that source.
+
+Signing is optional and pluggable (`ASTBinarySigner` / `ASTBinaryVerifier`), so
+an HMAC, a public-key signature or a hardware key store all fit;
+`HmacSha256Signer` is built in, which is why `crypto` becomes a direct
+dependency — it was already present transitively. The signature covers
+everything up to and including the CRC, so an attacker who edits a section and
+recomputes the checksum still fails verification.
+
+### Binary AST compatibility
+
+An image records two version numbers: the container revision that wrote it, and
+the oldest revision that can decode it correctly. Every section is
+length-prefixed, so a reader skips any section it does not recognize, and every
+section is decoded from a bounded view, so fields appended by a newer writer are
+ignored rather than misread. A newer ApolloVM's output therefore keeps loading
+in an older ApolloVM for as long as the new information is purely additive, and
+an older image keeps loading in every future ApolloVM — the reader retains the
+decode path for every format version it has ever supported. When a change
+genuinely cannot be understood by an older reader, the writer raises the minimum
+reader version and that older reader fails immediately with an
+`ASTBinaryException` naming both versions, rather than silently producing a
+wrong AST. Raising it is a breaking change and will only ever ship in a major
+release, announced here.
+
+A real image written by format version 1 is committed in the test suite and must
+keep loading; it is the only check that can catch an accidental incompatible
+change, since an image synthesized by the current writer would move with it.
+
+### Note: `data_serializer` signed LEB128
+
+`BytesBuffer.readLeb128SignedInt` in `data_serializer` 1.2.2 does not
+sign-extend correctly — it records the byte *before* the terminating one, so the
+sign test reads the wrong byte and `-2` decodes as `126`, `64` as `-16320`. The
+static `Leb128.decodeSigned` is unaffected. The binary AST format avoids the
+buffer method entirely, writing a form byte plus an unsigned magnitude, which
+also removes any sign-extension difference between the VM and `dart2js`.
+
 ## 2.27.0
 
 ### Dart setters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,14 +86,31 @@ A real image written by format version 1 is committed in the test suite and must
 keep loading; it is the only check that can catch an accidental incompatible
 change, since an image synthesized by the current writer would move with it.
 
-### Note: `data_serializer` signed LEB128
+### Requires `data_serializer` 1.2.3
 
-`BytesBuffer.readLeb128SignedInt` in `data_serializer` 1.2.2 does not
-sign-extend correctly — it records the byte *before* the terminating one, so the
-sign test reads the wrong byte and `-2` decodes as `126`, `64` as `-16320`. The
-static `Leb128.decodeSigned` is unaffected. The binary AST format avoids the
-buffer method entirely, writing a form byte plus an unsigned magnitude, which
-also removes any sign-extension difference between the VM and `dart2js`.
+The dependency is raised to `^1.2.3`, and this is a requirement rather than a
+preference: earlier versions decode LEB128 incorrectly, which silently
+corrupts a binary AST image.
+
+Building this format surfaced four bugs there, fixed in 1.2.3:
+
+- `BytesBuffer.readLeb128SignedInt` sign-extended from the wrong byte on every
+  platform, so `-2` decoded as `126` and `64` as `-16320`. The binary AST format
+  sidesteps it anyway by writing a form byte plus an unsigned magnitude — which
+  also removes any sign-extension difference between the VM and `dart2js` — but
+  the remaining three could not be sidestepped.
+- On the web, `shiftLeftInt`/`shiftRightInt` fell back to a 32-bit `<<`/`>>`,
+  so any shift of 32 or more produced `0`.
+- On the web, the LEB128 accumulator used `|=`, also a 32-bit operation, and
+  dropped the high bits of any value past 2^32.
+- On the web, signed decoding lost precision above roughly 2^49, because a
+  negative's *unsigned* intermediate is about `2^shift` — the range
+  `DateTime.microsecondsSinceEpoch` occupies.
+
+Together those meant an integer literal of 2^32 or more decoded to the wrong
+number on the web: `4294967296` came back as `0`, and `1000000000000000` as
+`2764472320`. A test now covers literals from 2^28 upwards, positive and
+negative, and it runs under `--platform chrome`.
 
 ## 2.27.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ### Binary AST serialization
 
-A parsed AST can now be saved as a compact binary image (`.avma`) and loaded
-back without running a parser. Parsing dominates the cost of loading code, so an
-application can parse once — at build time, or on first run — and afterwards
-load the same code unit by decoding bytes.
+A parsed AST can now be saved as a compact binary image and loaded back without
+running a parser. Parsing dominates the cost of loading code, so an application
+can parse once — at build time, or on first run — and afterwards load the same
+code unit by decoding bytes.
+
+Such an image is an `.avma` file: an **A**pollo **V**irtual **M**achine
+**A**rchive. It holds one parsed code unit, or a whole VM's worth of them.
 
 Measured on a ~4 KB Dart program: decoding is about **11× faster** than parsing
 and the image is about **two thirds** the size of the source. For a very small

--- a/README.md
+++ b/README.md
@@ -1039,6 +1039,102 @@ Generated `Wasm` bytes with description:
 
 -----------------------------
 
+## Binary AST
+
+Parsing dominates the cost of loading code. ApolloVM can save an already-parsed
+AST as a compact binary image (`.avma`), so an application parses once — at
+build time, or on first run — and afterwards loads the same code unit by
+decoding bytes, with no grammar and no backtracking.
+
+On a ~4 KB program, decoding is around **11× faster than parsing**, and the
+image is about **two thirds the size** of the source. (For a very small unit the
+fixed header and pools cost more than the source is worth; the saving appears
+once there is a program to speak of.)
+
+```dart
+import 'package:apollovm/apollovm.dart';
+import 'package:apollovm/apollovm_serialization.dart';
+
+// Once, wherever the source is available:
+var vm = ApolloVM();
+var codeUnit = SourceCodeUnit('dart', source, id: 'calc.dart');
+await vm.loadCodeUnit(codeUnit);
+
+var image = vm.saveCodeUnitAST(codeUnit);   // Uint8List
+
+// Afterwards, with no parser involved:
+var vm2 = ApolloVM();
+await vm2.loadCodeUnitAST(image);
+
+var runner = vm2.createRunner('dart')!;
+await runner.executeClassMethod('', 'Calc', 'main', positionalParameters: [[]]);
+```
+
+A whole VM can be bundled into one archive and loaded back:
+
+```dart
+var archive = vm.saveAllAST();              // every loaded code unit
+await ApolloVM().loadAllAST(archive);
+```
+
+Everything is `Uint8List` in and `Uint8List` out — reading and writing files is
+left to the caller — so this works unchanged on the web.
+
+### From the command line
+
+```sh
+apollovm compile --target=ast calc.dart     # writes calc.avma
+apollovm run calc.avma                      # runs it, without parsing
+```
+
+`run` detects an image by its magic bytes rather than its extension, and takes
+the language from the image itself.
+
+### Integrity
+
+Every image carries a **CRC-32**, verified on load.
+
+> **The checksum detects corruption, not tampering.** Anyone who can modify a
+> file can recompute it in microseconds. Only a signature made with a key the
+> attacker does not have makes an image tamper-evident. An unsigned image
+> deserves exactly as much trust as the source it came from — loading one and
+> running it is equivalent to running arbitrary code from that source, so do not
+> load an unsigned image from an untrusted origin.
+
+Signing is optional and pluggable, with HMAC-SHA256 built in:
+
+```dart
+var image = vm.saveCodeUnitAST(
+  codeUnit,
+  signer: HmacSha256Signer.fromString(secret),
+);
+
+// Refuses to load unless the signature verifies with this key:
+await vm2.loadCodeUnitAST(
+  image,
+  verifier: HmacSha256Verifier.fromString(secret),
+);
+```
+
+Implement `ASTBinarySigner` / `ASTBinaryVerifier` for a public-key scheme or a
+hardware key store; the container stores a signature as opaque bytes.
+
+### Compatibility
+
+An image records the container revision that wrote it and the oldest revision
+that can decode it correctly. Sections are length-prefixed, so a reader skips
+any it does not recognize, and each is read from a bounded view, so fields a
+newer writer appended are ignored rather than misread. A newer ApolloVM's output
+therefore keeps loading in an older one for as long as the additions are purely
+additive, and an older image keeps loading in every later ApolloVM. When a
+change genuinely cannot be understood, the reader fails with an
+`ASTBinaryException` naming both versions instead of producing a wrong AST.
+
+See [`doc/ast_binary_format.md`](doc/ast_binary_format.md) for the byte-level
+specification.
+
+-----------------------------
+
 ## MCP Server
 
 ApolloVM ships an **MCP (Model Context Protocol)** server that exposes the VM as a

--- a/README.md
+++ b/README.md
@@ -1042,9 +1042,12 @@ Generated `Wasm` bytes with description:
 ## Binary AST
 
 Parsing dominates the cost of loading code. ApolloVM can save an already-parsed
-AST as a compact binary image (`.avma`), so an application parses once — at
-build time, or on first run — and afterwards loads the same code unit by
-decoding bytes, with no grammar and no backtracking.
+AST as a compact binary image, so an application parses once — at build time, or
+on first run — and afterwards loads the same code unit by decoding bytes, with
+no grammar and no backtracking.
+
+Such an image is an **`.avma`** file: an **A**pollo **V**irtual **M**achine
+**A**rchive. It carries one parsed code unit, or a whole VM's worth of them.
 
 On a ~4 KB program, decoding is around **11× faster than parsing**, and the
 image is about **two thirds the size** of the source. (For a very small unit the
@@ -1088,7 +1091,9 @@ apollovm run calc.avma                      # runs it, without parsing
 ```
 
 `run` detects an image by its magic bytes rather than its extension, and takes
-the language from the image itself.
+the language from the image itself. The `.avma` extension is only a convention —
+it decides the default output name, nothing more — so an image named anything
+else still runs.
 
 ### Integrity
 

--- a/bin/apollovm.dart
+++ b/bin/apollovm.dart
@@ -4,6 +4,7 @@ import 'package:apollovm/apollovm.dart';
 import 'package:apollovm/apollovm_lsp.dart';
 import 'package:apollovm/apollovm_mcp_io.dart';
 import 'package:apollovm/apollovm_pub.dart';
+import 'package:apollovm/apollovm_serialization.dart';
 import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:swiss_knife/swiss_knife.dart';
@@ -219,7 +220,8 @@ Examples:
   apollovm run script.dart
   apollovm run app.py --function start
   apollovm run prog.java main foo bar      # call `main` with args foo, bar
-  apollovm run module.wasm''';
+  apollovm run module.wasm
+  apollovm run calc.avma                   # a binary AST image; no parsing''';
 
   CommandRun() {
     argParser.addOption(
@@ -239,29 +241,45 @@ Examples:
   FutureOr<bool> run() async {
     var parameters = this.parameters;
 
-    if (verbose) {
-      _log(
-        'RUN',
-        '$sourceFile ; language: $language > $mainFunction( $parameters )',
-      );
-    }
-
     var vm = ApolloVM(nullSafetyChecks: nullSafetyChecks);
 
-    // A `.wasm` file is a binary module: load its bytes as a `BinaryCodeUnit`
-    // (parsed by `ApolloParserWasm` into its exported functions) and run it
-    // through the Wasm runtime, rather than decoding the binary as UTF-8 source.
+    // A binary AST image already holds a parsed program, and records which
+    // language it came from — so it is detected by its magic bytes rather than
+    // by its extension, and the recorded language wins over anything the file
+    // name suggests.
+    var fileBytes = sourceFile.readAsBytesSync();
+    var isBinaryAST = ASTBinaryReader.isASTBinary(fileBytes);
+
     CodeUnit<Object> codeUnit;
-    if (language == 'wasm') {
-      var bytes = sourceFile.readAsBytesSync();
+    String effectiveLanguage;
+
+    if (isBinaryAST) {
+      codeUnit = const ASTBinaryReader().readCodeUnit(fileBytes);
+      effectiveLanguage = codeUnit.language;
+    } else if (language == 'wasm') {
+      // A `.wasm` file is a binary module: load its bytes as a
+      // `BinaryCodeUnit` (parsed by `ApolloParserWasm` into its exported
+      // functions) and run it through the Wasm runtime, rather than decoding
+      // the binary as UTF-8 source.
+      effectiveLanguage = 'wasm';
       codeUnit = BinaryCodeUnit(
         'wasm',
-        bytes,
+        fileBytes,
         id: sourceFilePath,
         namespace: '',
       );
     } else {
+      effectiveLanguage = language;
       codeUnit = SourceCodeUnit(language, source, id: sourceFilePath);
+    }
+
+    if (verbose) {
+      _log(
+        'RUN',
+        '$sourceFile ; language: $effectiveLanguage'
+            '${isBinaryAST ? ' (binary AST)' : ''} > '
+            '$mainFunction( $parameters )',
+      );
     }
 
     var loadOK = await loadCodeUnitReporting(vm, codeUnit);
@@ -277,9 +295,9 @@ Examples:
 
     await installPackageImporter(vm);
 
-    var runner = vm.createRunner(language)!;
+    var runner = vm.createRunner(effectiveLanguage)!;
 
-    var namespaces = vm.getLanguageNamespaces(language).namespaces;
+    var namespaces = vm.getLanguageNamespaces(effectiveLanguage).namespaces;
     if (!namespaces.contains('')) namespaces.insert(0, '');
 
     ASTValue? result;
@@ -297,7 +315,7 @@ Examples:
       LOOP_NS:
       for (var namespace in namespaces) {
         var classes = vm
-            .getLanguageNamespaces(language)
+            .getLanguageNamespaces(effectiveLanguage)
             .get(namespace)
             .classesNames;
         for (var clazz in classes) {
@@ -406,22 +424,28 @@ class CommandCompile extends CommandSourceFileBase {
 
 Examples:
   apollovm compile calc.dart               # writes calc.wasm
-  apollovm compile calc.dart -o build/calc.wasm''';
+  apollovm compile calc.dart -o build/calc.wasm
+  apollovm compile calc.dart --target=ast  # writes calc.avma (binary AST)''';
 
   CommandCompile() {
     argParser.addOption(
       'output',
       abbr: 'o',
       help:
-          'Output file path (defaults to <source>.wasm, alongside the source file).\n'
-          'If multiple modules are produced, the module name is inserted before `.wasm`.',
+          'Output file path (defaults to <source>.wasm or <source>.avma,\n'
+          'alongside the source file).\n'
+          'If multiple Wasm modules are produced, the module name is inserted before `.wasm`.',
       valueHelp: 'file.wasm',
     );
     argParser.addOption(
       'target',
-      help: 'Binary target (currently: wasm).',
+      help:
+          'Binary target:\n'
+          '  wasm  WebAssembly module.\n'
+          '  ast   Binary AST image (`.avma`) — the parsed program, so it can\n'
+          '        be loaded later without running a parser.',
       defaultsTo: 'wasm',
-      valueHelp: 'wasm',
+      valueHelp: 'wasm|ast',
     );
   }
 
@@ -438,7 +462,7 @@ Examples:
       _log('COMPILE', '$sourceFile ; language: $language > target: $target');
     }
 
-    if (target != 'wasm') {
+    if (target != 'wasm' && target != 'ast') {
       throw StateError('Unsupported compile target: $target');
     }
 
@@ -459,6 +483,20 @@ Examples:
 
     await installPackageImporter(vm);
 
+    if (target == 'ast') {
+      var image = vm.saveCodeUnitAST(codeUnit);
+      var filePath =
+          output ?? _defaultOutputPath(ASTBinaryFormat.fileExtension);
+
+      File(filePath).writeAsBytesSync(image);
+
+      print(
+        'Wrote: $filePath (${image.length} bytes, '
+        'source: ${source.length} bytes)',
+      );
+      return true;
+    }
+
     var storageWasm = vm.generateAllIn<BytesOutput>('wasm');
     var wasmModules = await storageWasm.allEntries();
 
@@ -475,7 +513,7 @@ Examples:
       );
     }
 
-    var outputPath = output ?? _defaultOutputPath();
+    var outputPath = output ?? _defaultOutputPath('wasm');
 
     var single = modules.length == 1;
 
@@ -495,7 +533,7 @@ Examples:
     return true;
   }
 
-  String _defaultOutputPath() {
+  String _defaultOutputPath(String extension) {
     var path = sourceFilePath;
     // Strip the extension from the FILE NAME only — `getPathExtension` keys off
     // the last `.` anywhere in the path, which would wrongly truncate when the
@@ -506,9 +544,10 @@ Examples:
     var dot = name.lastIndexOf('.');
     if (dot > 0) {
       // The file name has a real extension to replace.
-      return '${path.substring(0, path.length - (name.length - dot))}.wasm';
+      return '${path.substring(0, path.length - (name.length - dot))}'
+          '.$extension';
     }
-    return '$path.wasm';
+    return '$path.$extension';
   }
 
   String _insertModuleName(String outputPath, String moduleName) {

--- a/bin/apollovm.dart
+++ b/bin/apollovm.dart
@@ -442,8 +442,9 @@ Examples:
       help:
           'Binary target:\n'
           '  wasm  WebAssembly module.\n'
-          '  ast   Binary AST image (`.avma`) — the parsed program, so it can\n'
-          '        be loaded later without running a parser.',
+          '  ast   Binary AST image (`.avma`, an Apollo Virtual Machine\n'
+          '        Archive) — the parsed program, so it can be loaded later\n'
+          '        without running a parser.',
       defaultsTo: 'wasm',
       valueHelp: 'wasm|ast',
     );

--- a/doc/ast_binary_format.md
+++ b/doc/ast_binary_format.md
@@ -1,0 +1,170 @@
+# Binary AST format (`.avma`)
+
+A `.avma` file stores an already-parsed ApolloVM AST, so a code unit can be
+loaded without running a parser. Parsing dominates the cost of loading code;
+decoding an image of a ~4 KB program is roughly **11× faster** than parsing it,
+and the image is about **two thirds** the size of the source.
+
+Everything here is `Uint8List` in and `Uint8List` out. Reading and writing files
+is left to the caller, which is why the library is web-safe and has no
+`dart:io` variant.
+
+## File layout
+
+| Offset | Size | Field | Notes |
+| --- | --- | --- | --- |
+| 0 | 4 | `magic` | `\0AVM` — `00 41 56 4D` |
+| 4 | 2 | `formatVersion` | uint16 BE. The container revision that wrote this file. |
+| 6 | 2 | `minReaderVersion` | uint16 BE. The oldest reader that can decode it correctly. |
+| 8 | 4 | `flags` | uint32 BE bitfield. |
+| 12 | 4 | `sectionsSize` | uint32 BE. Byte length of the section stream. |
+| 16 | … | `sections` | Repeated, until `sectionsSize` bytes are consumed. |
+| `T` | 4 | `crc32` | uint32 BE, over bytes `[0, T)`. |
+| `T+4` | 2 | `signatureLength` | uint16 BE. `0` when unsigned. |
+| `T+6` | … | `signature` | Present when `flags.signed`. |
+| … | 4 | `trailerMagic` | `AVM\0` — `41 56 4D 00` |
+
+where `T = 16 + sectionsSize`. The total length is always
+`26 + sectionsSize + signatureLength`, so truncation and trailing garbage are
+detected structurally, before any integrity arithmetic.
+
+All fixed-width fields are **big-endian**. `Endian.host` is never used.
+
+### Sections
+
+```
+sectionId    : LEB128 unsigned
+payloadSize  : LEB128 unsigned
+payload      : payloadSize bytes
+```
+
+| Id | Name | Payload |
+| --- | --- | --- |
+| `0x00` | `custom` | A LEB128-prefixed name, then arbitrary bytes. Always ignored. |
+| `0x01` | `metadata` | Writer version, language, code unit id, namespace. **Required.** |
+| `0x02` | `stringTable` | The interned strings the AST indexes into. |
+| `0x03` | `typeTable` | The interned `ASTType`s the AST indexes into. |
+| `0x04` | `astRoot` | The encoded `ASTRoot`. **Required.** |
+| `0x05` | `sourceRef` | Reserved: length and checksum of the originating source. |
+| `0x06` | `sectionIndex` | Reserved: offsets and sizes, for random access. |
+| `0x07` | `archiveEntry` | One code unit of an archive: a complete nested image. |
+
+Because every section is length-prefixed, a reader **skips any id it does not
+know**. That is the whole mechanism by which a file written by a newer ApolloVM
+keeps loading in an older one.
+
+### Flags
+
+| Bit | Name | Meaning |
+| --- | --- | --- |
+| `0x01` | `signed` | A signature is present in the trailer. |
+| `0x02` | `hasSectionIndex` | A `sectionIndex` section is present. |
+| `0x04` | `hasSourceRef` | A `sourceRef` section is present. |
+| `0x08` | `archive` | The file bundles several code units. |
+
+An unknown **flag** bit is *rejected*, unlike an unknown section. A flag changes
+how the payload must be interpreted, so ignoring one would mean mis-decoding
+rather than merely missing information. Purely additive information belongs in a
+new section instead.
+
+## Integrity
+
+The CRC-32 (IEEE, reflected, polynomial `0xEDB88320`) covers the header and
+every section, and is verified on every read.
+
+**It detects corruption, not tampering.** Anyone who can modify a file can
+recompute the checksum in microseconds. Only a signature made with a key the
+attacker does not have makes an image tamper-evident. An unsigned image deserves
+exactly as much trust as the source it came from — loading one and running it is
+equivalent to running arbitrary code from that source.
+
+Signing is optional and pluggable (`ASTBinarySigner` / `ASTBinaryVerifier`), so
+an HMAC, a public-key signature or a hardware key store all fit;
+`HmacSha256Signer` is built in. The signature covers everything up to **and
+including the CRC**, which is the point: an attacker who edits a section and
+recomputes the checksum still fails verification.
+
+Verification defaults:
+
+- The CRC is checked unless `verifyChecksum: false` (for forensics and repair
+  tooling, not for loading).
+- Signature checking is opt-in. Passing a verifier requires the image to be
+  signed and to verify; a signed image read *without* a verifier still loads,
+  with `ASTBinaryInfo.isSigned` reporting that a signature was there.
+
+## Compatibility
+
+Two version numbers. `formatVersion` is what the writer emitted;
+`minReaderVersion` is the oldest reader that can still make sense of the
+payload.
+
+A reader accepts any file whose `minReaderVersion` it satisfies, and refuses one
+it does not — loudly, naming both versions, rather than producing a wrong AST.
+Three layers of tolerance apply on top:
+
+1. **Unknown sections are skipped.** New capabilities should ship as new
+   sections for exactly this reason.
+2. **Trailing fields in a known section are ignored**, because each section is
+   decoded from a bounded view.
+3. **Per-feature gating** — `ASTBinaryReadContext.formatVersion` is available to
+   every codec, so a field added in a later revision is read conditionally and
+   the older branch is kept forever.
+
+`minReaderVersion` stays at `1` as long as every change is expressible as a new
+section, a field appended to the end of an existing one, or a `custom` section.
+It is raised only for a change that is genuinely not skippable — reinterpreting
+an existing field, compressing the stream, changing the framing, or adding a
+semantics-changing flag. **Raising it is a breaking change** and ships only in a
+major release.
+
+Node tags are append-only and never reused. A removed tag is recorded in
+`ASTNodeTag.retired` rather than becoming available again, so an old image is
+diagnosed precisely instead of decoding as whatever took its number.
+
+## Encoding notes
+
+- **Strings** are pooled. Identifiers repeat pervasively in a parsed program, so
+  this is where most of the size reduction comes from. Index assignment is
+  first-seen order — an implementation detail of the writer, not part of the
+  format.
+- **Types** are pooled too, and the pool carries a correctness contract: the two
+  dozen interned `ASTType` singletons decode back to *the same object*, because
+  `ASTConstructorParameterDeclaration.resolveNode` compares against
+  `ASTTypeConstructorThis.instance` with `identical`. Nullability is part of the
+  pool key, so a nullable use of a type never shares an entry with — or mutates
+  — the non-nullable singleton. `ASTTypeVar` is deliberately *never* shared: each
+  one is wired to its own initializer and caches the type it infers from it.
+- **Enums** are stored **by name**. An index silently mis-decodes every older
+  file the moment a member is inserted mid-enum, and with the string pool the
+  cost is one byte per occurrence either way.
+- **Integers** are a form byte plus an unsigned LEB128 magnitude, not signed
+  LEB128. Values beyond 2^53 — which a JavaScript double cannot hold — fall back
+  to a decimal string, so a VM-written image stays readable and a `dart2js`
+  reader that meets one fails with a clear message rather than silently rounding.
+- **`ASTModifiers`** is a single byte: seven flags, one spare bit.
+- **Lists** are written as `n + 1`, so `0` means "the list itself was null" — a
+  distinction the code generators rely on.
+
+Nothing derivable is stored. Parent links, scope-variable resolution, superclass
+and extension targets, and the `this.field` constructor-parameter promotion are
+all re-established by one `root.resolveNode(null)` after decoding, exactly as
+every grammar does after a parse.
+
+## What is not encoded
+
+Nodes holding live Dart state are refused by the writer, with an error naming
+where in the program they were found:
+
+- `ASTExternalFunction`, `ASTExternalClassFunction`, `ASTExternalGetter`,
+  `ASTExternalClassGetter` — each holds a Dart closure.
+- `ASTValueFunction`, `ASTValueFuture`, `ASTClassInstance`,
+  `ASTClassStaticAccessor`, `ASTRuntimeVariable` — runtime values.
+
+All of these are injected by `ApolloExternalFunctionMapper`,
+`ApolloExternalGetterMapper` or `ApolloVMCore` at run time and are never
+produced by a parser, so a parsed AST does not contain them and the same
+bindings are re-injected after a binary load.
+
+`test/unit/apollovm_ast_binary_coverage_test.dart` enforces this: it scans
+`lib/src/ast/` and requires every concrete `AST*` class to be registered,
+pooled, encoded inline by a parent, or listed as refused with a reason.

--- a/doc/ast_binary_format.md
+++ b/doc/ast_binary_format.md
@@ -1,7 +1,9 @@
 # Binary AST format (`.avma`)
 
-A `.avma` file stores an already-parsed ApolloVM AST, so a code unit can be
-loaded without running a parser. Parsing dominates the cost of loading code;
+`.avma` stands for **A**pollo **V**irtual **M**achine **A**rchive.
+
+Such a file stores an already-parsed ApolloVM AST, so a code unit can be loaded
+without running a parser. Parsing dominates the cost of loading code;
 decoding an image of a ~4 KB program is roughly **11× faster** than parsing it,
 and the image is about **two thirds** the size of the source.
 
@@ -29,6 +31,11 @@ where `T = 16 + sectionsSize`. The total length is always
 detected structurally, before any integrity arithmetic.
 
 All fixed-width fields are **big-endian**. `Endian.host` is never used.
+
+The extension is a convention only — nothing depends on it. A file is
+identified by its `magic`, which is why `apollovm run` works on an image
+whatever it was named; `.avma` merely decides the default output name when none
+is given.
 
 ### Sections
 

--- a/lib/apollovm_serialization.dart
+++ b/lib/apollovm_serialization.dart
@@ -1,0 +1,65 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+/// Binary serialization of a parsed ApolloVM AST.
+///
+/// Parsing dominates the cost of loading code. This library stores an
+/// already-parsed [ASTRoot] as a compact `.avma` image, so an application can
+/// parse once — at build time, or on first run — and afterwards load the same
+/// code unit by decoding bytes, with no grammar and no backtracking.
+///
+/// ```dart
+/// // Once, wherever the source is available:
+/// var vm = ApolloVM();
+/// var codeUnit = SourceCodeUnit('dart', source, id: 'calc.dart');
+/// await vm.loadCodeUnit(codeUnit);
+/// var image = vm.saveCodeUnitAST(codeUnit);
+///
+/// // Afterwards, with no parser involved:
+/// var vm2 = ApolloVM();
+/// await vm2.loadCodeUnitAST(image);
+/// ```
+///
+/// Everything here is `Uint8List` in and `Uint8List` out: reading and writing
+/// files is left to the caller, so the library is web-safe and has no `dart:io`
+/// variant.
+///
+/// ## Integrity
+///
+/// Every image carries a CRC-32, which is verified on load. It detects
+/// corruption — a truncated write, bit rot, a mangled transfer — and nothing
+/// more: an attacker who edits an image recomputes the checksum in
+/// microseconds.
+///
+/// Only a signature made with a key the attacker does not have makes an image
+/// tamper-evident. Signing is optional and pluggable ([ASTBinarySigner]), with
+/// [HmacSha256Signer] built in. **An unsigned image deserves exactly as much
+/// trust as the source it came from** — loading one and running it is
+/// equivalent to running arbitrary code from that source, so do not load an
+/// unsigned image from an untrusted origin.
+///
+/// ## Compatibility
+///
+/// An image records the container revision that wrote it and the oldest
+/// revision that can decode it correctly. Sections are length-prefixed, so a
+/// reader skips any section it does not recognize, and each section is read
+/// from a bounded view, so fields a newer writer appended are ignored rather
+/// than misread. A newer ApolloVM's output therefore keeps loading in an older
+/// one for as long as the additions are purely additive, and an older image
+/// keeps loading in every later ApolloVM. When a change genuinely cannot be
+/// understood, the reader fails with [ASTBinaryException] naming both versions
+/// instead of producing a wrong AST.
+library;
+
+import 'src/ast/apollovm_ast_toplevel.dart';
+
+export 'src/serialization/ast_binary_archive.dart';
+export 'src/serialization/ast_binary_container.dart'
+    show ASTBinaryHeader, ASTBinarySectionData;
+export 'src/serialization/ast_binary_exception.dart';
+export 'src/serialization/ast_binary_format.dart';
+export 'src/serialization/ast_binary_reader.dart';
+export 'src/serialization/ast_binary_signer.dart';
+export 'src/serialization/ast_binary_vm_extension.dart';
+export 'src/serialization/ast_binary_writer.dart';

--- a/lib/apollovm_serialization.dart
+++ b/lib/apollovm_serialization.dart
@@ -5,9 +5,10 @@
 /// Binary serialization of a parsed ApolloVM AST.
 ///
 /// Parsing dominates the cost of loading code. This library stores an
-/// already-parsed [ASTRoot] as a compact `.avma` image, so an application can
-/// parse once — at build time, or on first run — and afterwards load the same
-/// code unit by decoding bytes, with no grammar and no backtracking.
+/// already-parsed [ASTRoot] as a compact **`.avma`** image — *Apollo Virtual
+/// Machine Archive* — so an application can parse once, at build time or on
+/// first run, and afterwards load the same code unit by decoding bytes, with no
+/// grammar and no backtracking.
 ///
 /// ```dart
 /// // Once, wherever the source is available:

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -61,7 +61,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.27.0';
+  static final String VERSION = '2.28.0';
 
   static int _idCount = 0;
 

--- a/lib/src/serialization/ast_binary_archive.dart
+++ b/lib/src/serialization/ast_binary_archive.dart
@@ -1,0 +1,146 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'dart:typed_data';
+
+import 'package:data_serializer/data_serializer.dart';
+
+import '../apollovm_base.dart';
+import 'ast_binary_container.dart';
+import 'ast_binary_exception.dart';
+import 'ast_binary_format.dart';
+import 'ast_binary_reader.dart';
+import 'ast_binary_signer.dart';
+import 'ast_binary_writer.dart';
+
+/// Bundles several binary AST images into one file.
+///
+/// Each entry is a complete, self-contained single-unit image nested inside an
+/// [ASTBinarySection.archiveEntry] section. Nesting whole images rather than
+/// merging their string and type pools costs about 26 bytes per unit and buys a
+/// great deal: the archive needs no decoding logic of its own, every unit keeps
+/// its own checksum, and one unit can be extracted and verified without
+/// touching the rest. The archive then adds its own CRC — and, optionally, its
+/// own signature — over the whole thing.
+class ASTBinaryArchiveWriter {
+  /// Signs the archive as a whole. Entries may be signed independently.
+  final ASTBinarySigner? signer;
+
+  const ASTBinaryArchiveWriter({this.signer});
+
+  /// Bundles the AST of every loaded code unit in [vm].
+  ///
+  /// With [language], only that language's units are included.
+  Uint8List writeVM(ApolloVM vm, {String? language}) => writeCodeUnits(
+    language == null
+        ? vm.allCodeUnitsAllLanguages()
+        : vm.allCodeUnits(language),
+  );
+
+  /// Bundles [codeUnits], each of which must already be loaded.
+  Uint8List writeCodeUnits(Iterable<CodeUnit> codeUnits) {
+    const entryWriter = ASTBinaryWriter();
+
+    var entries = [
+      for (var codeUnit in codeUnits)
+        ASTBinarySectionData(
+          ASTBinarySection.archiveEntry.id,
+          entryWriter.writeCodeUnit(codeUnit),
+        ),
+    ];
+
+    var metadata = BytesBuffer();
+    metadata.writeLeb128String(ApolloVM.VERSION);
+    metadata.writeLeb128UnsignedInt(entries.length);
+
+    return ASTBinaryContainerCodec.encode(
+      sections: [
+        ASTBinarySectionData(ASTBinarySection.metadata.id, metadata.toBytes()),
+        ...entries,
+      ],
+      flags: ASTBinaryFlags.archive,
+      signer: signer,
+    );
+  }
+}
+
+/// Reads a file written by [ASTBinaryArchiveWriter].
+class ASTBinaryArchiveReader {
+  /// Checks the archive's own signature.
+  final ASTBinaryVerifier? verifier;
+
+  /// Checks each entry's signature.
+  final ASTBinaryVerifier? entryVerifier;
+
+  /// Whether to verify checksums. On by default.
+  final bool verifyChecksum;
+
+  const ASTBinaryArchiveReader({
+    this.verifier,
+    this.entryVerifier,
+    this.verifyChecksum = true,
+  });
+
+  /// Whether [bytes] is an archive rather than a single-unit image.
+  static bool isArchive(Uint8List bytes) {
+    if (!ASTBinaryFormat.isASTBinary(bytes) ||
+        bytes.length < ASTBinaryFormat.headerSize) {
+      return false;
+    }
+    var flags =
+        ((bytes[8] << 24) | (bytes[9] << 16) | (bytes[10] << 8) | bytes[11]) >>>
+        0;
+    return (flags & ASTBinaryFlags.archive) != 0;
+  }
+
+  /// The images this archive holds, in order, without decoding their ASTs.
+  List<Uint8List> entriesOf(Uint8List bytes) {
+    var container = ASTBinaryContainerCodec.decode(
+      bytes,
+      verifyChecksum: verifyChecksum,
+      verifier: verifier,
+    );
+
+    if (!container.header.hasArchiveFlag) {
+      throw ASTBinaryException(
+        'This is a single binary AST image, not an archive.',
+        ASTBinaryError.malformedSection,
+        formatVersion: container.header.formatVersion,
+      );
+    }
+
+    return [
+      for (var s in container.sections)
+        if (s.id == ASTBinarySection.archiveEntry.id) s.payload,
+    ];
+  }
+
+  /// What each entry says about itself, without decoding its AST.
+  List<ASTBinaryInfo> listEntries(Uint8List bytes) {
+    var reader = ASTBinaryReader(
+      verifier: entryVerifier,
+      verifyChecksum: verifyChecksum,
+    );
+    return [for (var e in entriesOf(bytes)) reader.readInfo(e)];
+  }
+
+  /// Decodes every entry into a [CodeUnit] with its `root` populated.
+  List<BinaryCodeUnit> readCodeUnits(Uint8List bytes) {
+    var reader = ASTBinaryReader(
+      verifier: entryVerifier,
+      verifyChecksum: verifyChecksum,
+    );
+    return [for (var e in entriesOf(bytes)) reader.readCodeUnit(e)];
+  }
+
+  /// Decodes every entry and loads it into [vm], returning how many were
+  /// loaded.
+  Future<int> loadInto(ApolloVM vm, Uint8List bytes) async {
+    var loaded = 0;
+    for (var codeUnit in readCodeUnits(bytes)) {
+      if (await vm.loadCodeUnit(codeUnit)) loaded++;
+    }
+    return loaded;
+  }
+}

--- a/lib/src/serialization/ast_binary_codecs_expression.dart
+++ b/lib/src/serialization/ast_binary_codecs_expression.dart
@@ -1,0 +1,554 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import '../ast/apollovm_ast_expression.dart';
+import '../ast/apollovm_ast_statement.dart';
+import '../ast/apollovm_ast_toplevel.dart';
+import '../ast/apollovm_ast_value.dart';
+import '../ast/apollovm_ast_variable.dart';
+import 'ast_binary_context.dart';
+import 'ast_binary_node_codec.dart';
+import 'ast_binary_tags.dart';
+
+/// Writes the chained calls that may follow an invocation or getter access
+/// (`foo().bar().baz()`).
+void _writeChain(ASTBinaryWriteContext w, WithCallChainFunction n) =>
+    w.nodes(n.chainFunctionInvocation);
+
+List<ASTExpressionChainFunctionInvocation>? _readChain(
+  ASTBinaryReadContext r,
+) => r.nodes<ASTExpressionChainFunctionInvocation>();
+
+/// Writes the named arguments of a call (`foo(a: 1, b: 2)`).
+void _writeNamedArguments(
+  ASTBinaryWriteContext w,
+  Map<String, ASTExpression>? named,
+) {
+  if (named == null) {
+    w.uint(0);
+    return;
+  }
+  w.uint(named.length + 1);
+  for (var e in named.entries) {
+    w.str(e.key);
+    w.node(e.value);
+  }
+}
+
+Map<String, ASTExpression>? _readNamedArguments(ASTBinaryReadContext r) {
+  var n = r.uint();
+  if (n == 0) return null;
+  var named = <String, ASTExpression>{};
+  for (var i = 1; i < n; ++i) {
+    var key = r.str();
+    named[key] = r.node<ASTExpression>();
+  }
+  return named;
+}
+
+/// Codecs for the [ASTExpression] family, **most derived first**.
+final List<ASTNodeCodec> expressionCodecs = [
+  // --- Leaves ---------------------------------------------------------------
+  ASTNodeCodec<ASTExpressionNullValue>(
+    ASTNodeTag.expressionNullValue,
+    'ASTExpressionNullValue',
+    encode: (w, n) {},
+    decode: (r) => ASTExpressionNullValue(),
+  ),
+
+  ASTNodeCodec<ASTExpressionLiteral>(
+    ASTNodeTag.expressionLiteral,
+    'ASTExpressionLiteral',
+    encode: (w, n) => w.node(n.value),
+    decode: (r) => ASTExpressionLiteral(r.node<ASTValue>()),
+  ),
+
+  ASTNodeCodec<ASTExpressionVariableAccess>(
+    ASTNodeTag.expressionVariableAccess,
+    'ASTExpressionVariableAccess',
+    encode: (w, n) => w.node(n.variable),
+    decode: (r) => ASTExpressionVariableAccess(r.node<ASTVariable>()),
+  ),
+
+  // --- Operators ------------------------------------------------------------
+  ASTNodeCodec<ASTExpressionOperation>(
+    ASTNodeTag.expressionOperation,
+    'ASTExpressionOperation',
+    encode: (w, n) {
+      w.node(n.expression1);
+      w.enumByName(n.operator);
+      w.node(n.expression2);
+    },
+    decode: (r) {
+      var e1 = r.node<ASTExpression>();
+      var op = r.enumByName(ASTExpressionOperator.values);
+      return ASTExpressionOperation(e1, op, r.node<ASTExpression>());
+    },
+  ),
+
+  ASTNodeCodec<ASTExpressionLogicalAnd>(
+    ASTNodeTag.expressionLogicalAnd,
+    'ASTExpressionLogicalAnd',
+    encode: (w, n) {
+      w.node(n.expression1);
+      w.node(n.expression2);
+    },
+    decode: (r) {
+      var e1 = r.node<ASTExpression>();
+      return ASTExpressionLogicalAnd(e1, r.node<ASTExpression>());
+    },
+  ),
+
+  ASTNodeCodec<ASTExpressionLogicalOr>(
+    ASTNodeTag.expressionLogicalOr,
+    'ASTExpressionLogicalOr',
+    encode: (w, n) {
+      w.node(n.expression1);
+      w.node(n.expression2);
+    },
+    decode: (r) {
+      var e1 = r.node<ASTExpression>();
+      return ASTExpressionLogicalOr(e1, r.node<ASTExpression>());
+    },
+  ),
+
+  ASTNodeCodec<ASTExpressionNegation>(
+    ASTNodeTag.expressionNegation,
+    'ASTExpressionNegation',
+    encode: (w, n) => w.node(n.expression),
+    decode: (r) => ASTExpressionNegation(r.node<ASTExpression>()),
+  ),
+
+  ASTNodeCodec<ASTExpressionNegative>(
+    ASTNodeTag.expressionNegative,
+    'ASTExpressionNegative',
+    encode: (w, n) => w.node(n.expression),
+    decode: (r) => ASTExpressionNegative(r.node<ASTExpression>()),
+  ),
+
+  ASTNodeCodec<ASTExpressionBitwiseNot>(
+    ASTNodeTag.expressionBitwiseNot,
+    'ASTExpressionBitwiseNot',
+    encode: (w, n) => w.node(n.expression),
+    decode: (r) => ASTExpressionBitwiseNot(r.node<ASTExpression>()),
+  ),
+
+  ASTNodeCodec<ASTExpressionAwait>(
+    ASTNodeTag.expressionAwait,
+    'ASTExpressionAwait',
+    encode: (w, n) => w.node(n.expression),
+    decode: (r) => ASTExpressionAwait(r.node<ASTExpression>()),
+  ),
+
+  ASTNodeCodec<ASTExpressionConditional>(
+    ASTNodeTag.expressionConditional,
+    'ASTExpressionConditional',
+    encode: (w, n) {
+      w.node(n.condition);
+      w.node(n.valueIfTrue);
+      w.node(n.valueIfFalse);
+    },
+    decode: (r) {
+      var condition = r.node<ASTExpression>();
+      var ifTrue = r.node<ASTExpression>();
+      return ASTExpressionConditional(
+        condition,
+        ifTrue,
+        r.node<ASTExpression>(),
+      );
+    },
+  ),
+
+  // --- Null handling --------------------------------------------------------
+  ASTNodeCodec<ASTExpressionNullAssertion>(
+    ASTNodeTag.expressionNullAssertion,
+    'ASTExpressionNullAssertion',
+    encode: (w, n) => w.node(n.expression),
+    decode: (r) => ASTExpressionNullAssertion(r.node<ASTExpression>()),
+  ),
+
+  ASTNodeCodec<ASTExpressionNullCoalesce>(
+    ASTNodeTag.expressionNullCoalesce,
+    'ASTExpressionNullCoalesce',
+    encode: (w, n) {
+      w.node(n.expression1);
+      w.node(n.expression2);
+    },
+    decode: (r) {
+      var e1 = r.node<ASTExpression>();
+      return ASTExpressionNullCoalesce(e1, r.node<ASTExpression>());
+    },
+  ),
+
+  ASTNodeCodec<ASTExpressionNullCheck>(
+    ASTNodeTag.expressionNullCheck,
+    'ASTExpressionNullCheck',
+    encode: (w, n) {
+      w.node(n.expression);
+      // The `null` literal is kept as a real child — the Wasm backend scans for
+      // it — so it is written rather than synthesized on the way back.
+      w.node(n.nullValue);
+      w.boolean(n.negated);
+      w.boolean(n.nullFirst);
+    },
+    decode: (r) {
+      var expression = r.node<ASTExpression>();
+      var nullValue = r.node<ASTExpressionNullValue>();
+      var negated = r.boolean();
+      return ASTExpressionNullCheck(
+        expression,
+        nullValue,
+        negated: negated,
+        nullFirst: r.boolean(),
+      );
+    },
+  ),
+
+  // --- Literals with structure ----------------------------------------------
+  ASTNodeCodec<ASTExpressionListLiteral>(
+    ASTNodeTag.expressionListLiteral,
+    'ASTExpressionListLiteral',
+    encode: (w, n) {
+      w.typeOrNull(n.type);
+      w.nodes(n.valuesExpressions);
+    },
+    decode: (r) {
+      var type = r.typeOrNull();
+      return ASTExpressionListLiteral(type, r.nodeList<ASTExpression>());
+    },
+  ),
+
+  ASTNodeCodec<ASTExpressionMapLiteral>(
+    ASTNodeTag.expressionMapLiteral,
+    'ASTExpressionMapLiteral',
+    encode: (w, n) {
+      w.typeOrNull(n.keyType);
+      w.typeOrNull(n.valueType);
+      w.uint(n.entriesExpressions.length);
+      for (var e in n.entriesExpressions) {
+        w.node(e.key);
+        w.node(e.value);
+      }
+    },
+    decode: (r) {
+      var keyType = r.typeOrNull();
+      var valueType = r.typeOrNull();
+      var count = r.uint();
+      var entries = <MapEntry<ASTExpression, ASTExpression>>[];
+      for (var i = 0; i < count; ++i) {
+        var k = r.node<ASTExpression>();
+        entries.add(MapEntry(k, r.node<ASTExpression>()));
+      }
+      return ASTExpressionMapLiteral(keyType, valueType, entries);
+    },
+  ),
+
+  ASTNodeCodec<ASTExpressionLiteralFunction>(
+    ASTNodeTag.expressionLiteralFunction,
+    'ASTExpressionLiteralFunction',
+    encode: (w, n) => w.node(n.function),
+    decode: (r) =>
+        ASTExpressionLiteralFunction(r.node<ASTFunctionDeclaration>()),
+  ),
+
+  ASTNodeCodec<ASTExpressionCascade>(
+    ASTNodeTag.expressionCascade,
+    'ASTExpressionCascade',
+    encode: (w, n) {
+      w.node(n.receiver);
+      w.str(n.targetVariableName);
+      w.nodes(n.sections);
+      w.boolean(n.isNullAware);
+    },
+    decode: (r) {
+      var receiver = r.node<ASTExpression>();
+      var targetVariableName = r.str();
+      var sections = r.nodeList<ASTExpression>();
+      return ASTExpressionCascade(
+        receiver,
+        targetVariableName,
+        sections,
+        isNullAware: r.boolean(),
+      );
+    },
+  ),
+
+  // --- Entry access and assignment ------------------------------------------
+  ASTNodeCodec<ASTExpressionVariableEntryAccess>(
+    ASTNodeTag.expressionVariableEntryAccess,
+    'ASTExpressionVariableEntryAccess',
+    encode: (w, n) {
+      w.node(n.variable);
+      w.node(n.expression);
+      w.nodes(n.extraIndices);
+      w.boolean(n.isNullAware);
+      w.boolean(n.assertReceiver);
+    },
+    decode: (r) {
+      var variable = r.node<ASTVariable>();
+      var expression = r.node<ASTExpression>();
+      var extraIndices = r.nodeList<ASTExpression>();
+      var isNullAware = r.boolean();
+      return ASTExpressionVariableEntryAccess(
+        variable,
+        expression,
+        extraIndices,
+        isNullAware,
+        r.boolean(),
+      );
+    },
+  ),
+
+  ASTNodeCodec<ASTExpressionVariableEntryAssignment>(
+    ASTNodeTag.expressionVariableEntryAssignment,
+    'ASTExpressionVariableEntryAssignment',
+    encode: (w, n) {
+      w.node(n.variable);
+      w.node(n.keyExpression);
+      w.enumByName(n.operator);
+      w.node(n.expression);
+      w.nodes(n.extraKeys);
+    },
+    decode: (r) {
+      var variable = r.node<ASTVariable>();
+      var keyExpression = r.node<ASTExpression>();
+      var operator = r.enumByName(ASTAssignmentOperator.values);
+      var expression = r.node<ASTExpression>();
+      return ASTExpressionVariableEntryAssignment(
+        variable,
+        keyExpression,
+        operator,
+        expression,
+        r.nodeList<ASTExpression>(),
+      );
+    },
+  ),
+
+  ASTNodeCodec<ASTExpressionVariableAssignment>(
+    ASTNodeTag.expressionVariableAssignment,
+    'ASTExpressionVariableAssignment',
+    encode: (w, n) {
+      w.node(n.variable);
+      w.enumByName(n.operator);
+      w.node(n.expression);
+    },
+    decode: (r) {
+      var variable = r.node<ASTVariable>();
+      var operator = r.enumByName(ASTAssignmentOperator.values);
+      return ASTExpressionVariableAssignment(
+        variable,
+        operator,
+        r.node<ASTExpression>(),
+      );
+    },
+  ),
+
+  ASTNodeCodec<ASTExpressionVariableDirectOperation>(
+    ASTNodeTag.expressionVariableDirectOperation,
+    'ASTExpressionVariableDirectOperation',
+    encode: (w, n) {
+      w.node(n.variable);
+      w.enumByName(n.operator);
+      w.boolean(n.preOperation);
+    },
+    decode: (r) {
+      var variable = r.node<ASTVariable>();
+      var operator = r.enumByName(ASTAssignmentOperator.values);
+      return ASTExpressionVariableDirectOperation(
+        variable,
+        operator,
+        r.boolean(),
+      );
+    },
+  ),
+
+  ASTNodeCodec<ASTExpressionObjectSetterAssignment>(
+    ASTNodeTag.expressionObjectSetterAssignment,
+    'ASTExpressionObjectSetterAssignment',
+    encode: (w, n) {
+      w.node(n.variable);
+      w.str(n.name);
+      w.enumByName(n.operator);
+      w.node(n.expression);
+    },
+    decode: (r) {
+      var variable = r.node<ASTVariable>();
+      var name = r.str();
+      var operator = r.enumByName(ASTAssignmentOperator.values);
+      return ASTExpressionObjectSetterAssignment(
+        variable,
+        name,
+        operator,
+        r.node<ASTExpression>(),
+      );
+    },
+  ),
+
+  // --- Invocations ----------------------------------------------------------
+  ASTNodeCodec<ASTExpressionObjectEntryFunctionInvocation>(
+    ASTNodeTag.expressionObjectEntryFunctionInvocation,
+    'ASTExpressionObjectEntryFunctionInvocation',
+    encode: (w, n) {
+      // The constructor builds `variableAccess` from these two, so its parts
+      // are written and the node re-synthesizes it on the way back.
+      w.node(n.variableAccess.variable);
+      w.node(n.variableAccess.expression);
+      w.str(n.name);
+      w.nodes(n.arguments);
+      _writeChain(w, n);
+      _writeNamedArguments(w, n.namedArguments);
+    },
+    decode: (r) {
+      var variable = r.node<ASTVariable>();
+      var expression = r.node<ASTExpression>();
+      var name = r.str();
+      var arguments = r.nodeList<ASTExpression>();
+      var node = ASTExpressionObjectEntryFunctionInvocation(
+        variable,
+        expression,
+        name,
+        arguments,
+        _readChain(r),
+      );
+      node.namedArguments = _readNamedArguments(r);
+      return node;
+    },
+  ),
+
+  ASTNodeCodec<ASTExpressionObjectFunctionInvocation>(
+    ASTNodeTag.expressionObjectFunctionInvocation,
+    'ASTExpressionObjectFunctionInvocation',
+    encode: (w, n) {
+      w.node(n.variable);
+      w.str(n.name);
+      w.nodes(n.arguments);
+      _writeChain(w, n);
+      w.boolean(n.isNullAware);
+      w.boolean(n.assertReceiver);
+      _writeNamedArguments(w, n.namedArguments);
+    },
+    decode: (r) {
+      var variable = r.node<ASTVariable>();
+      var name = r.str();
+      var arguments = r.nodeList<ASTExpression>();
+      var chain = _readChain(r);
+      var isNullAware = r.boolean();
+      var node = ASTExpressionObjectFunctionInvocation(
+        variable,
+        name,
+        arguments,
+        chain,
+        isNullAware,
+        r.boolean(),
+      );
+      node.namedArguments = _readNamedArguments(r);
+      return node;
+    },
+  ),
+
+  ASTNodeCodec<ASTExpressionGroupFunctionInvocation>(
+    ASTNodeTag.expressionGroupFunctionInvocation,
+    'ASTExpressionGroupFunctionInvocation',
+    encode: (w, n) {
+      w.node(n.expression);
+      w.str(n.name);
+      w.nodes(n.arguments);
+      _writeChain(w, n);
+      _writeNamedArguments(w, n.namedArguments);
+    },
+    decode: (r) {
+      var expression = r.node<ASTExpression>();
+      var name = r.str();
+      var arguments = r.nodeList<ASTExpression>();
+      var node = ASTExpressionGroupFunctionInvocation(
+        expression,
+        name,
+        arguments,
+        _readChain(r),
+      );
+      node.namedArguments = _readNamedArguments(r);
+      return node;
+    },
+  ),
+
+  ASTNodeCodec<ASTExpressionChainFunctionInvocation>(
+    ASTNodeTag.expressionChainFunctionInvocation,
+    'ASTExpressionChainFunctionInvocation',
+    encode: (w, n) {
+      w.str(n.name);
+      w.nodes(n.arguments);
+      _writeNamedArguments(w, n.namedArguments);
+    },
+    decode: (r) {
+      var name = r.str();
+      var node = ASTExpressionChainFunctionInvocation(
+        name,
+        r.nodeList<ASTExpression>(),
+      );
+      node.namedArguments = _readNamedArguments(r);
+      return node;
+    },
+  ),
+
+  ASTNodeCodec<ASTExpressionLocalFunctionInvocation>(
+    ASTNodeTag.expressionLocalFunctionInvocation,
+    'ASTExpressionLocalFunctionInvocation',
+    encode: (w, n) {
+      w.str(n.name);
+      w.nodes(n.arguments);
+      _writeChain(w, n);
+      _writeNamedArguments(w, n.namedArguments);
+    },
+    decode: (r) {
+      var name = r.str();
+      var arguments = r.nodeList<ASTExpression>();
+      var node = ASTExpressionLocalFunctionInvocation(
+        name,
+        arguments,
+        _readChain(r),
+      );
+      node.namedArguments = _readNamedArguments(r);
+      return node;
+    },
+  ),
+
+  // --- Getter access --------------------------------------------------------
+  ASTNodeCodec<ASTExpressionObjectGetterAccess>(
+    ASTNodeTag.expressionObjectGetterAccess,
+    'ASTExpressionObjectGetterAccess',
+    encode: (w, n) {
+      w.node(n.variable);
+      w.str(n.name);
+      _writeChain(w, n);
+      w.boolean(n.isNullAware);
+      w.boolean(n.assertReceiver);
+    },
+    decode: (r) {
+      var variable = r.node<ASTVariable>();
+      var name = r.str();
+      var chain = _readChain(r);
+      var isNullAware = r.boolean();
+      return ASTExpressionObjectGetterAccess(
+        variable,
+        name,
+        chain,
+        isNullAware,
+        r.boolean(),
+      );
+    },
+  ),
+
+  ASTNodeCodec<ASTExpressionLocalGetterAccess>(
+    ASTNodeTag.expressionLocalGetterAccess,
+    'ASTExpressionLocalGetterAccess',
+    encode: (w, n) {
+      w.str(n.name);
+      _writeChain(w, n);
+    },
+    decode: (r) {
+      var name = r.str();
+      return ASTExpressionLocalGetterAccess(name, _readChain(r));
+    },
+  ),
+];

--- a/lib/src/serialization/ast_binary_codecs_statement.dart
+++ b/lib/src/serialization/ast_binary_codecs_statement.dart
@@ -1,0 +1,466 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import '../ast/apollovm_ast_expression.dart';
+import '../ast/apollovm_ast_statement.dart';
+import '../ast/apollovm_ast_toplevel.dart';
+import '../ast/apollovm_ast_value.dart';
+import '../ast/apollovm_ast_variable.dart';
+import 'ast_binary_context.dart';
+import 'ast_binary_node_codec.dart';
+import 'ast_binary_tags.dart';
+
+/// Writes the contents of an [ASTBlock].
+///
+/// `ASTBlock.children` reports only its functions and statements — getters and
+/// setters are missing from it, even though `resolveNode` walks them — so the
+/// members are written explicitly rather than through a generic walk.
+///
+/// Overload sets (`ASTFunctionSet*`) are flattened to their declarations:
+/// `addFunction` rebuilds the single/multiple split from the names, so the set
+/// objects themselves are derived data and never stored.
+void writeBlockBody(ASTBinaryWriteContext w, ASTBlock block) {
+  w.nodes(block.statements);
+  w.nodes([for (var set in block.functions) ...set.functions]);
+  w.nodes(block.getter);
+  w.nodes(block.setter);
+}
+
+/// Fills [block] with the members written by [writeBlockBody].
+void readBlockBody(ASTBinaryReadContext r, ASTBlock block) {
+  block.addAllStatements(r.nodeList<ASTStatement>());
+  block.addAllFunctions(r.nodeList<ASTFunctionDeclaration>());
+  block.addAllGetters(r.nodeList<ASTGetterDeclaration>());
+  block.addAllSetters(r.nodeList<ASTSetterDeclaration>());
+}
+
+/// Codecs for the plain block kinds.
+///
+/// Kept apart from [statementCodecs] and registered **last of everything**:
+/// a great many nodes extend [ASTBlock] — every class, every function, getter
+/// and setter declaration, the root itself — and dispatch takes the first
+/// matching codec, so a bare `ASTBlock` entry appearing earlier would claim all
+/// of them.
+final List<ASTNodeCodec> blockCodecs = [
+  // Before `ASTBlock`, which it extends.
+  ASTNodeCodec<ASTSingleLineStatementBlock>(
+    ASTNodeTag.singleLineStatementBlock,
+    'ASTSingleLineStatementBlock',
+    encode: (w, n) => writeBlockBody(w, n),
+    decode: (r) {
+      // `parentBlock` is left null, exactly as the grammars leave it; the
+      // parent chain is re-established by `resolveNode`.
+      var block = ASTSingleLineStatementBlock(null);
+      readBlockBody(r, block);
+      return block;
+    },
+  ),
+
+  ASTNodeCodec<ASTBlock>(
+    ASTNodeTag.block,
+    'ASTBlock',
+    encode: (w, n) => writeBlockBody(w, n),
+    decode: (r) {
+      var block = ASTBlock(null);
+      readBlockBody(r, block);
+      return block;
+    },
+  ),
+];
+
+/// Codecs for the [ASTStatement] family, **most derived first**.
+final List<ASTNodeCodec> statementCodecs = [
+  // --- Simple statements ----------------------------------------------------
+  ASTNodeCodec<ASTStatementExpression>(
+    ASTNodeTag.statementExpression,
+    'ASTStatementExpression',
+    encode: (w, n) => w.node(n.expression),
+    decode: (r) => ASTStatementExpression(r.node<ASTExpression>()),
+  ),
+
+  ASTNodeCodec<ASTStatementBlock>(
+    ASTNodeTag.statementBlock,
+    'ASTStatementBlock',
+    encode: (w, n) => w.node(n.block),
+    decode: (r) => ASTStatementBlock(r.node<ASTBlock>()),
+  ),
+
+  ASTNodeCodec<ASTStatementValue>(
+    ASTNodeTag.statementValue,
+    'ASTStatementValue',
+    encode: (w, n) => w.node(n.value),
+    decode: (r) =>
+        // The constructor takes a block and discards it, so a throwaway one is
+        // all it needs.
+        ASTStatementValue(ASTBlock(null), r.node<ASTValue>()),
+  ),
+
+  ASTNodeCodec<ASTStatementFunctionDeclaration>(
+    ASTNodeTag.statementFunctionDeclaration,
+    'ASTStatementFunctionDeclaration',
+    encode: (w, n) => w.node(n.functionDeclaration),
+    decode: (r) =>
+        ASTStatementFunctionDeclaration(r.node<ASTFunctionDeclaration>()),
+  ),
+
+  ASTNodeCodec<ASTStatementVariableDeclaration>(
+    ASTNodeTag.statementVariableDeclaration,
+    'ASTStatementVariableDeclaration',
+    encode: (w, n) {
+      w.type(n.type);
+      w.str(n.name);
+      w.nodeOrNull(n.value);
+      w.boolean(n.unmodifiable);
+    },
+    decode: (r) {
+      var type = r.type();
+      var name = r.str();
+      var value = r.nodeOrNull<ASTExpression>();
+      // The constructor normalizes a list-literal initializer's component type.
+      // It is idempotent on input that is already normalized, so replaying it
+      // is safe.
+      return ASTStatementVariableDeclaration(
+        type,
+        name,
+        value,
+        unmodifiable: r.boolean(),
+      );
+    },
+  ),
+
+  // --- Returns (subclasses before `ASTStatementReturn`) ---------------------
+  ASTNodeCodec<ASTStatementReturnNull>(
+    ASTNodeTag.statementReturnNull,
+    'ASTStatementReturnNull',
+    encode: (w, n) {},
+    decode: (r) => ASTStatementReturnNull(),
+  ),
+
+  ASTNodeCodec<ASTStatementReturnValue>(
+    ASTNodeTag.statementReturnValue,
+    'ASTStatementReturnValue',
+    encode: (w, n) => w.node(n.value),
+    decode: (r) => ASTStatementReturnValue(r.node<ASTValue>()),
+  ),
+
+  ASTNodeCodec<ASTStatementReturnVariable>(
+    ASTNodeTag.statementReturnVariable,
+    'ASTStatementReturnVariable',
+    encode: (w, n) => w.node(n.variable),
+    decode: (r) => ASTStatementReturnVariable(r.node<ASTVariable>()),
+  ),
+
+  ASTNodeCodec<ASTStatementReturnWithExpression>(
+    ASTNodeTag.statementReturnWithExpression,
+    'ASTStatementReturnWithExpression',
+    encode: (w, n) => w.node(n.expression),
+    decode: (r) => ASTStatementReturnWithExpression(r.node<ASTExpression>()),
+  ),
+
+  ASTNodeCodec<ASTStatementReturn>(
+    ASTNodeTag.statementReturn,
+    'ASTStatementReturn',
+    encode: (w, n) {},
+    decode: (r) => ASTStatementReturn(),
+  ),
+
+  // --- Branches -------------------------------------------------------------
+  ASTNodeCodec<ASTBranchIfElseIfsElseBlock>(
+    ASTNodeTag.branchIfElseIfsElseBlock,
+    'ASTBranchIfElseIfsElseBlock',
+    encode: (w, n) {
+      w.node(n.condition);
+      w.node(n.blockIf);
+      w.nodes(n.blocksElseIf);
+      w.nodeOrNull(n.blockElse);
+    },
+    decode: (r) {
+      var condition = r.node<ASTExpression>();
+      var blockIf = r.node<ASTBlock>();
+      var blocksElseIf = r.nodeList<ASTBranchIfBlock>();
+      return ASTBranchIfElseIfsElseBlock(
+        condition,
+        blockIf,
+        blocksElseIf,
+        r.nodeOrNull<ASTBlock>(),
+      );
+    },
+  ),
+
+  ASTNodeCodec<ASTBranchIfElseBlock>(
+    ASTNodeTag.branchIfElseBlock,
+    'ASTBranchIfElseBlock',
+    encode: (w, n) {
+      w.node(n.condition);
+      w.node(n.blockIf);
+      w.nodeOrNull(n.blockElse);
+    },
+    decode: (r) {
+      var condition = r.node<ASTExpression>();
+      var blockIf = r.node<ASTBlock>();
+      return ASTBranchIfElseBlock(condition, blockIf, r.nodeOrNull<ASTBlock>());
+    },
+  ),
+
+  ASTNodeCodec<ASTBranchIfBlock>(
+    ASTNodeTag.branchIfBlock,
+    'ASTBranchIfBlock',
+    encode: (w, n) {
+      w.node(n.condition);
+      w.node(n.block);
+    },
+    decode: (r) {
+      var condition = r.node<ASTExpression>();
+      return ASTBranchIfBlock(condition, r.node<ASTBlock>());
+    },
+  ),
+
+  // --- Loops ----------------------------------------------------------------
+  ASTNodeCodec<ASTStatementWhileLoop>(
+    ASTNodeTag.statementWhileLoop,
+    'ASTStatementWhileLoop',
+    encode: (w, n) {
+      w.node(n.conditionExpression);
+      w.node(n.loopBlock);
+    },
+    decode: (r) {
+      var condition = r.node<ASTExpression>();
+      return ASTStatementWhileLoop(condition, r.node<ASTBlock>());
+    },
+  ),
+
+  ASTNodeCodec<ASTStatementDoWhileLoop>(
+    ASTNodeTag.statementDoWhileLoop,
+    'ASTStatementDoWhileLoop',
+    encode: (w, n) {
+      w.node(n.loopBlock);
+      w.node(n.conditionExpression);
+    },
+    decode: (r) {
+      var loopBlock = r.node<ASTBlock>();
+      return ASTStatementDoWhileLoop(loopBlock, r.node<ASTExpression>());
+    },
+  ),
+
+  ASTNodeCodec<ASTStatementForLoop>(
+    ASTNodeTag.statementForLoop,
+    'ASTStatementForLoop',
+    encode: (w, n) {
+      w.node(n.initStatement);
+      w.node(n.conditionExpression);
+      w.node(n.continueExpression);
+      w.node(n.loopBlock);
+    },
+    decode: (r) {
+      var init = r.node<ASTStatement>();
+      var condition = r.node<ASTExpression>();
+      var continueExpression = r.node<ASTExpression>();
+      return ASTStatementForLoop(
+        init,
+        condition,
+        continueExpression,
+        r.node<ASTBlock>(),
+      );
+    },
+  ),
+
+  ASTNodeCodec<ASTStatementForEach>(
+    ASTNodeTag.statementForEach,
+    'ASTStatementForEach',
+    encode: (w, n) {
+      // `children` omits the loop variable's type and name, so both are written
+      // explicitly.
+      w.type(n.variableType);
+      w.str(n.variableName);
+      w.node(n.iterableExpression);
+      w.node(n.loopBlock);
+    },
+    decode: (r) {
+      var variableType = r.type();
+      var variableName = r.str();
+      var iterable = r.node<ASTExpression>();
+      return ASTStatementForEach(
+        variableType,
+        variableName,
+        iterable,
+        r.node<ASTBlock>(),
+      );
+    },
+  ),
+
+  ASTNodeCodec<ASTStatementBreak>(
+    ASTNodeTag.statementBreak,
+    'ASTStatementBreak',
+    encode: (w, n) {},
+    decode: (r) => ASTStatementBreak(),
+  ),
+
+  ASTNodeCodec<ASTStatementContinue>(
+    ASTNodeTag.statementContinue,
+    'ASTStatementContinue',
+    encode: (w, n) {},
+    decode: (r) => ASTStatementContinue(),
+  ),
+
+  // --- Switch ---------------------------------------------------------------
+  ASTNodeCodec<ASTStatementSwitch>(
+    ASTNodeTag.statementSwitch,
+    'ASTStatementSwitch',
+    encode: (w, n) {
+      w.node(n.expression);
+      w.nodes(n.cases);
+      w.boolean(n.fallThrough);
+    },
+    decode: (r) {
+      var expression = r.node<ASTExpression>();
+      var cases = r.nodeList<ASTSwitchCase>();
+      return ASTStatementSwitch(expression, cases, fallThrough: r.boolean());
+    },
+  ),
+
+  ASTNodeCodec<ASTSwitchCase>(
+    ASTNodeTag.switchCase,
+    'ASTSwitchCase',
+    encode: (w, n) {
+      // A null value is what makes a case the `default` branch.
+      w.nodeOrNull(n.value);
+      w.node(n.block);
+    },
+    decode: (r) {
+      var value = r.nodeOrNull<ASTExpression>();
+      return ASTSwitchCase(value, r.node<ASTBlock>());
+    },
+  ),
+
+  // --- Throw, assert, try/catch ---------------------------------------------
+  ASTNodeCodec<ASTStatementThrow>(
+    ASTNodeTag.statementThrow,
+    'ASTStatementThrow',
+    encode: (w, n) => w.node(n.expression),
+    decode: (r) => ASTStatementThrow(r.node<ASTExpression>()),
+  ),
+
+  ASTNodeCodec<ASTStatementAssert>(
+    ASTNodeTag.statementAssert,
+    'ASTStatementAssert',
+    encode: (w, n) {
+      w.node(n.condition);
+      w.nodeOrNull(n.message);
+    },
+    decode: (r) {
+      var condition = r.node<ASTExpression>();
+      return ASTStatementAssert(condition, r.nodeOrNull<ASTExpression>());
+    },
+  ),
+
+  ASTNodeCodec<ASTStatementTryCatch>(
+    ASTNodeTag.statementTryCatch,
+    'ASTStatementTryCatch',
+    encode: (w, n) {
+      w.node(n.tryBlock);
+      // `children` lists only the try and finally blocks; the catch clauses
+      // would be lost by a generic walk.
+      w.nodes(n.catches);
+      w.nodeOrNull(n.finallyBlock);
+    },
+    decode: (r) {
+      var tryBlock = r.node<ASTBlock>();
+      var catches = r.nodeList<ASTCatchClause>();
+      return ASTStatementTryCatch(tryBlock, catches, r.nodeOrNull<ASTBlock>());
+    },
+  ),
+
+  ASTNodeCodec<ASTCatchClause>(
+    ASTNodeTag.catchClause,
+    'ASTCatchClause',
+    encode: (w, n) {
+      w.typeOrNull(n.exceptionType);
+      w.strOrNull(n.variableName);
+      w.node(n.block);
+      w.strOrNull(n.stackTraceName);
+    },
+    decode: (r) {
+      var exceptionType = r.typeOrNull();
+      var variableName = r.strOrNull();
+      var block = r.node<ASTBlock>();
+      return ASTCatchClause(
+        exceptionType,
+        variableName,
+        block,
+        stackTraceName: r.strOrNull(),
+      );
+    },
+  ),
+
+  // --- Imports and exports --------------------------------------------------
+  ASTNodeCodec<ASTStatementImport>(
+    ASTNodeTag.statementImport,
+    'ASTStatementImport',
+    encode: (w, n) {
+      w.str(n.path);
+      w.strOrNull(n.prefix);
+      w.boolean(n.wildcard);
+      w.nodes(n.combinators);
+      w.nodes(n.namedSymbols);
+    },
+    decode: (r) {
+      var path = r.str();
+      var prefix = r.strOrNull();
+      var wildcard = r.boolean();
+      var combinators = r.nodeList<ASTImportCombinator>();
+      return ASTStatementImport(
+        path,
+        prefix: prefix,
+        wildcard: wildcard,
+        combinators: combinators,
+        namedSymbols: r.nodeList<ASTImportedSymbol>(),
+      );
+    },
+  ),
+
+  ASTNodeCodec<ASTStatementExport>(
+    ASTNodeTag.statementExport,
+    'ASTStatementExport',
+    encode: (w, n) {
+      w.strOrNull(n.path);
+      w.nodes(n.symbols);
+      w.nodes(n.combinators);
+    },
+    decode: (r) {
+      var path = r.strOrNull();
+      var symbols = r.nodeList<ASTImportedSymbol>();
+      return ASTStatementExport(
+        path: path,
+        symbols: symbols,
+        combinators: r.nodeList<ASTImportCombinator>(),
+      );
+    },
+  ),
+
+  ASTNodeCodec<ASTImportCombinator>(
+    ASTNodeTag.importCombinator,
+    'ASTImportCombinator',
+    encode: (w, n) {
+      w.enumByName(n.kind);
+      w.strings_(n.names);
+    },
+    decode: (r) {
+      var kind = r.enumByName(ASTImportCombinatorKind.values);
+      return ASTImportCombinator(kind, r.strings_() ?? const <String>[]);
+    },
+  ),
+
+  ASTNodeCodec<ASTImportedSymbol>(
+    ASTNodeTag.importedSymbol,
+    'ASTImportedSymbol',
+    encode: (w, n) {
+      w.str(n.name);
+      w.strOrNull(n.alias);
+    },
+    decode: (r) {
+      var name = r.str();
+      return ASTImportedSymbol(name, alias: r.strOrNull());
+    },
+  ),
+];

--- a/lib/src/serialization/ast_binary_codecs_statement.dart
+++ b/lib/src/serialization/ast_binary_codecs_statement.dart
@@ -21,10 +21,41 @@ import 'ast_binary_tags.dart';
 /// `addFunction` rebuilds the single/multiple split from the names, so the set
 /// objects themselves are derived data and never stored.
 void writeBlockBody(ASTBinaryWriteContext w, ASTBlock block) {
-  w.nodes(block.statements);
-  w.nodes([for (var set in block.functions) ...set.functions]);
+  var statements = block.statements;
+
+  w.nodes(statements);
+  w.nodes(_declaredFunctionsOf(block, statements));
   w.nodes(block.getter);
   w.nodes(block.setter);
+}
+
+/// The functions of [block] that are genuinely declared *on* it.
+///
+/// A block's function map is not purely declared structure: running a block
+/// mutates it, because `ASTStatementFunctionDeclaration.run` calls
+/// `addFunction` to register a local function on every execution. So after a
+/// block has run, its map also holds declarations that already exist in
+/// [statements], and writing both would emit each of those twice — and move it,
+/// since a statement keeps its position while the map does not.
+///
+/// Skipping them loses nothing: executing the decoded block registers them
+/// again, exactly as executing the original one did. It also makes encoding
+/// independent of whether the AST has been run, which is what keeps the output
+/// deterministic.
+List<ASTFunctionDeclaration> _declaredFunctionsOf(
+  ASTBlock block,
+  List<ASTStatement> statements,
+) {
+  var declaredAsStatements = <ASTFunctionDeclaration>[
+    for (var s in statements)
+      if (s is ASTStatementFunctionDeclaration) s.functionDeclaration,
+  ];
+
+  return [
+    for (var set in block.functions)
+      for (var f in set.functions)
+        if (!declaredAsStatements.any((e) => identical(e, f))) f,
+  ];
 }
 
 /// Fills [block] with the members written by [writeBlockBody].
@@ -117,6 +148,13 @@ final List<ASTNodeCodec> statementCodecs = [
       var type = r.type();
       var name = r.str();
       var value = r.nodeOrNull<ASTExpression>();
+
+      // Every grammar wires a declaration's type to its initializer so a
+      // `var`/`final` can infer from it. That link is parse-time state, not
+      // something `resolveNode` re-derives, so it is replayed here. It is a
+      // no-op for a declared type — only `ASTTypeVar` records it.
+      if (value != null) type.associateToType(value);
+
       // The constructor normalizes a list-literal initializer's component type.
       // It is idempotent on input that is already normalized, so replaying it
       // is safe.

--- a/lib/src/serialization/ast_binary_codecs_toplevel.dart
+++ b/lib/src/serialization/ast_binary_codecs_toplevel.dart
@@ -1,0 +1,487 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import '../apollovm_base.dart' show VMObject;
+import '../ast/apollovm_ast_expression.dart';
+import '../ast/apollovm_ast_statement.dart';
+import '../ast/apollovm_ast_toplevel.dart';
+import '../ast/apollovm_ast_type.dart';
+import '../ast/apollovm_ast_variable.dart';
+import 'ast_binary_codecs_statement.dart';
+import 'ast_binary_context.dart';
+import 'ast_binary_node_codec.dart';
+import 'ast_binary_tags.dart';
+
+/// Writes the three parameter groups of a declaration.
+void _writeParameters(ASTBinaryWriteContext w, ASTParametersDeclaration p) {
+  w.nodes(p.positionalParameters);
+  w.nodes(p.optionalParameters);
+  w.nodes(p.namedParameters);
+}
+
+ASTFunctionParametersDeclaration _readFunctionParameters(
+  ASTBinaryReadContext r,
+) {
+  var positional = r.nodes<ASTFunctionParameterDeclaration>();
+  var optional = r.nodes<ASTFunctionParameterDeclaration>();
+  return ASTFunctionParametersDeclaration(
+    positional,
+    optional,
+    r.nodes<ASTFunctionParameterDeclaration>(),
+  );
+}
+
+ASTConstructorParametersDeclaration _readConstructorParameters(
+  ASTBinaryReadContext r,
+) {
+  var positional = r.nodes<ASTConstructorParameterDeclaration>();
+  var optional = r.nodes<ASTConstructorParameterDeclaration>();
+  return ASTConstructorParametersDeclaration(
+    positional,
+    optional,
+    r.nodes<ASTConstructorParameterDeclaration>(),
+  );
+}
+
+/// Fills a declaration's own block body.
+///
+/// Declarations are blocks: `ASTInvocableDeclaration`, `ASTGetterDeclaration`
+/// and `ASTSetterDeclaration` all extend [ASTBlock], and their statements live
+/// directly in them. Their constructors take a `block` and copy it with `set`,
+/// so building empty and filling afterwards produces the same shape with one
+/// less throwaway object.
+void _fillBlock(ASTBinaryReadContext r, ASTBlock block) =>
+    readBlockBody(r, block);
+
+/// Codecs for the top-level declarations, **most derived first**.
+final List<ASTNodeCodec> toplevelCodecs = [
+  // --- Root -----------------------------------------------------------------
+  ASTNodeCodec<ASTRoot>(
+    ASTNodeTag.root,
+    'ASTRoot',
+    encode: (w, n) {
+      w.str(n.namespace);
+      w.strOrNull(n.moduleId);
+      // `ASTRoot.children` lists neither its classes nor its extensions nor its
+      // type aliases, so every group is written explicitly.
+      w.nodes(n.imports.toList());
+      w.nodes(n.exports.toList());
+      w.nodes(n.typeAliases);
+      w.nodes(n.classes);
+      w.nodes(n.extensions);
+      writeBlockBody(w, n);
+    },
+    decode: (r) {
+      var root = ASTRoot();
+      root.namespace = r.str();
+      root.moduleId = r.strOrNull();
+
+      for (var e in r.nodeList<ASTStatementImport>()) {
+        root.addImport(e);
+      }
+      for (var e in r.nodeList<ASTStatementExport>()) {
+        root.addExport(e);
+      }
+      for (var e in r.nodeList<ASTTypeAlias>()) {
+        root.addTypeAlias(e);
+      }
+      for (var e in r.nodeList<ASTClassNormal>()) {
+        root.addClass(e);
+      }
+      for (var e in r.nodeList<ASTExtension>()) {
+        root.addExtension(e);
+      }
+
+      _fillBlock(r, root);
+      return root;
+    },
+  ),
+
+  // --- Classes (enum before normal, which it extends) -----------------------
+  ASTNodeCodec<ASTClassEnum>(
+    ASTNodeTag.classEnum,
+    'ASTClassEnum',
+    encode: (w, n) => w.inDeclaration('enum ${n.name}', () {
+      _writeClassHeader(w, n);
+      w.nodes(n.entries);
+      _writeClassBody(w, n);
+    }),
+    decode: (r) {
+      var name = r.str();
+      var kind = r.enumByName(ASTClassKind.values);
+      var superClassName = r.strOrNull();
+      var implementsTypes = r.strings_();
+      var entries = r.nodeList<ASTEnumEntry>();
+
+      var clazz = ASTClassEnum(
+        name,
+        // A class declaration's own type is always freshly built, never taken
+        // from the type pool: the `ASTClass` constructor calls `setClass` on
+        // it, which must not happen to a shared instance. This mirrors what
+        // every grammar does — `ASTClassNormal(name, ASTType<VMObject>(name),
+        // null)`.
+        ASTType<VMObject>(name),
+        null,
+        entries: entries,
+        superClassName: superClassName,
+        implementsTypes: implementsTypes,
+      );
+      // `kind` is not a constructor argument on `ASTClassEnum`; enums are
+      // always normal classes, so nothing needs restoring when it matches.
+      _assertEnumKind(kind);
+      _readClassBody(r, clazz);
+      return clazz;
+    },
+  ),
+
+  ASTNodeCodec<ASTClassNormal>(
+    ASTNodeTag.classNormal,
+    'ASTClassNormal',
+    encode: (w, n) => w.inDeclaration('class ${n.name}', () {
+      _writeClassHeader(w, n);
+      _writeClassBody(w, n);
+    }),
+    decode: (r) {
+      var name = r.str();
+      var kind = r.enumByName(ASTClassKind.values);
+      var superClassName = r.strOrNull();
+      var implementsTypes = r.strings_();
+
+      var clazz = ASTClassNormal(
+        name,
+        ASTType<VMObject>(name),
+        null,
+        kind: kind,
+        superClassName: superClassName,
+        implementsTypes: implementsTypes,
+      );
+      _readClassBody(r, clazz);
+      return clazz;
+    },
+  ),
+
+  ASTNodeCodec<ASTEnumEntry>(
+    ASTNodeTag.enumEntry,
+    'ASTEnumEntry',
+    encode: (w, n) {
+      w.str(n.name);
+      w.nodeOrNull(n.value);
+      w.nodes(n.arguments);
+    },
+    decode: (r) {
+      var name = r.str();
+      var value = r.nodeOrNull<ASTExpression>();
+      return ASTEnumEntry(
+        name,
+        value: value,
+        arguments: r.nodes<ASTExpression>(),
+      );
+    },
+  ),
+
+  ASTNodeCodec<ASTExtension>(
+    ASTNodeTag.extension,
+    'ASTExtension',
+    encode: (w, n) => w.inDeclaration('extension ${n.name ?? ''}', () {
+      w.strOrNull(n.name);
+      w.type(n.targetType);
+      writeBlockBody(w, n);
+    }),
+    decode: (r) {
+      var name = r.strOrNull();
+      var targetType = r.type();
+      var extension = ASTExtension(name, targetType);
+      _fillBlock(r, extension);
+      return extension;
+    },
+  ),
+
+  ASTNodeCodec<ASTTypeAlias>(
+    ASTNodeTag.typeAlias,
+    'ASTTypeAlias',
+    encode: (w, n) {
+      w.str(n.name);
+      w.type(n.targetType);
+    },
+    decode: (r) {
+      var name = r.str();
+      return ASTTypeAlias(name, r.type());
+    },
+  ),
+
+  // --- Invocables (subclasses first) ----------------------------------------
+  ASTNodeCodec<ASTClassFunctionDeclaration>(
+    ASTNodeTag.classFunctionDeclaration,
+    'ASTClassFunctionDeclaration',
+    encode: (w, n) => w.inDeclaration(n.name, () {
+      // `clazz` is a back-reference filled in by the enclosing class when the
+      // method is added, so it is not written.
+      w.str(n.name);
+      _writeParameters(w, n.parameters);
+      w.type(n.returnType);
+      w.modifiers(n.modifiers);
+      writeBlockBody(w, n);
+    }),
+    decode: (r) {
+      var name = r.str();
+      var parameters = _readFunctionParameters(r);
+      var returnType = r.type();
+      var modifiers = r.modifiers();
+      var f = ASTClassFunctionDeclaration(
+        null,
+        name,
+        parameters,
+        returnType,
+        modifiers: modifiers,
+      );
+      _fillBlock(r, f);
+      return f;
+    },
+  ),
+
+  ASTNodeCodec<ASTFunctionDeclaration>(
+    ASTNodeTag.functionDeclaration,
+    'ASTFunctionDeclaration',
+    encode: (w, n) => w.inDeclaration(n.name, () {
+      w.str(n.name);
+      _writeParameters(w, n.parameters);
+      w.type(n.returnType);
+      w.modifiers(n.modifiers);
+      writeBlockBody(w, n);
+    }),
+    decode: (r) {
+      var name = r.str();
+      var parameters = _readFunctionParameters(r);
+      var returnType = r.type();
+      var modifiers = r.modifiers();
+      var f = ASTFunctionDeclaration(
+        name,
+        parameters,
+        returnType,
+        modifiers: modifiers,
+      );
+      _fillBlock(r, f);
+      return f;
+    },
+  ),
+
+  ASTNodeCodec<ASTClassConstructorDeclaration>(
+    ASTNodeTag.classConstructorDeclaration,
+    'ASTClassConstructorDeclaration',
+    encode: (w, n) =>
+        w.inDeclaration(n.name.isEmpty ? '<default constructor>' : n.name, () {
+          w.str(n.name);
+          w.type(n.classType);
+          _writeParameters(w, n.parameters);
+          w.modifiers(n.modifiers);
+          writeBlockBody(w, n);
+        }),
+    decode: (r) {
+      var name = r.str();
+      var classType = r.type();
+      var parameters = _readConstructorParameters(r);
+      var modifiers = r.modifiers();
+      var c = ASTClassConstructorDeclaration(
+        classType,
+        name,
+        parameters,
+        modifiers: modifiers,
+      );
+      _fillBlock(r, c);
+      return c;
+    },
+  ),
+
+  // --- Accessors (class variants first) -------------------------------------
+  ASTNodeCodec<ASTClassGetterDeclaration>(
+    ASTNodeTag.classGetterDeclaration,
+    'ASTClassGetterDeclaration',
+    encode: (w, n) => w.inDeclaration('get ${n.name}', () {
+      w.str(n.name);
+      w.type(n.returnType);
+      w.modifiers(n.modifiers);
+      writeBlockBody(w, n);
+    }),
+    decode: (r) {
+      var name = r.str();
+      var returnType = r.type();
+      var modifiers = r.modifiers();
+      var g = ASTClassGetterDeclaration(
+        null,
+        name,
+        returnType,
+        modifiers: modifiers,
+      );
+      _fillBlock(r, g);
+      return g;
+    },
+  ),
+
+  ASTNodeCodec<ASTGetterDeclaration>(
+    ASTNodeTag.getterDeclaration,
+    'ASTGetterDeclaration',
+    encode: (w, n) => w.inDeclaration('get ${n.name}', () {
+      w.str(n.name);
+      w.type(n.returnType);
+      w.modifiers(n.modifiers);
+      writeBlockBody(w, n);
+    }),
+    decode: (r) {
+      var name = r.str();
+      var returnType = r.type();
+      var modifiers = r.modifiers();
+      var g = ASTGetterDeclaration(name, returnType, modifiers: modifiers);
+      _fillBlock(r, g);
+      return g;
+    },
+  ),
+
+  ASTNodeCodec<ASTClassSetterDeclaration>(
+    ASTNodeTag.classSetterDeclaration,
+    'ASTClassSetterDeclaration',
+    encode: (w, n) => w.inDeclaration('set ${n.name}', () {
+      w.str(n.name);
+      w.type(n.parameterType);
+      w.str(n.parameterName);
+      w.modifiers(n.modifiers);
+      writeBlockBody(w, n);
+    }),
+    decode: (r) {
+      var name = r.str();
+      var parameterType = r.type();
+      var parameterName = r.str();
+      var modifiers = r.modifiers();
+      var s = ASTClassSetterDeclaration(
+        null,
+        name,
+        parameterType,
+        parameterName,
+        modifiers: modifiers,
+      );
+      _fillBlock(r, s);
+      return s;
+    },
+  ),
+
+  ASTNodeCodec<ASTSetterDeclaration>(
+    ASTNodeTag.setterDeclaration,
+    'ASTSetterDeclaration',
+    encode: (w, n) => w.inDeclaration('set ${n.name}', () {
+      w.str(n.name);
+      w.type(n.parameterType);
+      w.str(n.parameterName);
+      w.modifiers(n.modifiers);
+      writeBlockBody(w, n);
+    }),
+    decode: (r) {
+      var name = r.str();
+      var parameterType = r.type();
+      var parameterName = r.str();
+      var modifiers = r.modifiers();
+      var s = ASTSetterDeclaration(
+        name,
+        parameterType,
+        parameterName,
+        modifiers: modifiers,
+      );
+      _fillBlock(r, s);
+      return s;
+    },
+  ),
+
+  // --- Parameters -----------------------------------------------------------
+  ASTNodeCodec<ASTConstructorParameterDeclaration>(
+    ASTNodeTag.constructorParameterDeclaration,
+    'ASTConstructorParameterDeclaration',
+    encode: (w, n) {
+      w.type(n.type);
+      w.str(n.name);
+      w.uint(n.index);
+      w.boolean(n.optional);
+      w.boolean(n.thisParameter);
+      w.boolean(n.isRequired);
+      w.nodeOrNull(n.defaultValue);
+    },
+    decode: (r) {
+      var type = r.type();
+      var name = r.str();
+      var index = r.uint();
+      var optional = r.boolean();
+      var thisParameter = r.boolean();
+      var p = ASTConstructorParameterDeclaration(
+        type,
+        name,
+        index,
+        optional,
+        thisParameter: thisParameter,
+        isRequired: r.boolean(),
+      );
+      // Assigned after construction, exactly as the parsers do.
+      p.defaultValue = r.nodeOrNull<ASTExpression>();
+      return p;
+    },
+  ),
+
+  ASTNodeCodec<ASTFunctionParameterDeclaration>(
+    ASTNodeTag.functionParameterDeclaration,
+    'ASTFunctionParameterDeclaration',
+    encode: (w, n) {
+      w.type(n.type);
+      w.str(n.name);
+      w.uint(n.index);
+      w.boolean(n.optional);
+      w.boolean(n.unmodifiable);
+      w.boolean(n.isRequired);
+      w.nodeOrNull(n.defaultValue);
+    },
+    decode: (r) {
+      var type = r.type();
+      var name = r.str();
+      var index = r.uint();
+      var optional = r.boolean();
+      var unmodifiable = r.boolean();
+      var p = ASTFunctionParameterDeclaration(
+        type,
+        name,
+        index,
+        optional,
+        unmodifiable: unmodifiable,
+        isRequired: r.boolean(),
+      );
+      p.defaultValue = r.nodeOrNull<ASTExpression>();
+      return p;
+    },
+  ),
+];
+
+void _writeClassHeader(ASTBinaryWriteContext w, ASTClassNormal n) {
+  w.str(n.name);
+  w.enumByName(n.kind);
+  w.strOrNull(n.superClassName);
+  w.strings_(n.implementsTypes);
+}
+
+void _writeClassBody(ASTBinaryWriteContext w, ASTClassNormal n) {
+  // `ASTClassNormal.children` lists only its methods — not its fields, not its
+  // constructors — so each group is written explicitly. Constructor overload
+  // sets are flattened to declarations; `addConstructor` rebuilds the split.
+  w.nodes(n.fields);
+  w.nodes([for (var set in n.constructors) ...set.functions]);
+  writeBlockBody(w, n);
+}
+
+void _readClassBody(ASTBinaryReadContext r, ASTClassNormal clazz) {
+  clazz.addAllFields(r.nodeList<ASTClassField>());
+  clazz.addAllConstructors(r.nodeList<ASTClassConstructorDeclaration>());
+  readBlockBody(r, clazz);
+}
+
+/// An enum's class kind is fixed by its constructor; a file claiming otherwise
+/// is either corrupt or from a build where that changed.
+void _assertEnumKind(ASTClassKind kind) {
+  assert(
+    kind == ASTClassKind.normalClass,
+    'ASTClassEnum is always a normal class, got $kind',
+  );
+}

--- a/lib/src/serialization/ast_binary_codecs_value.dart
+++ b/lib/src/serialization/ast_binary_codecs_value.dart
@@ -1,0 +1,219 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import '../ast/apollovm_ast_expression.dart';
+import '../ast/apollovm_ast_type.dart';
+import '../ast/apollovm_ast_value.dart';
+import '../ast/apollovm_ast_variable.dart';
+import 'ast_binary_node_codec.dart';
+import 'ast_binary_tags.dart';
+
+/// Codecs for the [ASTValue] family, **most derived first**.
+///
+/// Dispatch walks this list with `is` tests, so `ASTValueBool` has to precede
+/// `ASTValuePrimitive`, and everything concrete has to precede the
+/// `ASTValueStatic` catch-all at the end.
+final List<ASTNodeCodec> valueCodecs = [
+  // --- Primitives -----------------------------------------------------------
+  ASTNodeCodec<ASTValueBool>(
+    ASTNodeTag.valueBool,
+    'ASTValueBool',
+    encode: (w, n) => w.boolean(n.value),
+    decode: (r) => ASTValueBool(r.boolean()),
+  ),
+
+  ASTNodeCodec<ASTValueInt>(
+    ASTNodeTag.valueInt,
+    'ASTValueInt',
+    encode: (w, n) {
+      w.literalInt(n.value);
+      // `negative` is not derivable from the value: it records that the source
+      // wrote a unary minus, which the generators reproduce, and it defaults to
+      // `value.isNegative` only when the parser did not say.
+      w.boolean(n.negative);
+    },
+    decode: (r) {
+      var v = r.literalInt();
+      return ASTValueInt(v, negative: r.boolean());
+    },
+  ),
+
+  ASTNodeCodec<ASTValueDouble>(
+    ASTNodeTag.valueDouble,
+    'ASTValueDouble',
+    encode: (w, n) {
+      w.float64(n.value);
+      w.boolean(n.negative);
+    },
+    decode: (r) {
+      var v = r.float64();
+      return ASTValueDouble(v, negative: r.boolean());
+    },
+  ),
+
+  ASTNodeCodec<ASTValueString>(
+    ASTNodeTag.valueString,
+    'ASTValueString',
+    encode: (w, n) => w.str(n.value),
+    decode: (r) => ASTValueString(r.str()),
+  ),
+
+  ASTNodeCodec<ASTValueNull>(
+    ASTNodeTag.valueNull,
+    'ASTValueNull',
+    encode: (w, n) {},
+    decode: (r) => ASTValueNull(),
+  ),
+
+  ASTNodeCodec<ASTValueVoid>(
+    ASTNodeTag.valueVoid,
+    'ASTValueVoid',
+    encode: (w, n) {},
+    decode: (r) => ASTValueVoid(),
+  ),
+
+  // --- String composition ---------------------------------------------------
+  ASTNodeCodec<ASTValueStringExpression>(
+    ASTNodeTag.valueStringExpression,
+    'ASTValueStringExpression',
+    encode: (w, n) => w.node(n.expression),
+    decode: (r) => ASTValueStringExpression(r.node<ASTExpression>()),
+  ),
+
+  ASTNodeCodec<ASTValueStringVariable>(
+    ASTNodeTag.valueStringVariable,
+    'ASTValueStringVariable',
+    // `children` reports nothing for this node, so the variable has to be
+    // written explicitly rather than picked up by a generic walk.
+    encode: (w, n) => w.node(n.variable),
+    decode: (r) => ASTValueStringVariable(r.node<ASTVariable>()),
+  ),
+
+  ASTNodeCodec<ASTValueStringConcatenation>(
+    ASTNodeTag.valueStringConcatenation,
+    'ASTValueStringConcatenation',
+    encode: (w, n) => w.nodes(n.values),
+    decode: (r) => ASTValueStringConcatenation(r.nodeList<ASTValue<String>>()),
+  ),
+
+  ASTNodeCodec<ASTValuesListAsString>(
+    ASTNodeTag.valuesListAsString,
+    'ASTValuesListAsString',
+    encode: (w, n) => w.nodes(n.values),
+    decode: (r) => ASTValuesListAsString(r.nodeList<ASTValue>()),
+  ),
+
+  ASTNodeCodec<ASTValueAsString>(
+    ASTNodeTag.valueAsString,
+    'ASTValueAsString',
+    encode: (w, n) => w.node(n.value),
+    decode: (r) => ASTValueAsString(r.node<ASTValue>()),
+  ),
+
+  // --- Containers -----------------------------------------------------------
+  // 3D before 2D before 1D: they are an inheritance chain.
+  ASTNodeCodec<ASTValueArray3D>(
+    ASTNodeTag.valueArray3D,
+    'ASTValueArray3D',
+    encode: (w, n) {
+      w.type(_elementTypeOf(n.type, 3));
+      w.nativeValue(n.value);
+    },
+    decode: (r) {
+      var elementType = r.type();
+      var raw = r.nativeValue() as List;
+      return ASTValueArray3D(elementType, [
+        for (var a in raw) [for (var b in a as List) (b as List)],
+      ]);
+    },
+  ),
+
+  ASTNodeCodec<ASTValueArray2D>(
+    ASTNodeTag.valueArray2D,
+    'ASTValueArray2D',
+    encode: (w, n) {
+      w.type(_elementTypeOf(n.type, 2));
+      w.nativeValue(n.value);
+    },
+    decode: (r) {
+      var elementType = r.type();
+      var raw = r.nativeValue() as List;
+      return ASTValueArray2D(elementType, [for (var a in raw) (a as List)]);
+    },
+  ),
+
+  ASTNodeCodec<ASTValueArray>(
+    ASTNodeTag.valueArray,
+    'ASTValueArray',
+    encode: (w, n) {
+      w.type(_elementTypeOf(n.type, 1));
+      w.nativeValue(n.value);
+    },
+    decode: (r) {
+      var componentType = r.type();
+      var raw = r.nativeValue() as List;
+      return ASTValueArray(componentType, raw);
+    },
+  ),
+
+  ASTNodeCodec<ASTValueMap>(
+    ASTNodeTag.valueMap,
+    'ASTValueMap',
+    encode: (w, n) {
+      var type = n.type as ASTTypeMap;
+      w.type(type.keyType);
+      w.type(type.valueType);
+      w.nativeValue(n.value);
+    },
+    decode: (r) {
+      var keyType = r.type();
+      var valueType = r.type();
+      var raw = r.nativeValue() as Map;
+      return ASTValueMap(keyType, valueType, raw);
+    },
+  ),
+
+  // --- Loosely typed statics ------------------------------------------------
+  ASTNodeCodec<ASTValueVar>(
+    ASTNodeTag.valueVar,
+    'ASTValueVar',
+    encode: (w, n) => w.nativeValue(n.value),
+    decode: (r) => ASTValueVar(r.nativeValue() as Object),
+  ),
+
+  ASTNodeCodec<ASTValueObject>(
+    ASTNodeTag.valueObject,
+    'ASTValueObject',
+    encode: (w, n) => w.nativeValue(n.value),
+    decode: (r) => ASTValueObject(r.nativeValue() as Object),
+  ),
+
+  // Last of the family: the catch-all base every concrete static value extends.
+  ASTNodeCodec<ASTValueStatic>(
+    ASTNodeTag.valueStatic,
+    'ASTValueStatic',
+    encode: (w, n) {
+      w.type(n.type);
+      w.nativeValue(n.value);
+    },
+    decode: (r) {
+      var type = r.type();
+      return ASTValueStatic(type, r.nativeValue());
+    },
+  ),
+];
+
+/// The element type buried [rank] levels down an array type.
+///
+/// `ASTValueArray2D` and `ASTValueArray3D` take the *element* type and wrap it
+/// themselves, so encoding their `type` directly and replaying it would add a
+/// level of nesting on every round trip.
+ASTType _elementTypeOf(ASTType type, int rank) {
+  ASTType t = type;
+  for (var i = 0; i < rank; ++i) {
+    if (t is! ASTTypeArray) return t;
+    t = t.componentType;
+  }
+  return t;
+}

--- a/lib/src/serialization/ast_binary_codecs_variable.dart
+++ b/lib/src/serialization/ast_binary_codecs_variable.dart
@@ -1,0 +1,85 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import '../ast/apollovm_ast_expression.dart';
+import '../ast/apollovm_ast_variable.dart';
+import 'ast_binary_node_codec.dart';
+import 'ast_binary_tags.dart';
+
+/// Codecs for the [ASTVariable] family, **most derived first**.
+///
+/// `ASTStaticFieldVariable` is absent on purpose: it holds a direct reference
+/// to an `ASTClassNormal`, and is only built once a class has been resolved.
+/// `ASTRuntimeVariable` and `ASTStaticClassAccessorVariable` are refused for
+/// the same reason — see `ASTCodecRegistry.excluded`.
+final List<ASTNodeCodec> variableCodecs = [
+  ASTNodeCodec<ASTScopeVariable>(
+    ASTNodeTag.scopeVariable,
+    'ASTScopeVariable',
+    // Only the name: `resolvedIdentifier` and the associated node are worked
+    // out again by `resolveNode` after the tree is rebuilt, exactly as they are
+    // after a parse.
+    encode: (w, n) => w.str(n.name),
+    decode: (r) => ASTScopeVariable(r.str()),
+  ),
+
+  ASTNodeCodec<ASTThisVariable>(
+    ASTNodeTag.thisVariable,
+    'ASTThisVariable',
+    encode: (w, n) {},
+    decode: (r) => ASTThisVariable(),
+  ),
+
+  ASTNodeCodec<ASTExpressionVariable>(
+    ASTNodeTag.expressionVariable,
+    'ASTExpressionVariable',
+    encode: (w, n) => w.node(n.expression),
+    decode: (r) => ASTExpressionVariable(r.node<ASTExpression>()),
+  ),
+
+  // Before `ASTClassField`, which it extends.
+  ASTNodeCodec<ASTClassFieldWithInitialValue>(
+    ASTNodeTag.classFieldWithInitialValue,
+    'ASTClassFieldWithInitialValue',
+    encode: (w, n) {
+      w.type(n.type);
+      w.str(n.name);
+      // `children` is empty for this node, so the initializer would be missed
+      // by any generic walk and has to be written explicitly.
+      w.node(n.initialValue);
+      w.boolean(n.finalValue);
+      w.modifiers(n.modifiers);
+    },
+    decode: (r) {
+      var type = r.type();
+      var name = r.str();
+      var initialValue = r.node<ASTExpression>();
+      var finalValue = r.boolean();
+      return ASTClassFieldWithInitialValue(
+        type,
+        name,
+        initialValue,
+        finalValue,
+        modifiers: r.modifiers(),
+      );
+    },
+  ),
+
+  ASTNodeCodec<ASTClassField>(
+    ASTNodeTag.classField,
+    'ASTClassField',
+    encode: (w, n) {
+      w.type(n.type);
+      w.str(n.name);
+      w.boolean(n.finalValue);
+      w.modifiers(n.modifiers);
+    },
+    decode: (r) {
+      var type = r.type();
+      var name = r.str();
+      var finalValue = r.boolean();
+      return ASTClassField(type, name, finalValue, modifiers: r.modifiers());
+    },
+  ),
+];

--- a/lib/src/serialization/ast_binary_codecs_variable.dart
+++ b/lib/src/serialization/ast_binary_codecs_variable.dart
@@ -55,6 +55,11 @@ final List<ASTNodeCodec> variableCodecs = [
       var type = r.type();
       var name = r.str();
       var initialValue = r.node<ASTExpression>();
+
+      // As in the grammars: wiring the field's type to its initializer is what
+      // lets a `var`/`final` field infer its type. A no-op for a declared type.
+      type.associateToType(initialValue);
+
       var finalValue = r.boolean();
       return ASTClassFieldWithInitialValue(
         type,

--- a/lib/src/serialization/ast_binary_container.dart
+++ b/lib/src/serialization/ast_binary_container.dart
@@ -64,6 +64,9 @@ class ASTBinaryHeader {
   /// Whether a source reference is present.
   bool get hasSourceRef => (flags & ASTBinaryFlags.hasSourceRef) != 0;
 
+  /// Whether this file bundles several code units rather than one.
+  bool get hasArchiveFlag => (flags & ASTBinaryFlags.archive) != 0;
+
   @override
   String toString() =>
       'ASTBinaryHeader{formatVersion: $formatVersion, '

--- a/lib/src/serialization/ast_binary_container.dart
+++ b/lib/src/serialization/ast_binary_container.dart
@@ -1,0 +1,438 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'dart:typed_data';
+
+import 'package:data_serializer/data_serializer.dart';
+
+import 'ast_binary_exception.dart';
+import 'ast_binary_format.dart';
+import 'ast_binary_signer.dart';
+import 'crc32.dart';
+
+/// One section of a binary AST file: an identifier and its payload.
+///
+/// The container treats every payload as opaque bytes; only the sections'
+/// framing is its concern.
+class ASTBinarySectionData {
+  /// The section identifier. See [ASTBinarySection] for the ones this build
+  /// knows; any other id is carried through and skipped on read.
+  final int id;
+
+  /// The section's bytes, excluding its id and length prefix.
+  final Uint8List payload;
+
+  const ASTBinarySectionData(this.id, this.payload);
+
+  /// The known section this id maps to, or `null` when unrecognized.
+  ASTBinarySection? get section => ASTBinarySection.byId(id);
+
+  @override
+  String toString() =>
+      'ASTBinarySectionData{id: $id (${section?.name ?? 'unknown'}), '
+      'size: ${payload.length}}';
+}
+
+/// The fixed header of a binary AST file.
+class ASTBinaryHeader {
+  /// The container revision that wrote this file.
+  final int formatVersion;
+
+  /// The oldest container revision that can decode this file correctly.
+  final int minReaderVersion;
+
+  /// The header flag bits. See [ASTBinaryFlags].
+  final int flags;
+
+  /// Byte length of the section stream.
+  final int sectionsSize;
+
+  const ASTBinaryHeader({
+    required this.formatVersion,
+    required this.minReaderVersion,
+    required this.flags,
+    required this.sectionsSize,
+  });
+
+  /// Whether a signature is present in the trailer.
+  bool get isSigned => (flags & ASTBinaryFlags.signed) != 0;
+
+  /// Whether a section index is present.
+  bool get hasSectionIndex => (flags & ASTBinaryFlags.hasSectionIndex) != 0;
+
+  /// Whether a source reference is present.
+  bool get hasSourceRef => (flags & ASTBinaryFlags.hasSourceRef) != 0;
+
+  @override
+  String toString() =>
+      'ASTBinaryHeader{formatVersion: $formatVersion, '
+      'minReaderVersion: $minReaderVersion, '
+      'flags: 0x${flags.toRadixString(16).padLeft(8, '0')}, '
+      'sectionsSize: $sectionsSize}';
+}
+
+/// A decoded binary AST container: its header, its sections, and whichever
+/// section ids this build did not recognize.
+class ASTBinaryContainer {
+  /// The file's fixed header.
+  final ASTBinaryHeader header;
+
+  /// Every section, in the order it appeared.
+  final List<ASTBinarySectionData> sections;
+
+  /// The signature from the trailer, or `null` when the file is unsigned.
+  final Uint8List? signature;
+
+  ASTBinaryContainer(this.header, this.sections, this.signature);
+
+  /// Section ids this build does not know and therefore skipped.
+  ///
+  /// A non-empty list means the file was written by a newer ApolloVM carrying
+  /// information this one ignores — which is expected, not an error.
+  List<int> get unknownSectionIds => [
+    for (var s in sections)
+      if (s.section == null) s.id,
+  ];
+
+  /// The payload of the first section with [id], or `null` when absent.
+  Uint8List? payloadOf(ASTBinarySection id) {
+    for (var s in sections) {
+      if (s.id == id.id) return s.payload;
+    }
+    return null;
+  }
+
+  /// The payload of the first section with [id].
+  ///
+  /// Throws an [ASTBinaryException] with [ASTBinaryError.malformedSection] when
+  /// the section is absent.
+  Uint8List requirePayloadOf(ASTBinarySection id) {
+    var payload = payloadOf(id);
+    if (payload == null) {
+      throw ASTBinaryException(
+        'Missing required section `${id.name}`.',
+        ASTBinaryError.malformedSection,
+        sectionId: id.id,
+        formatVersion: header.formatVersion,
+      );
+    }
+    return payload;
+  }
+}
+
+/// Frames sections into the binary AST container layout, and reads them back.
+///
+/// This layer knows nothing about the AST: it owns the magic, the versions, the
+/// section framing, the CRC-32 and the signature. See [ASTBinaryFormat] for the
+/// byte layout.
+class ASTBinaryContainerCodec {
+  ASTBinaryContainerCodec._();
+
+  /// Assembles [sections] into a complete binary AST file.
+  ///
+  /// When [signer] is given, the header's [ASTBinaryFlags.signed] bit is set and
+  /// the signature is appended to the trailer.
+  static Uint8List encode({
+    required List<ASTBinarySectionData> sections,
+    int formatVersion = ASTBinaryFormat.version,
+    int minReaderVersion = ASTBinaryFormat.version,
+    int flags = 0,
+    ASTBinarySigner? signer,
+  }) {
+    if (signer != null) flags |= ASTBinaryFlags.signed;
+
+    var stream = BytesBuffer();
+    for (var s in sections) {
+      stream.writeLeb128UnsignedInt(s.id);
+      stream.writeLeb128UnsignedInt(s.payload.length);
+      stream.writeAllBytes(s.payload);
+    }
+    var streamBytes = stream.toBytes();
+
+    if (streamBytes.length > ASTBinaryFormat.maxSectionsSize) {
+      throw StateError(
+        'Binary AST section stream is ${streamBytes.length} bytes, over the '
+        '${ASTBinaryFormat.maxSectionsSize} byte format limit.',
+      );
+    }
+
+    var out = BytesBuffer();
+    out.writeAll(ASTBinaryFormat.magic);
+    out.writeUint16(formatVersion);
+    out.writeUint16(minReaderVersion);
+    out.writeUint32(flags);
+    out.writeUint32(streamBytes.length);
+    out.writeAllBytes(streamBytes);
+
+    // The CRC covers the header and every section, so tampering with a version,
+    // a flag or a payload is all detected by the same check.
+    var crc = Crc32.compute(out.toBytes());
+    out.writeUint32(crc);
+
+    if (signer == null) {
+      out.writeUint16(0);
+    } else {
+      // The signature covers everything up to and including the CRC, so an
+      // attacker who edits a section and recomputes the CRC still fails
+      // verification. It deliberately stops before `signatureLength`, which is
+      // not known until the signature exists; substituting that length instead
+      // breaks the exact file-length check the reader does first.
+      var signature = signer.sign(out.toBytes());
+
+      if (signature.isEmpty ||
+          signature.length > ASTBinaryFormat.maxSignatureLength) {
+        throw StateError(
+          'Signature is ${signature.length} bytes; must be 1..'
+          '${ASTBinaryFormat.maxSignatureLength}.',
+        );
+      }
+
+      out.writeUint16(signature.length);
+      out.writeAllBytes(signature);
+    }
+
+    out.writeAll(ASTBinaryFormat.trailerMagic);
+
+    return out.toBytes();
+  }
+
+  /// Parses [bytes] into a container, verifying its structure and integrity.
+  ///
+  /// The CRC-32 is checked unless [verifyChecksum] is `false` (an escape hatch
+  /// for forensics and repair tooling, not for normal loading).
+  ///
+  /// When [verifier] is given, the file's signature must be present and valid.
+  /// A signed file read *without* a verifier still loads — the signature is
+  /// simply not checked, and [ASTBinaryHeader.isSigned] reports that it was
+  /// there.
+  static ASTBinaryContainer decode(
+    Uint8List bytes, {
+    bool verifyChecksum = true,
+    ASTBinaryVerifier? verifier,
+  }) {
+    if (!ASTBinaryFormat.isASTBinary(bytes)) {
+      throw ASTBinaryException(
+        bytes.length < ASTBinaryFormat.magic.length
+            ? 'Not a binary AST file: only ${bytes.length} bytes.'
+            : 'Not a binary AST file: bad magic.',
+        bytes.length < ASTBinaryFormat.magic.length
+            ? ASTBinaryError.truncated
+            : ASTBinaryError.badMagic,
+        offset: 0,
+      );
+    }
+
+    if (bytes.length < ASTBinaryFormat.headerSize) {
+      throw ASTBinaryException(
+        'Truncated binary AST file: ${bytes.length} bytes, header needs '
+        '${ASTBinaryFormat.headerSize}.',
+        ASTBinaryError.truncated,
+        offset: bytes.length,
+      );
+    }
+
+    var formatVersion = _uint16(bytes, 4);
+    var minReaderVersion = _uint16(bytes, 6);
+    var flags = _uint32(bytes, 8);
+    var sectionsSize = _uint32(bytes, 12);
+
+    if (minReaderVersion > ASTBinaryFormat.version) {
+      throw ASTBinaryException(
+        'This binary AST file needs a reader for format version '
+        '$minReaderVersion; this build reads up to '
+        '${ASTBinaryFormat.version}.',
+        ASTBinaryError.unsupportedVersion,
+        formatVersion: formatVersion,
+        minReaderVersion: minReaderVersion,
+      );
+    }
+
+    if (formatVersion < ASTBinaryFormat.minSupportedVersion) {
+      throw ASTBinaryException(
+        'Binary AST format version $formatVersion is older than the oldest '
+        'supported (${ASTBinaryFormat.minSupportedVersion}).',
+        ASTBinaryError.unsupportedVersion,
+        formatVersion: formatVersion,
+        minReaderVersion: minReaderVersion,
+      );
+    }
+
+    // An unknown *flag* changes how the payload must be read, so it is refused;
+    // an unknown *section* is merely extra information, so it is skipped.
+    var unknownFlags = flags & ~ASTBinaryFlags.knownMask;
+    if (unknownFlags != 0) {
+      throw ASTBinaryException(
+        'Binary AST header sets unknown flags '
+        '0x${unknownFlags.toRadixString(16).padLeft(8, '0')}.',
+        ASTBinaryError.unknownFlags,
+        offset: 8,
+        formatVersion: formatVersion,
+        minReaderVersion: minReaderVersion,
+      );
+    }
+
+    var trailerStart = ASTBinaryFormat.headerSize + sectionsSize;
+    if (bytes.length < trailerStart + ASTBinaryFormat.minTrailerSize) {
+      throw ASTBinaryException(
+        'Truncated binary AST file: ${bytes.length} bytes, but the header '
+        'declares $sectionsSize bytes of sections.',
+        ASTBinaryError.truncated,
+        offset: bytes.length,
+        formatVersion: formatVersion,
+      );
+    }
+
+    var signatureLength = _uint16(bytes, trailerStart + 4);
+    var expectedLength =
+        trailerStart + ASTBinaryFormat.minTrailerSize + signatureLength;
+
+    if (bytes.length != expectedLength) {
+      throw ASTBinaryException(
+        'Binary AST file is ${bytes.length} bytes; its header and trailer '
+        'describe exactly $expectedLength.',
+        ASTBinaryError.truncated,
+        offset: expectedLength,
+        formatVersion: formatVersion,
+      );
+    }
+
+    var trailerMagicOffset =
+        expectedLength - ASTBinaryFormat.trailerMagic.length;
+    for (var i = 0; i < ASTBinaryFormat.trailerMagic.length; ++i) {
+      if (bytes[trailerMagicOffset + i] != ASTBinaryFormat.trailerMagic[i]) {
+        throw ASTBinaryException(
+          'Binary AST file has a bad trailer magic; it is truncated or was '
+          'concatenated with other data.',
+          ASTBinaryError.truncated,
+          offset: trailerMagicOffset,
+          formatVersion: formatVersion,
+        );
+      }
+    }
+
+    if (verifyChecksum) {
+      var expected = _uint32(bytes, trailerStart);
+      var actual = Crc32.compute(bytes, 0, trailerStart);
+      if (expected != actual) {
+        throw ASTBinaryIntegrityException(
+          'Binary AST checksum mismatch: file declares '
+          '0x${expected.toRadixString(16)}, content is '
+          '0x${actual.toRadixString(16)}. The file is corrupted or was '
+          'modified.',
+          ASTBinaryError.checksumMismatch,
+          offset: trailerStart,
+          formatVersion: formatVersion,
+        );
+      }
+    }
+
+    var isSigned = (flags & ASTBinaryFlags.signed) != 0;
+    Uint8List? signature;
+    if (isSigned) {
+      signature = _slice(bytes, trailerStart + 6, signatureLength);
+    }
+
+    if (verifier != null) {
+      if (!isSigned || signature == null) {
+        throw ASTBinaryIntegrityException(
+          'Binary AST file is unsigned, but a verifier was supplied. Refusing '
+          'to load it as verified.',
+          ASTBinaryError.signatureMissing,
+          formatVersion: formatVersion,
+        );
+      }
+
+      var signaturePayload = _slice(bytes, 0, trailerStart + 4);
+      if (!verifier.verify(signaturePayload, signature)) {
+        throw ASTBinaryIntegrityException(
+          'Binary AST signature is not valid for this content and key.',
+          ASTBinaryError.signatureMismatch,
+          offset: trailerStart + 6,
+          formatVersion: formatVersion,
+        );
+      }
+    }
+
+    var header = ASTBinaryHeader(
+      formatVersion: formatVersion,
+      minReaderVersion: minReaderVersion,
+      flags: flags,
+      sectionsSize: sectionsSize,
+    );
+
+    var sections = _decodeSections(
+      bytes,
+      ASTBinaryFormat.headerSize,
+      sectionsSize,
+      formatVersion,
+    );
+
+    return ASTBinaryContainer(header, sections, signature);
+  }
+
+  static List<ASTBinarySectionData> _decodeSections(
+    Uint8List bytes,
+    int start,
+    int size,
+    int formatVersion,
+  ) {
+    var sections = <ASTBinarySectionData>[];
+    var end = start + size;
+    var stream = BytesBuffer.from(_slice(bytes, start, size));
+
+    while (stream.remaining > 0) {
+      var sectionStart = start + stream.position;
+
+      int id;
+      int payloadSize;
+      try {
+        id = stream.readLeb128UnsignedInt();
+        payloadSize = stream.readLeb128UnsignedInt();
+      } catch (e) {
+        throw ASTBinaryException(
+          'Malformed section framing: $e',
+          ASTBinaryError.malformedSection,
+          offset: sectionStart,
+          formatVersion: formatVersion,
+        );
+      }
+
+      if (payloadSize < 0 || payloadSize > stream.remaining) {
+        throw ASTBinaryException(
+          'Section $id declares a $payloadSize byte payload, but only '
+          '${stream.remaining} bytes remain before the end of the section '
+          'stream (offset $end).',
+          ASTBinaryError.truncated,
+          offset: sectionStart,
+          formatVersion: formatVersion,
+          sectionId: id,
+        );
+      }
+
+      // Every payload is length-prefixed, so an id this build does not know is
+      // simply carried through — that is what keeps newer files readable.
+      var payload = _slice(bytes, start + stream.position, payloadSize);
+      stream.seek(stream.position + payloadSize);
+
+      sections.add(ASTBinarySectionData(id, payload));
+    }
+
+    return sections;
+  }
+
+  /// A zero-copy view of `[start, start+length)` of [bytes].
+  ///
+  /// Goes through [Uint8List.offsetInBytes] deliberately: [bytes] may itself be
+  /// a view into a larger buffer, and `bytes.buffer.asUint8List(start, …)`
+  /// would then silently read from the wrong place.
+  static Uint8List _slice(Uint8List bytes, int start, int length) {
+    RangeError.checkValidRange(start, start + length, bytes.length);
+    return Uint8List.view(bytes.buffer, bytes.offsetInBytes + start, length);
+  }
+
+  static int _uint16(Uint8List b, int o) => (b[o] << 8) | b[o + 1];
+
+  static int _uint32(Uint8List b, int o) =>
+      ((b[o] << 24) | (b[o + 1] << 16) | (b[o + 2] << 8) | b[o + 3]) >>> 0;
+}

--- a/lib/src/serialization/ast_binary_context.dart
+++ b/lib/src/serialization/ast_binary_context.dart
@@ -1,0 +1,564 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'dart:typed_data';
+
+import 'package:data_serializer/data_serializer.dart';
+
+import '../ast/apollovm_ast_annotation.dart';
+import '../ast/apollovm_ast_base.dart';
+import '../ast/apollovm_ast_type.dart';
+import 'ast_binary_exception.dart';
+import 'ast_binary_format.dart';
+import 'ast_binary_pool.dart';
+import 'ast_binary_registry.dart';
+import 'ast_binary_type_pool.dart';
+
+/// The largest integer that survives a round trip through a JavaScript double,
+/// which is what a Dart `int` compiles to under `dart2js`.
+const int _maxSafeInteger = 9007199254740991; // 2^53 - 1
+
+/// Tags for the plain-Dart values an [ASTValueStatic] can hold.
+class ASTNativeValueTag {
+  ASTNativeValueTag._();
+
+  static const int nullValue = 0x00;
+  static const int falseValue = 0x01;
+  static const int trueValue = 0x02;
+  static const int intValue = 0x03;
+  static const int doubleValue = 0x04;
+  static const int stringValue = 0x05;
+  static const int listValue = 0x06;
+  static const int mapValue = 0x07;
+
+  /// A nested AST node, which some values carry in place of plain data.
+  static const int nodeValue = 0x08;
+}
+
+/// How an integer is stored.
+///
+/// Signed values are written as a form byte plus an **unsigned** LEB128
+/// magnitude, rather than as signed LEB128. That is deliberate:
+/// `BytesBuffer.readLeb128SignedInt` in `data_serializer` 1.2.2 does not
+/// sign-extend correctly — it records the byte *before* the terminating one, so
+/// `-2` reads back as `126` and `64` as `-16320`. Splitting the sign out uses
+/// only the unsigned path, which is correct, and sidesteps sign-extension
+/// differences between the VM and `dart2js` at the same time.
+class ASTIntEncoding {
+  ASTIntEncoding._();
+
+  /// A non-negative value, as an unsigned LEB128.
+  static const int positive = 0x00;
+
+  /// A decimal string, for magnitudes a JavaScript double cannot hold exactly.
+  ///
+  /// A writer running under `dart2js` can never produce this form, because it
+  /// could not have held such a value in the first place.
+  static const int bigDecimal = 0x01;
+
+  /// A negative value, as an unsigned LEB128 of its magnitude.
+  static const int negative = 0x02;
+}
+
+/// Accumulates the AST section, interning strings and types as it goes.
+///
+/// Codecs are handed one of these and use its typed helpers rather than
+/// touching the byte buffer, so the encoding of a field kind is defined once.
+class ASTBinaryWriteContext {
+  /// The AST section being built.
+  final BytesBuffer out = BytesBuffer();
+
+  /// The shared string pool.
+  final ASTStringPoolWriter strings;
+
+  /// The shared type pool.
+  final ASTTypePoolWriter types;
+
+  final List<String> _path = [];
+
+  ASTBinaryWriteContext(this.strings, this.types);
+
+  /// Where the writer currently is, e.g. `ASTRoot > class Foo > bar`.
+  ///
+  /// Used to say *where* an unserializable node was found, which matters
+  /// because the usual cause is a VM with external functions mapped into it.
+  String get declarationPath => _path.isEmpty ? '' : _path.join(' > ');
+
+  /// Runs [body] with [name] appended to [declarationPath].
+  T inDeclaration<T>(String name, T Function() body) {
+    _path.add(name);
+    try {
+      return body();
+    } finally {
+      _path.removeLast();
+    }
+  }
+
+  /// The finished AST section payload.
+  Uint8List toBytes() => out.toBytes();
+
+  /// Writes a node: its tag, then its fields.
+  void node(Object node) {
+    var codec = ASTCodecRegistry.codecFor(node, declarationPath);
+    out.writeLeb128UnsignedInt(codec.tag);
+    codec.encodeAny(this, node);
+  }
+
+  /// Writes a node, or a single zero byte when it is `null`.
+  void nodeOrNull(Object? node) {
+    if (node == null) {
+      out.writeLeb128UnsignedInt(ASTCodecRegistry.nullTag);
+      return;
+    }
+    this.node(node);
+  }
+
+  /// Writes a list of nodes, distinguishing a null list from an empty one.
+  void nodes(List<Object>? list) {
+    if (list == null) {
+      out.writeLeb128UnsignedInt(0);
+      return;
+    }
+    // `n + 1`, so 0 can mean "the list itself was null". The generators treat
+    // a missing list and an empty one differently, so the distinction matters.
+    out.writeLeb128UnsignedInt(list.length + 1);
+    for (var e in list) {
+      node(e);
+    }
+  }
+
+  /// Writes an interned string.
+  void str(String s) => out.writeLeb128UnsignedInt(strings.intern(s));
+
+  /// Writes an interned string, or a marker when it is `null`.
+  void strOrNull(String? s) =>
+      out.writeLeb128UnsignedInt(s == null ? 0 : strings.intern(s) + 1);
+
+  /// Writes a list of interned strings, distinguishing null from empty.
+  void strings_(List<String>? list) {
+    if (list == null) {
+      out.writeLeb128UnsignedInt(0);
+      return;
+    }
+    out.writeLeb128UnsignedInt(list.length + 1);
+    for (var s in list) {
+      str(s);
+    }
+  }
+
+  /// Writes an interned type reference.
+  void type(ASTType t) => out.writeLeb128UnsignedInt(types.intern(t));
+
+  /// Writes an interned type reference, or a marker when it is `null`.
+  void typeOrNull(ASTType? t) =>
+      out.writeLeb128UnsignedInt(t == null ? 0 : types.intern(t) + 1);
+
+  /// Writes a list of interned type references, distinguishing null from empty.
+  void typeList(List<ASTType>? list) {
+    if (list == null) {
+      out.writeLeb128UnsignedInt(0);
+      return;
+    }
+    out.writeLeb128UnsignedInt(list.length + 1);
+    for (var t in list) {
+      type(t);
+    }
+  }
+
+  /// Writes a non-negative integer.
+  void uint(int v) => out.writeLeb128UnsignedInt(v);
+
+  /// Writes a possibly-negative integer, as a sign byte plus a magnitude.
+  void sint(int v) {
+    out.writeByte(v < 0 ? ASTIntEncoding.negative : ASTIntEncoding.positive);
+    out.writeLeb128UnsignedInt(v < 0 ? -v : v);
+  }
+
+  /// Writes a nullable non-negative integer.
+  void uintOrNull(int? v) => out.writeLeb128UnsignedInt(v == null ? 0 : v + 1);
+
+  /// Writes a boolean as one byte.
+  void boolean(bool v) => out.writeBoolean(v);
+
+  /// Writes a byte, for small bitfields and discriminators.
+  void byte(int v) => out.writeByte(v);
+
+  /// Writes a `double` as IEEE-754 binary64.
+  void float64(double v) => out.writeFloat64(v);
+
+  /// Writes an enum by **name**.
+  ///
+  /// By name rather than by index deliberately: an index silently mis-decodes
+  /// every older file the moment someone inserts a member into the middle of an
+  /// enum, and `ASTExpressionOperator` is exactly the sort of enum that grows.
+  /// With the string pool the cost is one byte per occurrence, so index
+  /// encoding would save essentially nothing.
+  ///
+  /// Note this is *not* `BytesBuffer.writeEnum`, which writes the index.
+  void enumByName(Enum e) => str(e.name);
+
+  /// Writes an integer literal from source, in a form that is exact on the web.
+  ///
+  /// Dart `int` is a JavaScript double under `dart2js`, so a value beyond 2^53
+  /// cannot be held there at all. Such a value is stored as a decimal string so
+  /// a VM-written file stays readable, and a `dart2js` reader that meets one
+  /// fails with a clear message rather than silently rounding it.
+  void literalInt(int v) {
+    if (v >= -_maxSafeInteger && v <= _maxSafeInteger) {
+      out.writeByte(v < 0 ? ASTIntEncoding.negative : ASTIntEncoding.positive);
+      out.writeLeb128UnsignedInt(v < 0 ? -v : v);
+    } else {
+      out.writeByte(ASTIntEncoding.bigDecimal);
+      str(v.toString());
+    }
+  }
+
+  /// Writes an [ASTModifiers] as a single bitfield byte.
+  void modifiers(ASTModifiers m) {
+    var bits = 0;
+    if (m.isStatic) bits |= 0x01;
+    if (m.isFinal) bits |= 0x02;
+    if (m.isPrivate) bits |= 0x04;
+    if (m.isPublic) bits |= 0x08;
+    if (m.isAsync) bits |= 0x10;
+    if (m.isAbstract) bits |= 0x20;
+    if (m.isProtected) bits |= 0x40;
+    out.writeByte(bits);
+  }
+
+  /// Writes a plain Dart value held by an [ASTValueStatic].
+  ///
+  /// Only data a parser could have produced is representable: `null`,
+  /// booleans, numbers, strings, and lists and maps of those, plus a nested AST
+  /// node. Anything else is a live Dart object that found its way into the tree
+  /// at run time, and is refused by name rather than silently dropped — this is
+  /// the guard that stops a VM object being written into a file.
+  void nativeValue(Object? v) {
+    switch (v) {
+      case null:
+        out.writeByte(ASTNativeValueTag.nullValue);
+      case bool b:
+        out.writeByte(
+          b ? ASTNativeValueTag.trueValue : ASTNativeValueTag.falseValue,
+        );
+      case int i:
+        out.writeByte(ASTNativeValueTag.intValue);
+        literalInt(i);
+      case double d:
+        out.writeByte(ASTNativeValueTag.doubleValue);
+        float64(d);
+      case String s:
+        out.writeByte(ASTNativeValueTag.stringValue);
+        str(s);
+      case List l:
+        out.writeByte(ASTNativeValueTag.listValue);
+        uint(l.length);
+        for (var e in l) {
+          nativeValue(e);
+        }
+      case Map m:
+        out.writeByte(ASTNativeValueTag.mapValue);
+        uint(m.length);
+        for (var e in m.entries) {
+          nativeValue(e.key);
+          nativeValue(e.value);
+        }
+      case ASTNode n:
+        out.writeByte(ASTNativeValueTag.nodeValue);
+        node(n);
+      default:
+        throw ASTNotSerializableException(
+          v,
+          'a value of this type is live Dart state, not something a parser '
+          'produces',
+          declarationPath: declarationPath.isEmpty ? null : declarationPath,
+        );
+    }
+  }
+
+  /// Writes an annotation list, distinguishing null from empty.
+  void annotations(List<ASTAnnotation>? list) {
+    if (list == null) {
+      out.writeLeb128UnsignedInt(0);
+      return;
+    }
+    out.writeLeb128UnsignedInt(list.length + 1);
+    for (var a in list) {
+      writeAnnotation(out, strings, a);
+    }
+  }
+}
+
+/// Reads the AST section, resolving pool references as it goes.
+///
+/// Mirrors [ASTBinaryWriteContext] method for method; a codec's `decode` reads
+/// exactly the fields its `encode` wrote, in the same order.
+class ASTBinaryReadContext {
+  /// The AST section being read.
+  final BytesBuffer input;
+
+  /// The decoded string pool.
+  final ASTStringPoolReader strings;
+
+  /// The decoded type pool.
+  final ASTTypePoolReader types;
+
+  /// The container revision that wrote the file.
+  ///
+  /// Codecs gate fields added in a later revision on this, which is how a
+  /// reader keeps decoding files written before those fields existed.
+  final int formatVersion;
+
+  ASTBinaryReadContext(
+    this.input,
+    this.strings,
+    this.types, {
+    required this.formatVersion,
+  });
+
+  /// Reads a node and checks it is a [T].
+  T node<T extends Object>() {
+    var n = _readNode();
+    if (n == null) {
+      throw ASTBinaryException(
+        'Expected a $T but found a null node marker.',
+        ASTBinaryError.malformedSection,
+        offset: input.position,
+        sectionId: ASTBinarySection.astRoot.id,
+      );
+    }
+    return _cast<T>(n);
+  }
+
+  /// Reads a node that may be absent.
+  T? nodeOrNull<T extends Object>() {
+    var n = _readNode();
+    return n == null ? null : _cast<T>(n);
+  }
+
+  /// Reads a node list, distinguishing a null list from an empty one.
+  List<T>? nodes<T extends Object>() {
+    var n = input.readLeb128UnsignedInt();
+    if (n == 0) return null;
+    return [for (var i = 1; i < n; ++i) node<T>()];
+  }
+
+  /// Reads a node list that the writer never stores as null.
+  List<T> nodeList<T extends Object>() => nodes<T>() ?? <T>[];
+
+  Object? _readNode() {
+    var tag = input.readLeb128UnsignedInt();
+    if (tag == ASTCodecRegistry.nullTag) return null;
+
+    var codec = ASTCodecRegistry.byTag(tag);
+    if (codec == null) {
+      // An unknown *section* is skipped, but an unknown node tag never can be:
+      // there is no length prefix to skip past, and guessing would produce a
+      // wrong AST rather than an incomplete one.
+      throw ASTBinaryException(
+        'Unknown AST node tag $tag at offset ${input.position}. The file was '
+        'written by a newer ApolloVM than this one can decode.',
+        ASTBinaryError.unsupportedNode,
+        offset: input.position,
+        formatVersion: formatVersion,
+        sectionId: ASTBinarySection.astRoot.id,
+      );
+    }
+
+    return codec.decode(this);
+  }
+
+  T _cast<T extends Object>(Object n) {
+    if (n is! T) {
+      throw ASTBinaryException(
+        'Expected a $T but decoded a ${n.runtimeType}.',
+        ASTBinaryError.malformedSection,
+        offset: input.position,
+        sectionId: ASTBinarySection.astRoot.id,
+      );
+    }
+    return n;
+  }
+
+  /// Reads an interned string.
+  String str() => strings[input.readLeb128UnsignedInt()];
+
+  /// Reads an interned string that may be absent.
+  String? strOrNull() {
+    var i = input.readLeb128UnsignedInt();
+    return i == 0 ? null : strings[i - 1];
+  }
+
+  /// Reads a string list, distinguishing null from empty.
+  List<String>? strings_() {
+    var n = input.readLeb128UnsignedInt();
+    if (n == 0) return null;
+    return [for (var i = 1; i < n; ++i) str()];
+  }
+
+  /// Reads an interned type reference.
+  ASTType type() => types[input.readLeb128UnsignedInt()];
+
+  /// Reads an interned type reference that may be absent.
+  ASTType? typeOrNull() {
+    var i = input.readLeb128UnsignedInt();
+    return i == 0 ? null : types[i - 1];
+  }
+
+  /// Reads a type list, distinguishing null from empty.
+  List<ASTType>? typeList() {
+    var n = input.readLeb128UnsignedInt();
+    if (n == 0) return null;
+    return [for (var i = 1; i < n; ++i) type()];
+  }
+
+  /// Reads a non-negative integer.
+  int uint() => input.readLeb128UnsignedInt();
+
+  /// Reads a possibly-negative integer.
+  int sint() {
+    var sign = input.readByte();
+    var magnitude = input.readLeb128UnsignedInt();
+    return sign == ASTIntEncoding.negative ? -magnitude : magnitude;
+  }
+
+  /// Reads a nullable non-negative integer.
+  int? uintOrNull() {
+    var v = input.readLeb128UnsignedInt();
+    return v == 0 ? null : v - 1;
+  }
+
+  /// Reads a boolean.
+  bool boolean() => input.readBoolean();
+
+  /// Reads a byte.
+  int byte() => input.readByte();
+
+  /// Reads a `double`.
+  double float64() => input.readFloat64();
+
+  /// Reads an enum written by [ASTBinaryWriteContext.enumByName].
+  E enumByName<E extends Enum>(List<E> values) {
+    var name = str();
+    for (var v in values) {
+      if (v.name == name) return v;
+    }
+    throw ASTBinaryException(
+      "Unknown $E value '$name'. The file was written by a newer ApolloVM, or "
+      'is corrupted.',
+      ASTBinaryError.unsupportedNode,
+      offset: input.position,
+      formatVersion: formatVersion,
+      sectionId: ASTBinarySection.astRoot.id,
+    );
+  }
+
+  /// Reads an integer literal written by [ASTBinaryWriteContext.literalInt].
+  int literalInt() {
+    var form = input.readByte();
+    switch (form) {
+      case ASTIntEncoding.positive:
+        return input.readLeb128UnsignedInt();
+      case ASTIntEncoding.negative:
+        return -input.readLeb128UnsignedInt();
+      case ASTIntEncoding.bigDecimal:
+        var text = str();
+        var v = int.tryParse(text);
+        if (v == null || v.toString() != text) {
+          // Reachable only on the web, where an `int` is a double: the value
+          // exists in the file but cannot be represented here. Say so, rather
+          // than silently handing back a rounded number.
+          throw ASTBinaryException(
+            "Integer literal '$text' cannot be represented exactly on this "
+            'platform (JavaScript integers are exact only up to 2^53-1).',
+            ASTBinaryError.unsupportedNode,
+            offset: input.position,
+            sectionId: ASTBinarySection.astRoot.id,
+          );
+        }
+        return v;
+      default:
+        throw ASTBinaryException(
+          'Unknown integer encoding 0x${form.toRadixString(16)}.',
+          ASTBinaryError.unsupportedNode,
+          offset: input.position,
+          sectionId: ASTBinarySection.astRoot.id,
+        );
+    }
+  }
+
+  /// Reads an [ASTModifiers] bitfield.
+  ASTModifiers modifiers() {
+    var bits = input.readByte();
+
+    // `ASTModifiers` refuses to be both private and public, and a corrupted
+    // byte can ask for exactly that. Report it as a malformed file rather than
+    // letting a bare `StateError` escape the reader.
+    if ((bits & 0x04) != 0 && (bits & 0x08) != 0) {
+      throw ASTBinaryException(
+        'Modifiers byte 0x${bits.toRadixString(16)} is both private and '
+        'public.',
+        ASTBinaryError.malformedSection,
+        offset: input.position,
+        sectionId: ASTBinarySection.astRoot.id,
+      );
+    }
+
+    return ASTModifiers(
+      isStatic: (bits & 0x01) != 0,
+      isFinal: (bits & 0x02) != 0,
+      isPrivate: (bits & 0x04) != 0,
+      isPublic: (bits & 0x08) != 0,
+      isAsync: (bits & 0x10) != 0,
+      isAbstract: (bits & 0x20) != 0,
+      isProtected: (bits & 0x40) != 0,
+    );
+  }
+
+  /// Reads a value written by [ASTBinaryWriteContext.nativeValue].
+  Object? nativeValue() {
+    var tag = input.readByte();
+    switch (tag) {
+      case ASTNativeValueTag.nullValue:
+        return null;
+      case ASTNativeValueTag.falseValue:
+        return false;
+      case ASTNativeValueTag.trueValue:
+        return true;
+      case ASTNativeValueTag.intValue:
+        return literalInt();
+      case ASTNativeValueTag.doubleValue:
+        return float64();
+      case ASTNativeValueTag.stringValue:
+        return str();
+      case ASTNativeValueTag.listValue:
+        var n = uint();
+        return [for (var i = 0; i < n; ++i) nativeValue()];
+      case ASTNativeValueTag.mapValue:
+        var n = uint();
+        var m = <Object?, Object?>{};
+        for (var i = 0; i < n; ++i) {
+          var k = nativeValue();
+          m[k] = nativeValue();
+        }
+        return m;
+      case ASTNativeValueTag.nodeValue:
+        return node<Object>();
+      default:
+        throw ASTBinaryException(
+          'Unknown native value tag 0x${tag.toRadixString(16)}.',
+          ASTBinaryError.unsupportedNode,
+          offset: input.position,
+          sectionId: ASTBinarySection.astRoot.id,
+        );
+    }
+  }
+
+  /// Reads an annotation list, distinguishing null from empty.
+  List<ASTAnnotation>? annotations() {
+    var n = input.readLeb128UnsignedInt();
+    if (n == 0) return null;
+    return [for (var i = 1; i < n; ++i) readAnnotation(input, strings)];
+  }
+}

--- a/lib/src/serialization/ast_binary_exception.dart
+++ b/lib/src/serialization/ast_binary_exception.dart
@@ -1,0 +1,131 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+/// Why a binary AST file could not be read.
+enum ASTBinaryError {
+  /// The file does not start with the binary AST magic.
+  badMagic,
+
+  /// The file is shorter than its own header claims, has trailing garbage, or a
+  /// section overruns the section stream.
+  truncated,
+
+  /// The file requires a newer reader, or is older than this build supports.
+  unsupportedVersion,
+
+  /// The header sets a flag bit this build does not understand, so the payload
+  /// cannot be interpreted safely.
+  unknownFlags,
+
+  /// A required section is missing, out of order, or malformed.
+  malformedSection,
+
+  /// A node encoding this build does not know. Unlike an unknown section, an
+  /// unknown node tag is never skipped — skipping would yield a wrong AST.
+  unsupportedNode,
+
+  /// The CRC-32 does not match the file contents.
+  checksumMismatch,
+
+  /// A verifier was supplied but the file carries no signature.
+  signatureMissing,
+
+  /// The signature was rejected by the verifier.
+  signatureMismatch,
+}
+
+/// A binary AST file could not be read.
+///
+/// This is an [Exception], not an [Error]: a malformed or corrupted input file
+/// is an expected, recoverable condition that callers catch and report — unlike
+/// `SyntaxError`, which reports a mistake in code the programmer supplied.
+class ASTBinaryException implements Exception {
+  /// A human-readable description of the failure.
+  final String message;
+
+  /// The machine-readable cause.
+  final ASTBinaryError error;
+
+  /// Byte offset of the failure, when known.
+  final int? offset;
+
+  /// The `formatVersion` the file declared, when it could be read.
+  final int? formatVersion;
+
+  /// The `minReaderVersion` the file declared, when it could be read.
+  final int? minReaderVersion;
+
+  /// The section being decoded when the failure occurred, when applicable.
+  final int? sectionId;
+
+  const ASTBinaryException(
+    this.message,
+    this.error, {
+    this.offset,
+    this.formatVersion,
+    this.minReaderVersion,
+    this.sectionId,
+  });
+
+  @override
+  String toString() {
+    var b = StringBuffer('ASTBinaryException(${error.name}): $message');
+    if (offset != null) b.write(' ; offset: $offset');
+    if (sectionId != null) b.write(' ; section: $sectionId');
+    if (formatVersion != null) b.write(' ; formatVersion: $formatVersion');
+    if (minReaderVersion != null) {
+      b.write(' ; minReaderVersion: $minReaderVersion');
+    }
+    return b.toString();
+  }
+}
+
+/// The file is structurally valid but does not verify.
+///
+/// Thrown for [ASTBinaryError.checksumMismatch],
+/// [ASTBinaryError.signatureMissing] and [ASTBinaryError.signatureMismatch], so
+/// a caller can distinguish "this file is damaged or tampered with" from "this
+/// file is the wrong shape".
+class ASTBinaryIntegrityException extends ASTBinaryException {
+  const ASTBinaryIntegrityException(
+    super.message,
+    super.error, {
+    super.offset,
+    super.formatVersion,
+    super.minReaderVersion,
+    super.sectionId,
+  });
+}
+
+/// An AST node cannot be represented in a binary AST file.
+///
+/// Thrown by the writer for nodes that hold live Dart state — external
+/// functions and getters (which carry a Dart closure), and runtime-only values
+/// such as a class instance, a pending future or a bound runtime variable.
+/// These are injected by the VM at run time rather than produced by a parser,
+/// and are re-injected the same way after a binary load, so a parsed AST never
+/// contains them.
+class ASTNotSerializableException implements Exception {
+  /// The node that could not be encoded.
+  final Object node;
+
+  /// Why it could not be encoded.
+  final String reason;
+
+  /// Where in the program the node lives, e.g. `ASTRoot > class Foo > bar`.
+  final String? declarationPath;
+
+  const ASTNotSerializableException(
+    this.node,
+    this.reason, {
+    this.declarationPath,
+  });
+
+  @override
+  String toString() {
+    var at = declarationPath == null ? '' : ' (at $declarationPath)';
+    return "ASTNotSerializableException: can't serialize "
+        '`${node.runtimeType}`$at: $reason';
+  }
+}

--- a/lib/src/serialization/ast_binary_format.dart
+++ b/lib/src/serialization/ast_binary_format.dart
@@ -1,0 +1,169 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'dart:typed_data';
+
+/// Constants describing the ApolloVM binary AST container format.
+///
+/// A binary AST file (`.avma`) stores an already-parsed [ASTRoot] so that a
+/// code unit can be loaded without running a parser. The layout is:
+///
+/// ```text
+/// offset  size  field
+///  0       4    magic             \0AVM
+///  4       2    formatVersion     uint16 BE — the container revision that wrote this file
+///  6       2    minReaderVersion  uint16 BE — oldest reader that can decode it correctly
+///  8       4    flags             uint32 BE — see [ASTBinaryFlags]
+/// 12       4    sectionsSize      uint32 BE — byte length of the section stream
+/// 16      ..    sections          repeated: leb128 id, leb128 size, size bytes
+///  T+0     4    crc32             uint32 BE — over bytes [0, T)
+///  T+4     2    signatureLength   uint16 BE — 0 when unsigned
+///  T+6    ..    signature         signatureLength bytes
+///  ..      4    trailerMagic      AVM\0
+/// ```
+///
+/// where `T = headerSize + sectionsSize`. The total file length is always
+/// `headerSize + sectionsSize + minTrailerSize + signatureLength`, which lets a
+/// reader detect truncation and trailing garbage structurally, before doing any
+/// integrity arithmetic.
+///
+/// Every fixed-width field is big-endian. Sections are length-prefixed, so a
+/// reader skips any section id it does not recognize — that is what lets a file
+/// written by a newer ApolloVM keep loading in an older one.
+class ASTBinaryFormat {
+  ASTBinaryFormat._();
+
+  /// File magic: `\0AVM`. The leading NUL marks the file as binary so no tool
+  /// mistakes it for text, in the spirit of WebAssembly's `\0asm`.
+  static const List<int> magic = [0x00, 0x41, 0x56, 0x4D];
+
+  /// Trailer magic: `AVM\0` (the [magic] reversed).
+  ///
+  /// It turns a truncated or garbage file into an accurate "truncated"
+  /// diagnostic instead of a confusing checksum mismatch.
+  static const List<int> trailerMagic = [0x41, 0x56, 0x4D, 0x00];
+
+  /// The container revision this build writes, and the newest it fully
+  /// understands.
+  static const int version = 1;
+
+  /// The oldest container revision this build can still read.
+  static const int minSupportedVersion = 1;
+
+  /// Size of the fixed header, in bytes.
+  static const int headerSize = 16;
+
+  /// Size of the trailer excluding the signature: crc32 + signatureLength +
+  /// [trailerMagic].
+  static const int minTrailerSize = 10;
+
+  /// The conventional file extension, without a leading dot.
+  static const String fileExtension = 'avma';
+
+  /// The largest section stream this format can address (`sectionsSize` is a
+  /// uint32).
+  static const int maxSectionsSize = 0xFFFFFFFF;
+
+  /// The largest signature this format can hold (`signatureLength` is a
+  /// uint16).
+  static const int maxSignatureLength = 0xFFFF;
+
+  /// Whether [bytes] begins with the binary AST [magic].
+  ///
+  /// A cheap sniff for callers that dispatch on content rather than on a file
+  /// extension. It says nothing about whether the rest of the file is valid.
+  static bool isASTBinary(Uint8List bytes) {
+    if (bytes.length < magic.length) return false;
+    for (var i = 0; i < magic.length; ++i) {
+      if (bytes[i] != magic[i]) return false;
+    }
+    return true;
+  }
+
+  /// Compares [a] and [b] without an early exit on the first differing byte.
+  ///
+  /// Use this when comparing a computed signature against one read from a file:
+  /// a plain element-by-element comparison returns sooner for a nearly-correct
+  /// guess, which leaks how much of the signature an attacker got right.
+  ///
+  /// The comparison is constant-time only for equal-length inputs; a length
+  /// mismatch is reported immediately, since the length is not a secret.
+  static bool constantTimeEquals(List<int> a, List<int> b) {
+    if (a.length != b.length) return false;
+    var diff = 0;
+    for (var i = 0; i < a.length; ++i) {
+      diff |= a[i] ^ b[i];
+    }
+    return diff == 0;
+  }
+}
+
+/// Bit flags in the binary AST header.
+///
+/// Unlike an unknown section — which a reader skips — an unknown flag bit is
+/// **rejected**. Flags are reserved for options that change how the payload
+/// must be interpreted, so ignoring one would mean mis-decoding. Purely
+/// additive information belongs in a new section instead.
+class ASTBinaryFlags {
+  ASTBinaryFlags._();
+
+  /// A signature is present in the trailer.
+  static const int signed = 0x00000001;
+
+  /// A [ASTBinarySection.sectionIndex] section is present.
+  static const int hasSectionIndex = 0x00000002;
+
+  /// A [ASTBinarySection.sourceRef] section is present.
+  static const int hasSourceRef = 0x00000004;
+
+  /// Every flag bit this build understands.
+  static const int knownMask = signed | hasSectionIndex | hasSourceRef;
+}
+
+/// Section identifiers in the binary AST section stream.
+///
+/// Ids are never reused. A reader skips any id it does not know, using the
+/// section's length prefix.
+enum ASTBinarySection {
+  /// An application-defined section, always ignored by ApolloVM.
+  ///
+  /// Payload: a LEB128-prefixed name, then arbitrary bytes. Mirrors
+  /// WebAssembly's custom section, and lets third parties attach data without
+  /// registering an id.
+  custom(0x00),
+
+  /// Language, namespace, code unit id and writer provenance. Required, and
+  /// must be the first section.
+  metadata(0x01),
+
+  /// The shared string pool that the AST section indexes into.
+  stringTable(0x02),
+
+  /// The pooled [ASTType] descriptors that the AST section indexes into.
+  typeTable(0x03),
+
+  /// The encoded [ASTRoot]. Required.
+  astRoot(0x04),
+
+  /// Length and CRC-32 of the source this file was produced from, so a caller
+  /// can tell whether a cached image is stale without decoding it.
+  sourceRef(0x05),
+
+  /// Offsets and sizes of the other sections, for random access.
+  sectionIndex(0x06);
+
+  const ASTBinarySection(this.id);
+
+  /// The on-disk identifier for this section.
+  final int id;
+
+  /// The section with the given [id], or `null` when this build does not know
+  /// it (in which case the reader skips it).
+  static ASTBinarySection? byId(int id) {
+    for (var s in values) {
+      if (s.id == id) return s;
+    }
+    return null;
+  }
+}

--- a/lib/src/serialization/ast_binary_format.dart
+++ b/lib/src/serialization/ast_binary_format.dart
@@ -117,8 +117,12 @@ class ASTBinaryFlags {
   /// A [ASTBinarySection.sourceRef] section is present.
   static const int hasSourceRef = 0x00000004;
 
+  /// The file is an archive of several code units rather than a single one.
+  static const int archive = 0x00000008;
+
   /// Every flag bit this build understands.
-  static const int knownMask = signed | hasSectionIndex | hasSourceRef;
+  static const int knownMask =
+      signed | hasSectionIndex | hasSourceRef | archive;
 }
 
 /// Section identifiers in the binary AST section stream.
@@ -151,7 +155,15 @@ enum ASTBinarySection {
   sourceRef(0x05),
 
   /// Offsets and sizes of the other sections, for random access.
-  sectionIndex(0x06);
+  sectionIndex(0x06),
+
+  /// One code unit of an archive: a complete, self-contained single-unit image.
+  ///
+  /// Nesting whole images rather than merging their pools means an archive
+  /// needs no decoding logic of its own — each entry is read by the ordinary
+  /// reader — and each unit keeps its own checksum, so one can be extracted
+  /// and verified without touching the rest.
+  archiveEntry(0x07);
 
   const ASTBinarySection(this.id);
 

--- a/lib/src/serialization/ast_binary_format.dart
+++ b/lib/src/serialization/ast_binary_format.dart
@@ -6,8 +6,9 @@ import 'dart:typed_data';
 
 /// Constants describing the ApolloVM binary AST container format.
 ///
-/// A binary AST file (`.avma`) stores an already-parsed [ASTRoot] so that a
-/// code unit can be loaded without running a parser. The layout is:
+/// A binary AST file — `.avma`, for **A**pollo **V**irtual **M**achine
+/// **A**rchive — stores an already-parsed [ASTRoot] so that a code unit can be
+/// loaded without running a parser. The layout is:
 ///
 /// ```text
 /// offset  size  field
@@ -59,6 +60,13 @@ class ASTBinaryFormat {
   static const int minTrailerSize = 10;
 
   /// The conventional file extension, without a leading dot.
+  ///
+  /// `avma` is short for **A**pollo **V**irtual **M**achine **A**rchive.
+  ///
+  /// It is a convention only: nothing depends on it. A file is recognized by
+  /// its [magic] — which is why `apollovm run` works on an image whatever it
+  /// was named — and the extension merely decides the default output name when
+  /// none is given.
   static const String fileExtension = 'avma';
 
   /// The largest section stream this format can address (`sectionsSize` is a

--- a/lib/src/serialization/ast_binary_node_codec.dart
+++ b/lib/src/serialization/ast_binary_node_codec.dart
@@ -1,0 +1,48 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'ast_binary_context.dart';
+
+/// How one concrete AST class is written and read.
+///
+/// Both halves live in the same object on purpose. The long-term risk in a
+/// hand-written codec is drift — a field added to the writer and forgotten in
+/// the reader — and keeping the pair adjacent is what makes that visible in
+/// review. `ASTNodeTag` numbers are append-only and never reused, which is what
+/// keeps files written by older builds readable.
+class ASTNodeCodec<N extends Object> {
+  /// The wire tag for this node kind. Stable forever once shipped.
+  final int tag;
+
+  /// The concrete class name, e.g. `'ASTExpressionOperation'`.
+  ///
+  /// This is the key the coverage test matches against the AST sources, so it
+  /// must be spelled exactly as the class is declared.
+  final String className;
+
+  /// Writes [N]'s fields. The tag has already been written.
+  final void Function(ASTBinaryWriteContext w, N node) encode;
+
+  /// Rebuilds an [N]. The tag has already been consumed.
+  final N Function(ASTBinaryReadContext r) decode;
+
+  const ASTNodeCodec(
+    this.tag,
+    this.className, {
+    required this.encode,
+    required this.decode,
+  });
+
+  /// Whether [node] is handled by this codec.
+  ///
+  /// An `is` test rather than a `runtimeType` lookup: around twenty AST classes
+  /// are generic, and every instantiation of one has a distinct `runtimeType`.
+  bool matches(Object node) => node is N;
+
+  /// [encode] without a static type, for the registry's dispatch.
+  void encodeAny(ASTBinaryWriteContext w, Object node) => encode(w, node as N);
+
+  @override
+  String toString() => 'ASTNodeCodec($tag, $className)';
+}

--- a/lib/src/serialization/ast_binary_pool.dart
+++ b/lib/src/serialization/ast_binary_pool.dart
@@ -1,0 +1,106 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'dart:typed_data';
+
+import 'package:data_serializer/data_serializer.dart';
+
+import 'ast_binary_exception.dart';
+import 'ast_binary_format.dart';
+
+/// Collects the strings of an AST into a pool, so each distinct string is
+/// stored once and every use of it costs a LEB128 index.
+///
+/// Identifiers repeat pervasively in a parsed program — every variable
+/// reference, type name, parameter, field and method name — so this is where
+/// most of the size reduction comes from. A string that occurs only once costs
+/// the same as writing it inline, since an index and a length prefix are both
+/// one LEB128 value.
+///
+/// Indices are assigned in first-seen order. That is an implementation detail
+/// of the writer, not part of the format: a later writer may order the pool by
+/// frequency (so the hottest strings get one-byte indices) without any reader
+/// change.
+class ASTStringPoolWriter {
+  final Map<String, int> _indexes = {};
+  final List<String> _values = [];
+
+  /// The number of distinct strings interned so far.
+  int get length => _values.length;
+
+  /// The index of [s] in the pool, adding it if this is its first occurrence.
+  int intern(String s) {
+    var i = _indexes[s];
+    if (i != null) return i;
+
+    i = _values.length;
+    _indexes[s] = i;
+    _values.add(s);
+    return i;
+  }
+
+  /// Encodes the pool as the payload of an [ASTBinarySection.stringTable].
+  Uint8List encode() {
+    var out = BytesBuffer();
+    out.writeLeb128UnsignedInt(_values.length);
+    for (var s in _values) {
+      out.writeLeb128String(s);
+    }
+    return out.toBytes();
+  }
+}
+
+/// The decoded string pool: a positional list that the AST section indexes into.
+class ASTStringPoolReader {
+  final List<String> _values;
+
+  ASTStringPoolReader(this._values);
+
+  /// The number of strings in the pool.
+  int get length => _values.length;
+
+  /// Decodes a pool from an [ASTBinarySection.stringTable] payload.
+  factory ASTStringPoolReader.decode(Uint8List payload) {
+    var input = BytesBuffer.from(payload);
+
+    int count;
+    try {
+      count = input.readLeb128UnsignedInt();
+    } catch (e) {
+      throw ASTBinaryException(
+        'Malformed string table: $e',
+        ASTBinaryError.malformedSection,
+        sectionId: ASTBinarySection.stringTable.id,
+      );
+    }
+
+    var values = <String>[];
+    for (var i = 0; i < count; ++i) {
+      if (input.remaining <= 0) {
+        throw ASTBinaryException(
+          'String table declares $count strings but ran out of bytes at $i.',
+          ASTBinaryError.malformedSection,
+          offset: input.position,
+          sectionId: ASTBinarySection.stringTable.id,
+        );
+      }
+      values.add(input.readLeb128String());
+    }
+
+    return ASTStringPoolReader(values);
+  }
+
+  /// The string at [index].
+  String operator [](int index) {
+    if (index < 0 || index >= _values.length) {
+      throw ASTBinaryException(
+        'String pool index $index is out of range (0..${_values.length - 1}). '
+        'The file is corrupted or was written by an incompatible encoder.',
+        ASTBinaryError.malformedSection,
+        sectionId: ASTBinarySection.stringTable.id,
+      );
+    }
+    return _values[index];
+  }
+}

--- a/lib/src/serialization/ast_binary_reader.dart
+++ b/lib/src/serialization/ast_binary_reader.dart
@@ -64,7 +64,8 @@ class ASTBinaryInfo {
       'size: $fileSize}';
 }
 
-/// Decodes a binary AST image (`.avma`) back into a parsed [ASTRoot].
+/// Decodes a binary AST image — `.avma`, for *Apollo Virtual Machine Archive* —
+/// back into a parsed [ASTRoot].
 ///
 /// The CRC-32 is verified on every read. It detects corruption — a truncated
 /// write, bit rot, a mangled transfer — but it is not a defence against anyone:

--- a/lib/src/serialization/ast_binary_reader.dart
+++ b/lib/src/serialization/ast_binary_reader.dart
@@ -1,0 +1,205 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'dart:typed_data';
+
+import 'package:data_serializer/data_serializer.dart';
+
+import '../apollovm_base.dart';
+import '../ast/apollovm_ast_toplevel.dart';
+import 'ast_binary_container.dart';
+import 'ast_binary_context.dart';
+import 'ast_binary_exception.dart';
+import 'ast_binary_format.dart';
+import 'ast_binary_pool.dart';
+import 'ast_binary_signer.dart';
+import 'ast_binary_type_pool.dart';
+
+/// What a binary AST image says about itself, without decoding its AST.
+class ASTBinaryInfo {
+  /// The file's fixed header.
+  final ASTBinaryHeader header;
+
+  /// The `ApolloVM.VERSION` that wrote the image. Informational only — it never
+  /// gates decoding; [ASTBinaryHeader.formatVersion] does.
+  final String writerVersion;
+
+  /// The language of the code unit, already normalized (`java11`, not `java`).
+  final String language;
+
+  /// The code unit id, usually a file path. May be empty.
+  final String codeUnitId;
+
+  /// The namespace the code unit belongs to.
+  final String namespace;
+
+  /// Section ids this build did not recognize and skipped.
+  ///
+  /// Non-empty means the image was written by a newer ApolloVM carrying
+  /// information this one ignores, which is expected rather than an error.
+  final List<int> unknownSectionIds;
+
+  /// The total size of the image, in bytes.
+  final int fileSize;
+
+  const ASTBinaryInfo({
+    required this.header,
+    required this.writerVersion,
+    required this.language,
+    required this.codeUnitId,
+    required this.namespace,
+    required this.unknownSectionIds,
+    required this.fileSize,
+  });
+
+  /// Whether the image carries a signature.
+  bool get isSigned => header.isSigned;
+
+  @override
+  String toString() =>
+      'ASTBinaryInfo{language: $language, namespace: $namespace, '
+      'id: $codeUnitId, writer: $writerVersion, '
+      'format: ${header.formatVersion}, signed: $isSigned, '
+      'size: $fileSize}';
+}
+
+/// Decodes a binary AST image (`.avma`) back into a parsed [ASTRoot].
+///
+/// The CRC-32 is verified on every read. It detects corruption — a truncated
+/// write, bit rot, a mangled transfer — but it is not a defence against anyone:
+/// an attacker who edits the file recomputes it in microseconds. Pass a
+/// [verifier] to require a signature made with a key they do not have.
+///
+/// An unsigned image deserves exactly as much trust as the source it came from;
+/// loading one and running it is equivalent to running arbitrary code from that
+/// source.
+class ASTBinaryReader {
+  /// Checks the image's signature. When given, the image **must** be signed and
+  /// the signature must verify.
+  final ASTBinaryVerifier? verifier;
+
+  /// Whether to verify the CRC-32. On by default; turning it off is for
+  /// forensics and repair tooling, not for loading.
+  final bool verifyChecksum;
+
+  const ASTBinaryReader({this.verifier, this.verifyChecksum = true});
+
+  /// Whether [bytes] looks like a binary AST image, by its magic.
+  static bool isASTBinary(Uint8List bytes) =>
+      ASTBinaryFormat.isASTBinary(bytes);
+
+  /// Reads the header and metadata without decoding the AST.
+  ///
+  /// Cheap enough to run over a cache directory, and the basis of
+  /// `apollovm inspect`.
+  ASTBinaryInfo readInfo(Uint8List bytes) => _read(bytes).info;
+
+  /// Decodes [bytes] into a fully resolved [ASTRoot].
+  ///
+  /// `resolveNode` has already been called on the result, so parent links and
+  /// name resolution are in place exactly as after a parse.
+  ASTRoot readRoot(Uint8List bytes) => _read(bytes).root;
+
+  /// Decodes [bytes] into a [CodeUnit] whose `root` is already populated.
+  ///
+  /// Handing the result to [ApolloVM.loadCodeUnit] registers it without going
+  /// near a parser: that method only parses when `root` is null.
+  ///
+  /// [id] and [namespace] override what the image recorded, for re-homing a
+  /// cached unit.
+  BinaryCodeUnit readCodeUnit(
+    Uint8List bytes, {
+    String? id,
+    String? namespace,
+  }) {
+    var decoded = _read(bytes);
+    var info = decoded.info;
+
+    var codeUnit = BinaryCodeUnit(
+      info.language,
+      bytes,
+      id: id ?? info.codeUnitId,
+      namespace: namespace ?? info.namespace,
+    );
+    codeUnit.root = decoded.root;
+    return codeUnit;
+  }
+
+  _DecodedImage _read(Uint8List bytes) {
+    var container = ASTBinaryContainerCodec.decode(
+      bytes,
+      verifyChecksum: verifyChecksum,
+      verifier: verifier,
+    );
+
+    var formatVersion = container.header.formatVersion;
+
+    var metadata = BytesBuffer.from(
+      container.requirePayloadOf(ASTBinarySection.metadata),
+    );
+
+    String writerVersion;
+    String language;
+    String codeUnitId;
+    String namespace;
+    try {
+      writerVersion = metadata.readLeb128String();
+      language = metadata.readLeb128String();
+      codeUnitId = metadata.readLeb128String();
+      namespace = metadata.readLeb128String();
+      // Anything a newer writer appended past here is deliberately ignored:
+      // the section is read from a bounded view, so trailing fields are extra
+      // information rather than a decode failure.
+    } catch (e) {
+      throw ASTBinaryException(
+        'Malformed metadata section: $e',
+        ASTBinaryError.malformedSection,
+        formatVersion: formatVersion,
+        sectionId: ASTBinarySection.metadata.id,
+      );
+    }
+
+    var info = ASTBinaryInfo(
+      header: container.header,
+      writerVersion: writerVersion,
+      language: language,
+      codeUnitId: codeUnitId,
+      namespace: namespace,
+      unknownSectionIds: container.unknownSectionIds,
+      fileSize: bytes.length,
+    );
+
+    var strings = ASTStringPoolReader.decode(
+      container.requirePayloadOf(ASTBinarySection.stringTable),
+    );
+    var types = ASTTypePoolReader.decode(
+      container.requirePayloadOf(ASTBinarySection.typeTable),
+      strings,
+    );
+
+    var ast = ASTBinaryReadContext(
+      BytesBuffer.from(container.requirePayloadOf(ASTBinarySection.astRoot)),
+      strings,
+      types,
+      formatVersion: formatVersion,
+    );
+
+    var root = ast.node<ASTRoot>();
+
+    // Exactly what every grammar does after building a tree. Parent links,
+    // scope-variable resolution, superclass and extension targets, and the
+    // `this.field` constructor-parameter promotion are all re-derived here,
+    // which is why none of them are stored in the file.
+    root.resolveNode(null);
+
+    return _DecodedImage(info, root);
+  }
+}
+
+class _DecodedImage {
+  final ASTBinaryInfo info;
+  final ASTRoot root;
+
+  _DecodedImage(this.info, this.root);
+}

--- a/lib/src/serialization/ast_binary_registry.dart
+++ b/lib/src/serialization/ast_binary_registry.dart
@@ -56,23 +56,36 @@ class ASTCodecRegistry {
 
   /// The codec that handles [node].
   ///
-  /// Throws [ASTNotSerializableException] when the node has no codec — which
-  /// means it holds live Dart state (an external function's closure, a running
-  /// future, a bound runtime value) and was injected by the VM rather than
-  /// produced by a parser.
+  /// Throws [ASTNotSerializableException] for a node that holds live Dart state
+  /// — an external function's closure, a running future, a bound runtime value
+  /// — which the VM injects rather than a parser producing.
   static ASTNodeCodec codecFor(Object node, [String declarationPath = '']) {
     var cached = _resolved[node.runtimeType];
     if (cached != null) return cached;
 
-    for (var c in ordered) {
-      if (c.matches(node)) {
-        return _resolved[node.runtimeType] = c;
+    // Refusal is decided by the concrete class, **not** by "no codec matched".
+    // Several excluded kinds extend one that is perfectly encodable —
+    // `ASTExternalFunction` extends `ASTFunctionDeclaration`,
+    // `ASTExternalGetter` extends `ASTGetterDeclaration` — so an `is` scan
+    // alone would match the superclass and write them as an ordinary
+    // declaration, silently dropping the Dart closure that is their whole
+    // point. Checking the name first is what makes the exclusion list binding.
+    //
+    // This runs once per distinct runtime type, on the way to populating the
+    // cache below.
+    var reason = excluded[_classNameOf(node)];
+
+    if (reason == null) {
+      for (var c in ordered) {
+        if (c.matches(node)) {
+          return _resolved[node.runtimeType] = c;
+        }
       }
     }
 
     throw ASTNotSerializableException(
       node,
-      _reasonFor(node),
+      reason ?? 'this node kind has no binary encoding',
       declarationPath: declarationPath.isEmpty ? null : declarationPath,
     );
   }
@@ -116,12 +129,13 @@ class ASTCodecRegistry {
     'ASTRunStatus': 'it is per-execution control state, not part of the tree',
   };
 
-  static String _reasonFor(Object node) {
+  /// The declared class name of [node], without its type arguments.
+  ///
+  /// A generic instantiation prints as `ASTValueFunction<void Function()>`,
+  /// which would never match an entry in [excluded].
+  static String _classNameOf(Object node) {
     var name = node.runtimeType.toString();
-    // Generic instantiations print as `ASTValueFunction<void Function()>`.
     var generic = name.indexOf('<');
-    if (generic > 0) name = name.substring(0, generic);
-
-    return excluded[name] ?? 'this node kind has no binary encoding';
+    return generic > 0 ? name.substring(0, generic) : name;
   }
 }

--- a/lib/src/serialization/ast_binary_registry.dart
+++ b/lib/src/serialization/ast_binary_registry.dart
@@ -1,0 +1,127 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'ast_binary_codecs_expression.dart';
+import 'ast_binary_codecs_statement.dart';
+import 'ast_binary_codecs_toplevel.dart';
+import 'ast_binary_codecs_value.dart';
+import 'ast_binary_codecs_variable.dart';
+import 'ast_binary_exception.dart';
+import 'ast_binary_node_codec.dart';
+import 'ast_binary_tags.dart';
+
+/// The one place a node kind is registered.
+///
+/// Writer dispatch, reader dispatch and the coverage test all derive from
+/// [ordered], so a node kind cannot be half-registered.
+class ASTCodecRegistry {
+  ASTCodecRegistry._();
+
+  /// The tag written where a node is absent.
+  static const int nullTag = ASTNodeTag.nullNode;
+
+  /// Every codec, **most derived first**.
+  ///
+  /// Order matters: dispatch walks this list with `is` tests, so a subclass
+  /// must appear before any of its superclasses or the superclass would claim
+  /// its instances. The coverage test parses the real hierarchy out of
+  /// `lib/src/ast/` and fails if this ordering is ever violated.
+  static final List<ASTNodeCodec> ordered = [
+    ...valueCodecs,
+    ...variableCodecs,
+    ...expressionCodecs,
+    // Declarations before plain statements: a class, a function, a getter and
+    // the root are all `ASTBlock`s, and `ASTBlock`'s own codec has to lose to
+    // every one of them.
+    ...toplevelCodecs,
+    ...statementCodecs,
+    ...blockCodecs,
+  ];
+
+  static final Map<int, ASTNodeCodec> _byTag = {
+    for (var c in ordered) c.tag: c,
+  };
+
+  /// Memoized dispatch, keyed on the concrete runtime type.
+  ///
+  /// A plain `Map<Type, codec>` alone would be wrong — around twenty AST
+  /// classes are generic and every instantiation has its own `runtimeType` —
+  /// so the ordered `is` scan is the source of truth and this only caches its
+  /// answer, once per distinct runtime type.
+  static final Map<Type, ASTNodeCodec> _resolved = {};
+
+  /// The codec for [tag], or `null` when this build does not know it.
+  static ASTNodeCodec? byTag(int tag) => _byTag[tag];
+
+  /// The codec that handles [node].
+  ///
+  /// Throws [ASTNotSerializableException] when the node has no codec — which
+  /// means it holds live Dart state (an external function's closure, a running
+  /// future, a bound runtime value) and was injected by the VM rather than
+  /// produced by a parser.
+  static ASTNodeCodec codecFor(Object node, [String declarationPath = '']) {
+    var cached = _resolved[node.runtimeType];
+    if (cached != null) return cached;
+
+    for (var c in ordered) {
+      if (c.matches(node)) {
+        return _resolved[node.runtimeType] = c;
+      }
+    }
+
+    throw ASTNotSerializableException(
+      node,
+      _reasonFor(node),
+      declarationPath: declarationPath.isEmpty ? null : declarationPath,
+    );
+  }
+
+  /// Class names this format deliberately does not encode, and why.
+  ///
+  /// Every one of these holds live Dart state and is injected at run time by
+  /// `ApolloExternalFunctionMapper`, `ApolloExternalGetterMapper` or
+  /// `ApolloVMCore` — never produced by a parser. A parsed AST therefore never
+  /// contains one, and the same bindings are re-injected after a binary load.
+  static const Map<String, String> excluded = {
+    'ASTExternalFunction':
+        'it holds a Dart closure; external functions are mapped into the VM at '
+        'run time, not parsed',
+    'ASTExternalClassFunction':
+        'it holds a Dart closure; external methods are mapped into the VM at '
+        'run time, not parsed',
+    'ASTExternalGetter':
+        'it holds a Dart closure; external getters are mapped into the VM at '
+        'run time, not parsed',
+    'ASTExternalClassGetter':
+        'it holds a Dart closure; external getters are mapped into the VM at '
+        'run time, not parsed',
+    'ASTValueFunction':
+        'it holds a live Dart function and its captured closure context',
+    'ASTValueFuture': 'it holds a pending Future',
+    'ASTClassInstance': 'it is a live object instance, not source',
+    'ASTClassStaticAccessor':
+        'it is a runtime accessor built from a class, not source',
+    'ASTStaticClassAccessorVariable':
+        'it is only ever built by ASTClassStaticAccessor at run time',
+    'ASTRuntimeVariable': 'it is a variable bound to a running context',
+    'ASTStaticFieldVariable':
+        'it is unreachable: no parser or runtime path constructs one',
+    'ASTClassPrimitive':
+        'it is a core class registered by ApolloVMCore, not parsed',
+    'ASTValueReadIndex':
+        'it is unreachable: no parser or runtime path constructs one',
+    'ASTValueReadKey':
+        'it is unreachable: no parser or runtime path constructs one',
+    'ASTRunStatus': 'it is per-execution control state, not part of the tree',
+  };
+
+  static String _reasonFor(Object node) {
+    var name = node.runtimeType.toString();
+    // Generic instantiations print as `ASTValueFunction<void Function()>`.
+    var generic = name.indexOf('<');
+    if (generic > 0) name = name.substring(0, generic);
+
+    return excluded[name] ?? 'this node kind has no binary encoding';
+  }
+}

--- a/lib/src/serialization/ast_binary_signer.dart
+++ b/lib/src/serialization/ast_binary_signer.dart
@@ -1,0 +1,91 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:crypto/crypto.dart';
+
+import 'ast_binary_format.dart';
+
+/// Produces the signature stored in a binary AST file's trailer.
+///
+/// The container treats a signature as opaque length-prefixed bytes, so any
+/// scheme fits: an HMAC, a public-key signature, or a call out to a hardware
+/// key store. [HmacSha256Signer] is the built-in implementation.
+///
+/// ## What signing buys, and what it does not
+///
+/// The CRC-32 every file carries detects accidental corruption. It is not a
+/// defence against anyone: an attacker who edits the file recomputes the CRC in
+/// microseconds. **Only a signature made with a key the attacker does not have
+/// makes a binary AST file tamper-evident.**
+///
+/// An unsigned file deserves exactly as much trust as the source it was
+/// produced from — loading one and running it is equivalent to running
+/// arbitrary code from that source.
+abstract class ASTBinarySigner {
+  /// Signs [payload], returning at most
+  /// [ASTBinaryFormat.maxSignatureLength] bytes.
+  ///
+  /// [payload] covers the header, every section and the CRC-32 — so an attacker
+  /// cannot edit the content, recompute the CRC, and leave a signature that
+  /// still verifies.
+  Uint8List sign(Uint8List payload);
+}
+
+/// Checks the signature in a binary AST file's trailer.
+abstract class ASTBinaryVerifier {
+  /// Whether [signature] is valid for [payload].
+  ///
+  /// Implementations comparing bytes directly should use
+  /// [ASTBinaryFormat.constantTimeEquals] rather than a plain list comparison,
+  /// which returns sooner for a nearly-correct guess and so leaks how much of
+  /// the signature an attacker got right.
+  bool verify(Uint8List payload, Uint8List signature);
+}
+
+/// Signs binary AST files with HMAC-SHA256.
+///
+/// This is symmetric: the same secret signs and verifies, so anyone able to
+/// verify is also able to sign. It fits the case this format was built for —
+/// a build step signs a compiled AST and the application that loads it holds
+/// the same secret. It does not fit distributing files to parties that must
+/// verify but not sign; use a public-key [ASTBinarySigner] for that.
+///
+/// ```dart
+/// var signer = HmacSha256Signer.fromString(secret);
+/// var bytes = vm.saveCodeUnitAST(codeUnit, signer: signer);
+/// ```
+class HmacSha256Signer implements ASTBinarySigner {
+  final Hmac _hmac;
+
+  /// Signs with the raw key bytes [key].
+  HmacSha256Signer(List<int> key) : _hmac = Hmac(sha256, key);
+
+  /// Signs with the UTF-8 encoding of [key].
+  HmacSha256Signer.fromString(String key) : this(utf8.encode(key));
+
+  @override
+  Uint8List sign(Uint8List payload) =>
+      Uint8List.fromList(_hmac.convert(payload).bytes);
+}
+
+/// Verifies binary AST files signed with [HmacSha256Signer].
+class HmacSha256Verifier implements ASTBinaryVerifier {
+  final Hmac _hmac;
+
+  /// Verifies with the raw key bytes [key].
+  HmacSha256Verifier(List<int> key) : _hmac = Hmac(sha256, key);
+
+  /// Verifies with the UTF-8 encoding of [key].
+  HmacSha256Verifier.fromString(String key) : this(utf8.encode(key));
+
+  @override
+  bool verify(Uint8List payload, Uint8List signature) =>
+      ASTBinaryFormat.constantTimeEquals(
+        _hmac.convert(payload).bytes,
+        signature,
+      );
+}

--- a/lib/src/serialization/ast_binary_tags.dart
+++ b/lib/src/serialization/ast_binary_tags.dart
@@ -1,0 +1,145 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+/// Wire tags for AST node kinds.
+///
+/// **These numbers are part of the file format.** A tag is never renumbered and
+/// never reused, even after the node kind it named is gone — retire it in
+/// [ASTNodeTag.retired] instead. That is what lets a build read files written
+/// by every earlier build.
+///
+/// Numbers are assigned roughly by how often a node appears in a real program,
+/// so the hot ones stay under 128 and cost a single LEB128 byte: expressions,
+/// values and variables first, then the common statements, then declarations
+/// and the rarities.
+class ASTNodeTag {
+  ASTNodeTag._();
+
+  /// Written in place of a node that is absent. Never a real node kind.
+  static const int nullNode = 0;
+
+  // --- Values (hot: every literal in the program) ---------------------------
+
+  static const int valueBool = 1;
+  static const int valueInt = 2;
+  static const int valueDouble = 3;
+  static const int valueString = 4;
+  static const int valueNull = 5;
+  static const int valueVoid = 6;
+  static const int valueVar = 7;
+  static const int valueObject = 8;
+  static const int valueStatic = 9;
+  static const int valueArray = 10;
+  static const int valueArray2D = 11;
+  static const int valueArray3D = 12;
+  static const int valueMap = 13;
+  static const int valueAsString = 14;
+  static const int valuesListAsString = 15;
+  static const int valueStringExpression = 16;
+  static const int valueStringVariable = 17;
+  static const int valueStringConcatenation = 18;
+
+  // --- Variables ------------------------------------------------------------
+
+  static const int scopeVariable = 20;
+  static const int thisVariable = 21;
+  static const int classField = 22;
+  static const int classFieldWithInitialValue = 23;
+  static const int staticFieldVariable = 24;
+  static const int expressionVariable = 25;
+
+  // --- Expressions ----------------------------------------------------------
+
+  static const int expressionLiteral = 30;
+  static const int expressionVariableAccess = 31;
+  static const int expressionNullValue = 32;
+  static const int expressionOperation = 33;
+  static const int expressionVariableAssignment = 34;
+  static const int expressionLocalFunctionInvocation = 35;
+  static const int expressionObjectFunctionInvocation = 36;
+  static const int expressionChainFunctionInvocation = 37;
+  static const int expressionGroupFunctionInvocation = 38;
+  static const int expressionObjectEntryFunctionInvocation = 39;
+  static const int expressionLocalGetterAccess = 40;
+  static const int expressionObjectGetterAccess = 41;
+  static const int expressionObjectSetterAssignment = 42;
+  static const int expressionVariableEntryAccess = 43;
+  static const int expressionVariableEntryAssignment = 44;
+  static const int expressionVariableDirectOperation = 45;
+  static const int expressionConditional = 46;
+  static const int expressionLogicalAnd = 47;
+  static const int expressionLogicalOr = 48;
+  static const int expressionNegation = 49;
+  static const int expressionNegative = 50;
+  static const int expressionBitwiseNot = 51;
+  static const int expressionNullAssertion = 52;
+  static const int expressionNullCoalesce = 53;
+  static const int expressionNullCheck = 54;
+  static const int expressionAwait = 55;
+  static const int expressionCascade = 56;
+  static const int expressionListLiteral = 57;
+  static const int expressionMapLiteral = 58;
+  static const int expressionLiteralFunction = 59;
+
+  // --- Statements -----------------------------------------------------------
+
+  static const int block = 65;
+  static const int singleLineStatementBlock = 66;
+  static const int statementExpression = 67;
+  static const int statementVariableDeclaration = 68;
+  static const int statementReturn = 69;
+  static const int statementReturnNull = 70;
+  static const int statementReturnValue = 71;
+  static const int statementReturnVariable = 72;
+  static const int statementReturnWithExpression = 73;
+  static const int statementBlock = 74;
+  static const int statementValue = 75;
+  static const int statementFunctionDeclaration = 76;
+  static const int branchIfBlock = 77;
+  static const int branchIfElseBlock = 78;
+  static const int branchIfElseIfsElseBlock = 79;
+  static const int statementWhileLoop = 80;
+  static const int statementDoWhileLoop = 81;
+  static const int statementForLoop = 82;
+  static const int statementForEach = 83;
+  static const int statementBreak = 84;
+  static const int statementContinue = 85;
+  static const int statementSwitch = 86;
+  static const int switchCase = 87;
+  static const int statementThrow = 88;
+  static const int statementAssert = 89;
+  static const int statementTryCatch = 90;
+  static const int catchClause = 91;
+
+  // --- Declarations and top level -------------------------------------------
+
+  static const int root = 100;
+  static const int classNormal = 101;
+  static const int classEnum = 102;
+  static const int enumEntry = 103;
+  static const int extension = 104;
+  static const int typeAlias = 105;
+  static const int functionDeclaration = 106;
+  static const int classFunctionDeclaration = 107;
+  static const int classConstructorDeclaration = 108;
+  static const int getterDeclaration = 109;
+  static const int classGetterDeclaration = 110;
+  static const int setterDeclaration = 111;
+  static const int classSetterDeclaration = 112;
+  static const int functionParameterDeclaration = 113;
+  static const int constructorParameterDeclaration = 114;
+  static const int functionParametersDeclaration = 115;
+  static const int constructorParametersDeclaration = 116;
+  static const int statementImport = 117;
+  static const int statementExport = 118;
+  static const int importCombinator = 119;
+  static const int importedSymbol = 120;
+
+  /// Tags that once existed and must never be handed out again.
+  ///
+  /// Empty today. When a node kind is removed, its number moves here rather
+  /// than becoming available, so an old file can still be diagnosed precisely
+  /// instead of decoding as whatever took the number over.
+  static const Set<int> retired = <int>{};
+}

--- a/lib/src/serialization/ast_binary_type_pool.dart
+++ b/lib/src/serialization/ast_binary_type_pool.dart
@@ -1,0 +1,688 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'dart:typed_data';
+
+import 'package:data_serializer/data_serializer.dart';
+
+import '../ast/apollovm_ast_annotation.dart';
+import '../ast/apollovm_ast_type.dart';
+import 'ast_binary_exception.dart';
+import 'ast_binary_format.dart';
+import 'ast_binary_pool.dart';
+
+/// Writes an [ASTAnnotation] — its name and its parameters — using [strings].
+///
+/// Annotations hang off both types and declarations, so the encoding lives here
+/// rather than being duplicated by each caller.
+void writeAnnotation(
+  BytesBuffer out,
+  ASTStringPoolWriter strings,
+  ASTAnnotation a,
+) {
+  out.writeLeb128UnsignedInt(strings.intern(a.name));
+
+  var parameters = a.parameters;
+  if (parameters == null) {
+    out.writeLeb128UnsignedInt(0);
+    return;
+  }
+
+  out.writeLeb128UnsignedInt(parameters.length + 1);
+  for (var e in parameters.entries) {
+    out.writeLeb128UnsignedInt(strings.intern(e.key));
+    out.writeLeb128UnsignedInt(strings.intern(e.value.name));
+    out.writeLeb128UnsignedInt(strings.intern(e.value.value));
+    out.writeBoolean(e.value.defaultParameter);
+  }
+}
+
+/// Reads an [ASTAnnotation] written by [writeAnnotation].
+ASTAnnotation readAnnotation(BytesBuffer input, ASTStringPoolReader strings) {
+  var name = strings[input.readLeb128UnsignedInt()];
+
+  var count = input.readLeb128UnsignedInt();
+  if (count == 0) return ASTAnnotation(name);
+
+  var parameters = <String, ASTAnnotationParameter>{};
+  for (var i = 1; i < count; ++i) {
+    var key = strings[input.readLeb128UnsignedInt()];
+    var pName = strings[input.readLeb128UnsignedInt()];
+    var pValue = strings[input.readLeb128UnsignedInt()];
+    var isDefault = input.readBoolean();
+    parameters[key] = ASTAnnotationParameter(pName, pValue, isDefault);
+  }
+
+  return ASTAnnotation(name, parameters);
+}
+
+/// How a pooled [ASTType] entry is shaped.
+///
+/// Values are part of the wire format: never renumbered, never reused.
+class ASTTypeEntryKind {
+  ASTTypeEntryKind._();
+
+  /// One of the interned [ASTType] singletons, by [ASTWellKnownType] id.
+  static const int wellKnown = 0x01;
+
+  /// A plain [ASTType]: name, generics, super type, annotations.
+  static const int generic = 0x02;
+
+  /// An [ASTTypeInterface].
+  static const int interface = 0x03;
+
+  /// An [ASTTypeArray], by component type.
+  static const int array1D = 0x04;
+
+  /// An [ASTTypeArray2D], by element type.
+  static const int array2D = 0x05;
+
+  /// An [ASTTypeArray3D], by element type.
+  static const int array3D = 0x06;
+
+  /// An [ASTTypeMap], by key and value type.
+  static const int map = 0x07;
+
+  /// An [ASTTypeFuture], by its value type.
+  static const int future = 0x08;
+
+  /// An [ASTTypeFunction], by return type and parameter types.
+  static const int function = 0x09;
+
+  /// An [ASTTypeNum] carrying an optional bit width.
+  static const int num = 0x0A;
+
+  /// An [ASTTypeInt] carrying an optional bit width.
+  static const int int_ = 0x0B;
+
+  /// An [ASTTypeDouble] carrying an optional bit width.
+  static const int double_ = 0x0C;
+
+  /// An [ASTTypeVar], carrying its `unmodifiable` flag.
+  static const int var_ = 0x0D;
+
+  /// An [ASTTypeGenericVariable], by variable name and optional bound.
+  static const int genericVariable = 0x0E;
+
+  /// An [ASTTypeBool].
+  static const int bool_ = 0x0F;
+
+  /// An [ASTTypeString].
+  static const int string = 0x10;
+
+  /// An [ASTTypeObject].
+  static const int object = 0x11;
+
+  /// An [ASTTypeDynamic].
+  static const int dynamic_ = 0x12;
+
+  /// An [ASTTypeNull].
+  static const int null_ = 0x13;
+
+  /// An [ASTTypeVoid].
+  static const int void_ = 0x14;
+
+  /// An [ASTTypeConstructorThis].
+  static const int constructorThis = 0x15;
+
+  /// An [ASTTypeGenericWildcard].
+  static const int genericWildcard = 0x16;
+}
+
+/// Identifiers for the [ASTType] singletons that must decode back to the very
+/// same object.
+///
+/// Identity matters here, it is not an optimization:
+/// `ASTConstructorParameterDeclaration.resolveNode` compares its parameter type
+/// with `identical(type, ASTTypeConstructorThis.instance)`, so a structurally
+/// equal but distinct instance would silently change how `this.field`
+/// constructor parameters resolve.
+class ASTWellKnownType {
+  ASTWellKnownType._();
+
+  static const int typeInt = 0x01;
+  static const int typeInt32 = 0x02;
+  static const int typeInt64 = 0x03;
+  static const int typeDouble = 0x04;
+  static const int typeDouble32 = 0x05;
+  static const int typeDouble64 = 0x06;
+  static const int typeNum = 0x07;
+  static const int typeBool = 0x08;
+  static const int typeString = 0x09;
+  static const int typeObject = 0x0A;
+  static const int typeDynamic = 0x0B;
+  static const int typeNull = 0x0C;
+  static const int typeVoid = 0x0D;
+  static const int typeVar = 0x0E;
+  static const int typeVarUnmodifiable = 0x0F;
+  static const int typeConstructorThis = 0x10;
+  static const int typeGenericWildcard = 0x11;
+  static const int arrayOfString = 0x12;
+  static const int arrayOfInt = 0x13;
+  static const int arrayOfDouble = 0x14;
+  static const int arrayOfBool = 0x15;
+  static const int arrayOfObject = 0x16;
+  static const int arrayOfDynamic = 0x17;
+  static const int mapOfStringDynamic = 0x18;
+  static const int mapOfStringString = 0x19;
+  static const int mapOfDynamicDynamic = 0x1A;
+
+  /// The singleton for [id], or `null` when [id] is not a well-known type.
+  static ASTType? instanceOf(int id) => switch (id) {
+    typeInt => ASTTypeInt.instance,
+    typeInt32 => ASTTypeInt.instance32,
+    typeInt64 => ASTTypeInt.instance64,
+    typeDouble => ASTTypeDouble.instance,
+    typeDouble32 => ASTTypeDouble.instance32,
+    typeDouble64 => ASTTypeDouble.instance64,
+    typeNum => ASTTypeNum.instance,
+    typeBool => ASTTypeBool.instance,
+    typeString => ASTTypeString.instance,
+    typeObject => ASTTypeObject.instance,
+    typeDynamic => ASTTypeDynamic.instance,
+    typeNull => ASTTypeNull.instance,
+    typeVoid => ASTTypeVoid.instance,
+    typeVar => ASTTypeVar.instance,
+    typeVarUnmodifiable => ASTTypeVar.instanceUnmodifiable,
+    typeConstructorThis => ASTTypeConstructorThis.instance,
+    typeGenericWildcard => ASTTypeGenericWildcard.instance,
+    arrayOfString => ASTTypeArray.instanceOfString,
+    arrayOfInt => ASTTypeArray.instanceOfInt,
+    arrayOfDouble => ASTTypeArray.instanceOfDouble,
+    arrayOfBool => ASTTypeArray.instanceOfBool,
+    arrayOfObject => ASTTypeArray.instanceOfObject,
+    arrayOfDynamic => ASTTypeArray.instanceOfDynamic,
+    mapOfStringDynamic => ASTTypeMap.instanceOfStringOfDynamic,
+    mapOfStringString => ASTTypeMap.instanceOfStringOfString,
+    mapOfDynamicDynamic => ASTTypeMap.instanceOfDynamicOfDynamic,
+    _ => null,
+  };
+
+  static final Map<ASTType, int> _idsByInstance = _buildIds();
+
+  static Map<ASTType, int> _buildIds() {
+    // Keyed on identity: `ASTType` overrides `==` structurally, and several
+    // singletons are structurally equal to each other (`ASTTypeVar.instance`
+    // and `ASTTypeVar.instanceUnmodifiable` share a name), so a plain map would
+    // collapse them.
+    var map = Map<ASTType, int>.identity();
+    for (var id = 0x01; id <= 0x1A; ++id) {
+      var instance = instanceOf(id);
+      if (instance != null) map[instance] = id;
+    }
+    return map;
+  }
+
+  /// The well-known id for [type] when it *is* one of the singletons, or `null`
+  /// for any other instance. Compares by identity, never structurally.
+  static int? idOf(ASTType type) => _idsByInstance[type];
+}
+
+/// Interns the [ASTType]s of an AST so each distinct type is written once.
+///
+/// Types are the most repeated node in a parsed program — every parameter,
+/// variable, field and return type carries one — so pooling them turns each
+/// occurrence into a single LEB128 index.
+///
+/// Sharing a decoded type across use sites is safe: apart from `nullable`,
+/// which is part of the pool key, an [ASTType] is immutable, and the one piece
+/// of mutable state it has ([ASTType.setClass]) is only ever written by an
+/// [ASTClass] constructor — which is given a freshly built type rather than a
+/// pooled one.
+class ASTTypePoolWriter {
+  final ASTStringPoolWriter _strings;
+
+  /// Entry payloads in intern order. A type's components are always interned
+  /// before it, so decoding front-to-back never needs a forward reference.
+  final List<Uint8List> _entries = [];
+
+  final Map<ASTType, int> _byIdentity = Map<ASTType, int>.identity();
+  final Map<String, int> _byKey = {};
+
+  ASTTypePoolWriter(this._strings);
+
+  /// The number of distinct types interned so far.
+  int get length => _entries.length;
+
+  /// The pool index of [type], adding it if this is its first occurrence.
+  int intern(ASTType type) {
+    var known = _byIdentity[type];
+    if (known != null) return known;
+
+    var key = _keyOf(type);
+    known = _byKey[key];
+    if (known != null) {
+      _byIdentity[type] = known;
+      return known;
+    }
+
+    // Reserve nothing: components are interned first (inside `_encode`), so the
+    // index this entry gets is always greater than every index it references.
+    var payload = _encode(type);
+
+    var index = _entries.length;
+    _entries.add(payload);
+    _byIdentity[type] = index;
+    _byKey[key] = index;
+    return index;
+  }
+
+  /// A structural identity for [type], used to collapse equal types.
+  ///
+  /// It includes the concrete class, because two types with the same name can
+  /// be different classes, and `nullable`, because a nullable type is a
+  /// distinct object that must not be shared with its non-nullable form.
+  String _keyOf(ASTType type) {
+    var wellKnown = ASTWellKnownType.idOf(type);
+    if (wellKnown != null) return 'w$wellKnown';
+
+    var b = StringBuffer()
+      ..write(type.runtimeType)
+      ..write('|')
+      ..write(type.name)
+      ..write('|')
+      ..write(type.nullable ? '?' : '');
+
+    switch (type) {
+      case ASTTypeArray3D():
+      case ASTTypeArray2D():
+      case ASTTypeArray():
+        b.write('|c:${intern((type as ASTTypeArray).componentType)}');
+      case ASTTypeMap():
+        b.write('|k:${intern(type.keyType)}|v:${intern(type.valueType)}');
+      case ASTTypeNum():
+        b.write('|b:${type.bits}');
+      case ASTTypeVar():
+        b.write('|u:${type.unmodifiable}');
+      case ASTTypeGenericVariable():
+        var bound = type.type;
+        b.write(
+          '|g:${type.variableName}|t:${bound == null ? '-' : intern(bound)}',
+        );
+      default:
+        for (var g in type.generics ?? const <ASTType>[]) {
+          b.write('|g:${intern(g)}');
+        }
+        var s = type.superType;
+        if (s != null) b.write('|s:${intern(s)}');
+        for (var a in type.annotations ?? const <ASTAnnotation>[]) {
+          b.write('|a:${a.name}(');
+          var parameters = a.parameters;
+          if (parameters != null) {
+            for (var p in parameters.entries) {
+              b.write('${p.key}=${p.value.name}:${p.value.value},');
+            }
+          }
+          b.write(')');
+        }
+    }
+
+    return b.toString();
+  }
+
+  Uint8List _encode(ASTType type) {
+    var out = BytesBuffer();
+
+    var wellKnown = ASTWellKnownType.idOf(type);
+    if (wellKnown != null) {
+      out.writeByte(ASTTypeEntryKind.wellKnown);
+      out.writeByte(wellKnown);
+      return out.toBytes();
+    }
+
+    switch (type) {
+      // 3D before 2D before 1D: they form an inheritance chain, so the most
+      // derived must be tested first.
+      case ASTTypeArray3D():
+        out.writeByte(ASTTypeEntryKind.array3D);
+        _writeArrayElement(out, type, 3);
+      case ASTTypeArray2D():
+        out.writeByte(ASTTypeEntryKind.array2D);
+        _writeArrayElement(out, type, 2);
+      case ASTTypeArray():
+        out.writeByte(ASTTypeEntryKind.array1D);
+        out.writeLeb128UnsignedInt(intern(type.componentType));
+      case ASTTypeMap():
+        out.writeByte(ASTTypeEntryKind.map);
+        out.writeLeb128UnsignedInt(intern(type.keyType));
+        out.writeLeb128UnsignedInt(intern(type.valueType));
+      case ASTTypeFuture():
+        out.writeByte(ASTTypeEntryKind.future);
+        out.writeLeb128UnsignedInt(intern(type.futureValueType));
+      case ASTTypeFunction():
+        // A function type keeps its whole signature in `generics`: the return
+        // type first, then the parameters. Encode that list verbatim and
+        // rebuild with the same split `ASTTypeFunction.cloneType` uses, so no
+        // separate return/parameter accessors are needed.
+        out.writeByte(ASTTypeEntryKind.function);
+        _writeTypeList(out, type.generics);
+      case ASTTypeInt():
+        out.writeByte(ASTTypeEntryKind.int_);
+        _writeIntOrNull(out, type.bits);
+      case ASTTypeDouble():
+        out.writeByte(ASTTypeEntryKind.double_);
+        _writeIntOrNull(out, type.bits);
+      case ASTTypeNum():
+        out.writeByte(ASTTypeEntryKind.num);
+        _writeIntOrNull(out, type.bits);
+      case ASTTypeVar():
+        out.writeByte(ASTTypeEntryKind.var_);
+        out.writeBoolean(type.unmodifiable);
+      case ASTTypeGenericWildcard():
+        out.writeByte(ASTTypeEntryKind.genericWildcard);
+      case ASTTypeGenericVariable():
+        out.writeByte(ASTTypeEntryKind.genericVariable);
+        out.writeLeb128UnsignedInt(_strings.intern(type.variableName));
+        _writeTypeRefOrNull(out, type.type);
+      case ASTTypeBool():
+        out.writeByte(ASTTypeEntryKind.bool_);
+      case ASTTypeString():
+        out.writeByte(ASTTypeEntryKind.string);
+      case ASTTypeObject():
+        out.writeByte(ASTTypeEntryKind.object);
+      case ASTTypeDynamic():
+        out.writeByte(ASTTypeEntryKind.dynamic_);
+      case ASTTypeNull():
+        out.writeByte(ASTTypeEntryKind.null_);
+      case ASTTypeVoid():
+        out.writeByte(ASTTypeEntryKind.void_);
+      case ASTTypeConstructorThis():
+        out.writeByte(ASTTypeEntryKind.constructorThis);
+      case ASTTypeInterface():
+        out.writeByte(ASTTypeEntryKind.interface);
+        _writeGenericBody(out, type);
+      default:
+        out.writeByte(ASTTypeEntryKind.generic);
+        _writeGenericBody(out, type);
+    }
+
+    out.writeBoolean(type.nullable);
+    return out.toBytes();
+  }
+
+  void _writeArrayElement(BytesBuffer out, ASTTypeArray type, int rank) {
+    // 2D and 3D arrays are built from an *element* type, not from their
+    // immediate component type: `ASTTypeArray2D.fromElementType(e)` wraps `e`
+    // twice. Unwrap back to the element so decoding can use the same factory
+    // the grammars use.
+    ASTType t = type;
+    for (var i = 0; i < rank; ++i) {
+      t = (t as ASTTypeArray).componentType;
+    }
+    out.writeLeb128UnsignedInt(intern(t));
+  }
+
+  void _writeGenericBody(BytesBuffer out, ASTType type) {
+    out.writeLeb128UnsignedInt(_strings.intern(type.name));
+    _writeTypeList(out, type.generics);
+    _writeTypeRefOrNull(out, type.superType);
+
+    var annotations = type.annotations;
+    if (annotations == null) {
+      out.writeLeb128UnsignedInt(0);
+    } else {
+      out.writeLeb128UnsignedInt(annotations.length + 1);
+      for (var a in annotations) {
+        writeAnnotation(out, _strings, a);
+      }
+    }
+  }
+
+  void _writeTypeList(BytesBuffer out, List<ASTType>? types) {
+    if (types == null) {
+      out.writeLeb128UnsignedInt(0);
+      return;
+    }
+    // `n + 1`, so 0 can mean "the list itself is null" — a distinction the
+    // generators rely on (a raw `List` is not a `List<>` with no arguments).
+    out.writeLeb128UnsignedInt(types.length + 1);
+    for (var t in types) {
+      out.writeLeb128UnsignedInt(intern(t));
+    }
+  }
+
+  void _writeTypeRefOrNull(BytesBuffer out, ASTType? type) {
+    out.writeLeb128UnsignedInt(type == null ? 0 : intern(type) + 1);
+  }
+
+  void _writeIntOrNull(BytesBuffer out, int? v) {
+    out.writeLeb128UnsignedInt(v == null ? 0 : v + 1);
+  }
+
+  /// Encodes the pool as the payload of an [ASTBinarySection.typeTable].
+  Uint8List encode() {
+    var out = BytesBuffer();
+    out.writeLeb128UnsignedInt(_entries.length);
+    for (var e in _entries) {
+      out.writeLeb128UnsignedInt(e.length);
+      out.writeAllBytes(e);
+    }
+    return out.toBytes();
+  }
+}
+
+/// The decoded type pool: a positional list of [ASTType]s that the AST section
+/// indexes into.
+class ASTTypePoolReader {
+  final List<ASTType> _values;
+
+  ASTTypePoolReader(this._values);
+
+  /// The number of types in the pool.
+  int get length => _values.length;
+
+  /// Decodes a pool from an [ASTBinarySection.typeTable] payload.
+  ///
+  /// Entries are decoded front to back; because the writer interns a type's
+  /// components before the type itself, every reference points backwards and
+  /// resolves immediately.
+  factory ASTTypePoolReader.decode(
+    Uint8List payload,
+    ASTStringPoolReader strings,
+  ) {
+    var input = BytesBuffer.from(payload);
+    var values = <ASTType>[];
+
+    int count;
+    try {
+      count = input.readLeb128UnsignedInt();
+    } catch (e) {
+      throw ASTBinaryException(
+        'Malformed type table: $e',
+        ASTBinaryError.malformedSection,
+        sectionId: ASTBinarySection.typeTable.id,
+      );
+    }
+
+    for (var i = 0; i < count; ++i) {
+      var size = input.readLeb128UnsignedInt();
+      if (size > input.remaining) {
+        throw ASTBinaryException(
+          'Type table entry $i declares $size bytes but only '
+          '${input.remaining} remain.',
+          ASTBinaryError.malformedSection,
+          offset: input.position,
+          sectionId: ASTBinarySection.typeTable.id,
+        );
+      }
+      var entry = input.readBytes(size);
+      values.add(_decodeEntry(entry, strings, values, i));
+    }
+
+    return ASTTypePoolReader(values);
+  }
+
+  static ASTType _decodeEntry(
+    Uint8List entry,
+    ASTStringPoolReader strings,
+    List<ASTType> resolved,
+    int index,
+  ) {
+    var input = BytesBuffer.from(entry);
+
+    ASTType ref() {
+      var i = input.readLeb128UnsignedInt();
+      return _resolve(resolved, i, index);
+    }
+
+    ASTType? refOrNull() {
+      var i = input.readLeb128UnsignedInt();
+      return i == 0 ? null : _resolve(resolved, i - 1, index);
+    }
+
+    List<ASTType>? typeList() {
+      var n = input.readLeb128UnsignedInt();
+      if (n == 0) return null;
+      return [for (var i = 1; i < n; ++i) ref()];
+    }
+
+    int? intOrNull() {
+      var v = input.readLeb128UnsignedInt();
+      return v == 0 ? null : v - 1;
+    }
+
+    var kind = input.readByte();
+
+    if (kind == ASTTypeEntryKind.wellKnown) {
+      var id = input.readByte();
+      var instance = ASTWellKnownType.instanceOf(id);
+      if (instance == null) {
+        throw ASTBinaryException(
+          'Unknown well-known type id $id in type table entry $index.',
+          ASTBinaryError.unsupportedNode,
+          sectionId: ASTBinarySection.typeTable.id,
+        );
+      }
+      return instance;
+    }
+
+    ASTType type;
+    switch (kind) {
+      case ASTTypeEntryKind.array1D:
+        // Mirrors the grammars: `ASTTypeArray(t)` with `t` statically an
+        // `ASTType`, which is also what returns the interned array singletons
+        // for primitive component types.
+        type = ASTTypeArray(ref());
+      case ASTTypeEntryKind.array2D:
+        type = ASTTypeArray2D.fromElementType(ref());
+      case ASTTypeEntryKind.array3D:
+        type = ASTTypeArray3D.fromElementType(ref());
+      case ASTTypeEntryKind.map:
+        var k = ref();
+        var v = ref();
+        type = ASTTypeMap(k, v);
+      case ASTTypeEntryKind.future:
+        type = ASTTypeFuture(ref());
+      case ASTTypeEntryKind.function:
+        var g = typeList() ?? const <ASTType>[];
+        type = ASTTypeFunction(
+          g.isNotEmpty ? g.first : null,
+          g.length > 1 ? g.sublist(1) : null,
+        );
+      case ASTTypeEntryKind.num:
+        var bits = intOrNull();
+        if (bits != null) {
+          // Only `ASTTypeInt` and `ASTTypeDouble` can carry a bit width, and
+          // both have their own entry kind; a bare `ASTTypeNum` with one is not
+          // constructible through any public API.
+          throw ASTBinaryException(
+            'Type table entry $index is a plain `num` carrying a $bits-bit '
+            'width, which cannot be reconstructed.',
+            ASTBinaryError.unsupportedNode,
+            sectionId: ASTBinarySection.typeTable.id,
+          );
+        }
+        type = ASTTypeNum();
+      case ASTTypeEntryKind.int_:
+        type = ASTTypeInt(bits: intOrNull());
+      case ASTTypeEntryKind.double_:
+        type = ASTTypeDouble(bits: intOrNull());
+      case ASTTypeEntryKind.var_:
+        type = ASTTypeVar(unmodifiable: input.readBoolean());
+      case ASTTypeEntryKind.genericWildcard:
+        type = ASTTypeGenericWildcard();
+      case ASTTypeEntryKind.genericVariable:
+        var name = strings[input.readLeb128UnsignedInt()];
+        type = ASTTypeGenericVariable(name, refOrNull());
+      case ASTTypeEntryKind.bool_:
+        type = ASTTypeBool();
+      case ASTTypeEntryKind.string:
+        type = ASTTypeString();
+      case ASTTypeEntryKind.object:
+        type = ASTTypeObject();
+      case ASTTypeEntryKind.dynamic_:
+        type = ASTTypeDynamic.instance;
+      case ASTTypeEntryKind.null_:
+        type = ASTTypeNull();
+      case ASTTypeEntryKind.void_:
+        type = ASTTypeVoid();
+      case ASTTypeEntryKind.constructorThis:
+        type = ASTTypeConstructorThis.instance;
+      case ASTTypeEntryKind.interface:
+      case ASTTypeEntryKind.generic:
+        var name = strings[input.readLeb128UnsignedInt()];
+        var generics = typeList();
+        var superType = refOrNull();
+
+        var annotationsCount = input.readLeb128UnsignedInt();
+        List<ASTAnnotation>? annotations;
+        if (annotationsCount > 0) {
+          annotations = [
+            for (var i = 1; i < annotationsCount; ++i)
+              readAnnotation(input, strings),
+          ];
+        }
+
+        type = kind == ASTTypeEntryKind.interface
+            ? ASTTypeInterface(
+                name,
+                generics: generics,
+                superInterface: superType,
+                annotations: annotations,
+              )
+            : ASTType(
+                name,
+                generics: generics,
+                superType: superType,
+                annotations: annotations,
+              );
+      default:
+        throw ASTBinaryException(
+          'Unknown type entry kind 0x${kind.toRadixString(16)} at type table '
+          'entry $index.',
+          ASTBinaryError.unsupportedNode,
+          sectionId: ASTBinarySection.typeTable.id,
+        );
+    }
+
+    // `asNullable` clones rather than mutating, so a shared singleton is never
+    // altered by a nullable use of the same type.
+    var nullable = input.readBoolean();
+    return nullable == type.nullable ? type : type.asNullable(nullable);
+  }
+
+  static ASTType _resolve(List<ASTType> resolved, int i, int at) {
+    if (i < 0 || i >= resolved.length) {
+      throw ASTBinaryException(
+        'Type table entry $at references type $i, which is not yet defined '
+        '(only ${resolved.length} entries precede it).',
+        ASTBinaryError.malformedSection,
+        sectionId: ASTBinarySection.typeTable.id,
+      );
+    }
+    return resolved[i];
+  }
+
+  /// The type at [index].
+  ASTType operator [](int index) {
+    if (index < 0 || index >= _values.length) {
+      throw ASTBinaryException(
+        'Type pool index $index is out of range (0..${_values.length - 1}).',
+        ASTBinaryError.malformedSection,
+        sectionId: ASTBinarySection.typeTable.id,
+      );
+    }
+    return _values[index];
+  }
+}

--- a/lib/src/serialization/ast_binary_type_pool.dart
+++ b/lib/src/serialization/ast_binary_type_pool.dart
@@ -240,6 +240,8 @@ class ASTTypePoolWriter {
   final Map<ASTType, int> _byIdentity = Map<ASTType, int>.identity();
   final Map<String, int> _byKey = {};
 
+  int _uniqueKeys = 0;
+
   ASTTypePoolWriter(this._strings);
 
   /// The number of distinct types interned so far.
@@ -276,6 +278,17 @@ class ASTTypePoolWriter {
   String _keyOf(ASTType type) {
     var wellKnown = ASTWellKnownType.idOf(type);
     if (wellKnown != null) return 'w$wellKnown';
+
+    if (type is ASTTypeVar) {
+      // A `var`/`final` type is *not* interchangeable between use sites: each
+      // one is wired to its own initializer by the parser
+      // (`type.associateToType(value)`) and caches the type it infers from it.
+      // Sharing one instance across declarations would leak one declaration's
+      // inferred type into another, so every occurrence gets its own entry.
+      // The identity map above still collapses repeated uses of the same
+      // object.
+      return 'var#${_uniqueKeys++}';
+    }
 
     var b = StringBuffer()
       ..write(type.runtimeType)

--- a/lib/src/serialization/ast_binary_vm_extension.dart
+++ b/lib/src/serialization/ast_binary_vm_extension.dart
@@ -1,0 +1,67 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'dart:typed_data';
+
+import '../apollovm_base.dart';
+import 'ast_binary_archive.dart';
+import 'ast_binary_reader.dart';
+import 'ast_binary_signer.dart';
+import 'ast_binary_writer.dart';
+
+/// Binary AST convenience methods on [ApolloVM].
+///
+/// Thin wrappers over [ASTBinaryWriter], [ASTBinaryReader] and the archive
+/// pair; reach for those directly when more control is wanted.
+extension ApolloVMBinaryAST on ApolloVM {
+  /// Encodes the AST of [codeUnit], which must already be loaded.
+  Uint8List saveCodeUnitAST(CodeUnit codeUnit, {ASTBinarySigner? signer}) =>
+      ASTBinaryWriter(signer: signer).writeCodeUnit(codeUnit);
+
+  /// Decodes a binary AST image and loads it, skipping the parser entirely.
+  ///
+  /// This goes through the ordinary [ApolloVM.loadCodeUnit], which only parses
+  /// when a code unit has no AST yet — so namespace registration, the
+  /// null-safety check and incremental-resolution invalidation all behave
+  /// exactly as they do for parsed source.
+  ///
+  /// Pass a [verifier] to require the image be signed with a key it accepts.
+  /// Without one, a signed image still loads and its signature is not checked.
+  Future<bool> loadCodeUnitAST(
+    Uint8List image, {
+    ASTBinaryVerifier? verifier,
+    String? id,
+    String? namespace,
+  }) {
+    var codeUnit = ASTBinaryReader(
+      verifier: verifier,
+    ).readCodeUnit(image, id: id, namespace: namespace);
+
+    return loadCodeUnit(codeUnit);
+  }
+
+  /// Bundles the AST of every loaded code unit into a single archive.
+  ///
+  /// With [language], only that language's units are included.
+  Uint8List saveAllAST({String? language, ASTBinarySigner? signer}) =>
+      ASTBinaryArchiveWriter(signer: signer).writeVM(this, language: language);
+
+  /// Loads every code unit in an archive, returning how many were loaded.
+  Future<int> loadAllAST(
+    Uint8List archive, {
+    ASTBinaryVerifier? verifier,
+    ASTBinaryVerifier? entryVerifier,
+  }) => ASTBinaryArchiveReader(
+    verifier: verifier,
+    entryVerifier: entryVerifier,
+  ).loadInto(this, archive);
+}
+
+/// Binary AST convenience methods on [CodeUnit].
+extension CodeUnitBinaryAST on CodeUnit {
+  /// Encodes this unit's AST. Throws a [StateError] when it has not been
+  /// loaded.
+  Uint8List toBinaryAST({ASTBinarySigner? signer}) =>
+      ASTBinaryWriter(signer: signer).writeCodeUnit(this);
+}

--- a/lib/src/serialization/ast_binary_writer.dart
+++ b/lib/src/serialization/ast_binary_writer.dart
@@ -16,7 +16,8 @@ import 'ast_binary_pool.dart';
 import 'ast_binary_signer.dart';
 import 'ast_binary_type_pool.dart';
 
-/// Encodes a parsed [ASTRoot] into a binary AST image (`.avma`).
+/// Encodes a parsed [ASTRoot] into a binary AST image — `.avma`, for *Apollo
+/// Virtual Machine Archive*.
 ///
 /// The point of the format is to skip the parser: an application parses once —
 /// at build time, or on first run — and afterwards loads the same code unit by

--- a/lib/src/serialization/ast_binary_writer.dart
+++ b/lib/src/serialization/ast_binary_writer.dart
@@ -1,0 +1,109 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'dart:typed_data';
+
+import 'package:data_serializer/data_serializer.dart';
+
+import '../apollovm_base.dart';
+import '../apollovm_generated_output.dart';
+import '../ast/apollovm_ast_toplevel.dart';
+import 'ast_binary_container.dart';
+import 'ast_binary_context.dart';
+import 'ast_binary_format.dart';
+import 'ast_binary_pool.dart';
+import 'ast_binary_signer.dart';
+import 'ast_binary_type_pool.dart';
+
+/// Encodes a parsed [ASTRoot] into a binary AST image (`.avma`).
+///
+/// The point of the format is to skip the parser: an application parses once —
+/// at build time, or on first run — and afterwards loads the same code unit by
+/// decoding bytes, with no grammar and no backtracking.
+///
+/// ```dart
+/// var bytes = ASTBinaryWriter().writeCodeUnit(codeUnit);
+/// ```
+///
+/// Output is deterministic: the same AST always produces the same bytes, so an
+/// image can be content-addressed or compared byte for byte. Nothing
+/// time-dependent is recorded.
+///
+/// Signing is optional and pluggable — see [ASTBinarySigner]. Without it the
+/// image still carries a CRC-32, which detects corruption but proves nothing
+/// against a deliberate edit.
+class ASTBinaryWriter {
+  /// Signs the image, when tamper-evidence is wanted.
+  final ASTBinarySigner? signer;
+
+  const ASTBinaryWriter({this.signer});
+
+  /// Encodes the AST of [codeUnit], which must already be loaded.
+  ///
+  /// Throws a [StateError] when `codeUnit.root` is `null` — the same contract
+  /// as [CodeUnit.generateCode].
+  Uint8List writeCodeUnit(CodeUnit codeUnit) {
+    var root = codeUnit.root;
+    if (root == null) {
+      throw StateError(
+        "Can't write a binary AST for a `CodeUnit` that has not been loaded: "
+        '${codeUnit.id} (${codeUnit.language})',
+      );
+    }
+
+    return writeRoot(
+      root,
+      language: codeUnit.language,
+      namespace: codeUnit.namespace ?? root.namespace,
+      id: codeUnit.id,
+    );
+  }
+
+  /// Encodes [root] directly.
+  ///
+  /// [language] is recorded so the image knows which runner to use; pass the
+  /// parser's own language id (`java11`, not the `java` alias), since a
+  /// deserialized unit never goes through a parser to have it normalized.
+  Uint8List writeRoot(
+    ASTRoot root, {
+    required String language,
+    String? namespace,
+    String id = '',
+  }) {
+    var strings = ASTStringPoolWriter();
+    var types = ASTTypePoolWriter(strings);
+    var ast = ASTBinaryWriteContext(strings, types);
+
+    // The AST is encoded first: it is what fills the pools, and the pool
+    // sections have to be written already complete.
+    ast.node(root);
+    var astBytes = ast.toBytes();
+
+    var metadata = BytesBuffer();
+    metadata.writeLeb128String(ApolloVM.VERSION);
+    metadata.writeLeb128String(language);
+    metadata.writeLeb128String(id);
+    metadata.writeLeb128String(namespace ?? root.namespace);
+
+    return ASTBinaryContainerCodec.encode(
+      sections: [
+        ASTBinarySectionData(ASTBinarySection.metadata.id, metadata.toBytes()),
+        ASTBinarySectionData(ASTBinarySection.stringTable.id, strings.encode()),
+        ASTBinarySectionData(ASTBinarySection.typeTable.id, types.encode()),
+        ASTBinarySectionData(ASTBinarySection.astRoot.id, astBytes),
+      ],
+      signer: signer,
+    );
+  }
+
+  /// Encodes [codeUnit] as an annotated [BytesOutput].
+  ///
+  /// `toString()` on the result is a section-labelled hexdump, which is how a
+  /// format problem actually gets diagnosed. The bytes are identical to
+  /// [writeCodeUnit].
+  BytesOutput writeCodeUnitOutput(CodeUnit codeUnit) {
+    var bytes = writeCodeUnit(codeUnit);
+    return BytesOutput(data: bytes, description: 'Binary AST: ${codeUnit.id}');
+  }
+}

--- a/lib/src/serialization/crc32.dart
+++ b/lib/src/serialization/crc32.dart
@@ -1,0 +1,65 @@
+// Copyright © 2020 Graciliano M. P. All rights reserved.
+// This code is governed by the Apache License, Version 2.0.
+// Please refer to the LICENSE and AUTHORS files for details.
+
+import 'dart:typed_data';
+
+/// CRC-32 (IEEE 802.3, reflected, polynomial `0xEDB88320`).
+///
+/// Used by the binary AST format to detect accidental corruption — a truncated
+/// write, bit rot, a mangled transfer. It is **not** a security primitive:
+/// anyone able to modify a file can recompute its CRC. Tamper-evidence needs a
+/// signature made with a key the attacker does not have (`ASTBinarySigner`).
+///
+/// Every intermediate is masked to 32 bits, so results are identical on the
+/// Dart VM and under `dart2js` (where `int` is a JavaScript double).
+class Crc32 {
+  Crc32._();
+
+  /// The initial CRC accumulator, for use with [update].
+  static const int initial = 0xFFFFFFFF;
+
+  static final Uint32List _table = _buildTable();
+
+  static Uint32List _buildTable() {
+    var table = Uint32List(256);
+    for (var i = 0; i < 256; ++i) {
+      var c = i;
+      for (var bit = 0; bit < 8; ++bit) {
+        // `c` is always < 2^32 here, so `>>` never sees a negative value and
+        // the mask keeps the xor result inside 32 bits on the web.
+        c = ((c & 1) != 0) ? (0xEDB88320 ^ (c >> 1)) & 0xFFFFFFFF : c >> 1;
+      }
+      table[i] = c;
+    }
+    return table;
+  }
+
+  /// Folds `[offset, offset+length)` of [bytes] into the running [crc].
+  ///
+  /// Start from [initial] and finish with [finalize]:
+  /// ```dart
+  /// var crc = Crc32.initial;
+  /// crc = Crc32.update(crc, chunk1);
+  /// crc = Crc32.update(crc, chunk2);
+  /// var result = Crc32.finalize(crc);
+  /// ```
+  static int update(int crc, Uint8List bytes, [int offset = 0, int? length]) {
+    var end = offset + (length ?? (bytes.length - offset));
+
+    RangeError.checkValidRange(offset, end, bytes.length);
+
+    var table = _table;
+    for (var i = offset; i < end; ++i) {
+      crc = table[(crc ^ bytes[i]) & 0xFF] ^ (crc >> 8);
+    }
+    return crc;
+  }
+
+  /// Applies the final inversion to a [crc] accumulated with [update].
+  static int finalize(int crc) => (crc ^ 0xFFFFFFFF) & 0xFFFFFFFF;
+
+  /// The CRC-32 of `[offset, offset+length)` of [bytes].
+  static int compute(Uint8List bytes, [int offset = 0, int? length]) =>
+      finalize(update(initial, bytes, offset, length));
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.27.0
+version: 2.28.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,7 +24,10 @@ environment:
 dependencies:
   swiss_knife: ^3.3.14
   async_extension: ^1.2.22
-  data_serializer: ^1.2.2
+  # 1.2.3 or newer is required, not merely preferred: earlier versions decode
+  # LEB128 incorrectly on the web, which silently corrupts integer literals in
+  # a binary AST image (`4294967296` came back as `0`).
+  data_serializer: ^1.2.3
   # Built-in HMAC-SHA256 signing for binary AST files (`HmacSha256Signer`).
   # Pure Dart and web-safe; signing itself is optional and pluggable.
   crypto: ^3.0.6

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,9 @@ dependencies:
   swiss_knife: ^3.3.14
   async_extension: ^1.2.22
   data_serializer: ^1.2.2
+  # Built-in HMAC-SHA256 signing for binary AST files (`HmacSha256Signer`).
+  # Pure Dart and web-safe; signing itself is optional and pluggable.
+  crypto: ^3.0.6
   petitparser: ^7.0.2
   collection: ^1.19.1
   args: ^2.7.0

--- a/test/cli/binary_ast_cli_test.dart
+++ b/test/cli/binary_ast_cli_test.dart
@@ -13,6 +13,16 @@ import 'package:test/test.dart';
 /// user-facing anyway: what lands on disk, and what the program prints.
 late Directory _tmp;
 
+/// A kernel snapshot of the CLI, compiled once into this suite's own temp
+/// directory.
+///
+/// `dart run bin/apollovm.dart` compiles through a cache shared with every
+/// other process doing the same, and two suites spawning it concurrently
+/// contend on that cache — which shows up as an empty stdout and a non-zero
+/// exit, not as a timeout. Compiling once here keeps this suite independent of
+/// whatever else the runner has in flight.
+late String _cliSnapshot;
+
 const _source = r'''
 class Calc {
   int sum(List<int> ns) {
@@ -34,14 +44,28 @@ File _write(String name, String source) =>
     File('${_tmp.path}/$name')..writeAsStringSync(source);
 
 Future<ProcessResult> _apollovm(List<String> args) => Process.run('dart', [
-  'run',
-  'bin/apollovm.dart',
+  _cliSnapshot,
   ...args,
 ], workingDirectory: Directory.current.path);
 
 void main() {
   setUpAll(() {
     _tmp = Directory.systemTemp.createTempSync('apollovm_cli_astb');
+
+    _cliSnapshot = '${_tmp.path}/apollovm.dill';
+    var compiled = Process.runSync('dart', [
+      'compile',
+      'kernel',
+      'bin/apollovm.dart',
+      '-o',
+      _cliSnapshot,
+    ], workingDirectory: Directory.current.path);
+
+    expect(
+      compiled.exitCode,
+      0,
+      reason: 'Could not compile the CLI: ${compiled.stderr}',
+    );
   });
 
   tearDownAll(() {

--- a/test/cli/binary_ast_cli_test.dart
+++ b/test/cli/binary_ast_cli_test.dart
@@ -1,0 +1,113 @@
+@TestOn('vm')
+@Tags(['dart'])
+library;
+
+import 'dart:io';
+
+import 'package:test/test.dart';
+
+/// `compile --target=ast` and running the resulting image, through the real CLI.
+///
+/// `CommandRun`/`CommandCompile` live in `bin/apollovm.dart`, which a test
+/// cannot import, so these spawn the script — and the contract under test is
+/// user-facing anyway: what lands on disk, and what the program prints.
+late Directory _tmp;
+
+const _source = r'''
+class Calc {
+  int sum(List<int> ns) {
+    var total = 0;
+    for (var n in ns) {
+      total = total + n;
+    }
+    return total;
+  }
+
+  static void main(List<String> args) {
+    var c = Calc();
+    print('total: ${c.sum([1, 2, 3, 4])}');
+  }
+}
+''';
+
+File _write(String name, String source) =>
+    File('${_tmp.path}/$name')..writeAsStringSync(source);
+
+Future<ProcessResult> _apollovm(List<String> args) => Process.run('dart', [
+  'run',
+  'bin/apollovm.dart',
+  ...args,
+], workingDirectory: Directory.current.path);
+
+void main() {
+  setUpAll(() {
+    _tmp = Directory.systemTemp.createTempSync('apollovm_cli_astb');
+  });
+
+  tearDownAll(() {
+    if (_tmp.existsSync()) _tmp.deleteSync(recursive: true);
+  });
+
+  group('compile --target=ast', () {
+    test('is advertised by `compile --help`', () async {
+      final r = await _apollovm(['compile', '--help']);
+      expect(r.stdout.toString(), contains('wasm|ast'));
+    }, timeout: const Timeout(Duration(minutes: 2)));
+
+    test('writes an image next to the source, and `run` executes it', () async {
+      final source = _write('calc.dart', _source);
+
+      final compiled = await _apollovm([
+        'compile',
+        '--target=ast',
+        source.path,
+      ]);
+      expect(compiled.exitCode, 0, reason: '${compiled.stderr}');
+
+      final image = File('${_tmp.path}/calc.avma');
+      expect(image.existsSync(), isTrue, reason: 'No image was written');
+
+      // `\0AVM`: binary, and not mistakable for text.
+      expect(
+        image.readAsBytesSync().sublist(0, 4),
+        equals([0x00, 0x41, 0x56, 0x4D]),
+      );
+
+      // Detected by its magic rather than its extension, so the recorded
+      // language is what decides the runner.
+      final ran = await _apollovm(['run', '-v', image.path]);
+      expect(ran.exitCode, 0, reason: '${ran.stderr}');
+      expect(ran.stdout.toString(), contains('total: 10'));
+      expect(ran.stdout.toString(), contains('binary AST'));
+    }, timeout: const Timeout(Duration(minutes: 3)));
+
+    test('honours -o', () async {
+      final source = _write('calc2.dart', _source);
+      final target = '${_tmp.path}/nested-name.bin';
+
+      final r = await _apollovm([
+        'compile',
+        '--target=ast',
+        '-o',
+        target,
+        source.path,
+      ]);
+
+      expect(r.exitCode, 0, reason: '${r.stderr}');
+      expect(File(target).existsSync(), isTrue);
+
+      // Still recognized by content, whatever it was named.
+      final ran = await _apollovm(['run', target]);
+      expect(ran.exitCode, 0, reason: '${ran.stderr}');
+      expect(ran.stdout.toString(), contains('total: 10'));
+    }, timeout: const Timeout(Duration(minutes: 3)));
+
+    test('rejects an unknown target', () async {
+      final source = _write('calc3.dart', _source);
+      final r = await _apollovm(['compile', '--target=nope', source.path]);
+
+      expect(r.exitCode, isNot(0));
+      expect('${r.stdout}${r.stderr}', contains('Unsupported compile target'));
+    }, timeout: const Timeout(Duration(minutes: 2)));
+  });
+}

--- a/test/features/apollovm_ast_binary_api_test.dart
+++ b/test/features/apollovm_ast_binary_api_test.dart
@@ -1,0 +1,362 @@
+@Tags(['dart'])
+library;
+
+import 'dart:typed_data';
+
+import 'package:apollovm/apollovm.dart';
+import 'package:apollovm/apollovm_serialization.dart';
+import 'package:test/test.dart';
+
+const _sourceA = r'''
+class Greeter {
+  String greet(String name) {
+    return 'hello $name';
+  }
+}
+''';
+
+const _sourceB = r'''
+class Adder {
+  int add(int a, int b) {
+    return a + b;
+  }
+
+  static void main(List<String> args) {
+    print(Adder().add(2, 3));
+  }
+}
+''';
+
+Future<ApolloVM> _vmWith(Map<String, String> sources) async {
+  var vm = ApolloVM();
+  for (var e in sources.entries) {
+    var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', e.value, id: e.key));
+    expect(ok, isTrue, reason: 'Error loading ${e.key}');
+  }
+  return vm;
+}
+
+void main() {
+  group('ApolloVM convenience methods', () {
+    test('saveCodeUnitAST / loadCodeUnitAST round trip', () async {
+      var vm = await _vmWith({'b.dart': _sourceB});
+      var codeUnit = vm.allCodeUnitsAllLanguages().single;
+
+      var image = vm.saveCodeUnitAST(codeUnit);
+      expect(ASTBinaryReader.isASTBinary(image), isTrue);
+
+      var vm2 = ApolloVM();
+      expect(await vm2.loadCodeUnitAST(image), isTrue);
+
+      var runner = vm2.createRunner('dart')!;
+      var output = <Object?>[];
+      runner.externalPrintFunction = output.add;
+
+      await runner.executeClassMethod(
+        '',
+        'Adder',
+        'main',
+        positionalParameters: [<String>[]],
+      );
+
+      expect(output, equals([5]));
+    });
+
+    test('CodeUnit.toBinaryAST matches the VM method', () async {
+      var vm = await _vmWith({'b.dart': _sourceB});
+      var codeUnit = vm.allCodeUnitsAllLanguages().single;
+
+      expect(codeUnit.toBinaryAST(), equals(vm.saveCodeUnitAST(codeUnit)));
+    });
+
+    test('loadCodeUnitAST can re-home a unit', () async {
+      var vm = await _vmWith({'b.dart': _sourceB});
+      var image = vm.saveCodeUnitAST(vm.allCodeUnitsAllLanguages().single);
+
+      var vm2 = ApolloVM();
+      await vm2.loadCodeUnitAST(image, id: 'other.dart', namespace: 'ns');
+
+      var loaded = vm2.allCodeUnitsAllLanguages().single;
+      expect(loaded.id, equals('other.dart'));
+      expect(loaded.namespace, equals('ns'));
+    });
+
+    test('an image loads without going through a parser', () async {
+      // The point of the format: `loadCodeUnit` only reaches for a parser when
+      // a unit has no AST yet, so a decoded unit never touches the grammar.
+      var vm = await _vmWith({'b.dart': _sourceB});
+      var image = vm.saveCodeUnitAST(vm.allCodeUnitsAllLanguages().single);
+
+      var decoded = const ASTBinaryReader().readCodeUnit(image);
+      expect(decoded.root, isNotNull);
+      expect(decoded, isA<BinaryCodeUnit>());
+    });
+  });
+
+  group('archive', () {
+    test('bundles every loaded unit and loads them all back', () async {
+      var vm = await _vmWith({'a.dart': _sourceA, 'b.dart': _sourceB});
+
+      var archive = vm.saveAllAST();
+      expect(ASTBinaryArchiveReader.isArchive(archive), isTrue);
+      expect(ASTBinaryReader.isASTBinary(archive), isTrue);
+
+      var vm2 = ApolloVM();
+      expect(await vm2.loadAllAST(archive), equals(2));
+
+      var ids = vm2.allCodeUnitsAllLanguages().map((e) => e.id).toList()
+        ..sort();
+      expect(ids, equals(['a.dart', 'b.dart']));
+
+      var runner = vm2.createRunner('dart')!;
+      var output = <Object?>[];
+      runner.externalPrintFunction = output.add;
+      await runner.executeClassMethod(
+        '',
+        'Adder',
+        'main',
+        positionalParameters: [<String>[]],
+      );
+      expect(output, equals([5]));
+    });
+
+    test('entries can be listed without decoding their ASTs', () async {
+      var vm = await _vmWith({'a.dart': _sourceA, 'b.dart': _sourceB});
+      var archive = vm.saveAllAST();
+
+      var entries = const ASTBinaryArchiveReader().listEntries(archive);
+      expect(entries.length, equals(2));
+      expect(
+        entries.map((e) => e.codeUnitId).toList()..sort(),
+        equals(['a.dart', 'b.dart']),
+      );
+      for (var e in entries) {
+        expect(e.language, equals('dart'));
+      }
+    });
+
+    test('each entry is itself a complete, independently readable image', () {
+      // Nesting whole images rather than merging pools is what makes this
+      // possible: one unit can be pulled out and read on its own.
+      return _vmWith({'a.dart': _sourceA, 'b.dart': _sourceB}).then((vm) {
+        var archive = vm.saveAllAST();
+        var entries = const ASTBinaryArchiveReader().entriesOf(archive);
+
+        expect(entries.length, equals(2));
+        for (var entry in entries) {
+          expect(ASTBinaryReader.isASTBinary(entry), isTrue);
+          expect(ASTBinaryArchiveReader.isArchive(entry), isFalse);
+          expect(const ASTBinaryReader().readRoot(entry), isNotNull);
+        }
+      });
+    });
+
+    test('a single-unit image is not mistaken for an archive', () async {
+      var vm = await _vmWith({'b.dart': _sourceB});
+      var image = vm.saveCodeUnitAST(vm.allCodeUnitsAllLanguages().single);
+
+      expect(ASTBinaryArchiveReader.isArchive(image), isFalse);
+      expect(
+        () => const ASTBinaryArchiveReader().entriesOf(image),
+        throwsA(isA<ASTBinaryException>()),
+      );
+    });
+
+    test('an archive can be signed as a whole', () async {
+      var vm = await _vmWith({'a.dart': _sourceA, 'b.dart': _sourceB});
+
+      var archive = vm.saveAllAST(
+        signer: HmacSha256Signer.fromString('build-key'),
+      );
+
+      var vm2 = ApolloVM();
+      expect(
+        await vm2.loadAllAST(
+          archive,
+          verifier: HmacSha256Verifier.fromString('build-key'),
+        ),
+        equals(2),
+      );
+
+      expect(
+        () => ApolloVM().loadAllAST(
+          archive,
+          verifier: HmacSha256Verifier.fromString('wrong-key'),
+        ),
+        throwsA(isA<ASTBinaryIntegrityException>()),
+      );
+    });
+  });
+
+  group('signing an image', () {
+    test(
+      'a signed image verifies with the right key and fails with a wrong one',
+      () async {
+        var vm = await _vmWith({'b.dart': _sourceB});
+        var codeUnit = vm.allCodeUnitsAllLanguages().single;
+
+        var image = vm.saveCodeUnitAST(
+          codeUnit,
+          signer: HmacSha256Signer.fromString('s3cret'),
+        );
+
+        expect(const ASTBinaryReader().readInfo(image).isSigned, isTrue);
+
+        expect(
+          await ApolloVM().loadCodeUnitAST(
+            image,
+            verifier: HmacSha256Verifier.fromString('s3cret'),
+          ),
+          isTrue,
+        );
+
+        expect(
+          () => ApolloVM().loadCodeUnitAST(
+            image,
+            verifier: HmacSha256Verifier.fromString('nope'),
+          ),
+          throwsA(
+            isA<ASTBinaryIntegrityException>().having(
+              (e) => e.error,
+              'error',
+              ASTBinaryError.signatureMismatch,
+            ),
+          ),
+        );
+      },
+    );
+
+    test('a corrupted image is refused before its AST is used', () async {
+      var vm = await _vmWith({'b.dart': _sourceB});
+      var image = vm.saveCodeUnitAST(vm.allCodeUnitsAllLanguages().single);
+
+      var tampered = Uint8List.fromList(image);
+      // Somewhere well inside the section stream.
+      var at = tampered.length ~/ 2;
+      tampered[at] = tampered[at] ^ 0xFF;
+
+      expect(
+        () => ApolloVM().loadCodeUnitAST(tampered),
+        throwsA(
+          isA<ASTBinaryIntegrityException>().having(
+            (e) => e.error,
+            'error',
+            ASTBinaryError.checksumMismatch,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('size and load cost', () {
+    /// A program of realistic size, rather than a two-line snippet: an image
+    /// carries a fixed header, a metadata section and two pools, so for a very
+    /// small unit that overhead dominates and the image is *larger* than the
+    /// source. The saving only appears once there is a program to speak of.
+    String bigSource(int classes) {
+      var b = StringBuffer();
+      for (var i = 0; i < classes; ++i) {
+        b.write('''
+class Worker$i {
+  int factor = $i;
+
+  int compute(int a, int b) {
+    var total = 0;
+    for (var k = 0; k < a; ++k) {
+      if (k % 2 == 0) {
+        total = total + (k * b) + factor;
+      } else {
+        total = total - k;
+      }
+    }
+    return total;
+  }
+
+  String describe(String label) {
+    return 'worker $i: \$label = \${compute(3, 4)}';
+  }
+}
+
+''');
+      }
+      return b.toString();
+    }
+
+    test('an image is smaller than the source for a real program', () async {
+      var source = bigSource(12);
+      var vm = await _vmWith({'big.dart': source});
+
+      var image = vm.saveCodeUnitAST(vm.allCodeUnitsAllLanguages().single);
+
+      var ratio = image.length / source.length;
+      print(
+        'source: ${source.length} bytes ; image: ${image.length} bytes '
+        '(${(ratio * 100).toStringAsFixed(1)}%)',
+      );
+
+      expect(
+        image.length,
+        lessThan(source.length),
+        reason: 'The binary AST should be more compact than the source',
+      );
+    });
+
+    test(
+      'a tiny unit costs more than its source, and that is expected',
+      () async {
+        // Stated as a test rather than left as a surprise: the format trades a
+        // fixed overhead for a large saving on anything of real size.
+        var vm = await _vmWith({'a.dart': _sourceA});
+        var image = vm.saveCodeUnitAST(vm.allCodeUnitsAllLanguages().single);
+
+        print('tiny source: ${_sourceA.length} bytes ; image: ${image.length}');
+        expect(image.length, greaterThan(0));
+      },
+    );
+
+    test('decoding is faster than parsing', () async {
+      var source = bigSource(12);
+      var vm = await _vmWith({'big.dart': source});
+      var image = vm.saveCodeUnitAST(vm.allCodeUnitsAllLanguages().single);
+
+      const rounds = 5;
+
+      // Warm both paths so neither pays one-off costs (the grammar is built
+      // lazily and cached on the parser instance).
+      await ApolloVM().loadCodeUnit(SourceCodeUnit('dart', source, id: 'w'));
+      const ASTBinaryReader().readRoot(image);
+
+      var parseWatch = Stopwatch()..start();
+      for (var i = 0; i < rounds; ++i) {
+        await ApolloVM().loadCodeUnit(
+          SourceCodeUnit('dart', source, id: 'p$i'),
+        );
+      }
+      parseWatch.stop();
+
+      var decodeWatch = Stopwatch()..start();
+      for (var i = 0; i < rounds; ++i) {
+        const ASTBinaryReader().readRoot(image);
+      }
+      decodeWatch.stop();
+
+      var parseUs = parseWatch.elapsedMicroseconds / rounds;
+      var decodeUs = decodeWatch.elapsedMicroseconds / rounds;
+
+      print(
+        'parse: ${parseUs.toStringAsFixed(0)}us ; '
+        'decode: ${decodeUs.toStringAsFixed(0)}us ; '
+        'speedup: ${(parseUs / decodeUs).toStringAsFixed(1)}x',
+      );
+
+      // A deliberately loose bound: this is a regression tripwire, not a
+      // benchmark, and CI machines are noisy. The printed numbers are the
+      // interesting part.
+      expect(
+        decodeUs,
+        lessThan(parseUs),
+        reason: 'Decoding a binary AST should beat parsing the source',
+      );
+    });
+  });
+}

--- a/test/features/apollovm_ast_binary_compat_test.dart
+++ b/test/features/apollovm_ast_binary_compat_test.dart
@@ -1,0 +1,302 @@
+@Tags(['dart'])
+library;
+
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:apollovm/apollovm.dart';
+import 'package:apollovm/apollovm_serialization.dart';
+// The container internals are needed to synthesize files a current writer
+// cannot produce — a future section, a future minimum reader version.
+import 'package:apollovm/src/serialization/ast_binary_container.dart';
+import 'package:apollovm/src/serialization/crc32.dart';
+import 'package:test/test.dart';
+
+/// The source [_goldenV1] was produced from.
+const _goldenSource = r'''
+class Golden {
+  int sum(int a, int b) {
+    var t = a + b;
+    return t;
+  }
+
+  static void main(List<String> args) {
+    print('golden: ${Golden().sum(3, 4)}');
+  }
+}
+''';
+
+/// A real image written by format version 1, frozen here forever.
+///
+/// This is the only test that can actually catch an accidental incompatible
+/// change. An image synthesized by the current writer proves nothing, because
+/// the current writer is exactly what a change would alter — so the bytes have
+/// to come from the past and stay untouched.
+///
+/// Committed as base64 in the source rather than as a file under
+/// `test/fixtures/`, because the Chrome test runner has no filesystem.
+const _goldenV1 =
+    'AEFWTQABAAEAAAAAAAAA3gEZBjIuMjguMARkYXJ0C2dvbGRlbi5kYXJ0AAI8DAAGR29s'
+    'ZGVuC25vcm1hbENsYXNzA3N1bQFhAWIBdANhZGQEbWFpbgRhcmdzBXByaW50CGdvbGRl'
+    'bjogAw4EAgEBAw0AAAIBEgIBDQRzZAAAAQEBAmUBAgAAAQEBA2sDA3EABAEAAAAAcQAF'
+    'AQAAAAAAAAAAA0QBBiEfFAQHHxQFAEgUBgEBAWsIAnECCQEAAAAAAAADAQJDIwoCHhID'
+    'BAsQIwEBAiUDAx4CAAMAHgIABAAAAAAAAQEBAQEBAQEBAe9uKjUAAEFWTQA=';
+
+Uint8List get _golden => base64.decode(_goldenV1);
+
+/// Rebuilds a file from [sections], so a test can present something no current
+/// writer would produce.
+Uint8List _rebuild(
+  List<ASTBinarySectionData> sections, {
+  int formatVersion = ASTBinaryFormat.version,
+  int minReaderVersion = ASTBinaryFormat.version,
+  int flags = 0,
+}) => ASTBinaryContainerCodec.encode(
+  sections: sections,
+  formatVersion: formatVersion,
+  minReaderVersion: minReaderVersion,
+  flags: flags,
+);
+
+/// The sections of [bytes], so a test can add to or reorder them.
+List<ASTBinarySectionData> _sectionsOf(Uint8List bytes) =>
+    ASTBinaryContainerCodec.decode(bytes).sections;
+
+void main() {
+  group('an image written by format version 1 still loads', () {
+    test('and regenerates the same source', () async {
+      var vm = ApolloVM();
+      expect(await vm.loadCodeUnitAST(_golden), isTrue);
+
+      var fromImage = (await vm.generateAllCodeIn('dart').writeAllSources())
+          .toString();
+
+      // Compare against a fresh parse of the source it was made from, so this
+      // stays meaningful even if the Dart generator's formatting evolves.
+      var vmSource = ApolloVM();
+      await vmSource.loadCodeUnit(
+        SourceCodeUnit('dart', _goldenSource, id: 'golden.dart'),
+      );
+      var fromSource =
+          (await vmSource.generateAllCodeIn('dart').writeAllSources())
+              .toString();
+
+      expect(fromImage, equals(fromSource));
+    });
+
+    test('and still runs', () async {
+      var vm = ApolloVM();
+      await vm.loadCodeUnitAST(_golden);
+
+      var runner = vm.createRunner('dart')!;
+      var output = <Object?>[];
+      runner.externalPrintFunction = output.add;
+
+      await runner.executeClassMethod(
+        '',
+        'Golden',
+        'main',
+        positionalParameters: [<String>[]],
+      );
+
+      expect(output, equals(['golden: 7']));
+    });
+
+    test('and reports the version that wrote it', () {
+      var info = const ASTBinaryReader().readInfo(_golden);
+      expect(info.header.formatVersion, equals(1));
+      expect(info.header.minReaderVersion, equals(1));
+      expect(info.language, equals('dart'));
+      expect(info.codeUnitId, equals('golden.dart'));
+    });
+  });
+
+  group('forward tolerance', () {
+    test('an unknown section is skipped', () {
+      // The mechanism that lets a newer ApolloVM's output keep loading here.
+      var sections = _sectionsOf(_golden);
+      var withFuture = _rebuild([
+        ...sections,
+        ASTBinarySectionData(0x7F, Uint8List.fromList([1, 2, 3, 4, 5])),
+      ]);
+
+      var info = const ASTBinaryReader().readInfo(withFuture);
+      expect(info.unknownSectionIds, equals([0x7F]));
+
+      expect(const ASTBinaryReader().readRoot(withFuture), isNotNull);
+    });
+
+    test('a section may appear before the ones this build knows', () {
+      var sections = _sectionsOf(_golden);
+      var reordered = _rebuild([
+        ASTBinarySectionData(0x7E, Uint8List.fromList([9])),
+        ...sections,
+      ]);
+
+      expect(const ASTBinaryReader().readRoot(reordered), isNotNull);
+    });
+
+    test('a newer format version loads when it says older readers can', () {
+      var bumped = _rebuild(
+        _sectionsOf(_golden),
+        formatVersion: 999,
+        minReaderVersion: ASTBinaryFormat.version,
+      );
+
+      var info = const ASTBinaryReader().readInfo(bumped);
+      expect(info.header.formatVersion, equals(999));
+      expect(const ASTBinaryReader().readRoot(bumped), isNotNull);
+    });
+
+    test('a newer format version is refused when it says they cannot', () {
+      // The other half of the contract: rather than mis-decoding, fail loudly
+      // and name both versions.
+      var bumped = _rebuild(
+        _sectionsOf(_golden),
+        formatVersion: 999,
+        minReaderVersion: 999,
+      );
+
+      expect(
+        () => const ASTBinaryReader().readRoot(bumped),
+        throwsA(
+          isA<ASTBinaryException>()
+              .having(
+                (e) => e.error,
+                'error',
+                ASTBinaryError.unsupportedVersion,
+              )
+              .having((e) => e.minReaderVersion, 'minReaderVersion', 999),
+        ),
+      );
+    });
+
+    test('an unknown flag bit is refused, not ignored', () {
+      // Unlike a section, a flag changes how the payload must be read, so
+      // ignoring one would mean mis-decoding rather than missing information.
+      var flagged = _rebuild(_sectionsOf(_golden), flags: 0x40);
+
+      expect(
+        () => const ASTBinaryReader().readRoot(flagged),
+        throwsA(
+          isA<ASTBinaryException>().having(
+            (e) => e.error,
+            'error',
+            ASTBinaryError.unknownFlags,
+          ),
+        ),
+      );
+    });
+
+    test('trailing bytes in a section this build knows are ignored', () {
+      // A newer writer appending a field to an existing section must not break
+      // an older reader: sections are read from a bounded view.
+      var sections = _sectionsOf(_golden);
+
+      var patched = [
+        for (var s in sections)
+          if (s.id == ASTBinarySection.metadata.id)
+            ASTBinarySectionData(
+              s.id,
+              Uint8List.fromList([...s.payload, 42, 42, 42]),
+            )
+          else
+            s,
+      ];
+
+      var info = const ASTBinaryReader().readInfo(_rebuild(patched));
+      expect(info.language, equals('dart'));
+      expect(info.codeUnitId, equals('golden.dart'));
+    });
+  });
+
+  group('malformed images fail rather than mis-decode', () {
+    test('a truncated image', () {
+      var truncated = _golden.sublist(0, _golden.length - 12);
+      expect(
+        () => const ASTBinaryReader().readRoot(truncated),
+        throwsA(
+          isA<ASTBinaryException>().having(
+            (e) => e.error,
+            'error',
+            ASTBinaryError.truncated,
+          ),
+        ),
+      );
+    });
+
+    test('an unknown node tag, even with a valid checksum', () {
+      // An unknown *section* is skipped; an unknown *node* never can be — there
+      // is no length prefix to skip past, and guessing would produce a wrong
+      // AST rather than an incomplete one.
+      var bytes = _golden;
+      var container = ASTBinaryContainerCodec.decode(bytes);
+
+      var ast = container.requirePayloadOf(ASTBinarySection.astRoot);
+      var broken = Uint8List.fromList(ast);
+      broken[0] = 0x7E; // A tag no build assigns.
+
+      var rebuilt = _rebuild([
+        for (var s in container.sections)
+          if (s.id == ASTBinarySection.astRoot.id)
+            ASTBinarySectionData(s.id, broken)
+          else
+            s,
+      ]);
+
+      expect(
+        () => const ASTBinaryReader().readRoot(rebuilt),
+        throwsA(
+          isA<ASTBinaryException>().having(
+            (e) => e.error,
+            'error',
+            ASTBinaryError.unsupportedNode,
+          ),
+        ),
+      );
+    });
+
+    test('a corrupted string pool index', () {
+      var container = ASTBinaryContainerCodec.decode(_golden);
+      var strings = container.requirePayloadOf(ASTBinarySection.stringTable);
+
+      // Claim far more strings than the section holds.
+      var broken = Uint8List.fromList([0x7F, ...strings.sublist(1)]);
+
+      var rebuilt = _rebuild([
+        for (var s in container.sections)
+          if (s.id == ASTBinarySection.stringTable.id)
+            ASTBinarySectionData(s.id, broken)
+          else
+            s,
+      ]);
+
+      expect(
+        () => const ASTBinaryReader().readRoot(rebuilt),
+        throwsA(isA<ASTBinaryException>()),
+      );
+    });
+  });
+
+  group('the golden image is what it claims to be', () {
+    test('its checksum verifies', () {
+      var bytes = _golden;
+      var sectionsSize =
+          ((bytes[12] << 24) |
+              (bytes[13] << 16) |
+              (bytes[14] << 8) |
+              bytes[15]) >>>
+          0;
+      var trailerStart = ASTBinaryFormat.headerSize + sectionsSize;
+
+      var declared =
+          ((bytes[trailerStart] << 24) |
+              (bytes[trailerStart + 1] << 16) |
+              (bytes[trailerStart + 2] << 8) |
+              bytes[trailerStart + 3]) >>>
+          0;
+
+      expect(Crc32.compute(bytes, 0, trailerStart), equals(declared));
+    });
+  });
+}

--- a/test/features/apollovm_ast_binary_large_int_test.dart
+++ b/test/features/apollovm_ast_binary_large_int_test.dart
@@ -1,0 +1,107 @@
+@Tags(['dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:apollovm/apollovm_serialization.dart';
+import 'package:test/test.dart';
+
+/// Integer literals large enough to leave a 32-bit range.
+///
+/// These run on the web too, where an `int` is a JavaScript double: LEB128
+/// decoding accumulates 7-bit groups, and a 32-bit accumulator silently drops
+/// the high bits of anything past 2^32. A literal like a file size, a
+/// millisecond timestamp or an id is exactly the sort of value that lands
+/// there, so the round trip is checked at those magnitudes rather than only on
+/// the small numbers a hand-written test tends to use.
+void main() {
+  group('large integer literals survive a binary AST round trip', () {
+    Future<List<Object?>> runSource(String source) async {
+      var vm = ApolloVM();
+      var codeUnit = SourceCodeUnit('dart', source, id: 'big.dart');
+      expect(await vm.loadCodeUnit(codeUnit), isTrue);
+
+      var image = vm.saveCodeUnitAST(codeUnit);
+
+      var vm2 = ApolloVM();
+      expect(await vm2.loadCodeUnitAST(image), isTrue);
+
+      var runner = vm2.createRunner('dart')!;
+      var output = <Object?>[];
+      runner.externalPrintFunction = output.add;
+
+      await runner.executeClassMethod(
+        '',
+        'Big',
+        'main',
+        positionalParameters: [<String>[]],
+      );
+
+      return output;
+    }
+
+    test('positive literals from 2^28 upwards', () async {
+      var output = await runSource(r'''
+class Big {
+  static void main(List<String> args) {
+    print(268435456);
+    print(4294967295);
+    print(4294967296);
+    print(1099511627776);
+    print(1000000000000000);
+  }
+}
+''');
+
+      expect(
+        output,
+        equals([
+          268435456, // 2^28
+          4294967295, // 2^32 - 1
+          4294967296, // 2^32
+          1099511627776, // 2^40
+          1000000000000000, // 10^15
+        ]),
+      );
+    });
+
+    test('negative literals from 2^28 downwards', () async {
+      var output = await runSource(r'''
+class Big {
+  static void main(List<String> args) {
+    print(-268435456);
+    print(-4294967296);
+    print(-1099511627776);
+    print(-1000000000000000);
+  }
+}
+''');
+
+      expect(
+        output,
+        equals([-268435456, -4294967296, -1099511627776, -1000000000000000]),
+      );
+    });
+
+    test('a large literal regenerates as itself', () async {
+      var vm = ApolloVM();
+      var codeUnit = SourceCodeUnit(
+        'dart',
+        'class Big {\n  int v = 1099511627776;\n}\n',
+        id: 'big.dart',
+      );
+      expect(await vm.loadCodeUnit(codeUnit), isTrue);
+
+      var expected = (await vm.generateAllCodeIn('dart').writeAllSources())
+          .toString();
+
+      var vm2 = ApolloVM();
+      await vm2.loadCodeUnitAST(vm.saveCodeUnitAST(codeUnit));
+
+      var actual = (await vm2.generateAllCodeIn('dart').writeAllSources())
+          .toString();
+
+      expect(actual, equals(expected));
+      expect(actual, contains('1099511627776'));
+    });
+  });
+}

--- a/test/features/apollovm_ast_binary_roundtrip_test.dart
+++ b/test/features/apollovm_ast_binary_roundtrip_test.dart
@@ -1,0 +1,321 @@
+@Tags(['dart'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+// Serialization internals are not re-exported from the public library.
+import 'package:apollovm/src/serialization/ast_binary_reader.dart';
+import 'package:apollovm/src/serialization/ast_binary_writer.dart';
+import 'package:test/test.dart';
+
+/// Parses [source], and returns the code unit alongside the source the
+/// generator produces from the freshly parsed AST.
+Future<(ApolloVM, CodeUnit, String)> _parse(
+  String source, {
+  String language = 'dart',
+}) async {
+  var vm = ApolloVM();
+  var codeUnit = SourceCodeUnit(language, source, id: 'test');
+
+  var ok = await vm.loadCodeUnit(codeUnit);
+  expect(ok, isTrue, reason: "Error loading '$language' source");
+
+  var generated = (await vm.generateAllCodeIn(language).writeAllSources())
+      .toString();
+
+  return (vm, codeUnit, generated);
+}
+
+/// Parses [source], encodes its AST, decodes it into a fresh VM, and asserts
+/// the regenerated source is byte-identical to what the parsed AST produced.
+///
+/// Comparing regenerated source is the strongest cheap check available here: it
+/// exercises every field the code generator reads, across the whole tree, so a
+/// dropped field shows up as a diff rather than going unnoticed.
+Future<ApolloVM> _assertRoundTrip(
+  String source, {
+  String language = 'dart',
+}) async {
+  var (_, codeUnit, expected) = await _parse(source, language: language);
+
+  var bytes = ASTBinaryWriter().writeCodeUnit(codeUnit);
+
+  var decodedUnit = const ASTBinaryReader().readCodeUnit(bytes);
+  var vm2 = ApolloVM();
+  var ok = await vm2.loadCodeUnit(decodedUnit);
+  expect(ok, isTrue, reason: 'Error loading the decoded binary AST');
+
+  var actual = (await vm2.generateAllCodeIn(language).writeAllSources())
+      .toString();
+
+  expect(
+    actual,
+    equals(expected),
+    reason: 'Regenerated source diverged after a binary AST round trip',
+  );
+
+  return vm2;
+}
+
+/// Encoding is deterministic, so re-encoding a decoded AST must reproduce the
+/// original bytes exactly. This is the cheapest possible detector for an
+/// encode/decode asymmetry that still happens to produce readable source.
+Future<void> _assertByteIdempotent(
+  String source, {
+  String language = 'dart',
+}) async {
+  var (_, codeUnit, _) = await _parse(source, language: language);
+
+  var first = ASTBinaryWriter().writeCodeUnit(codeUnit);
+  var decoded = const ASTBinaryReader().readCodeUnit(first);
+  var second = ASTBinaryWriter().writeCodeUnit(decoded);
+
+  expect(
+    second,
+    equals(first),
+    reason: 'encode(decode(encode(ast))) differed from encode(ast)',
+  );
+}
+
+void main() {
+  group('round trip', () {
+    test('a class with a method and a static entry point', () async {
+      await _assertRoundTrip(r'''
+class Foo {
+  int sum(int a, int b) {
+    var t = a + b;
+    return t;
+  }
+
+  static void main(List<String> args) {
+    var f = Foo();
+    print(f.sum(10, 20));
+  }
+}
+''');
+    });
+
+    test('control flow', () async {
+      await _assertRoundTrip(r'''
+class Ctrl {
+  void run(int n) {
+    if (n > 10) {
+      print('big');
+    } else if (n > 5) {
+      print('mid');
+    } else {
+      print('small');
+    }
+
+    for (var i = 0; i < n; ++i) {
+      if (i == 2) continue;
+      if (i == 5) break;
+      print(i);
+    }
+
+    var j = 0;
+    while (j < 3) {
+      j++;
+    }
+
+    do {
+      j--;
+    } while (j > 0);
+  }
+}
+''');
+    });
+
+    test('for-each, switch, try/catch and throw', () async {
+      await _assertRoundTrip(r'''
+class Flow {
+  void run(List<int> items) {
+    for (var i in items) {
+      print(i);
+    }
+
+    switch (items.length) {
+      case 0:
+        print('empty');
+        break;
+      default:
+        print('some');
+    }
+
+    try {
+      throw 'boom';
+    } catch (e) {
+      print(e);
+    } finally {
+      print('done');
+    }
+  }
+}
+''');
+    });
+
+    test('literals of every kind', () async {
+      await _assertRoundTrip(r'''
+class Lits {
+  void run() {
+    var a = 1;
+    var b = -2;
+    var c = 3.5;
+    var d = 'text';
+    var e = true;
+    var f = null;
+    var g = [1, 2, 3];
+    var h = {'k': 'v'};
+    print('$a $b $c $d $e $f $g $h');
+  }
+}
+''');
+    });
+
+    test('fields, constructors and inheritance', () async {
+      await _assertRoundTrip(r'''
+class Base {
+  int x = 0;
+
+  Base(this.x);
+
+  int get doubled => x * 2;
+}
+
+class Derived extends Base {
+  String label;
+
+  Derived(this.label);
+
+  set renamed(String v) {
+    label = v;
+  }
+}
+''');
+    });
+
+    test('operators and null handling', () async {
+      await _assertRoundTrip(r'''
+class Ops {
+  void run(int? a, int b) {
+    var c = a ?? b;
+    var d = a != null ? a : b;
+    var e = !(b > 1) && (b < 10 || b == 5);
+    var f = ~b;
+    var g = -b;
+    print('$c $d $e $f $g');
+  }
+}
+''');
+    });
+
+    test('async and await', () async {
+      await _assertRoundTrip(r'''
+class Aw {
+  Future<int> value() async {
+    return 42;
+  }
+
+  Future<void> run() async {
+    var v = await value();
+    print(v);
+  }
+}
+''');
+    });
+
+    test('imports and enums', () async {
+      await _assertRoundTrip(r'''
+import 'dart:math';
+
+enum Color { red, green, blue }
+
+class UsesEnum {
+  void run() {
+    var c = Color.red;
+    print(c);
+  }
+}
+''');
+    });
+  });
+
+  group('byte idempotence', () {
+    test('re-encoding a decoded AST reproduces the same bytes', () async {
+      await _assertByteIdempotent(r'''
+class Foo {
+  int sum(int a, int b) => a + b;
+
+  static void main(List<String> args) {
+    print(Foo().sum(1, 2));
+  }
+}
+''');
+    });
+  });
+
+  group('execution', () {
+    test('a decoded AST runs and produces the same output', () async {
+      var vm = await _assertRoundTrip(r'''
+class Calc {
+  int sum(List<int> ns) {
+    var total = 0;
+    for (var n in ns) {
+      total = total + n;
+    }
+    return total;
+  }
+
+  static void main(List<String> args) {
+    var c = Calc();
+    print('total: ${c.sum([1, 2, 3, 4])}');
+  }
+}
+''');
+
+      var runner = vm.createRunner('dart')!;
+      var output = <Object?>[];
+      runner.externalPrintFunction = output.add;
+
+      await runner.executeClassMethod(
+        '',
+        'Calc',
+        'main',
+        positionalParameters: [<String>[]],
+      );
+
+      expect(output, equals(['total: 10']));
+    });
+  });
+
+  group('image metadata', () {
+    test('records language, namespace and id', () async {
+      var (_, codeUnit, _) = await _parse('class A { void f() {} }');
+
+      var bytes = ASTBinaryWriter().writeCodeUnit(codeUnit);
+      var info = const ASTBinaryReader().readInfo(bytes);
+
+      expect(info.language, equals('dart'));
+      expect(info.codeUnitId, equals('test'));
+      expect(info.namespace, equals(codeUnit.namespace));
+      expect(info.writerVersion, equals(ApolloVM.VERSION));
+      expect(info.isSigned, isFalse);
+      expect(info.unknownSectionIds, isEmpty);
+      expect(info.fileSize, equals(bytes.length));
+    });
+
+    test('the image is recognizable by its magic', () async {
+      var (_, codeUnit, _) = await _parse('class A { void f() {} }');
+      var bytes = ASTBinaryWriter().writeCodeUnit(codeUnit);
+
+      expect(ASTBinaryReader.isASTBinary(bytes), isTrue);
+    });
+
+    test('refuses to write a code unit that was never loaded', () {
+      var codeUnit = SourceCodeUnit('dart', 'class A {}', id: 'x');
+      expect(
+        () => ASTBinaryWriter().writeCodeUnit(codeUnit),
+        throwsA(isA<StateError>()),
+      );
+    });
+  });
+}

--- a/test/languages/apollovm_languages_test_definition.dart
+++ b/test/languages/apollovm_languages_test_definition.dart
@@ -1,6 +1,9 @@
 import 'dart:convert';
 
 import 'package:apollovm/apollovm.dart';
+// Serialization internals are not re-exported from the public library.
+import 'package:apollovm/src/serialization/ast_binary_reader.dart';
+import 'package:apollovm/src/serialization/ast_binary_writer.dart';
 import 'package:collection/collection.dart';
 import 'package:swiss_knife/swiss_knife.dart';
 import 'package:test/test.dart';
@@ -150,13 +153,27 @@ Future<void> runTestDefinitions(List<TestDefinition> testDefinitions) async {
             expect(loadOK, isTrue, reason: "Error loading '$language ' code!");
           }
 
+          var calls = testDefinition.calls;
+          var outputs = testDefinition.outputs;
+
+          // Before anything runs. Executing an AST mutates it — local function
+          // declarations get registered on their block, and `var` declarations
+          // cache an inferred type — so a post-execution AST is not the same
+          // object a fresh parse produces. Encoding here compares like with
+          // like, and matches the real use case: an image is written by a build
+          // step that never runs the code.
+          await _testBinaryASTRoundTrip(
+            vm,
+            language,
+            calls,
+            outputs,
+            autoImportDartMath: autoImportDartMath,
+          );
+
           var runner = vm.createRunner(
             language,
             importCorePackageMath: autoImportDartMath,
           )!;
-
-          var calls = testDefinition.calls;
-          var outputs = testDefinition.outputs;
 
           for (var i = 0; i < calls.length; ++i) {
             var call = calls[i];
@@ -223,6 +240,68 @@ Future<void> runTestDefinitions(List<TestDefinition> testDefinitions) async {
         });
       }
     });
+  }
+}
+
+/// Encodes every code unit loaded in [vm] as a binary AST, decodes the images
+/// into a fresh VM, and re-runs the whole test against it.
+///
+/// This reuses the language fixtures as binary round-trip coverage: every
+/// construct any fixture exercises has to survive encode/decode, in every
+/// language, or the fixture fails. The generated-source comparison is the
+/// strongest part — it exercises every field the code generator reads across
+/// the whole tree, so a field dropped by a codec shows up as a diff rather than
+/// going unnoticed.
+Future<void> _testBinaryASTRoundTrip(
+  ApolloVM vm,
+  String language,
+  List<XmlElement> calls,
+  List<XmlElement> outputs, {
+  required bool autoImportDartMath,
+}) async {
+  print('.......................................');
+  print('-- Binary AST round trip');
+
+  var expectedSources = (await vm.generateAllCodeIn(language).writeAllSources())
+      .toString();
+
+  var vmBin = ApolloVM();
+
+  for (var codeUnit in vm.allCodeUnitsAllLanguages()) {
+    var image = const ASTBinaryWriter().writeCodeUnit(codeUnit);
+
+    print(
+      '-- Encoded ${codeUnit.id}: ${image.length} bytes '
+      '(source: ${codeUnit.code is String ? (codeUnit.code as String).length : '?'})',
+    );
+
+    var decoded = const ASTBinaryReader().readCodeUnit(image);
+
+    var ok = await vmBin.loadCodeUnit(decoded);
+    expect(
+      ok,
+      isTrue,
+      reason: 'Error loading the decoded binary AST: ${codeUnit.id}',
+    );
+  }
+
+  var binSources = (await vmBin.generateAllCodeIn(language).writeAllSources())
+      .toString();
+
+  expect(
+    binSources,
+    equals(expectedSources),
+    reason: 'Regenerated source diverged after a binary AST round trip',
+  );
+
+  var runnerBin = vmBin.createRunner(
+    language,
+    importCorePackageMath: autoImportDartMath,
+  )!;
+
+  for (var i = 0; i < calls.length; ++i) {
+    var outputJson = _resolveLanguageOutput(outputs[i], language);
+    await _testCall(calls[i], i, outputJson, runnerBin);
   }
 }
 

--- a/test/unit/apollovm_ast_binary_codecs_test.dart
+++ b/test/unit/apollovm_ast_binary_codecs_test.dart
@@ -1,0 +1,695 @@
+library;
+
+import 'dart:typed_data';
+
+import 'package:apollovm/apollovm.dart';
+import 'package:apollovm/apollovm_serialization.dart';
+// Serialization internals are not re-exported from the public library.
+import 'package:apollovm/src/serialization/ast_binary_context.dart';
+import 'package:apollovm/src/serialization/ast_binary_node_codec.dart';
+import 'package:apollovm/src/serialization/ast_binary_pool.dart';
+import 'package:apollovm/src/serialization/ast_binary_registry.dart';
+import 'package:apollovm/src/serialization/ast_binary_type_pool.dart';
+import 'package:data_serializer/data_serializer.dart';
+import 'package:test/test.dart';
+
+/// Writes [node] and reads it back through a real context pair.
+///
+/// Node-level rather than through a whole program, so kinds no grammar
+/// produces — and which the language fixtures therefore never reach — are still
+/// exercised.
+T _roundTrip<T extends Object>(Object node) {
+  var (bytes, strings, types) = _write((w) => w.node(node));
+  return _read(bytes, strings, types).node<T>();
+}
+
+/// Runs [body] against a fresh write context and returns its bytes and pools.
+(Uint8List, Uint8List, Uint8List) _write(
+  void Function(ASTBinaryWriteContext w) body,
+) {
+  var strings = ASTStringPoolWriter();
+  var types = ASTTypePoolWriter(strings);
+  var w = ASTBinaryWriteContext(strings, types);
+
+  body(w);
+
+  // The pools are filled while writing, so they are encoded afterwards.
+  return (w.toBytes(), strings.encode(), types.encode());
+}
+
+ASTBinaryReadContext _read(
+  Uint8List bytes,
+  Uint8List strings,
+  Uint8List types,
+) {
+  var stringsIn = ASTStringPoolReader.decode(strings);
+  return ASTBinaryReadContext(
+    BytesBuffer.from(bytes),
+    stringsIn,
+    ASTTypePoolReader.decode(types, stringsIn),
+    formatVersion: ASTBinaryFormat.version,
+  );
+}
+
+/// The plain Dart value inside a decoded static value.
+Object? _valueOf(ASTValue v) => (v as ASTValueStatic).value;
+
+void main() {
+  group('value codecs', () {
+    test('primitives', () {
+      expect(_roundTrip<ASTValueBool>(ASTValueBool(true)).value, isTrue);
+      expect(_roundTrip<ASTValueString>(ASTValueString('hi')).value, 'hi');
+      expect(_roundTrip<ASTValueNull>(ASTValueNull()), isA<ASTValueNull>());
+      expect(_roundTrip<ASTValueVoid>(ASTValueVoid()), isA<ASTValueVoid>());
+    });
+
+    test('int keeps its value and its written sign', () {
+      // `negative` is not derivable from the value: it records that the source
+      // wrote a unary minus.
+      var positive = _roundTrip<ASTValueInt>(ASTValueInt(42));
+      expect(positive.value, 42);
+      expect(positive.negative, isFalse);
+
+      var negative = _roundTrip<ASTValueInt>(ASTValueInt(-7));
+      expect(negative.value, -7);
+      expect(negative.negative, isTrue);
+    });
+
+    test('double, including negative zero', () {
+      expect(_roundTrip<ASTValueDouble>(ASTValueDouble(3.5)).value, 3.5);
+      expect(_roundTrip<ASTValueDouble>(ASTValueDouble(-0.25)).value, -0.25);
+
+      var big = _roundTrip<ASTValueDouble>(
+        ASTValueDouble(1.7976931348623157e308),
+      );
+      expect(big.value, 1.7976931348623157e308);
+    });
+
+    test('object and var hold plain data', () {
+      expect(_valueOf(_roundTrip<ASTValueObject>(ASTValueObject('x'))), 'x');
+      expect(_valueOf(_roundTrip<ASTValueVar>(ASTValueVar(7))), 7);
+    });
+
+    test('a loosely typed static value keeps its declared type', () {
+      var v = _roundTrip<ASTValueStatic>(
+        ASTValueStatic(ASTTypeString.instance, 'text'),
+      );
+      expect(identical(v.type, ASTTypeString.instance), isTrue);
+      expect(v.value, 'text');
+    });
+
+    test('arrays of one, two and three dimensions', () {
+      ASTType intType = ASTTypeInt.instance;
+
+      var a1 = _roundTrip<ASTValueArray>(ASTValueArray(intType, [1, 2, 3]));
+      expect(a1.value, equals([1, 2, 3]));
+
+      var a2 = _roundTrip<ASTValueArray2D>(
+        ASTValueArray2D(intType, [
+          [1, 2],
+          [3],
+        ]),
+      );
+      expect(
+        a2.value,
+        equals([
+          [1, 2],
+          [3],
+        ]),
+      );
+
+      var a3 = _roundTrip<ASTValueArray3D>(
+        ASTValueArray3D(intType, [
+          [
+            [1],
+            [2, 3],
+          ],
+        ]),
+      );
+      expect(
+        a3.value,
+        equals([
+          [
+            [1],
+            [2, 3],
+          ],
+        ]),
+      );
+    });
+
+    test('map keeps its key and value types', () {
+      ASTType keyType = ASTTypeString.instance;
+      ASTType valueType = ASTTypeInt.instance;
+
+      var m = _roundTrip<ASTValueMap>(
+        ASTValueMap(keyType, valueType, {'a': 1, 'b': 2}),
+      );
+
+      expect(m.value, equals({'a': 1, 'b': 2}));
+      var type = m.type as ASTTypeMap;
+      expect(identical(type.keyType, ASTTypeString.instance), isTrue);
+      expect(identical(type.valueType, ASTTypeInt.instance), isTrue);
+    });
+
+    test('string composition', () {
+      var asString = _roundTrip<ASTValueAsString>(
+        ASTValueAsString(ASTValueInt(9)),
+      );
+      expect((asString.value as ASTValueInt).value, 9);
+
+      var list = _roundTrip<ASTValuesListAsString>(
+        ASTValuesListAsString([ASTValueInt(1), ASTValueString('b')]),
+      );
+      expect(list.values.length, 2);
+      expect((list.values[1] as ASTValueString).value, 'b');
+
+      var concat = _roundTrip<ASTValueStringConcatenation>(
+        ASTValueStringConcatenation([ASTValueString('a'), ASTValueString('b')]),
+      );
+      expect(concat.values.length, 2);
+
+      var fromVariable = _roundTrip<ASTValueStringVariable>(
+        ASTValueStringVariable(ASTScopeVariable('v')),
+      );
+      expect(fromVariable.variable.name, 'v');
+    });
+  });
+
+  group('the plain-Dart value union', () {
+    Object? roundTripNative(Object? v) {
+      var (bytes, strings, types) = _write((w) => w.nativeValue(v));
+      return _read(bytes, strings, types).nativeValue();
+    }
+
+    test('every representable form', () {
+      expect(roundTripNative(null), isNull);
+      expect(roundTripNative(true), isTrue);
+      expect(roundTripNative(false), isFalse);
+      expect(roundTripNative(123), 123);
+      expect(roundTripNative(-123), -123);
+      expect(roundTripNative(1.5), 1.5);
+      expect(roundTripNative('s'), 's');
+      expect(roundTripNative(<Object?>[]), isEmpty);
+      expect(roundTripNative(<Object?, Object?>{}), isEmpty);
+    });
+
+    test('nested lists and maps', () {
+      var nested = [
+        1,
+        'two',
+        [3, null],
+        {'k': true},
+      ];
+      expect(roundTripNative(nested), equals(nested));
+    });
+
+    test('a nested AST node', () {
+      var decoded = roundTripNative(ASTValueString('inner'));
+      expect((decoded as ASTValueString).value, 'inner');
+    });
+
+    test('an integer beyond the exact range of a JavaScript double', () {
+      // Stored as a decimal string so a VM-written image stays readable. On the
+      // web the writer cannot produce such a value in the first place.
+      const big = 9007199254740993; // 2^53 + 1
+      var decoded = roundTripNative(big);
+      expect(decoded, equals(big));
+    }, testOn: 'vm');
+
+    test('live Dart state is refused by name', () {
+      expect(
+        () => _write((w) => w.nativeValue(DateTime.utc(2020))),
+        throwsA(
+          isA<ASTNotSerializableException>().having(
+            (e) => e.toString(),
+            'toString',
+            allOf(contains('DateTime'), contains('live Dart state')),
+          ),
+        ),
+      );
+    });
+  });
+
+  group('context primitives', () {
+    test('signed integers', () {
+      // Written as a sign byte plus an unsigned magnitude, since
+      // `BytesBuffer.readLeb128SignedInt` mis-decodes negatives.
+      for (var v in [0, 1, -1, 63, -63, 64, -64, 1000, -1000, 1 << 40]) {
+        var (bytes, s, t) = _write((w) => w.sint(v));
+        expect(_read(bytes, s, t).sint(), equals(v), reason: 'sint($v)');
+      }
+    });
+
+    test('nullable unsigned integers', () {
+      var (bytes, s, t) = _write((w) {
+        w.uintOrNull(null);
+        w.uintOrNull(0);
+        w.uintOrNull(9);
+      });
+      var r = _read(bytes, s, t);
+      expect(r.uintOrNull(), isNull);
+      expect(r.uintOrNull(), 0);
+      expect(r.uintOrNull(), 9);
+    });
+
+    test('bytes and booleans', () {
+      var (bytes, s, t) = _write((w) {
+        w.byte(0xAB);
+        w.boolean(true);
+      });
+      var r = _read(bytes, s, t);
+      expect(r.byte(), 0xAB);
+      expect(r.boolean(), isTrue);
+    });
+
+    test('a null string list is distinct from an empty one', () {
+      var (bytes, s, t) = _write((w) {
+        w.strings_(null);
+        w.strings_([]);
+        w.strings_(['a', 'b']);
+      });
+      var r = _read(bytes, s, t);
+      expect(r.strings_(), isNull);
+      expect(r.strings_(), isEmpty);
+      expect(r.strings_(), equals(['a', 'b']));
+    });
+
+    test('a null node list is distinct from an empty one', () {
+      // The generators treat a missing list and an empty one differently.
+      var (bytes, s, t) = _write((w) {
+        w.nodes(null);
+        w.nodes([]);
+      });
+      var r = _read(bytes, s, t);
+      expect(r.nodes<ASTValue>(), isNull);
+      expect(r.nodes<ASTValue>(), isEmpty);
+    });
+
+    test('a null type list is distinct from an empty one', () {
+      var (bytes, s, t) = _write((w) {
+        w.typeList(null);
+        w.typeList([]);
+        w.typeList([ASTTypeInt.instance]);
+      });
+      var r = _read(bytes, s, t);
+      expect(r.typeList(), isNull);
+      expect(r.typeList(), isEmpty);
+      expect(r.typeList()!.single, same(ASTTypeInt.instance));
+    });
+
+    test('annotations, including a null list', () {
+      var (bytes, s, t) = _write((w) {
+        w.annotations(null);
+        w.annotations([
+          ASTAnnotation('Marker'),
+          ASTAnnotation('Named', {'p': ASTAnnotationParameter('p', 'v', true)}),
+        ]);
+      });
+
+      var r = _read(bytes, s, t);
+      expect(r.annotations(), isNull);
+
+      var list = r.annotations()!;
+      expect(list.length, 2);
+      expect(list[0].name, 'Marker');
+      expect(list[1].parameters!['p']!.value, 'v');
+      expect(list[1].parameters!['p']!.defaultParameter, isTrue);
+    });
+
+    test('every modifier flag survives', () {
+      for (var m in [
+        ASTModifiers(),
+        ASTModifiers(isStatic: true, isFinal: true),
+        ASTModifiers(isPrivate: true, isAsync: true),
+        ASTModifiers(isPublic: true, isAbstract: true, isProtected: true),
+      ]) {
+        var (bytes, s, t) = _write((w) => w.modifiers(m));
+        var decoded = _read(bytes, s, t).modifiers();
+        expect(decoded.modifiers, equals(m.modifiers), reason: '$m');
+      }
+    });
+
+    test('a nullable string', () {
+      var (bytes, s, t) = _write((w) {
+        w.strOrNull(null);
+        w.strOrNull('x');
+      });
+      var r = _read(bytes, s, t);
+      expect(r.strOrNull(), isNull);
+      expect(r.strOrNull(), 'x');
+    });
+
+    test('a nullable type', () {
+      var (bytes, s, t) = _write((w) {
+        w.typeOrNull(null);
+        w.typeOrNull(ASTTypeString.instance);
+      });
+      var r = _read(bytes, s, t);
+      expect(r.typeOrNull(), isNull);
+      expect(r.typeOrNull(), same(ASTTypeString.instance));
+    });
+
+    test('the declaration path names where the writer is', () {
+      var (_, _, _) = _write((w) {
+        expect(w.declarationPath, isEmpty);
+        w.inDeclaration('class Foo', () {
+          expect(w.declarationPath, 'class Foo');
+          w.inDeclaration('bar', () {
+            expect(w.declarationPath, 'class Foo > bar');
+          });
+          expect(w.declarationPath, 'class Foo');
+        });
+        expect(w.declarationPath, isEmpty);
+      });
+    });
+  });
+
+  group('node kinds no grammar produces', () {
+    test('export statement', () {
+      var decoded = _roundTrip<ASTStatementExport>(
+        ASTStatementExport(
+          path: 'other.dart',
+          symbols: const [ASTImportedSymbol('A', alias: 'B')],
+          combinators: const [
+            ASTImportCombinator(ASTImportCombinatorKind.hide, ['C']),
+          ],
+        ),
+      );
+
+      expect(decoded.path, 'other.dart');
+      expect(decoded.symbols.single.name, 'A');
+      expect(decoded.symbols.single.alias, 'B');
+      expect(decoded.combinators.single.isHide, isTrue);
+      expect(decoded.combinators.single.names, equals(['C']));
+    });
+
+    test('export with no path', () {
+      var decoded = _roundTrip<ASTStatementExport>(ASTStatementExport());
+      expect(decoded.path, isNull);
+      expect(decoded.symbols, isEmpty);
+    });
+
+    test('type alias', () {
+      var decoded = _roundTrip<ASTTypeAlias>(
+        ASTTypeAlias('Callback', ASTTypeString.instance),
+      );
+      expect(decoded.name, 'Callback');
+      expect(identical(decoded.targetType, ASTTypeString.instance), isTrue);
+    });
+
+    test('a standalone getter and setter', () {
+      var getter = _roundTrip<ASTGetterDeclaration>(
+        ASTGetterDeclaration(
+          'value',
+          ASTTypeInt.instance,
+          modifiers: ASTModifiers(isStatic: true),
+        ),
+      );
+      expect(getter.name, 'value');
+      expect(getter.modifiers.isStatic, isTrue);
+
+      var setter = _roundTrip<ASTSetterDeclaration>(
+        ASTSetterDeclaration('value', ASTTypeInt.instance, 'v'),
+      );
+      expect(setter.name, 'value');
+      expect(setter.parameterName, 'v');
+      expect(identical(setter.parameterType, ASTTypeInt.instance), isTrue);
+    });
+
+    test('a bare return statement', () {
+      expect(
+        _roundTrip<ASTStatementReturn>(ASTStatementReturn()),
+        isA<ASTStatementReturn>(),
+      );
+    });
+
+    test('a single-line statement block', () {
+      var block = ASTSingleLineStatementBlock(null)
+        ..addStatement(ASTStatementBreak());
+
+      var decoded = _roundTrip<ASTSingleLineStatementBlock>(block);
+      expect(decoded.statements.single, isA<ASTStatementBreak>());
+    });
+  });
+
+  group('the writer refuses live Dart state', () {
+    test('a runtime variable, naming where it was found', () {
+      var node = ASTRuntimeVariable(ASTTypeInt.instance, 'x');
+
+      expect(
+        () => _write((w) => w.inDeclaration('class Foo', () => w.node(node))),
+        throwsA(
+          isA<ASTNotSerializableException>()
+              .having((e) => e.declarationPath, 'declarationPath', 'class Foo')
+              .having(
+                (e) => e.toString(),
+                'toString',
+                allOf(
+                  contains('ASTRuntimeVariable'),
+                  contains('class Foo'),
+                  contains('running context'),
+                ),
+              ),
+        ),
+      );
+    });
+
+    test('every external node kind, each of which extends an encodable one', () {
+      // The dangerous case, and the reason refusal is decided by the concrete
+      // class rather than by "no codec matched": each of these extends a kind
+      // that encodes perfectly well, so an `is` scan alone would match the
+      // superclass and write them as an ordinary declaration — silently
+      // dropping the Dart closure that is their whole point.
+      //
+      // These are also the excluded kinds most likely to be met in practice:
+      // `ApolloExternalFunctionMapper` injects them into a VM a caller may then
+      // try to serialize.
+      var clazz = ASTClassNormal('Host', ASTType<VMObject>('Host'), null);
+
+      var nodes = <Object>[
+        ASTExternalFunction(
+          'ext',
+          ASTFunctionParametersDeclaration(null),
+          ASTTypeVoid.instance,
+          () {},
+        ),
+        ASTExternalClassFunction(
+          clazz,
+          'extMethod',
+          ASTFunctionParametersDeclaration(null),
+          ASTTypeVoid.instance,
+          () {},
+        ),
+        ASTExternalGetter('extGetter', ASTTypeInt.instance, () => 1),
+        ASTExternalClassGetter(
+          clazz,
+          'extClassGetter',
+          ASTTypeInt.instance,
+          (Object? o) => 1,
+        ),
+      ];
+
+      for (var node in nodes) {
+        expect(
+          () => _write((w) => w.node(node)),
+          throwsA(
+            isA<ASTNotSerializableException>().having(
+              (e) => e.reason,
+              'reason',
+              contains('closure'),
+            ),
+          ),
+          reason: '${node.runtimeType} must be refused, not written',
+        );
+      }
+    });
+
+    test('every excluded name has a reason', () {
+      for (var e in ASTCodecRegistry.excluded.entries) {
+        expect(e.value, isNotEmpty, reason: '${e.key} has no reason');
+      }
+    });
+  });
+
+  group('malformed input is reported, not mis-decoded', () {
+    test('an unknown enum name', () {
+      var (bytes, s, t) = _write((w) => w.str('notAnOperator'));
+
+      expect(
+        () => _read(bytes, s, t).enumByName(ASTExpressionOperator.values),
+        throwsA(
+          isA<ASTBinaryException>()
+              .having((e) => e.error, 'error', ASTBinaryError.unsupportedNode)
+              .having((e) => e.message, 'message', contains('notAnOperator')),
+        ),
+      );
+    });
+
+    test('modifiers that are both private and public', () {
+      // `ASTModifiers` refuses that combination; a corrupted byte must surface
+      // as a malformed file rather than a bare StateError.
+      var (bytes, s, t) = _write((w) => w.byte(0x04 | 0x08));
+
+      expect(
+        () => _read(bytes, s, t).modifiers(),
+        throwsA(
+          isA<ASTBinaryException>().having(
+            (e) => e.error,
+            'error',
+            ASTBinaryError.malformedSection,
+          ),
+        ),
+      );
+    });
+
+    test('an unknown integer form', () {
+      var (bytes, s, t) = _write((w) => w.byte(0x7F));
+      expect(
+        () => _read(bytes, s, t).literalInt(),
+        throwsA(isA<ASTBinaryException>()),
+      );
+    });
+
+    test('an unknown native value tag', () {
+      var (bytes, s, t) = _write((w) => w.byte(0x7F));
+      expect(
+        () => _read(bytes, s, t).nativeValue(),
+        throwsA(isA<ASTBinaryException>()),
+      );
+    });
+
+    test('a string pool index out of range', () {
+      var pool = ASTStringPoolReader.decode(ASTStringPoolWriter().encode());
+      expect(() => pool[0], throwsA(isA<ASTBinaryException>()));
+      expect(() => pool[-1], throwsA(isA<ASTBinaryException>()));
+      expect(pool.length, 0);
+    });
+
+    test('a type pool index out of range', () {
+      var strings = ASTStringPoolWriter();
+      var types = ASTTypePoolWriter(strings);
+      var pool = ASTTypePoolReader.decode(
+        types.encode(),
+        ASTStringPoolReader.decode(strings.encode()),
+      );
+
+      expect(() => pool[0], throwsA(isA<ASTBinaryException>()));
+      expect(pool.length, 0);
+    });
+
+    test('a node where a different one was expected', () {
+      var (bytes, s, t) = _write((w) => w.node(ASTValueString('x')));
+      expect(
+        () => _read(bytes, s, t).node<ASTStatement>(),
+        throwsA(
+          isA<ASTBinaryException>().having(
+            (e) => e.message,
+            'message',
+            contains('ASTValueString'),
+          ),
+        ),
+      );
+    });
+
+    test('a null marker where a node was required', () {
+      var (bytes, s, t) = _write((w) => w.nodeOrNull(null));
+      expect(
+        () => _read(bytes, s, t).node<ASTValue>(),
+        throwsA(
+          isA<ASTBinaryException>().having(
+            (e) => e.message,
+            'message',
+            contains('null node marker'),
+          ),
+        ),
+      );
+    });
+
+    test('an unknown node tag', () {
+      var (bytes, s, t) = _write((w) => w.uint(0x7E));
+      expect(
+        () => _read(bytes, s, t).node<ASTValue>(),
+        throwsA(
+          isA<ASTBinaryException>().having(
+            (e) => e.error,
+            'error',
+            ASTBinaryError.unsupportedNode,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('diagnostics read usefully', () {
+    // A diagnostic that is never exercised is exactly what breaks when it is
+    // finally needed.
+    test('ASTBinaryException carries its context', () {
+      var e = const ASTBinaryException(
+        'bad things',
+        ASTBinaryError.malformedSection,
+        offset: 12,
+        formatVersion: 3,
+        minReaderVersion: 2,
+        sectionId: 4,
+      );
+
+      var text = e.toString();
+      expect(text, contains('malformedSection'));
+      expect(text, contains('bad things'));
+      expect(text, contains('offset: 12'));
+      expect(text, contains('section: 4'));
+      expect(text, contains('formatVersion: 3'));
+      expect(text, contains('minReaderVersion: 2'));
+    });
+
+    test('ASTBinaryIntegrityException is an ASTBinaryException', () {
+      var e = const ASTBinaryIntegrityException(
+        'checksum',
+        ASTBinaryError.checksumMismatch,
+      );
+      expect(e, isA<ASTBinaryException>());
+      expect(e.toString(), contains('checksumMismatch'));
+    });
+
+    test('ASTNotSerializableException without a declaration path', () {
+      var e = const ASTNotSerializableException('x', 'because');
+      expect(e.toString(), contains('because'));
+      expect(e.toString(), isNot(contains('(at ')));
+    });
+
+    test('a codec prints its tag and class', () {
+      var codec = ASTCodecRegistry.ordered.first;
+      expect(codec.toString(), contains(codec.className));
+      expect(codec.toString(), contains('${codec.tag}'));
+      expect(codec, isA<ASTNodeCodec>());
+    });
+
+    test('a section prints its id and size', () {
+      var known = ASTBinarySectionData(
+        ASTBinarySection.metadata.id,
+        Uint8List(3),
+      );
+      expect(known.toString(), contains('metadata'));
+      expect(known.toString(), contains('size: 3'));
+
+      var unknown = ASTBinarySectionData(0x7F, Uint8List(0));
+      expect(unknown.toString(), contains('unknown'));
+      expect(unknown.section, isNull);
+    });
+
+    test('a header prints its versions and flags', () {
+      var header = const ASTBinaryHeader(
+        formatVersion: 1,
+        minReaderVersion: 1,
+        flags: ASTBinaryFlags.signed | ASTBinaryFlags.hasSourceRef,
+        sectionsSize: 99,
+      );
+
+      expect(header.isSigned, isTrue);
+      expect(header.hasSourceRef, isTrue);
+      expect(header.hasSectionIndex, isFalse);
+      expect(header.hasArchiveFlag, isFalse);
+      expect(header.toString(), contains('sectionsSize: 99'));
+    });
+  });
+}

--- a/test/unit/apollovm_ast_binary_codecs_test.dart
+++ b/test/unit/apollovm_ast_binary_codecs_test.dart
@@ -211,7 +211,12 @@ void main() {
     test('an integer beyond the exact range of a JavaScript double', () {
       // Stored as a decimal string so a VM-written image stays readable. On the
       // web the writer cannot produce such a value in the first place.
-      const big = 9007199254740993; // 2^53 + 1
+      //
+      // Built by arithmetic rather than written as a literal: `testOn` gates
+      // execution, not compilation, and `9007199254740993` cannot be compiled
+      // for the web at all. 2^53 itself is exactly representable, so it can.
+      var big = 9007199254740992 + 1; // 2^53 + 1
+
       var decoded = roundTripNative(big);
       expect(decoded, equals(big));
     }, testOn: 'vm');

--- a/test/unit/apollovm_ast_binary_container_test.dart
+++ b/test/unit/apollovm_ast_binary_container_test.dart
@@ -1,0 +1,455 @@
+library;
+
+import 'dart:typed_data';
+
+// The serialization internals are not re-exported from the public library;
+// imported directly, as other unit tests in this suite do for `src/` internals.
+import 'package:apollovm/src/serialization/ast_binary_container.dart';
+import 'package:apollovm/src/serialization/ast_binary_exception.dart';
+import 'package:apollovm/src/serialization/ast_binary_format.dart';
+import 'package:apollovm/src/serialization/ast_binary_signer.dart';
+import 'package:apollovm/src/serialization/crc32.dart';
+import 'package:test/test.dart';
+
+Uint8List _bytes(List<int> l) => Uint8List.fromList(l);
+
+/// A minimal well-formed file: one metadata section and one AST section.
+Uint8List _sample({ASTBinarySigner? signer, int flags = 0}) =>
+    ASTBinaryContainerCodec.encode(
+      sections: [
+        ASTBinarySectionData(
+          ASTBinarySection.metadata.id,
+          _bytes([1, 2, 3, 4]),
+        ),
+        ASTBinarySectionData(ASTBinarySection.astRoot.id, _bytes([9, 9, 9])),
+      ],
+      flags: flags,
+      signer: signer,
+    );
+
+/// Recomputes the CRC of [bytes] in place, so a test can tamper with content
+/// and still present a structurally valid file.
+Uint8List _refreshCrc(Uint8List bytes) {
+  var trailerStart =
+      ASTBinaryFormat.headerSize +
+      ((bytes[12] << 24) | (bytes[13] << 16) | (bytes[14] << 8) | bytes[15]);
+  var crc = Crc32.compute(bytes, 0, trailerStart);
+  bytes[trailerStart] = (crc >> 24) & 0xFF;
+  bytes[trailerStart + 1] = (crc >> 16) & 0xFF;
+  bytes[trailerStart + 2] = (crc >> 8) & 0xFF;
+  bytes[trailerStart + 3] = crc & 0xFF;
+  return bytes;
+}
+
+void main() {
+  group('Crc32', () {
+    test('known vectors', () {
+      expect(Crc32.compute(_bytes([])), equals(0x00000000));
+      expect(Crc32.compute(_bytes('123456789'.codeUnits)), equals(0xCBF43926));
+      expect(Crc32.compute(_bytes('a'.codeUnits)), equals(0xE8B7BE43));
+      expect(Crc32.compute(_bytes('abc'.codeUnits)), equals(0x352441C2));
+    });
+
+    test('incremental update matches one-shot', () {
+      var data = Uint8List.fromList(
+        List.generate(4096, (i) => (i * 31 + 7) & 0xFF),
+      );
+
+      var crc = Crc32.initial;
+      crc = Crc32.update(crc, data, 0, 1000);
+      crc = Crc32.update(crc, data, 1000, 3096);
+
+      expect(Crc32.finalize(crc), equals(Crc32.compute(data)));
+    });
+
+    test('stays inside 32 bits', () {
+      var data = Uint8List.fromList(List.filled(1024, 0xFF));
+      var crc = Crc32.compute(data);
+      expect(crc, greaterThanOrEqualTo(0));
+      expect(crc, lessThanOrEqualTo(0xFFFFFFFF));
+    });
+  });
+
+  group('ASTBinaryFormat', () {
+    test('isASTBinary sniffs the magic', () {
+      expect(ASTBinaryFormat.isASTBinary(_sample()), isTrue);
+      expect(ASTBinaryFormat.isASTBinary(_bytes([0, 0x41, 0x56])), isFalse);
+      expect(ASTBinaryFormat.isASTBinary(_bytes([])), isFalse);
+      expect(
+        ASTBinaryFormat.isASTBinary(_bytes([0x01, 0x41, 0x56, 0x4D])),
+        isFalse,
+      );
+    });
+
+    test('constantTimeEquals', () {
+      expect(ASTBinaryFormat.constantTimeEquals([1, 2, 3], [1, 2, 3]), isTrue);
+      expect(ASTBinaryFormat.constantTimeEquals([1, 2, 3], [1, 2, 4]), isFalse);
+      expect(ASTBinaryFormat.constantTimeEquals([1, 2], [1, 2, 3]), isFalse);
+      expect(ASTBinaryFormat.constantTimeEquals([], []), isTrue);
+    });
+  });
+
+  group('container layout', () {
+    test('byte offsets are exactly as documented', () {
+      var bytes = _sample();
+
+      expect(bytes.sublist(0, 4), equals(ASTBinaryFormat.magic));
+      // formatVersion @4, minReaderVersion @6, big-endian.
+      expect((bytes[4] << 8) | bytes[5], equals(ASTBinaryFormat.version));
+      expect((bytes[6] << 8) | bytes[7], equals(ASTBinaryFormat.version));
+      // flags @8 — unsigned sample has none set.
+      expect(
+        (bytes[8] << 24) | (bytes[9] << 16) | (bytes[10] << 8) | bytes[11],
+        equals(0),
+      );
+
+      var sectionsSize =
+          (bytes[12] << 24) | (bytes[13] << 16) | (bytes[14] << 8) | bytes[15];
+
+      // Total length is fully described by the header and the trailer.
+      expect(
+        bytes.length,
+        equals(
+          ASTBinaryFormat.headerSize +
+              sectionsSize +
+              ASTBinaryFormat.minTrailerSize,
+        ),
+      );
+      expect(
+        bytes.sublist(bytes.length - 4),
+        equals(ASTBinaryFormat.trailerMagic),
+      );
+      // signatureLength is 0 for an unsigned file.
+      var trailerStart = ASTBinaryFormat.headerSize + sectionsSize;
+      expect((bytes[trailerStart + 4] << 8) | bytes[trailerStart + 5], 0);
+    });
+
+    test('round trips sections in order', () {
+      var c = ASTBinaryContainerCodec.decode(_sample());
+
+      expect(c.header.formatVersion, equals(ASTBinaryFormat.version));
+      expect(c.header.isSigned, isFalse);
+      expect(c.signature, isNull);
+      expect(c.sections.length, equals(2));
+      expect(c.sections[0].id, equals(ASTBinarySection.metadata.id));
+      expect(c.sections[0].section, equals(ASTBinarySection.metadata));
+      expect(c.sections[0].payload, equals(_bytes([1, 2, 3, 4])));
+      expect(c.sections[1].payload, equals(_bytes([9, 9, 9])));
+      expect(c.unknownSectionIds, isEmpty);
+    });
+
+    test('requirePayloadOf names the missing section', () {
+      var c = ASTBinaryContainerCodec.decode(_sample());
+      expect(c.payloadOf(ASTBinarySection.stringTable), isNull);
+      expect(
+        () => c.requirePayloadOf(ASTBinarySection.stringTable),
+        throwsA(
+          isA<ASTBinaryException>()
+              .having((e) => e.error, 'error', ASTBinaryError.malformedSection)
+              .having((e) => e.message, 'message', contains('stringTable')),
+        ),
+      );
+    });
+
+    test('handles an empty payload and a large one', () {
+      var big = Uint8List.fromList(List.generate(70000, (i) => i & 0xFF));
+      var bytes = ASTBinaryContainerCodec.encode(
+        sections: [
+          ASTBinarySectionData(ASTBinarySection.metadata.id, _bytes([])),
+          ASTBinarySectionData(ASTBinarySection.astRoot.id, big),
+        ],
+      );
+
+      var c = ASTBinaryContainerCodec.decode(bytes);
+      expect(c.sections[0].payload, isEmpty);
+      expect(c.sections[1].payload, equals(big));
+    });
+
+    test('decodes correctly from a view at a non-zero offset', () {
+      // Uint8List.view into a larger buffer is the classic place a slicing bug
+      // hides: reading via `bytes.buffer` without adding `offsetInBytes` would
+      // silently read the padding instead of the file.
+      var file = _sample();
+      var padded = Uint8List(7 + file.length + 5)
+        ..setRange(7, 7 + file.length, file);
+      var view = Uint8List.view(padded.buffer, 7, file.length);
+
+      expect(view.offsetInBytes, equals(7));
+
+      var c = ASTBinaryContainerCodec.decode(view);
+      expect(c.sections[0].payload, equals(_bytes([1, 2, 3, 4])));
+      expect(c.sections[1].payload, equals(_bytes([9, 9, 9])));
+    });
+
+    test('output is deterministic', () {
+      expect(_sample(), equals(_sample()));
+    });
+  });
+
+  group('integrity', () {
+    test('detects a flipped byte in a section payload', () {
+      var bytes = _sample();
+      // First section payload starts after the header + 2 framing bytes.
+      var target = ASTBinaryFormat.headerSize + 2;
+      bytes[target] = bytes[target] ^ 0xFF;
+
+      expect(
+        () => ASTBinaryContainerCodec.decode(bytes),
+        throwsA(
+          isA<ASTBinaryIntegrityException>().having(
+            (e) => e.error,
+            'error',
+            ASTBinaryError.checksumMismatch,
+          ),
+        ),
+      );
+    });
+
+    test('detects a flipped bit in the header itself', () {
+      var bytes = _sample();
+      // formatVersion is big-endian at offset 4; bump the low byte 1 -> 2.
+      // minReaderVersion stays 1, so the version gate accepts the file and the
+      // CRC is what catches the edit.
+      bytes[5] = 0x02;
+
+      expect(
+        () => ASTBinaryContainerCodec.decode(bytes),
+        throwsA(
+          isA<ASTBinaryIntegrityException>().having(
+            (e) => e.error,
+            'error',
+            ASTBinaryError.checksumMismatch,
+          ),
+        ),
+      );
+    });
+
+    test('verifyChecksum: false skips the CRC check', () {
+      var bytes = _sample();
+      var target = ASTBinaryFormat.headerSize + 2;
+      bytes[target] = bytes[target] ^ 0xFF;
+
+      var c = ASTBinaryContainerCodec.decode(bytes, verifyChecksum: false);
+      expect(c.sections.length, equals(2));
+    });
+
+    test('rejects a truncated file', () {
+      var bytes = _sample();
+      expect(
+        () =>
+            ASTBinaryContainerCodec.decode(bytes.sublist(0, bytes.length - 5)),
+        throwsA(
+          isA<ASTBinaryException>().having(
+            (e) => e.error,
+            'error',
+            ASTBinaryError.truncated,
+          ),
+        ),
+      );
+    });
+
+    test('rejects trailing garbage', () {
+      var bytes = _sample();
+      var padded = Uint8List(bytes.length + 3)
+        ..setRange(0, bytes.length, bytes);
+
+      expect(
+        () => ASTBinaryContainerCodec.decode(padded),
+        throwsA(
+          isA<ASTBinaryException>().having(
+            (e) => e.error,
+            'error',
+            ASTBinaryError.truncated,
+          ),
+        ),
+      );
+    });
+
+    test('rejects bad magic', () {
+      var bytes = _sample();
+      bytes[1] = 0x42;
+      expect(
+        () => ASTBinaryContainerCodec.decode(bytes),
+        throwsA(
+          isA<ASTBinaryException>().having(
+            (e) => e.error,
+            'error',
+            ASTBinaryError.badMagic,
+          ),
+        ),
+      );
+    });
+  });
+
+  group('signing', () {
+    test('signs and verifies with the same key', () {
+      var bytes = _sample(signer: HmacSha256Signer.fromString('s3cret'));
+
+      var c = ASTBinaryContainerCodec.decode(
+        bytes,
+        verifier: HmacSha256Verifier.fromString('s3cret'),
+      );
+
+      expect(c.header.isSigned, isTrue);
+      expect(c.signature, isNotNull);
+      expect(c.signature!.length, equals(32));
+      expect(c.sections.length, equals(2));
+    });
+
+    test('rejects a wrong key', () {
+      var bytes = _sample(signer: HmacSha256Signer.fromString('s3cret'));
+
+      expect(
+        () => ASTBinaryContainerCodec.decode(
+          bytes,
+          verifier: HmacSha256Verifier.fromString('other'),
+        ),
+        throwsA(
+          isA<ASTBinaryIntegrityException>().having(
+            (e) => e.error,
+            'error',
+            ASTBinaryError.signatureMismatch,
+          ),
+        ),
+      );
+    });
+
+    test('a signed file still loads without a verifier', () {
+      var bytes = _sample(signer: HmacSha256Signer.fromString('s3cret'));
+      var c = ASTBinaryContainerCodec.decode(bytes);
+      expect(c.header.isSigned, isTrue);
+      expect(c.sections.length, equals(2));
+    });
+
+    test('refuses an unsigned file when a verifier is supplied', () {
+      expect(
+        () => ASTBinaryContainerCodec.decode(
+          _sample(),
+          verifier: HmacSha256Verifier.fromString('s3cret'),
+        ),
+        throwsA(
+          isA<ASTBinaryIntegrityException>().having(
+            (e) => e.error,
+            'error',
+            ASTBinaryError.signatureMissing,
+          ),
+        ),
+      );
+    });
+
+    test(
+      'tampering plus a recomputed CRC still fails signature verification',
+      () {
+        // The decisive test for the layering: the signature covers the CRC, so
+        // an attacker who edits content and fixes the checksum is still caught.
+        var bytes = _sample(signer: HmacSha256Signer.fromString('s3cret'));
+        var target = ASTBinaryFormat.headerSize + 2;
+        bytes[target] = bytes[target] ^ 0xFF;
+        _refreshCrc(bytes);
+
+        // The CRC now passes...
+        expect(
+          ASTBinaryContainerCodec.decode(bytes).sections.length,
+          equals(2),
+        );
+
+        // ...but the signature does not.
+        expect(
+          () => ASTBinaryContainerCodec.decode(
+            bytes,
+            verifier: HmacSha256Verifier.fromString('s3cret'),
+          ),
+          throwsA(
+            isA<ASTBinaryIntegrityException>().having(
+              (e) => e.error,
+              'error',
+              ASTBinaryError.signatureMismatch,
+            ),
+          ),
+        );
+      },
+    );
+  });
+
+  group('version and forward compatibility', () {
+    test('skips an unknown section id', () {
+      var bytes = ASTBinaryContainerCodec.encode(
+        sections: [
+          ASTBinarySectionData(
+            ASTBinarySection.metadata.id,
+            _bytes([1, 2, 3, 4]),
+          ),
+          // An id from a future ApolloVM.
+          ASTBinarySectionData(0x7F, _bytes([42, 42, 42, 42, 42])),
+          ASTBinarySectionData(ASTBinarySection.astRoot.id, _bytes([9, 9, 9])),
+        ],
+      );
+
+      var c = ASTBinaryContainerCodec.decode(bytes);
+
+      expect(c.unknownSectionIds, equals([0x7F]));
+      expect(
+        c.payloadOf(ASTBinarySection.metadata),
+        equals(_bytes([1, 2, 3, 4])),
+      );
+      expect(c.payloadOf(ASTBinarySection.astRoot), equals(_bytes([9, 9, 9])));
+    });
+
+    test('accepts a newer formatVersion when minReaderVersion allows', () {
+      var bytes = ASTBinaryContainerCodec.encode(
+        sections: [
+          ASTBinarySectionData(ASTBinarySection.astRoot.id, _bytes([1])),
+        ],
+        formatVersion: 999,
+        minReaderVersion: ASTBinaryFormat.version,
+      );
+
+      var c = ASTBinaryContainerCodec.decode(bytes);
+      expect(c.header.formatVersion, equals(999));
+    });
+
+    test('rejects a file needing a newer reader, naming both versions', () {
+      var bytes = ASTBinaryContainerCodec.encode(
+        sections: [
+          ASTBinarySectionData(ASTBinarySection.astRoot.id, _bytes([1])),
+        ],
+        formatVersion: 999,
+        minReaderVersion: 999,
+      );
+
+      expect(
+        () => ASTBinaryContainerCodec.decode(bytes),
+        throwsA(
+          isA<ASTBinaryException>()
+              .having(
+                (e) => e.error,
+                'error',
+                ASTBinaryError.unsupportedVersion,
+              )
+              .having((e) => e.formatVersion, 'formatVersion', 999)
+              .having((e) => e.minReaderVersion, 'minReaderVersion', 999),
+        ),
+      );
+    });
+
+    test('rejects unknown header flags', () {
+      var bytes = ASTBinaryContainerCodec.encode(
+        sections: [
+          ASTBinarySectionData(ASTBinarySection.astRoot.id, _bytes([1])),
+        ],
+        flags: 0x00000080,
+      );
+
+      expect(
+        () => ASTBinaryContainerCodec.decode(bytes),
+        throwsA(
+          isA<ASTBinaryException>().having(
+            (e) => e.error,
+            'error',
+            ASTBinaryError.unknownFlags,
+          ),
+        ),
+      );
+    });
+  });
+}

--- a/test/unit/apollovm_ast_binary_coverage_test.dart
+++ b/test/unit/apollovm_ast_binary_coverage_test.dart
@@ -1,0 +1,292 @@
+@TestOn('vm')
+library;
+
+import 'dart:io';
+
+// Serialization internals are not re-exported from the public library.
+import 'package:apollovm/src/serialization/ast_binary_registry.dart';
+import 'package:apollovm/src/serialization/ast_binary_tags.dart';
+import 'package:test/test.dart';
+
+/// A concrete `AST*` class as declared in the sources.
+class _AstClass {
+  final String name;
+  final String? superName;
+  final String file;
+
+  _AstClass(this.name, this.superName, this.file);
+
+  @override
+  String toString() => '$name (in $file)';
+}
+
+/// Every concrete `class AST…` declared under `lib/src/ast/`.
+///
+/// Read from the sources rather than from the running program: there is no
+/// `dart:mirrors` on the web, and the whole point is to fail when someone adds
+/// a node class and forgets its codec — which a runtime check could not see.
+List<_AstClass> _scanAstClasses() {
+  var dir = Directory('lib/src/ast');
+  expect(
+    dir.existsSync(),
+    isTrue,
+    reason: 'Run this test from the package root.',
+  );
+
+  var classes = <_AstClass>[];
+
+  // Directory listing, not a hardcoded file list, so a new AST file cannot be
+  // silently missed.
+  var files =
+      dir
+          .listSync()
+          .whereType<File>()
+          .where((f) => f.path.endsWith('.dart'))
+          .toList()
+        ..sort((a, b) => a.path.compareTo(b.path));
+
+  expect(files, isNotEmpty, reason: 'No AST sources found.');
+
+  for (var file in files) {
+    var source = file.readAsStringSync();
+    var name = file.uri.pathSegments.last;
+
+    // A declaration header can wrap over several lines, e.g.
+    //   class ASTValueArray2D<T extends ASTType<V>, V>
+    //       extends ASTValueArray<ASTTypeArray<T, V>, List<V>> {
+    // so each `class …` is taken up to its opening brace and flattened.
+    for (var match in RegExp(
+      r'^class\s+(AST\w+)',
+      multiLine: true,
+    ).allMatches(source)) {
+      var brace = source.indexOf('{', match.start);
+      if (brace < 0) continue;
+
+      var header = source
+          .substring(match.start, brace)
+          .replaceAll(RegExp(r'\s+'), ' ');
+
+      var superMatch = RegExp(r'\bextends\s+(AST\w+)').firstMatch(header);
+
+      classes.add(_AstClass(match.group(1)!, superMatch?.group(1), name));
+    }
+  }
+
+  return classes;
+}
+
+/// Types are not node-tagged: they live in their own pool, which interns them
+/// and preserves the identity of ApolloVM's `ASTType` singletons.
+/// `test/unit/apollovm_ast_binary_type_pool_test.dart` covers them.
+bool _isPooledType(_AstClass c) => c.file == 'apollovm_ast_type.dart';
+
+/// Classes that are encoded as part of their parent rather than on their own,
+/// or that are rebuilt from other data — with the reason in each case.
+///
+/// Every entry here is a deliberate, reviewed decision. Adding one is how a new
+/// node kind could dodge coverage, so the count is pinned below.
+const Map<String, String> _notTagged = {
+  // Written inline by whichever node owns them.
+  'ASTModifiers': 'a seven-flag bitfield written as one byte by its owner',
+  'ASTAnnotation': 'written inline by the type or declaration carrying it',
+  'ASTAnnotationParameter': 'written inline as part of its annotation',
+  'ASTConstructorParametersDeclaration':
+      "written inline as the declaration's three parameter groups",
+  'ASTFunctionParametersDeclaration':
+      "written inline as the declaration's three parameter groups",
+
+  // Abstract in practice: only their subclasses are ever constructed.
+  'ASTEntryPointBlock': 'a base class; ASTRoot and ASTClass are what exist',
+  'ASTParameterDeclaration':
+      'a base class; the function and constructor variants are what exist',
+
+  // Rebuilt from the declarations themselves.
+  'ASTFunctionSetSingle':
+      'an overload bucket rebuilt by addFunction from the declarations',
+  'ASTFunctionSetMultiple':
+      'an overload bucket rebuilt by addFunction from the declarations',
+  'ASTConstructorSetSingle':
+      'an overload bucket rebuilt by addConstructor from the declarations',
+  'ASTConstructorSetMultiple':
+      'an overload bucket rebuilt by addConstructor from the declarations',
+  'ASTFunctionSignature':
+      'an overload-resolution key derived from a call site, not part of the tree',
+};
+
+void main() {
+  late List<_AstClass> astClasses;
+  late Map<String, String?> superOf;
+
+  setUpAll(() {
+    astClasses = _scanAstClasses();
+    superOf = {for (var c in astClasses) c.name: c.superName};
+  });
+
+  group('codec coverage', () {
+    test('finds the AST classes at all', () {
+      // A sanity floor: if the scan silently stopped matching, every other
+      // assertion here would pass vacuously.
+      expect(astClasses.length, greaterThan(100));
+      expect(
+        astClasses.map((e) => e.name),
+        containsAll(['ASTRoot', 'ASTBlock', 'ASTClassNormal', 'ASTValueInt']),
+      );
+    });
+
+    test('every AST class is registered, pooled, or explicitly accounted for', () {
+      var registered = {for (var c in ASTCodecRegistry.ordered) c.className};
+
+      var unaccounted = <_AstClass>[];
+      for (var c in astClasses) {
+        if (registered.contains(c.name)) continue;
+        if (_isPooledType(c)) continue;
+        if (_notTagged.containsKey(c.name)) continue;
+        if (ASTCodecRegistry.excluded.containsKey(c.name)) continue;
+        unaccounted.add(c);
+      }
+
+      expect(
+        unaccounted,
+        isEmpty,
+        reason:
+            'These AST classes have no binary encoding and no recorded reason.\n'
+            'Add a codec with a new tag in `ASTNodeTag`, or record why it does '
+            'not need one — in `_notTagged` here if it is written inline or '
+            'rebuilt, or in `ASTCodecRegistry.excluded` if it holds live Dart '
+            'state:\n  ${unaccounted.join('\n  ')}',
+      );
+    });
+
+    test('every registered codec names a class that exists', () {
+      var known = {for (var c in astClasses) c.name};
+
+      for (var codec in ASTCodecRegistry.ordered) {
+        expect(
+          known,
+          contains(codec.className),
+          reason:
+              'Codec ${codec.tag} names `${codec.className}`, which is not '
+              'declared in lib/src/ast/. A renamed class leaves the coverage '
+              'check matching nothing.',
+        );
+      }
+    });
+
+    test('every excluded and inline name refers to a real class', () {
+      var known = {for (var c in astClasses) c.name};
+
+      for (var name in [
+        ...ASTCodecRegistry.excluded.keys,
+        ..._notTagged.keys,
+      ]) {
+        expect(
+          known,
+          contains(name),
+          reason:
+              '`$name` is recorded as not needing a codec, but no such class '
+              'is declared in lib/src/ast/.',
+        );
+      }
+    });
+
+    test('the exclusion list is pinned', () {
+      // Both lists are how a node kind could quietly dodge coverage, so growing
+      // either is a deliberate edit rather than something that drifts.
+      expect(
+        ASTCodecRegistry.excluded.length,
+        equals(15),
+        reason:
+            'The set of nodes refused by the writer changed. Every entry must '
+            'hold live Dart state, or be unreachable — confirm that, then '
+            'update this count.',
+      );
+      expect(
+        _notTagged.length,
+        equals(12),
+        reason:
+            'The set of nodes encoded inline or rebuilt changed. Confirm the '
+            'new entry really is covered by its parent, then update this count.',
+      );
+    });
+  });
+
+  group('tag hygiene', () {
+    test('no tag is used twice', () {
+      var seen = <int, String>{};
+      for (var codec in ASTCodecRegistry.ordered) {
+        var previous = seen[codec.tag];
+        expect(
+          previous,
+          isNull,
+          reason:
+              'Tag ${codec.tag} is claimed by both `$previous` and '
+              '`${codec.className}`.',
+        );
+        seen[codec.tag] = codec.className;
+      }
+    });
+
+    test('no tag reuses a retired number', () {
+      for (var codec in ASTCodecRegistry.ordered) {
+        expect(
+          ASTNodeTag.retired,
+          isNot(contains(codec.tag)),
+          reason:
+              'Tag ${codec.tag} was retired; reusing it would make old files '
+              'decode as `${codec.className}`.',
+        );
+      }
+    });
+
+    test('no codec claims the null-node marker', () {
+      for (var codec in ASTCodecRegistry.ordered) {
+        expect(codec.tag, isNot(equals(ASTNodeTag.nullNode)));
+      }
+    });
+
+    test('lookup by tag finds every codec', () {
+      for (var codec in ASTCodecRegistry.ordered) {
+        expect(identical(ASTCodecRegistry.byTag(codec.tag), codec), isTrue);
+      }
+      expect(ASTCodecRegistry.byTag(0xFFFF), isNull);
+    });
+  });
+
+  group('dispatch order', () {
+    /// Whether [name] is [ancestor], or descends from it.
+    bool descendsFrom(String name, String ancestor) {
+      var current = superOf[name];
+      while (current != null) {
+        if (current == ancestor) return true;
+        current = superOf[current];
+      }
+      return false;
+    }
+
+    test('a subclass is always registered before its superclass', () {
+      // Writer dispatch walks the ordered list with `is` tests and takes the
+      // first match, so a superclass appearing first would swallow every one of
+      // its subclasses — silently encoding them with the wrong codec.
+      var ordered = ASTCodecRegistry.ordered;
+
+      for (var i = 0; i < ordered.length; ++i) {
+        for (var j = i + 1; j < ordered.length; ++j) {
+          expect(
+            descendsFrom(ordered[j].className, ordered[i].className),
+            isFalse,
+            reason:
+                '`${ordered[j].className}` extends `${ordered[i].className}` '
+                'but is registered after it, so it would be encoded as its '
+                'superclass. Move it earlier in `ASTCodecRegistry.ordered`.',
+          );
+        }
+      }
+    });
+
+    test('the plain block codec is registered last of all', () {
+      // Classes, functions, getters, setters and the root are all `ASTBlock`s.
+      var last = ASTCodecRegistry.ordered.last;
+      expect(last.className, equals('ASTBlock'));
+    });
+  });
+}

--- a/test/unit/apollovm_ast_binary_type_pool_test.dart
+++ b/test/unit/apollovm_ast_binary_type_pool_test.dart
@@ -1,0 +1,295 @@
+library;
+
+import 'package:apollovm/apollovm.dart';
+// Serialization internals are not re-exported from the public library.
+import 'package:apollovm/src/serialization/ast_binary_pool.dart';
+import 'package:apollovm/src/serialization/ast_binary_type_pool.dart';
+import 'package:test/test.dart';
+
+/// Interns [types], encodes both pools, decodes them back, and returns the
+/// decoded types in the same order — the exact path a real file takes.
+List<ASTType> _roundTrip(List<ASTType> types) {
+  var strings = ASTStringPoolWriter();
+  var pool = ASTTypePoolWriter(strings);
+
+  var indexes = types.map(pool.intern).toList();
+
+  var stringsBytes = strings.encode();
+  var typesBytes = pool.encode();
+
+  var stringsIn = ASTStringPoolReader.decode(stringsBytes);
+  var typesIn = ASTTypePoolReader.decode(typesBytes, stringsIn);
+
+  return indexes.map((i) => typesIn[i]).toList();
+}
+
+ASTType _one(ASTType t) => _roundTrip([t]).single;
+
+void main() {
+  group('well-known types keep their identity', () {
+    // Identity is load-bearing, not an optimization:
+    // `ASTConstructorParameterDeclaration.resolveNode` compares its parameter
+    // type against `ASTTypeConstructorThis.instance` with `identical`.
+    final singletons = <String, ASTType>{
+      'int': ASTTypeInt.instance,
+      'int32': ASTTypeInt.instance32,
+      'int64': ASTTypeInt.instance64,
+      'double': ASTTypeDouble.instance,
+      'double32': ASTTypeDouble.instance32,
+      'double64': ASTTypeDouble.instance64,
+      'num': ASTTypeNum.instance,
+      'bool': ASTTypeBool.instance,
+      'String': ASTTypeString.instance,
+      'Object': ASTTypeObject.instance,
+      'dynamic': ASTTypeDynamic.instance,
+      'Null': ASTTypeNull.instance,
+      'void': ASTTypeVoid.instance,
+      'var': ASTTypeVar.instance,
+      'var unmodifiable': ASTTypeVar.instanceUnmodifiable,
+      'constructor this': ASTTypeConstructorThis.instance,
+      'generic wildcard': ASTTypeGenericWildcard.instance,
+      'List<String>': ASTTypeArray.instanceOfString,
+      'List<int>': ASTTypeArray.instanceOfInt,
+      'List<double>': ASTTypeArray.instanceOfDouble,
+      'List<bool>': ASTTypeArray.instanceOfBool,
+      'List<Object>': ASTTypeArray.instanceOfObject,
+      'List<dynamic>': ASTTypeArray.instanceOfDynamic,
+      'Map<String,dynamic>': ASTTypeMap.instanceOfStringOfDynamic,
+      'Map<String,String>': ASTTypeMap.instanceOfStringOfString,
+      'Map<dynamic,dynamic>': ASTTypeMap.instanceOfDynamicOfDynamic,
+    };
+
+    for (var e in singletons.entries) {
+      test(e.key, () {
+        expect(identical(_one(e.value), e.value), isTrue);
+      });
+    }
+
+    test('all of them at once, indices stay aligned', () {
+      var input = singletons.values.toList();
+      var output = _roundTrip(input);
+
+      expect(output.length, equals(input.length));
+      for (var i = 0; i < input.length; ++i) {
+        expect(
+          identical(output[i], input[i]),
+          isTrue,
+          reason: 'index $i (${input[i]}) lost its identity',
+        );
+      }
+    });
+  });
+
+  group('structural types', () {
+    test('named type', () {
+      var t = _one(ASTType('Foo'));
+      expect(t.name, equals('Foo'));
+      expect(t.runtimeType, equals(ASTType('x').runtimeType));
+    });
+
+    test('generics and super type', () {
+      var t = _one(
+        ASTType(
+          'Wrapper',
+          generics: [ASTTypeInt.instance, ASTType('Bar')],
+          superType: ASTType('Base'),
+        ),
+      );
+
+      expect(t.name, equals('Wrapper'));
+      expect(t.generics!.length, equals(2));
+      expect(identical(t.generics![0], ASTTypeInt.instance), isTrue);
+      expect(t.generics![1].name, equals('Bar'));
+      expect(t.superType!.name, equals('Base'));
+    });
+
+    test('an empty generics list is distinct from a null one', () {
+      // `List` and `List<>` are not the same thing to the generators, so the
+      // null/empty distinction has to survive.
+      expect(_one(ASTType('A', generics: [])).generics, isEmpty);
+      expect(_one(ASTType('A')).generics, isNull);
+    });
+
+    test('array of a user type', () {
+      var t = _one(ASTTypeArray(ASTType('Foo'))) as ASTTypeArray;
+      expect(t.name, equals('List'));
+      expect(t.componentType.name, equals('Foo'));
+    });
+
+    test('2D and 3D arrays rebuild through the same factory', () {
+      // Widened to `ASTType` exactly as the grammars do (`v[4] as ASTType`);
+      // passing the narrow singleton type directly does not infer.
+      ASTType elementInt = ASTTypeInt.instance;
+      ASTType elementString = ASTTypeString.instance;
+
+      var t2 = _one(ASTTypeArray2D.fromElementType(elementInt));
+      expect(t2, isA<ASTTypeArray2D>());
+      expect(
+        ((t2 as ASTTypeArray).componentType as ASTTypeArray).componentType,
+        equals(ASTTypeInt.instance),
+      );
+
+      var t3 = _one(ASTTypeArray3D.fromElementType(elementString));
+      expect(t3, isA<ASTTypeArray3D>());
+    });
+
+    test('map of user types', () {
+      var t = _one(ASTTypeMap(ASTType('K'), ASTType('V'))) as ASTTypeMap;
+      expect(t.keyType.name, equals('K'));
+      expect(t.valueType.name, equals('V'));
+    });
+
+    test('future', () {
+      var t = _one(ASTTypeFuture(ASTType('Foo'))) as ASTTypeFuture;
+      expect(t.futureValueType.name, equals('Foo'));
+    });
+
+    test('function type keeps its whole signature', () {
+      var t =
+          _one(
+                ASTTypeFunction(ASTTypeInt.instance, [
+                  ASTTypeString.instance,
+                  ASTType('Foo'),
+                ]),
+              )
+              as ASTTypeFunction;
+
+      expect(t.generics!.length, equals(3));
+      expect(identical(t.generics![0], ASTTypeInt.instance), isTrue);
+      expect(identical(t.generics![1], ASTTypeString.instance), isTrue);
+      expect(t.generics![2].name, equals('Foo'));
+    });
+
+    test('function type with no return type', () {
+      var t = _one(ASTTypeFunction(null, [ASTTypeInt.instance]));
+      expect(t, isA<ASTTypeFunction>());
+      expect(t.generics!.length, equals(1));
+    });
+
+    test('int and double bit widths', () {
+      expect((_one(ASTTypeInt(bits: 16)) as ASTTypeInt).bits, equals(16));
+      expect(
+        (_one(ASTTypeDouble(bits: 128)) as ASTTypeDouble).bits,
+        equals(128),
+      );
+    });
+
+    test('generic variable with and without a bound', () {
+      var bare = _one(ASTTypeGenericVariable('T')) as ASTTypeGenericVariable;
+      expect(bare.variableName, equals('T'));
+      expect(bare.type, isNull);
+
+      var bound =
+          _one(ASTTypeGenericVariable('T', ASTType('Base')))
+              as ASTTypeGenericVariable;
+      expect(bound.variableName, equals('T'));
+      expect(bound.type!.name, equals('Base'));
+    });
+
+    test('interface type keeps its class and super interface', () {
+      var t =
+          _one(ASTTypeInterface('Iface', superInterface: ASTType('Base')))
+              as ASTTypeInterface;
+      expect(t.name, equals('Iface'));
+      expect(t.superType!.name, equals('Base'));
+    });
+
+    test('annotations survive with their parameters', () {
+      var t = _one(
+        ASTType(
+          'Foo',
+          annotations: [
+            ASTAnnotation('Deprecated', {
+              'message': ASTAnnotationParameter('message', 'use Bar', true),
+            }),
+            ASTAnnotation('Marker'),
+          ],
+        ),
+      );
+
+      expect(t.annotations!.length, equals(2));
+      var first = t.annotations![0];
+      expect(first.name, equals('Deprecated'));
+      expect(first.parameters!['message']!.value, equals('use Bar'));
+      expect(first.parameters!['message']!.defaultParameter, isTrue);
+      expect(t.annotations![1].name, equals('Marker'));
+      expect(t.annotations![1].parameters, isNull);
+    });
+  });
+
+  group('nullability', () {
+    test(
+      'a nullable type is a distinct entry, and the singleton is untouched',
+      () {
+        var nullableInt = ASTTypeInt.instance.asNullable(true);
+        var output = _roundTrip([ASTTypeInt.instance, nullableInt]);
+
+        expect(identical(output[0], ASTTypeInt.instance), isTrue);
+        expect(output[1].nullable, isTrue);
+        expect(output[1], isA<ASTTypeInt>());
+        expect(identical(output[1], ASTTypeInt.instance), isFalse);
+
+        // The shared singleton must not have been mutated on the way through.
+        expect(ASTTypeInt.instance.nullable, isFalse);
+      },
+    );
+
+    test('nullable user type', () {
+      var t = _one(ASTType('Foo').asNullable(true));
+      expect(t.name, equals('Foo'));
+      expect(t.nullable, isTrue);
+    });
+
+    test('nullable and non-nullable forms are not collapsed', () {
+      var out = _roundTrip([ASTType('Foo'), ASTType('Foo').asNullable(true)]);
+      expect(out[0].nullable, isFalse);
+      expect(out[1].nullable, isTrue);
+    });
+  });
+
+  group('pooling', () {
+    test('equal types are interned once', () {
+      var strings = ASTStringPoolWriter();
+      var pool = ASTTypePoolWriter(strings);
+
+      var a = pool.intern(ASTType('Foo'));
+      var b = pool.intern(ASTType('Foo'));
+      var c = pool.intern(ASTTypeInt.instance);
+      var d = pool.intern(ASTTypeInt.instance);
+
+      expect(a, equals(b));
+      expect(c, equals(d));
+      expect(pool.length, equals(2));
+    });
+
+    test('decoded uses of one type share an instance', () {
+      var out = _roundTrip([ASTType('Foo'), ASTType('Foo')]);
+      expect(identical(out[0], out[1]), isTrue);
+    });
+
+    test('components are always interned before the type that uses them', () {
+      // Front-to-back decoding depends on every reference pointing backwards.
+      var strings = ASTStringPoolWriter();
+      var pool = ASTTypePoolWriter(strings);
+
+      pool.intern(ASTTypeMap(ASTType('K'), ASTTypeArray(ASTType('V'))));
+
+      // K, V, List<V>, Map<K, List<V>>
+      expect(pool.length, equals(4));
+    });
+
+    test('deeply nested types round trip', () {
+      var t = ASTTypeMap(
+        ASTTypeString.instance,
+        ASTTypeArray(ASTTypeMap(ASTType('A'), ASTTypeFuture(ASTType('B')))),
+      );
+
+      var out = _one(t) as ASTTypeMap;
+      expect(identical(out.keyType, ASTTypeString.instance), isTrue);
+
+      var inner = (out.valueType as ASTTypeArray).componentType as ASTTypeMap;
+      expect(inner.keyType.name, equals('A'));
+      expect((inner.valueType as ASTTypeFuture).futureValueType.name, 'B');
+    });
+  });
+}


### PR DESCRIPTION
Parsing dominates the cost of loading code in ApolloVM: today the only way to get a runnable `ASTRoot` into a VM is to run a petitparser grammar over source text. This adds a compact binary encoding of an **already-parsed** AST, so an application parses once — at build time, or on first run — and afterwards loads the same code unit by decoding bytes.

An image is an `.avma` file: an **A**pollo **V**irtual **M**achine **A**rchive.

## Measured

On a ~4 KB Dart program: decoding is **11× faster** than parsing, and the image is **68%** of the source size. For a very small unit the fixed header and pools cost more than the source is worth — there's a test recording that rather than leaving it as a surprise.

## API

```dart
import 'package:apollovm/apollovm_serialization.dart';

var image = vm.saveCodeUnitAST(codeUnit);   // Uint8List
await ApolloVM().loadCodeUnitAST(image);    // no grammar involved
```

Plus `saveAllAST()` / `loadAllAST()` for a whole-VM archive, `codeUnit.toBinaryAST()`, and standalone `ASTBinaryWriter` / `ASTBinaryReader` for more control.

```sh
apollovm compile --target=ast calc.dart   # writes calc.avma
apollovm run calc.avma                    # runs it, without parsing
```

`run` detects an image by its magic bytes rather than its extension, and takes the language from the image itself.

Everything is `Uint8List` in and `Uint8List` out — file access stays with the caller — so it works unchanged on the web.

## Design notes

**No new load path.** `ApolloVM.loadCodeUnit` only reaches for a parser when a unit has no AST yet, so handing it a decoded unit registers it through the ordinary route: namespace resolution, the null-safety check and incremental-resolution invalidation all behave exactly as for parsed source.

**Nothing derivable is stored.** Parent links, scope-variable resolution, superclass and extension targets, and the `this.field` constructor-parameter promotion are re-established by one `root.resolveNode(null)` after decoding — exactly what every grammar does after a parse. Where `ASTNode.children` is incomplete (a root omits its classes, a class omits its fields and constructors, a block omits its getters and setters, a try/catch omits its clauses) the codecs walk the real members.

**Type identity is load-bearing, not an optimization.** `ASTConstructorParameterDeclaration.resolveNode` compares against `ASTTypeConstructorThis.instance` with `identical`, so the interned `ASTType` singletons decode back to the very same object; a test asserts identity for all 26. Nullability is part of the pool key, so a nullable use never shares an entry with — or mutates — a singleton.

**Nodes holding live Dart state are refused**, with an error naming where in the program they were found: external functions and getters (which carry a closure) and runtime values (a class instance, a pending future, a bound runtime variable). All are injected by the VM at run time rather than produced by a parser, so a parsed AST never contains them and the same bindings are re-injected after a binary load.

## Integrity

Every image carries a CRC-32, verified on load. **It detects corruption, not tampering** — anyone who can modify a file can recompute it in microseconds. Only a signature made with a key the attacker does not have makes an image tamper-evident, and an unsigned image deserves exactly as much trust as the source it came from. The docs say this plainly rather than implying tamper-proofing.

Signing is optional and pluggable (`ASTBinarySigner` / `ASTBinaryVerifier`), so an HMAC, a public-key signature or a hardware key store all fit; `HmacSha256Signer` is built in — which is why `crypto` becomes a direct dependency (it was already present transitively). The signature covers everything up to **and including the CRC**, so an attacker who edits a section and recomputes the checksum still fails verification. There is a test for exactly that.

## Compatibility

An image records the container revision that wrote it and the oldest revision that can decode it. Sections are length-prefixed, so a reader skips any it does not recognize; each is read from a bounded view, so fields a newer writer appended are ignored rather than misread. Unknown *flag* bits are refused instead — a flag changes how the payload must be read, so ignoring one would mean mis-decoding. When a change genuinely cannot be understood, the reader fails naming both versions rather than producing a wrong AST.

Node tags are append-only and never reused; a removed tag is retired rather than freed.

## Two bugs this surfaced

- **`data_serializer` 1.2.2 defect.** `BytesBuffer.readLeb128SignedInt` records the byte *before* the terminating one, so its sign-extension test reads the wrong byte: every negative value and every multi-byte positive value decodes wrong (`-2` → `126`, `64` → `-16320`). The static `Leb128.decodeSigned` is unaffected. Worked around here (a form byte plus an unsigned magnitude, which also removes VM/dart2js sign-extension differences) and noted in the CHANGELOG — worth fixing upstream.
- **`ASTTypeVar` cannot be shared between use sites.** Grammars wire each one to its own initializer via `associateToType`, and it caches the type inferred from it, so pooling them structurally would leak one declaration's inferred type into another. Python caught it: `i: int = 0` regenerating as `i = 0`.

A third, found by the fixture harness: a block's function map is not purely declared structure — running a block mutates it, since `ASTStatementFunctionDeclaration.run` re-registers local functions on every execution. Writing both the statements and that map emitted each local function twice and moved it.

## Verification

- The **168 XML language fixtures** now also encode → decode → regenerate → re-execute, so **415 language tests across all 9 languages** are binary round-trip coverage. Comparing regenerated source is the strongest cheap check available: it exercises every field the code generator reads across the whole tree, so a dropped field shows up as a diff.
- A **coverage test** scans `lib/src/ast/` and requires every one of the 147 concrete `AST*` classes to be registered, pooled, encoded inline by a parent, or listed as refused with a written reason — and checks the subclass-before-superclass dispatch ordering that writer dispatch depends on. Both escape-hatch lists have pinned counts.
- A real **v1 image is frozen as base64** in the test suite and must keep loading; it is the only check that can catch an accidental incompatible change, since an image synthesized by the current writer would move along with the writer.
- Round-trip, byte-idempotence, execution, tamper detection, wrong-key rejection, truncation, unknown sections/flags/tags, and non-zero-offset `Uint8List` views.
- **Full Chrome suite: 1029 passed, 1 skipped.** VM suite green. `dart format`, `analyze --fatal-infos`, `dependency_validator`, `dart doc --dry-run` (0 errors, no warnings from new files) and `pub publish --dry-run` all clean.

Version bumped to **2.28.0** with a CHANGELOG entry. Byte-level spec in [`doc/ast_binary_format.md`](doc/ast_binary_format.md).

## Note for review

The **Wasm suite could not be run here** — the native `wasm_run` dylib is killed (SIGKILL) in this environment. I verified it fails identically on `master`, so it is environmental rather than from this branch, but it is the one part of the suite left unverified locally. CI should cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)