### PR TITLE
Give `int` and `double` the same `num` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+## 2.29.0
+
+### `int` and `double` now expose the same `num` interface
+
+Each primitive only carried the conversion that changed its type: `int` had
+`toDouble()` and `double` had `toInt()`, so the identity half of the pair was
+missing on both. `3.toInt()` and `1.5.toDouble()` — both valid Dart, since
+`num.toInt()` / `num.toDouble()` return `this` — failed with
+`Bad state: Can't find core function: int.toInt(...)`.
+
+The same gap covered the rest of the `num` interface on `int`, which had none
+of the members that only `double` had been given:
+
+| on `int` | before | now |
+|---|---|---|
+| `toInt()` | ✗ | ✓ (identity) |
+| `round()`, `floor()`, `ceil()`, `truncate()` | ✗ | ✓ (identities) |
+| `toStringAsFixed()`, `toStringAsExponential()`, `toStringAsPrecision()` | ✗ | ✓ |
+| `toDouble()` | ✓ | ✓ |
+
+and on `double`, `toDouble()` is added as the matching identity.
+
+This mattered most for a `num`-typed variable. ApolloVM has no `num` core
+class, so `num n = ...` dispatches on the *runtime* value's class — meaning
+`n.toInt()` worked or failed depending on whether `n` happened to hold a
+`double` or an `int`. Both now work either way:
+
+```dart
+num n = 3;      // was: Can't find core function: int.toInt
+n.toInt();      // 3
+n.toDouble();   // 3.0
+```
+
+`toNum()` remains unsupported, as it is not a method on `num`, `int` or
+`double` in Dart.
+
 ## 2.28.1
 
 ### Fixed: `compile <file> --target=ast` silently compiled to Wasm

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -61,7 +61,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.28.1';
+  static final String VERSION = '2.29.0';
 
   static int _idCount = 0;
 

--- a/lib/src/core/apollovm_core_base.dart
+++ b/lib/src/core/apollovm_core_base.dart
@@ -798,6 +798,18 @@ class CoreClassInt extends CoreClassPrimitive<int> {
   late final ASTExternalClassGetter _getterSign;
   late final ASTExternalClassFunction _functionToDouble;
 
+  // Inherited from `num`: `int` implements these as identities or as `String`
+  // conversions. They are declared here (and mirrored on [CoreClassDouble]) so
+  // both primitives expose the same `num` surface.
+  late final ASTExternalClassFunction _functionToInt;
+  late final ASTExternalClassFunction _functionRound;
+  late final ASTExternalClassFunction _functionFloor;
+  late final ASTExternalClassFunction _functionCeil;
+  late final ASTExternalClassFunction _functionTruncate;
+  late final ASTExternalClassFunction _functionToStringAsFixed;
+  late final ASTExternalClassFunction _functionToStringAsExponential;
+  late final ASTExternalClassFunction _functionToStringAsPrecision;
+
   CoreClassInt._() : super(ASTTypeInt.instance, 'int') {
     _functionToString = _externalClassFunctionArgs0(
       'toString',
@@ -878,6 +890,73 @@ class CoreClassInt extends CoreClassPrimitive<int> {
       ASTTypeDouble.instance,
       (int self) => self.toDouble(),
     );
+
+    // Identity on `int`, but valid Dart: `num.toInt()` returns `this`.
+    _functionToInt = _externalClassFunctionArgs0(
+      'toInt',
+      ASTTypeInt.instance,
+      (int self) => self,
+    );
+
+    _functionRound = _externalClassFunctionArgs0(
+      'round',
+      ASTTypeInt.instance,
+      (int self) => self.round(),
+    );
+
+    _functionFloor = _externalClassFunctionArgs0(
+      'floor',
+      ASTTypeInt.instance,
+      (int self) => self.floor(),
+    );
+
+    _functionCeil = _externalClassFunctionArgs0(
+      'ceil',
+      ASTTypeInt.instance,
+      (int self) => self.ceil(),
+    );
+
+    _functionTruncate = _externalClassFunctionArgs0(
+      'truncate',
+      ASTTypeInt.instance,
+      (int self) => self.truncate(),
+    );
+
+    _functionToStringAsFixed = _externalClassFunctionArgs1(
+      'toStringAsFixed',
+      ASTTypeString.instance,
+      ASTFunctionParameterDeclaration(
+        ASTTypeInt.instance,
+        'fractionDigits',
+        0,
+        false,
+      ),
+      (int self, dynamic digits) => self.toStringAsFixed(digits),
+    );
+
+    _functionToStringAsExponential = _externalClassFunctionArgs1(
+      'toStringAsExponential',
+      ASTTypeString.instance,
+      ASTFunctionParameterDeclaration(
+        ASTTypeInt.instance,
+        'fractionDigits',
+        0,
+        true,
+      ),
+      (int self, dynamic digits) => self.toStringAsExponential(digits),
+    );
+
+    _functionToStringAsPrecision = _externalClassFunctionArgs1(
+      'toStringAsPrecision',
+      ASTTypeString.instance,
+      ASTFunctionParameterDeclaration(
+        ASTTypeInt.instance,
+        'precision',
+        0,
+        false,
+      ),
+      (int self, dynamic precision) => self.toStringAsPrecision(precision),
+    );
   }
 
   @override
@@ -926,6 +1005,22 @@ class CoreClassInt extends CoreClassPrimitive<int> {
         return _functionToRadixString;
       case 'toDouble':
         return _functionToDouble;
+      case 'toInt':
+        return _functionToInt;
+      case 'round':
+        return _functionRound;
+      case 'floor':
+        return _functionFloor;
+      case 'ceil':
+        return _functionCeil;
+      case 'truncate':
+        return _functionTruncate;
+      case 'toStringAsFixed':
+        return _functionToStringAsFixed;
+      case 'toStringAsExponential':
+        return _functionToStringAsExponential;
+      case 'toStringAsPrecision':
+        return _functionToStringAsPrecision;
 
       case 'toString':
         return _functionToString;
@@ -964,6 +1059,9 @@ class CoreClassDouble extends CoreClassPrimitive<double> {
   late final ASTExternalClassFunction _functionFloor;
   late final ASTExternalClassFunction _functionCeil;
   late final ASTExternalClassFunction _functionTruncate;
+
+  /// Inherited from `num`: identity on `double`, mirroring `int.toInt()`.
+  late final ASTExternalClassFunction _functionToDouble;
 
   CoreClassDouble._() : super(ASTTypeDouble.instance, 'double') {
     _functionToString = _externalClassFunctionArgs0(
@@ -1127,6 +1225,13 @@ class CoreClassDouble extends CoreClassPrimitive<double> {
       ASTTypeInt.instance,
       (double self) => self.truncate(),
     );
+
+    // Identity on `double`, but valid Dart: `num.toDouble()` returns `this`.
+    _functionToDouble = _externalClassFunctionArgs0(
+      'toDouble',
+      ASTTypeDouble.instance,
+      (double self) => self,
+    );
   }
 
   @override
@@ -1187,6 +1292,8 @@ class CoreClassDouble extends CoreClassPrimitive<double> {
         return _functionCeil;
       case 'truncate':
         return _functionTruncate;
+      case 'toDouble':
+        return _functionToDouble;
 
       case 'toString':
         return _functionToString;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.28.1
+version: 2.29.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/unit/apollovm_core_library_test.dart
+++ b/test/unit/apollovm_core_library_test.dart
@@ -141,6 +141,37 @@ void main() {
       expect(await _run('var a = 3; return a.toDouble();'), equals(3.0));
     });
 
+    test('toInt is an identity', () async {
+      // Inherited from `num`, where `toInt()` returns `this` for an `int`.
+      expect(await _run('var a = 7; return a.toInt();'), equals(7));
+      expect(await _run('var a = -5; return a.toInt();'), equals(-5));
+      expect(await _run('var a = 0; return a.toInt();'), equals(0));
+    });
+
+    test('rounding: round, floor, ceil and truncate', () async {
+      // All four are identities on `int`, negatives included.
+      expect(await _run('var a = 7; return a.round();'), equals(7));
+      expect(await _run('var a = 7; return a.floor();'), equals(7));
+      expect(await _run('var a = 7; return a.ceil();'), equals(7));
+      expect(await _run('var a = 7; return a.truncate();'), equals(7));
+      expect(await _run('var a = -5; return a.round();'), equals(-5));
+      expect(await _run('var a = -5; return a.floor();'), equals(-5));
+      expect(await _run('var a = -5; return a.ceil();'), equals(-5));
+      expect(await _run('var a = -5; return a.truncate();'), equals(-5));
+    });
+
+    test('string formatting', () async {
+      expect(await _run('var a = 10; return a.toStringAsFixed(2);'), '10.00');
+      expect(
+        await _run('var a = 10; return a.toStringAsPrecision(3);'),
+        equals('10.0'),
+      );
+      expect(
+        await _run('var a = 1000; return a.toStringAsExponential(1);'),
+        equals('1.0e+3'),
+      );
+    });
+
     test('toString', () async {
       expect(await _run('var a = 7; return a.toString();'), equals('7'));
     });
@@ -177,6 +208,13 @@ void main() {
       expect(await _run('var d = 2.9; return d.toInt();'), equals(2));
     });
 
+    test('toDouble is an identity', () async {
+      // Inherited from `num`, where `toDouble()` returns `this` for a `double`.
+      expect(await _run('var d = 1.5; return d.toDouble();'), equals(1.5));
+      expect(await _run('var d = -2.5; return d.toDouble();'), equals(-2.5));
+      expect(await _run('var d = 0.0; return d.toDouble();'), equals(0.0));
+    });
+
     test('string formatting', () async {
       expect(await _run('var d = 1.5; return d.toStringAsFixed(2);'), '1.50');
       expect(
@@ -192,6 +230,59 @@ void main() {
     test('clamp and toString', () async {
       expect(await _run('var d = 9.0; return d.clamp(1.0, 5.0);'), equals(5.0));
       expect(await _run('var d = 1.5; return d.toString();'), equals('1.5'));
+    });
+  });
+
+  group('core num', () {
+    // There is no `num` core class: a `num`-declared variable dispatches on the
+    // runtime value's class, so `int` and `double` must each carry the whole
+    // `num` surface, not just the half that converts to the other type.
+    test('conversions on a num holding an int', () async {
+      expect(await _run('num n = 3; return n.toInt();'), equals(3));
+      expect(await _run('num n = 3; return n.toDouble();'), equals(3.0));
+    });
+
+    test('conversions on a num holding a double', () async {
+      expect(await _run('num n = 2.5; return n.toInt();'), equals(2));
+      expect(await _run('num n = 2.5; return n.toDouble();'), equals(2.5));
+    });
+
+    test('rounding on a num holding an int', () async {
+      expect(await _run('num n = 3; return n.round();'), equals(3));
+      expect(await _run('num n = 3; return n.floor();'), equals(3));
+      expect(await _run('num n = 3; return n.ceil();'), equals(3));
+      expect(await _run('num n = 3; return n.truncate();'), equals(3));
+    });
+
+    test('string formatting on a num holding an int', () async {
+      expect(await _run('num n = 2; return n.toStringAsFixed(1);'), '2.0');
+      expect(await _run('num n = 2; return n.toStringAsPrecision(2);'), '2.0');
+      expect(
+        await _run('num n = 2; return n.toStringAsExponential(1);'),
+        equals('2.0e+0'),
+      );
+    });
+
+    test('conversions chain in both directions', () async {
+      expect(await _run('var a = 4; return a.toDouble().toInt();'), equals(4));
+      expect(
+        await _run('var d = 4.5; return d.toInt().toDouble();'),
+        equals(4.0),
+      );
+      expect(await _run('var a = 4; return a.toInt().toInt();'), equals(4));
+      expect(
+        await _run('var d = 4.5; return d.toDouble().toDouble();'),
+        equals(4.5),
+      );
+    });
+
+    test('toNum() is not a Dart method and stays unsupported', () async {
+      expect(() => _run('var a = 1; return a.toNum();'), throwsA(isA<Error>()));
+      expect(
+        () => _run('var d = 1.5; return d.toNum();'),
+        throwsA(isA<Error>()),
+      );
+      expect(() => _run('num n = 1; return n.toNum();'), throwsA(isA<Error>()));
     });
   });
 


### PR DESCRIPTION
## Problem

Each primitive only carried the conversion that *changed* its type: `CoreClassInt` registered `toDouble()`, `CoreClassDouble` registered `toInt()`. The identity half of the pair was missing on both, so this valid Dart failed:

```
3.toInt()      -> Bad state: Can't find core function: int.toInt( {} )
1.5.toDouble() -> Bad state: Can't find core function: double.toDouble( {} )
```

Both are legal — `num.toInt()` and `num.toDouble()` return `this` — and neither is exotic; they are what you write when a value's static type is `num` and you need a definite one.

The gap covered the rest of the `num` interface on `int`, which had none of the members `double` had been given.

It bit hardest on `num`-typed variables. ApolloVM has no `num` core class (`ApolloVMCore.getClass('num')` returns `null`), so `num n = ...` dispatches on the **runtime** value's class — `n.toInt()` worked or threw purely on whether `n` happened to hold a `double` or an `int`.

## Change

Registered the missing members so both primitives expose the same `num` surface:

| on `int` | before | after |
|---|---|---|
| `toInt()` | ✗ | ✓ (identity) |
| `round()`, `floor()`, `ceil()`, `truncate()` | ✗ | ✓ (identities) |
| `toStringAsFixed()`, `toStringAsExponential()`, `toStringAsPrecision()` | ✗ | ✓ |
| `toDouble()` | ✓ | ✓ |

| on `double` | before | after |
|---|---|---|
| `toDouble()` | ✗ | ✓ (identity) |
| everything else | ✓ | ✓ |

`toNum()` is deliberately still unsupported — it is not a method on `num`, `int` or `double` in Dart, so rejecting it is correct behavior rather than a gap.

## Tests

`test/unit/apollovm_core_library_test.dart` gains identity/rounding/formatting cases in the `core int` and `core double` groups, plus a new `core num` group covering the parity contract directly: conversions on a `num` holding each of an `int` and a `double`, chained round-trips in both directions, and `toNum()` staying an error.

Full VM suite passes (2299 tests). Version bumped to `2.29.0` with a CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)