### PR TITLE
Support multiple variables per Dart declaration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,45 @@
+## 2.30.0
+
+### Dart: multiple variables per declaration
+
+A declaration could only introduce one variable, so the ordinary Dart form of
+declaring several at once was a syntax error:
+
+```dart
+void main() {
+  num nr = 0.96, ng = 0.24, nb = 0.56;  // was: [SyntaxError] ";" expected
+
+  print(nr);
+  print(ng);
+  print(nb);
+}
+```
+
+Every declarator is now accepted, in a function body and at the top level,
+sharing the declared type and the `final` / `const` / `late` modifier of the
+first one. A declarator may omit its initializer (`int a, b = 5;`) and may read
+the ones before it (`int p = 1, q = p + 1;`), matching Dart's left-to-right
+initialization.
+
+The declarators are expanded into one declaration each as the code is parsed,
+so translation emits the form every target already supports:
+
+```dart
+num nr = 0.96;
+num ng = 0.24;
+num nb = 0.56;
+```
+
+```python
+nr: float = 0.96
+ng: float = 0.24
+nb: float = 0.56
+```
+
+A `for` initializer still takes a single declarator: a `for` header has no
+place for the extra declarations the expansion produces, and the
+comma-separated form does not exist in every target language.
+
 ## 2.29.0
 
 ### `int` and `double` now expose the same `num` interface

--- a/lib/src/apollovm_base.dart
+++ b/lib/src/apollovm_base.dart
@@ -61,7 +61,7 @@ import 'resolution/symbol_table.dart';
 /// The Apollo VM.
 class ApolloVM implements VMTypeResolver {
   // ignore: non_constant_identifier_names
-  static final String VERSION = '2.29.0';
+  static final String VERSION = '2.30.0';
 
   static int _idCount = 0;
 

--- a/lib/src/ast/apollovm_ast_statement.dart
+++ b/lib/src/ast/apollovm_ast_statement.dart
@@ -536,6 +536,14 @@ class ASTBlock extends ASTStatement {
   }
 
   void addStatement(ASTStatement statement) {
+    // Expand `int a = 1, b = 2;` into one declaration per statement: the
+    // declarators already share this block's scope, and this keeps
+    // [ASTStatementVariableDeclarationList] out of the generators and runners.
+    if (statement is ASTStatementVariableDeclarationList) {
+      addAllStatements(statement.declarations);
+      return;
+    }
+
     _statements.add(statement);
     if (statement is ASTBlock) {
       statement.parentBlock = this;
@@ -1146,6 +1154,58 @@ class ASTStatementVariableDeclaration<V> extends ASTStatementTyped {
       return '$type $name;';
     }
   }
+}
+
+/// A variable declaration statement with more than one declarator, as parsed
+/// from `num nr = 0.96, ng = 0.24, nb = 0.56;`.
+///
+/// This node is transient: [ASTBlock.addStatement] expands it into its
+/// individual [declarations], so no generator, runner or serializer ever sees
+/// it. The expansion is faithful because every declarator of a multi-declarator
+/// statement shares the enclosing scope and is initialized left to right —
+/// exactly the semantics of the same declarations written one per line. It also
+/// keeps the code generators portable: targets without a comma-separated
+/// declaration form (Python, Go, Kotlin) get one declaration per statement for
+/// free.
+class ASTStatementVariableDeclarationList extends ASTStatement {
+  final List<ASTStatementVariableDeclaration> declarations;
+
+  ASTStatementVariableDeclarationList(this.declarations);
+
+  @override
+  Iterable<ASTNode> get children => declarations;
+
+  @override
+  void resolveNode(ASTNode? parentNode) {
+    super.resolveNode(parentNode);
+
+    for (var d in declarations) {
+      d.resolveNode(parentNode);
+    }
+  }
+
+  /// Runs each declaration in [parentContext]: the declarators share the
+  /// enclosing scope, so no run context is defined here. Only reachable if this
+  /// node escapes the expansion in [ASTBlock.addStatement].
+  @override
+  FutureOr<ASTValue> run(
+    VMContext parentContext,
+    ASTRunStatus runStatus,
+  ) async {
+    FutureOr<ASTValue> returnValue = ASTValueVoid.instance;
+
+    for (var d in declarations) {
+      returnValue = await d.run(parentContext, runStatus);
+    }
+
+    return returnValue;
+  }
+
+  @override
+  ASTType resolveType(VMContext? context) => ASTTypeVoid.instance;
+
+  @override
+  String toString() => declarations.join(' ');
 }
 
 /// [ASTStatement] base for branches.

--- a/lib/src/languages/dart/dart_grammar.dart
+++ b/lib/src/languages/dart/dart_grammar.dart
@@ -80,8 +80,11 @@ class DartGrammarDefinition extends DartGrammarLexer {
                   root.addExtension(def);
                 } else if (def is ASTTypeAlias) {
                   root.addTypeAlias(def);
-                } else if (def is ASTStatementVariableDeclaration) {
-                  root.addStatement(def);
+                } else if (def is ASTStatementVariableDeclaration ||
+                    def is ASTStatementVariableDeclarationList) {
+                  // `addStatement` expands a declaration list into one
+                  // top-level declaration per declarator.
+                  root.addStatement(def as ASTStatement);
                 }
               }
             }
@@ -982,7 +985,7 @@ class DartGrammarDefinition extends DartGrammarLexer {
           });
 
   Parser<ASTStatement> statementSimple() =>
-      (statementVariableDeclaration() | statementExpression())
+      (statementVariableDeclarationSingle() | statementExpression())
           .cast<ASTStatement>();
 
   Parser<ASTStatementForLoop> statementForLoop() =>
@@ -1176,69 +1179,132 @@ class DartGrammarDefinition extends DartGrammarLexer {
             );
           });
 
-  Parser<ASTStatementVariableDeclaration> statementVariableDeclaration() =>
-      (
-          // Metadata attaches to the *declaration*, deliberately not to
-          // `statement()`: attempting a metadata parse at every statement
-          // position would move the farthest-failure offset that
-          // `apollovm_dart_parse_error_position_test` pins on a stray `@`.
-          ref0(metadata).star() &
-              // `late` is accepted and dropped: ApolloVM has no
-              // lazy-initialization semantics, and `late int x = 1;` runs the
-              // same as `int x = 1;`.
-              lateKeyword().optional() &
-              // var definition:
-              (
-              // final Type name:
-              ((finalToken() | constToken()).trimHidden() &
-                      type() &
-                      identifier().trimHidden()) |
-                  // final name:
-                  ((finalToken() | constToken()) & identifier().trimHidden()) |
-                  // Type name:
-                  (type() & identifier().trimHidden())
-              // end var definition
-              ) &
-              (char('=').trimHidden() & ref0(expression)).optional() &
-              char(';').trimHidden())
-          .map((v) {
-            var varDef = v[2] as List;
+  /// A variable declaration statement, with one declarator (`int a = 1;`) or
+  /// several (`num nr = 0.96, ng = 0.24, nb = 0.56;`).
+  ///
+  /// Returns an [ASTStatementVariableDeclaration] for the single-declarator
+  /// form and an [ASTStatementVariableDeclarationList] — expanded back into one
+  /// statement per declarator by `ASTBlock.addStatement` — for the multi form.
+  Parser<ASTStatement> statementVariableDeclaration() =>
+      _variableDeclaration(multipleDeclarators: true);
 
-            bool unmodifiable;
-            ASTType type;
-            String name;
+  /// [statementVariableDeclaration] restricted to a single declarator, for the
+  /// `for` initializer. A `for` header has no place to put the extra
+  /// declarations of the multi form: unlike a block, it can't hold a statement
+  /// list, and the comma-separated form doesn't exist in every target language.
+  Parser<ASTStatementVariableDeclaration>
+  statementVariableDeclarationSingle() => _variableDeclaration(
+    multipleDeclarators: false,
+  ).cast<ASTStatementVariableDeclaration>();
 
-            if (varDef.length == 3) {
+  Parser<ASTStatement> _variableDeclaration({
+    required bool multipleDeclarators,
+  }) {
+    // Extra declarators: `, ng = 0.24`. Each reuses the type and the
+    // `final`/`const` modifier of the first one.
+    final extraDeclarators = multipleDeclarators
+        ? (char(',').trimHidden() &
+                  identifier().trimHidden() &
+                  (char('=').trimHidden() & ref0(expression)).optional())
+              .star()
+        : epsilonWith<List>(const []);
+
+    return (
+        // Metadata attaches to the *declaration*, deliberately not to
+        // `statement()`: attempting a metadata parse at every statement
+        // position would move the farthest-failure offset that
+        // `apollovm_dart_parse_error_position_test` pins on a stray `@`.
+        ref0(metadata).star() &
+            // `late` is accepted and dropped: ApolloVM has no
+            // lazy-initialization semantics, and `late int x = 1;` runs the
+            // same as `int x = 1;`.
+            lateKeyword().optional() &
+            // var definition:
+            (
+            // final Type name:
+            ((finalToken() | constToken()).trimHidden() &
+                    type() &
+                    identifier().trimHidden()) |
+                // final name:
+                ((finalToken() | constToken()) & identifier().trimHidden()) |
+                // Type name:
+                (type() & identifier().trimHidden())
+            // end var definition
+            ) &
+            (char('=').trimHidden() & ref0(expression)).optional() &
+            extraDeclarators &
+            char(';').trimHidden())
+        .map((v) {
+          var varDef = v[2] as List;
+
+          bool unmodifiable;
+          ASTType type;
+          String name;
+
+          if (varDef.length == 3) {
+            unmodifiable = true;
+            assert(['final', 'const'].contains((varDef[0] as Token).value));
+            type = varDef[1];
+            name = varDef[2];
+          } else if (varDef.length == 2) {
+            final varDef0 = varDef[0];
+            if (varDef0 is Token &&
+                (varDef0.value == 'final' || varDef0.value == 'const')) {
               unmodifiable = true;
-              assert(['final', 'const'].contains((varDef[0] as Token).value));
-              type = varDef[1];
-              name = varDef[2];
-            } else if (varDef.length == 2) {
-              final varDef0 = varDef[0];
-              if (varDef0 is Token &&
-                  (varDef0.value == 'final' || varDef0.value == 'const')) {
-                unmodifiable = true;
-                type = getTypeByName(varDef0.value);
-                name = varDef[1];
-              } else {
-                unmodifiable = false;
-                type = varDef[0];
-                name = varDef[1];
-              }
+              type = getTypeByName(varDef0.value);
+              name = varDef[1];
             } else {
-              throw StateError("Invalid var definition: $varDef");
+              unmodifiable = false;
+              type = varDef[0];
+              name = varDef[1];
             }
+          } else {
+            throw StateError("Invalid var definition: $varDef");
+          }
 
-            var valueOpt = v[3];
-            var value = valueOpt != null ? valueOpt[1] as ASTExpression : null;
-            if (value != null) type.associateToType(value);
-            return ASTStatementVariableDeclaration(
-              type,
-              name,
-              value,
-              unmodifiable: unmodifiable,
-            );
-          });
+          var declaration = _newVariableDeclaration(
+            type,
+            name,
+            v[3],
+            unmodifiable: unmodifiable,
+          );
+
+          var extras = v[4] as List;
+          if (extras.isEmpty) return declaration;
+
+          return ASTStatementVariableDeclarationList([
+            declaration,
+            for (var extra in extras)
+              // Each declarator needs its own type instance: the declarations
+              // are independent nodes, and `_newVariableDeclaration` associates
+              // the type to that declarator's own value expression.
+              _newVariableDeclaration(
+                type.cloneType(),
+                extra[1] as String,
+                extra[2],
+                unmodifiable: unmodifiable,
+              ),
+          ]);
+        });
+  }
+
+  ASTStatementVariableDeclaration _newVariableDeclaration(
+    ASTType type,
+    String name,
+    Object? valueOpt, {
+    required bool unmodifiable,
+  }) {
+    var value = valueOpt != null
+        ? (valueOpt as List)[1] as ASTExpression
+        : null;
+    if (value != null) type.associateToType(value);
+    return ASTStatementVariableDeclaration(
+      type,
+      name,
+      value,
+      unmodifiable: unmodifiable,
+    );
+  }
 
   Parser<ASTBranch> branch() =>
       (ref0(branchIfElseIfsElseBlock) |

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Portable multi-language VM: parse, run and translate Dart, Java, Kotlin, Go,
   C#, JavaScript, TypeScript, Lua and Python — with on-the-fly Wasm compilation
   and MCP/LSP servers.
-version: 2.29.0
+version: 2.30.0
 repository: https://github.com/ApolloVM/apollovm_dart
 issue_tracker: https://github.com/ApolloVM/apollovm_dart/issues
 

--- a/test/features/apollovm_multi_variable_declaration_test.dart
+++ b/test/features/apollovm_multi_variable_declaration_test.dart
@@ -207,6 +207,81 @@ void main() {
     });
   });
 
+  group('ASTStatementVariableDeclarationList', () {
+    ASTStatementVariableDeclarationList list() =>
+        ASTStatementVariableDeclarationList([
+          ASTStatementVariableDeclaration(
+            ASTTypeInt.instance,
+            'a',
+            ASTExpressionLiteral(ASTValueInt(1)),
+          ),
+          ASTStatementVariableDeclaration(
+            ASTTypeInt.instance,
+            'b',
+            ASTExpressionLiteral(ASTValueInt(2)),
+          ),
+        ]);
+
+    test('a block expands it away instead of storing it', () {
+      var block = ASTBlock(null)..addStatement(list());
+
+      expect(block.statements, hasLength(2));
+      expect(
+        block.statements.map(
+          (s) => (s as ASTStatementVariableDeclaration).name,
+        ),
+        equals(['a', 'b']),
+      );
+      expect(
+        block.statements,
+        everyElement(isA<ASTStatementVariableDeclaration>()),
+      );
+    });
+
+    test('exposes the declarations as its children', () {
+      var l = list();
+      expect(l.children, equals(l.declarations));
+    });
+
+    test('resolveNode reaches every declaration', () {
+      var block = ASTBlock(null);
+      var l = list();
+      l.resolveNode(block);
+
+      expect(l.parentNode, same(block));
+      for (var d in l.declarations) {
+        expect(d.parentNode, same(block));
+      }
+    });
+
+    test('running it declares every variable in the same context', () async {
+      var l = list();
+      var context = VMScopeContext(ASTBlock(null));
+
+      var result = await l.run(context, ASTRunStatus());
+
+      expect(result.getValueNoContext(), equals(2));
+      for (var (name, value) in [('a', 1), ('b', 2)]) {
+        var variable = await context.getVariable(name, false);
+        expect(
+          variable,
+          isNotNull,
+          reason: 'Variable `$name` not declared in the run context.',
+        );
+        expect(
+          (await variable!.getValue(context)).getValueNoContext(),
+          equals(value),
+        );
+      }
+    });
+
+    test('resolveType is void, toString lists the declarations', () {
+      var l = list();
+      expect(l.resolveType(null), isA<ASTTypeVoid>());
+      expect(l.toString(), equals('${l.declarations[0]} ${l.declarations[1]}'));
+    });
+  });
+
   group('translation', () {
     const source = '''
       void main() {

--- a/test/features/apollovm_multi_variable_declaration_test.dart
+++ b/test/features/apollovm_multi_variable_declaration_test.dart
@@ -1,0 +1,252 @@
+@TestOn('vm')
+@Tags(['dart', 'javascript', 'python'])
+library;
+
+import 'package:apollovm/apollovm.dart';
+import 'package:test/test.dart';
+
+/// Loads a single Dart [source] and runs the top-level [function], returning
+/// the values captured from its `print` calls.
+Future<List> runPrint(String source, [String function = 'main']) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', source, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source!");
+
+  var runner = vm.createRunner('dart')!;
+  var output = [];
+  runner.externalPrintFunction = output.add;
+
+  await runner.executeFunction('', function);
+  return output;
+}
+
+/// Translates a Dart [source] to [language] and returns the generated code.
+Future<String> translate(String source, String language) async {
+  var vm = ApolloVM();
+  var ok = await vm.loadCodeUnit(SourceCodeUnit('dart', source, id: 'test'));
+  expect(ok, isTrue, reason: "Can't load Dart source!");
+
+  var codeStorage = vm.generateAllCodeIn(language);
+
+  var buffer = StringBuffer();
+  for (var ns in await codeStorage.getNamespaces()) {
+    for (var id in await codeStorage.getNamespaceCodeUnitsIDs(ns)) {
+      buffer.write(await codeStorage.getNamespaceCodeUnit(ns, id));
+    }
+  }
+  return buffer.toString();
+}
+
+void main() {
+  group('multiple declarators', () {
+    test('num nr = 0.96, ng = 0.24, nb = 0.56', () async {
+      var output = await runPrint('''
+        void main() {
+          num nr = 0.96, ng = 0.24, nb = 0.56;
+
+          print(nr);
+          print(ng);
+          print(nb);
+        }
+      ''');
+
+      expect(output, equals([0.96, 0.24, 0.56]));
+    });
+
+    test('declarators are independent variables', () async {
+      var output = await runPrint('''
+        void main() {
+          int a = 1, b = 2;
+          a = a + 10;
+          print(a);
+          print(b);
+        }
+      ''');
+
+      expect(output, equals([11, 2]));
+    });
+
+    test('initialized left to right, later reads earlier', () async {
+      var output = await runPrint('''
+        void main() {
+          int p = 1, q = p + 1, r = q * 10;
+          print(p);
+          print(q);
+          print(r);
+        }
+      ''');
+
+      expect(output, equals([1, 2, 20]));
+    });
+
+    test('a declarator may omit its initializer', () async {
+      var output = await runPrint('''
+        void main() {
+          int a, b = 5, c;
+          print(a);
+          print(b);
+          print(c);
+        }
+      ''');
+
+      expect(output, equals([null, 5, null]));
+    });
+
+    test('`var` infers each declarator separately', () async {
+      var output = await runPrint('''
+        void main() {
+          var a = 1, b = 'x', c = 2.5;
+          print(a);
+          print(b);
+          print(c);
+        }
+      ''');
+
+      expect(output, equals([1, 'x', 2.5]));
+    });
+
+    test('`final`, `const` and `late` cover every declarator', () async {
+      var output = await runPrint('''
+        void main() {
+          final int f1 = 10, f2 = 20;
+          const int k1 = 3, k2 = 4;
+          late int z1 = 7, z2 = 8;
+
+          print(f1 + f2);
+          print(k1 * k2);
+          print(z1 + z2);
+        }
+      ''');
+
+      expect(output, equals([30, 12, 15]));
+    });
+
+    test('non-primitive types', () async {
+      var output = await runPrint('''
+        void main() {
+          List<int> l1 = [1, 2], l2 = [3];
+          String s1 = 'a', s2 = 'b';
+
+          print(l1);
+          print(l2);
+          print(s1 + s2);
+        }
+      ''');
+
+      expect(
+        output,
+        equals([
+          [1, 2],
+          [3],
+          'ab',
+        ]),
+      );
+    });
+
+    test('declared at the top level', () async {
+      var output = await runPrint('''
+        int gx = 1, gy = 2;
+
+        void main() {
+          print(gx);
+          print(gy);
+          print(gx + gy);
+        }
+      ''');
+
+      expect(output, equals([1, 2, 3]));
+    });
+
+    test('inside a nested block and a loop body', () async {
+      var output = await runPrint('''
+        void main() {
+          for (int i = 0; i < 2; ++i) {
+            int p = i, q = i * 10;
+            print(p + q);
+          }
+          {
+            int a = 1, b = 2;
+            print(a + b);
+          }
+        }
+      ''');
+
+      expect(output, equals([0, 11, 3]));
+    });
+
+    test('each declarator is type checked against the declared type', () async {
+      expect(
+        () => runPrint('''
+          void main() {
+            int a = 1, b = 'x';
+            print(a);
+            print(b);
+          }
+        '''),
+        throwsA(isA<ApolloVMRuntimeError>()),
+      );
+    });
+
+    test('a `for` initializer still takes a single declarator', () async {
+      // The `for` header has nowhere to put the extra declarations the multi
+      // form expands into, so it is rejected at parse time rather than parsed
+      // into something no target language can express.
+      var vm = ApolloVM();
+      expect(
+        () => vm.loadCodeUnit(
+          SourceCodeUnit('dart', '''
+            void main() {
+              for (int i = 0, j = 2; i < j; ++i) {
+                print(i);
+              }
+            }
+          ''', id: 'test'),
+        ),
+        throwsA(isA<SyntaxError>()),
+      );
+    });
+  });
+
+  group('translation', () {
+    const source = '''
+      void main() {
+        num nr = 0.96, ng = 0.24, nb = 0.56;
+
+        print(nr);
+        print(ng);
+        print(nb);
+      }
+    ''';
+
+    test('Dart emits one declaration per declarator', () async {
+      var code = await translate(source, 'dart');
+
+      expect(code, contains('num nr = 0.96;'));
+      expect(code, contains('num ng = 0.24;'));
+      expect(code, contains('num nb = 0.56;'));
+    });
+
+    test('JavaScript emits one declaration per declarator', () async {
+      var code = await translate(source, 'javascript');
+
+      expect(code, contains('let nr = 0.96;'));
+      expect(code, contains('let ng = 0.24;'));
+      expect(code, contains('let nb = 0.56;'));
+    });
+
+    test('Python emits one declaration per declarator', () async {
+      var code = await translate(source, 'python');
+
+      expect(code, contains('nr: float = 0.96'));
+      expect(code, contains('ng: float = 0.24'));
+      expect(code, contains('nb: float = 0.56'));
+    });
+
+    test('generated Dart parses and runs the same', () async {
+      var code = await translate(source, 'dart');
+      var output = await runPrint(code);
+
+      expect(output, equals([0.96, 0.24, 0.56]));
+    });
+  });
+}

--- a/test/unit/apollovm_ast_binary_coverage_test.dart
+++ b/test/unit/apollovm_ast_binary_coverage_test.dart
@@ -95,6 +95,12 @@ const Map<String, String> _notTagged = {
   'ASTFunctionParametersDeclaration':
       "written inline as the declaration's three parameter groups",
 
+  // Transient: expanded away before the tree is complete.
+  'ASTStatementVariableDeclarationList':
+      'expanded by ASTBlock.addStatement into one '
+      'ASTStatementVariableDeclaration per declarator, so it never reaches a '
+      'finished tree',
+
   // Abstract in practice: only their subclasses are ever constructed.
   'ASTEntryPointBlock': 'a base class; ASTRoot and ASTClass are what exist',
   'ASTParameterDeclaration':
@@ -202,7 +208,7 @@ void main() {
       );
       expect(
         _notTagged.length,
-        equals(12),
+        equals(13),
         reason:
             'The set of nodes encoded inline or rebuilt changed. Confirm the '
             'new entry really is covered by its parent, then update this count.',


### PR DESCRIPTION
## Problem

A declaration could only introduce one variable, so the ordinary Dart form of declaring several at once was a syntax error:

```dart
void main() {
  num nr = 0.96, ng = 0.24, nb = 0.56;

  print(nr);
  print(ng);
  print(nb);
}
```

```
[SyntaxError] ";" expected @29[2, 16]:
2>  num nr = 0.96, ng = 0.24, nb = 0.56;
                 ^
```

## Change

`statementVariableDeclaration` accepts extra declarators after the first, each reusing the declared type and the `final` / `const` / `late` modifier. A declarator may omit its initializer (`int a, b = 5;`) and may read the ones before it (`int p = 1, q = p + 1;`), matching Dart's left-to-right initialization. Works in a function body and at the top level.

The declarators are expanded into one `ASTStatementVariableDeclaration` each by `ASTBlock.addStatement`, through a transient `ASTStatementVariableDeclarationList` node. That keeps the change confined to the grammar — no generator, runner or codec ever sees the new node — and translation emits the one-per-line form that every target already supports, including Python, Go and Kotlin, which have no comma-separated declaration syntax at all:

```python
nr: float = 0.96
ng: float = 0.24
nb: float = 0.56
```

### Not included

A `for` initializer keeps the single-declarator parser. The header has nowhere to put the extra declarations the expansion produces, and the comma form is not portable across targets, so `for (int i = 0, j = 2; ...)` stays a syntax error rather than parsing into something that cannot be generated. Class fields are parsed by a separate production and are unchanged.

## Tests

New `test/features/apollovm_multi_variable_declaration_test.dart` (15 tests): the reported snippet, independence of the declarators, left-to-right initialization, omitted initializers, per-declarator `var` inference, `final`/`const`/`late`, non-primitive types, top-level and nested-block positions, per-declarator type checking, the `for`-initializer boundary, and translation to Dart / JavaScript / Python plus a re-run of the generated Dart.

Full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)